### PR TITLE
Major performance improvements (.NET Core + Linux)

### DIFF
--- a/src/MSBuildTaskHost/Concurrent/ConcurrentDictionary.cs
+++ b/src/MSBuildTaskHost/Concurrent/ConcurrentDictionary.cs
@@ -1,0 +1,534 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Build.Shared.Concurrent
+{
+    // The following class is back-ported from .NET 4.X CoreFX library because
+    // MSBuildTaskHost requires 3.5 .NET Framework. Only GetOrAdd method kept.
+    internal class ConcurrentDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Tables that hold the internal state of the ConcurrentDictionary
+        ///
+        /// Wrapping the three tables in a single object allows us to atomically
+        /// replace all tables at once.
+        /// </summary>
+        private sealed class Tables
+        {
+            internal readonly Node[] _buckets; // A singly-linked list for each bucket.
+            internal readonly object[] _locks; // A set of locks, each guarding a section of the table.
+            internal volatile int[] _countPerLock; // The number of elements guarded by each lock.
+
+            internal Tables(Node[] buckets, object[] locks, int[] countPerLock)
+            {
+                _buckets = buckets;
+                _locks = locks;
+                _countPerLock = countPerLock;
+            }
+        }
+
+        private volatile Tables _tables; // Internal tables of the dictionary
+        private IEqualityComparer<TKey> _comparer; // Key equality comparer
+        private readonly bool _growLockArray; // Whether to dynamically increase the size of the striped lock
+        private int _budget; // The maximum number of elements per lock before a resize operation is triggered
+
+        // The default capacity, i.e. the initial # of buckets. When choosing this value, we are making
+        // a trade-off between the size of a very small dictionary, and the number of resizes when
+        // constructing a large dictionary. Also, the capacity should not be divisible by a small prime.
+        private const int DefaultCapacity = 31;
+
+        // The maximum size of the striped lock that will not be exceeded when locks are automatically
+        // added as the dictionary grows. However, the user is allowed to exceed this limit by passing
+        // a concurrency level larger than MaxLockNumber into the constructor.
+        private const int MaxLockNumber = 1024;
+
+        // Whether TValue is a type that can be written atomically (i.e., with no danger of torn reads)
+        private static readonly bool s_isValueWriteAtomic = IsValueWriteAtomic();
+
+        /// <summary>
+        /// Determines whether type TValue can be written atomically
+        /// </summary>
+        private static bool IsValueWriteAtomic()
+        {
+            //
+            // Section 12.6.6 of ECMA CLI explains which types can be read and written atomically without
+            // the risk of tearing.
+            //
+            // See http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-335.pdf
+            //
+            Type valueType = typeof(TValue);
+            if (!valueType.IsValueType)
+            {
+                return true;
+            }
+
+            switch (Type.GetTypeCode(valueType))
+            {
+                case TypeCode.Boolean:
+                case TypeCode.Byte:
+                case TypeCode.Char:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.SByte:
+                case TypeCode.Single:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                    return true;
+                case TypeCode.Int64:
+                case TypeCode.Double:
+                case TypeCode.UInt64:
+                    return IntPtr.Size == 8;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>
+        /// class that is empty, has the default concurrency level, has the default initial capacity, and
+        /// uses the default comparer for the key type.
+        /// </summary>
+        public ConcurrentDictionary(IEqualityComparer<TKey> comparer = null)
+        {
+
+            int concurrencyLevel = Environment.ProcessorCount;
+            int capacity = DefaultCapacity;
+
+            // The capacity should be at least as large as the concurrency level. Otherwise, we would have locks that don't guard
+            // any buckets.
+            if (capacity < concurrencyLevel)
+            {
+                capacity = concurrencyLevel;
+            }
+
+            object[] locks = new object[concurrencyLevel];
+            for (int i = 0; i < locks.Length; i++)
+            {
+                locks[i] = new object();
+            }
+
+            int[] countPerLock = new int[locks.Length];
+            Node[] buckets = new Node[capacity];
+            _tables = new Tables(buckets, locks, countPerLock);
+
+            _comparer = comparer ?? EqualityComparer<TKey>.Default;
+            _growLockArray = true;
+            _budget = buckets.Length / locks.Length;
+        }
+
+        private bool TryGetValueInternal(TKey key, int hashcode, out TValue value)
+        {
+            Debug.Assert(_comparer.GetHashCode(key) == hashcode);
+
+            // We must capture the _buckets field in a local variable. It is set to a new table on each table resize.
+            Tables tables = _tables;
+
+            int bucketNo = GetBucket(hashcode, tables._buckets.Length);
+
+            // We can get away w/out a lock here.
+            // The Volatile.Read ensures that we have a copy of the reference to tables._buckets[bucketNo].
+            // This protects us from reading fields ('_hashcode', '_key', '_value' and '_next') of different instances.
+            Thread.MemoryBarrier();
+            Node n = tables._buckets[bucketNo];
+
+            while (n != null)
+            {
+                if (hashcode == n._hashcode && _comparer.Equals(n._key, key))
+                {
+                    value = n._value;
+                    return true;
+                }
+                n = n._next;
+            }
+
+            value = default(TValue);
+            return false;
+        }
+
+        /// <summary>
+        /// Shared internal implementation for inserts and updates.
+        /// If key exists, we always return false; and if updateIfExists == true we force update with value;
+        /// If key doesn't exist, we always add value and return true;
+        /// </summary>
+        private bool TryAddInternal(TKey key, int hashcode, TValue value, bool updateIfExists, bool acquireLock, out TValue resultingValue)
+        {
+            Debug.Assert(_comparer.GetHashCode(key) == hashcode);
+
+            while (true)
+            {
+                int bucketNo, lockNo;
+
+                Tables tables = _tables;
+                GetBucketAndLockNo(hashcode, out bucketNo, out lockNo, tables._buckets.Length, tables._locks.Length);
+
+                bool resizeDesired = false;
+                bool lockTaken = false;
+                try
+                {
+                    if (acquireLock)
+                        lockTaken = Monitor.TryEnter(tables._locks[lockNo]);
+
+                    // If the table just got resized, we may not be holding the right lock, and must retry.
+                    // This should be a rare occurrence.
+                    if (tables != _tables)
+                    {
+                        continue;
+                    }
+
+                    // Try to find this key in the bucket
+                    Node prev = null;
+                    for (Node node = tables._buckets[bucketNo]; node != null; node = node._next)
+                    {
+                        Debug.Assert((prev == null && node == tables._buckets[bucketNo]) || prev._next == node);
+                        if (hashcode == node._hashcode && _comparer.Equals(node._key, key))
+                        {
+                            // The key was found in the dictionary. If updates are allowed, update the value for that key.
+                            // We need to create a new node for the update, in order to support TValue types that cannot
+                            // be written atomically, since lock-free reads may be happening concurrently.
+                            if (updateIfExists)
+                            {
+                                if (s_isValueWriteAtomic)
+                                {
+                                    node._value = value;
+                                }
+                                else
+                                {
+                                    Node newNode = new Node(node._key, value, hashcode, node._next);
+                                    if (prev == null)
+                                    {
+                                        Interlocked.Exchange(ref tables._buckets[bucketNo], newNode);
+                                    }
+                                    else
+                                    {
+                                        prev._next = newNode;
+                                    }
+                                }
+                                resultingValue = value;
+                            }
+                            else
+                            {
+                                resultingValue = node._value;
+                            }
+                            return false;
+                        }
+                        prev = node;
+                    }
+
+                    // The key was not found in the bucket. Insert the key-value pair.
+                    Interlocked.Exchange(ref tables._buckets[bucketNo], new Node(key, value, hashcode, tables._buckets[bucketNo]));
+                    checked
+                    {
+                        tables._countPerLock[lockNo]++;
+                    }
+
+                    //
+                    // If the number of elements guarded by this lock has exceeded the budget, resize the bucket table.
+                    // It is also possible that GrowTable will increase the budget but won't resize the bucket table.
+                    // That happens if the bucket table is found to be poorly utilized due to a bad hash function.
+                    //
+                    if (tables._countPerLock[lockNo] > _budget)
+                    {
+                        resizeDesired = true;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken)
+                        Monitor.Exit(tables._locks[lockNo]);
+                }
+
+                //
+                // The fact that we got here means that we just performed an insertion. If necessary, we will grow the table.
+                //
+                // Concurrency notes:
+                // - Notice that we are not holding any locks at when calling GrowTable. This is necessary to prevent deadlocks.
+                // - As a result, it is possible that GrowTable will be called unnecessarily. But, GrowTable will obtain lock 0
+                //   and then verify that the table we passed to it as the argument is still the current table.
+                //
+                if (resizeDesired)
+                {
+                    GrowTable(tables);
+                }
+
+                resultingValue = value;
+                return true;
+            }
+        }
+
+        private static void ThrowKeyNullException()
+        {
+            throw new ArgumentNullException("key");
+        }
+
+        /// <summary>
+        /// Adds a key/value pair to the <see cref="ConcurrentDictionary{TKey,TValue}"/>
+        /// if the key does not already exist.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The function used to generate a value for the key</param>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="key"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="valueFactory"/> is a null reference
+        /// (Nothing in Visual Basic).</exception>
+        /// <exception cref="T:System.OverflowException">The dictionary contains too many
+        /// elements.</exception>
+        /// <returns>The value for the key.  This will be either the existing value for the key if the
+        /// key is already in the dictionary, or the new value for the key as returned by valueFactory
+        /// if the key was not in the dictionary.</returns>
+        public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
+        {
+            if (key == null) ThrowKeyNullException();
+            if (valueFactory == null) throw new ArgumentNullException(nameof(valueFactory));
+
+            int hashcode = _comparer.GetHashCode(key);
+
+            TValue resultingValue;
+            if (!TryGetValueInternal(key, hashcode, out resultingValue))
+            {
+                TryAddInternal(key, hashcode, valueFactory(key), false, true, out resultingValue);
+            }
+            return resultingValue;
+        }
+
+        /// <summary>
+        /// Replaces the bucket table with a larger one. To prevent multiple threads from resizing the
+        /// table as a result of races, the Tables instance that holds the table of buckets deemed too
+        /// small is passed in as an argument to GrowTable(). GrowTable() obtains a lock, and then checks
+        /// the Tables instance has been replaced in the meantime or not.
+        /// </summary>
+        private void GrowTable(Tables tables)
+        {
+            const int MaxArrayLength = 0X7FEFFFFF;
+            int locksAcquired = 0;
+            try
+            {
+                // The thread that first obtains _locks[0] will be the one doing the resize operation
+                AcquireLocks(0, 1, ref locksAcquired);
+
+                // Make sure nobody resized the table while we were waiting for lock 0:
+                if (tables != _tables)
+                {
+                    // We assume that since the table reference is different, it was already resized (or the budget
+                    // was adjusted). If we ever decide to do table shrinking, or replace the table for other reasons,
+                    // we will have to revisit this logic.
+                    return;
+                }
+
+                // Compute the (approx.) total size. Use an Int64 accumulation variable to avoid an overflow.
+                long approxCount = 0;
+                for (int i = 0; i < tables._countPerLock.Length; i++)
+                {
+                    approxCount += tables._countPerLock[i];
+                }
+
+                //
+                // If the bucket array is too empty, double the budget instead of resizing the table
+                //
+                if (approxCount < tables._buckets.Length / 4)
+                {
+                    _budget = 2 * _budget;
+                    if (_budget < 0)
+                    {
+                        _budget = int.MaxValue;
+                    }
+                    return;
+                }
+
+
+                // Compute the new table size. We find the smallest integer larger than twice the previous table size, and not divisible by
+                // 2,3,5 or 7. We can consider a different table-sizing policy in the future.
+                int newLength = 0;
+                bool maximizeTableSize = false;
+                try
+                {
+                    checked
+                    {
+                        // Double the size of the buckets table and add one, so that we have an odd integer.
+                        newLength = tables._buckets.Length * 2 + 1;
+
+                        // Now, we only need to check odd integers, and find the first that is not divisible
+                        // by 3, 5 or 7.
+                        while (newLength % 3 == 0 || newLength % 5 == 0 || newLength % 7 == 0)
+                        {
+                            newLength += 2;
+                        }
+
+                        Debug.Assert(newLength % 2 != 0);
+
+                        if (newLength > MaxArrayLength)
+                        {
+                            maximizeTableSize = true;
+                        }
+                    }
+                }
+                catch (OverflowException)
+                {
+                    maximizeTableSize = true;
+                }
+
+                if (maximizeTableSize)
+                {
+                    newLength = MaxArrayLength;
+
+                    // We want to make sure that GrowTable will not be called again, since table is at the maximum size.
+                    // To achieve that, we set the budget to int.MaxValue.
+                    //
+                    // (There is one special case that would allow GrowTable() to be called in the future:
+                    // calling Clear() on the ConcurrentDictionary will shrink the table and lower the budget.)
+                    _budget = int.MaxValue;
+                }
+
+                // Now acquire all other locks for the table
+                AcquireLocks(1, tables._locks.Length, ref locksAcquired);
+
+                object[] newLocks = tables._locks;
+
+                // Add more locks
+                if (_growLockArray && tables._locks.Length < MaxLockNumber)
+                {
+                    newLocks = new object[tables._locks.Length * 2];
+                    Array.Copy(tables._locks, 0, newLocks, 0, tables._locks.Length);
+                    for (int i = tables._locks.Length; i < newLocks.Length; i++)
+                    {
+                        newLocks[i] = new object();
+                    }
+                }
+
+                Node[] newBuckets = new Node[newLength];
+                int[] newCountPerLock = new int[newLocks.Length];
+
+                // Copy all data into a new table, creating new nodes for all elements
+                for (int i = 0; i < tables._buckets.Length; i++)
+                {
+                    Node current = tables._buckets[i];
+                    while (current != null)
+                    {
+                        Node next = current._next;
+                        int newBucketNo, newLockNo;
+                        GetBucketAndLockNo(current._hashcode, out newBucketNo, out newLockNo, newBuckets.Length, newLocks.Length);
+
+                        newBuckets[newBucketNo] = new Node(current._key, current._value, current._hashcode, newBuckets[newBucketNo]);
+
+                        checked
+                        {
+                            newCountPerLock[newLockNo]++;
+                        }
+
+                        current = next;
+                    }
+                }
+
+                // Adjust the budget
+                _budget = Math.Max(1, newBuckets.Length / newLocks.Length);
+
+                // Replace tables with the new versions
+                _tables = new Tables(newBuckets, newLocks, newCountPerLock);
+            }
+            finally
+            {
+                // Release all locks that we took earlier
+                ReleaseLocks(0, locksAcquired);
+            }
+        }
+
+        /// <summary>
+        /// Computes the bucket for a particular key.
+        /// </summary>
+        private static int GetBucket(int hashcode, int bucketCount)
+        {
+            int bucketNo = (hashcode & 0x7fffffff) % bucketCount;
+            Debug.Assert(bucketNo >= 0 && bucketNo < bucketCount);
+            return bucketNo;
+        }
+
+        /// <summary>
+        /// Computes the bucket and lock number for a particular key.
+        /// </summary>
+        private static void GetBucketAndLockNo(int hashcode, out int bucketNo, out int lockNo, int bucketCount, int lockCount)
+        {
+            bucketNo = (hashcode & 0x7fffffff) % bucketCount;
+            lockNo = bucketNo % lockCount;
+
+            Debug.Assert(bucketNo >= 0 && bucketNo < bucketCount);
+            Debug.Assert(lockNo >= 0 && lockNo < lockCount);
+        }
+
+        /// <summary>
+        /// Acquires all locks for this hash table, and increments locksAcquired by the number
+        /// of locks that were successfully acquired. The locks are acquired in an increasing
+        /// order.
+        /// </summary>
+        private void AcquireAllLocks(ref int locksAcquired)
+        {
+            // First, acquire lock 0
+            AcquireLocks(0, 1, ref locksAcquired);
+
+            // Now that we have lock 0, the _locks array will not change (i.e., grow),
+            // and so we can safely read _locks.Length.
+            AcquireLocks(1, _tables._locks.Length, ref locksAcquired);
+            Debug.Assert(locksAcquired == _tables._locks.Length);
+        }
+
+        /// <summary>
+        /// Acquires a contiguous range of locks for this hash table, and increments locksAcquired
+        /// by the number of locks that were successfully acquired. The locks are acquired in an
+        /// increasing order.
+        /// </summary>
+        private void AcquireLocks(int fromInclusive, int toExclusive, ref int locksAcquired)
+        {
+            Debug.Assert(fromInclusive <= toExclusive);
+            object[] locks = _tables._locks;
+
+            for (int i = fromInclusive; i < toExclusive; i++)
+            {
+                bool lockTaken = false;
+                try
+                {
+                    lockTaken = Monitor.TryEnter(locks[i]);
+                }
+                finally
+                {
+                    if (lockTaken)
+                    {
+                        locksAcquired++;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Releases a contiguous range of locks.
+        /// </summary>
+        private void ReleaseLocks(int fromInclusive, int toExclusive)
+        {
+            Debug.Assert(fromInclusive <= toExclusive);
+
+            for (int i = fromInclusive; i < toExclusive; i++)
+            {
+                Monitor.Exit(_tables._locks[i]);
+            }
+        }
+
+        /// <summary>
+        /// A node in a singly-linked list representing a particular hash table bucket.
+        /// </summary>
+        private sealed class Node
+        {
+            internal readonly TKey _key;
+            internal TValue _value;
+            internal volatile Node _next;
+            internal readonly int _hashcode;
+
+            internal Node(TKey key, TValue value, int hashcode, Node next)
+            {
+                _key = key;
+                _value = value;
+                _next = next;
+                _hashcode = hashcode;
+            }
+        }
+    }
+}

--- a/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
+++ b/src/MSBuildTaskHost/Concurrent/ConcurrentQueue.cs
@@ -1,0 +1,558 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.Build.Shared.Concurrent
+{
+    // The following class is back-ported from .NET 4.X CoreFX library because
+    // MSBuildTaskHost requires 3.5 .NET Framework. Only important methods (Enqueue, TryDequeue) are kept.
+    internal class ConcurrentQueue<T>
+    {
+        // This implementation provides an unbounded, multi-producer multi-consumer queue
+        // that supports the standard Enqueue/TryDequeue operations, as well as support for
+        // snapshot enumeration (GetEnumerator, ToArray, CopyTo), peeking, and Count/IsEmpty.
+        // It is composed of a linked list of bounded ring buffers, each of which has a head
+        // and a tail index, isolated from each other to minimize false sharing.  As long as
+        // the number of elements in the queue remains less than the size of the current
+        // buffer (Segment), no additional allocations are required for enqueued items.  When
+        // the number of items exceeds the size of the current segment, the current segment is
+        // "frozen" to prevent further enqueues, and a new segment is linked from it and set
+        // as the new tail segment for subsequent enqueues.  As old segments are consumed by
+        // dequeues, the head reference is updated to point to the segment that dequeuers should
+        // try next.  To support snapshot enumeration, segments also support the notion of
+        // preserving for observation, whereby they avoid overwriting state as part of dequeues.
+        // Any operation that requires a snapshot results in all current segments being
+        // both frozen for enqueues and preserved for observation: any new enqueues will go
+        // to new segments, and dequeuers will consume from the existing segments but without
+        // overwriting the existing data.
+
+        /// <summary>Initial length of the segments used in the queue.</summary>
+        private const int InitialSegmentLength = 32;
+        /// <summary>
+        /// Maximum length of the segments used in the queue.  This is a somewhat arbitrary limit:
+        /// larger means that as long as we don't exceed the size, we avoid allocating more segments,
+        /// but if we do exceed it, then the segment becomes garbage.
+        /// </summary>
+        private const int MaxSegmentLength = 1024 * 1024;
+
+        /// <summary>
+        /// Lock used to protect cross-segment operations, including any updates to <see cref="_tail"/> or <see cref="_head"/>
+        /// and any operations that need to get a consistent view of them.
+        /// </summary>
+        private object _crossSegmentLock;
+        /// <summary>The current tail segment.</summary>
+        private volatile Segment _tail;
+        /// <summary>The current head segment.</summary>
+        private volatile Segment _head;
+
+        static internal object VolatileReader(ref object o) => Thread.VolatileRead(ref o);
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcurrentQueue{T}"/> class.
+        /// </summary>
+        public ConcurrentQueue()
+        {
+            _crossSegmentLock = new object();
+            _tail = _head = new Segment(InitialSegmentLength);
+        }
+
+        /// <summary>Adds an object to the end of the <see cref="ConcurrentQueue{T}"/>.</summary>
+        /// <param name="item">
+        /// The object to add to the end of the <see cref="ConcurrentQueue{T}"/>.
+        /// The value can be a null reference (Nothing in Visual Basic) for reference types.
+        /// </param>
+        public void Enqueue(T item)
+        {
+            // Try to enqueue to the current tail.
+            if (!_tail.TryEnqueue(item))
+            {
+                // If we're unable to, we need to take a slow path that will
+                // try to add a new tail segment.
+                EnqueueSlow(item);
+            }
+        }
+
+        /// <summary>Adds to the end of the queue, adding a new segment if necessary.</summary>
+        private void EnqueueSlow(T item)
+        {
+            while (true)
+            {
+                Segment tail = _tail;
+
+                // Try to append to the existing tail.
+                if (tail.TryEnqueue(item))
+                {
+                    return;
+                }
+
+                // If we were unsuccessful, take the lock so that we can compare and manipulate
+                // the tail.  Assuming another enqueuer hasn't already added a new segment,
+                // do so, then loop around to try enqueueing again.
+                lock (_crossSegmentLock)
+                {
+                    if (tail == _tail)
+                    {
+                        // Make sure no one else can enqueue to this segment.
+                        tail.EnsureFrozenForEnqueues();
+
+                        // We determine the new segment's length based on the old length.
+                        // In general, we double the size of the segment, to make it less likely
+                        // that we'll need to grow again.  However, if the tail segment is marked
+                        // as preserved for observation, something caused us to avoid reusing this
+                        // segment, and if that happens a lot and we grow, we'll end up allocating
+                        // lots of wasted space.  As such, in such situations we reset back to the
+                        // initial segment length; if these observations are happening frequently,
+                        // this will help to avoid wasted memory, and if they're not, we'll
+                        // relatively quickly grow again to a larger size.
+                        int nextSize = tail._preservedForObservation != 0 ? InitialSegmentLength : Math.Min(tail.Capacity * 2, MaxSegmentLength);
+                        var newTail = new Segment(nextSize);
+
+                        // Hook up the new tail.
+                        tail._nextSegment = newTail;
+                        _tail = newTail;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to remove and return the object at the beginning of the <see
+        /// cref="ConcurrentQueue{T}"/>.
+        /// </summary>
+        /// <param name="result">
+        /// When this method returns, if the operation was successful, <paramref name="result"/> contains the
+        /// object removed. If no object was available to be removed, the value is unspecified.
+        /// </param>
+        /// <returns>
+        /// true if an element was removed and returned from the beginning of the
+        /// <see cref="ConcurrentQueue{T}"/> successfully; otherwise, false.
+        /// </returns>
+        public bool TryDequeue(out T result) =>
+            _head.TryDequeue(out result) || // fast-path that operates just on the head segment
+            TryDequeueSlow(out result); // slow path that needs to fix up segments
+
+        /// <summary>Tries to dequeue an item, removing empty segments as needed.</summary>
+        private bool TryDequeueSlow(out T item)
+        {
+            while (true)
+            {
+                // Get the current head
+                Segment head = _head;
+
+                // Try to take.  If we're successful, we're done.
+                if (head.TryDequeue(out item))
+                {
+                    return true;
+                }
+
+                // Check to see whether this segment is the last. If it is, we can consider
+                // this to be a moment-in-time empty condition (even though between the TryDequeue
+                // check and this check, another item could have arrived).
+                if (head._nextSegment == null)
+                {
+                    item = default(T);
+                    return false;
+                }
+
+                // At this point we know that head.Next != null, which means
+                // this segment has been frozen for additional enqueues. But between
+                // the time that we ran TryDequeue and checked for a next segment,
+                // another item could have been added.  Try to dequeue one more time
+                // to confirm that the segment is indeed empty.
+                Debug.Assert(head._frozenForEnqueues);
+                if (head.TryDequeue(out item))
+                {
+                    return true;
+                }
+
+                // This segment is frozen (nothing more can be added) and empty (nothing is in it).
+                // Update head to point to the next segment in the list, assuming no one's beat us to it.
+                lock (_crossSegmentLock)
+                {
+                    if (head == _head)
+                    {
+                        _head = head._nextSegment;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to return an object from the beginning of the <see cref="ConcurrentQueue{T}"/>
+        /// without removing it.
+        /// </summary>
+        /// <param name="result">
+        /// When this method returns, <paramref name="result"/> contains an object from
+        /// the beginning of the <see cref="Concurrent.ConcurrentQueue{T}"/> or default(T)
+        /// if the operation failed.
+        /// </param>
+        /// <returns>true if and object was returned successfully; otherwise, false.</returns>
+        /// <remarks>
+        /// For determining whether the collection contains any items, use of the <see cref="IsEmpty"/>
+        /// property is recommended rather than peeking.
+        /// </remarks>
+        public bool TryPeek(out T result) => TryPeek(out result, resultUsed: true);
+
+        /// <summary>Attempts to retrieve the value for the first element in the queue.</summary>
+        /// <param name="result">The value of the first element, if found.</param>
+        /// <param name="resultUsed">true if the result is neede; otherwise false if only the true/false outcome is needed.</param>
+        /// <returns>true if an element was found; otherwise, false.</returns>
+        private bool TryPeek(out T result, bool resultUsed)
+        {
+            // Starting with the head segment, look through all of the segments
+            // for the first one we can find that's not empty.
+            Segment s = _head;
+            while (true)
+            {
+                // Grab the next segment from this one, before we peek.
+                // This is to be able to see whether the value has changed
+                // during the peek operation.
+                Thread.MemoryBarrier();
+                Segment next = s._nextSegment;
+
+                // Peek at the segment.  If we find an element, we're done.
+                if (s.TryPeek(out result, resultUsed))
+                {
+                    return true;
+                }
+
+                // The current segment was empty at the moment we checked.
+
+                if (next != null)
+                {
+                    // If prior to the peek there was already a next segment, then
+                    // during the peek no additional items could have been enqueued
+                    // to it and we can just move on to check the next segment.
+                    Debug.Assert(next == s._nextSegment);
+                    s = next;
+                }
+                else
+                {
+                    Thread.MemoryBarrier();
+                    if (s._nextSegment == null)
+                    {
+                        // The next segment is null.  Nothing more to peek at.
+                        break;
+                    }
+                }
+
+                // The next segment was null before we peeked but non-null after.
+                // That means either when we peeked the first segment had
+                // already been frozen but the new segment not yet added,
+                // or that the first segment was empty and between the time
+                // that we peeked and then checked _nextSegment, so many items
+                // were enqueued that we filled the first segment and went
+                // into the next.  Since we need to peek in order, we simply
+                // loop around again to peek on the same segment.  The next
+                // time around on this segment we'll then either successfully
+                // peek or we'll find that next was non-null before peeking,
+                // and we'll traverse to that segment.
+            }
+
+            result = default(T);
+            return false;
+        }
+
+        /// <summary>
+        /// Provides a multi-producer, multi-consumer thread-safe bounded segment.  When the queue is full,
+        /// enqueues fail and return false.  When the queue is empty, dequeues fail and return null.
+        /// These segments are linked together to form the unbounded <see cref="ConcurrentQueue{T}"/>. 
+        /// </summary>
+        [DebuggerDisplay("Capacity = {Capacity}")]
+        private sealed class Segment
+        {
+            // Segment design is inspired by the algorithm outlined at:
+            // http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
+
+            /// <summary>The array of items in this queue.  Each slot contains the item in that slot and its "sequence number".</summary>
+            internal readonly Slot[] _slots;
+            /// <summary>Mask for quickly accessing a position within the queue's array.</summary>
+            internal readonly int _slotsMask;
+            /// <summary>The head and tail positions, with padding to help avoid false sharing contention.</summary>
+            /// <remarks>Dequeuing happens from the head, enqueuing happens at the tail.</remarks>
+            internal PaddedHeadAndTail _headAndTail; // mutable struct: do not make this readonly
+
+            /// <summary>Indicates whether the segment has been marked such that dequeues don't overwrite the removed data.</summary>
+            internal byte _preservedForObservation;
+            /// <summary>Indicates whether the segment has been marked such that no additional items may be enqueued.</summary>
+            internal bool _frozenForEnqueues;
+            /// <summary>The segment following this one in the queue, or null if this segment is the last in the queue.</summary>
+            internal Segment _nextSegment;
+
+            /// <summary>Creates the segment.</summary>
+            /// <param name="boundedLength">
+            /// The maximum number of elements the segment can contain.  Must be a power of 2.
+            /// </param>
+            public Segment(int boundedLength)
+            {
+                // Validate the length
+                Debug.Assert(boundedLength >= 2, $"Must be >= 2, got {boundedLength}");
+                Debug.Assert((boundedLength & (boundedLength - 1)) == 0, $"Must be a power of 2, got {boundedLength}");
+
+                // Initialize the slots and the mask.  The mask is used as a way of quickly doing "% _slots.Length",
+                // instead letting us do "& _slotsMask".
+                _slots = new Slot[boundedLength];
+                _slotsMask = boundedLength - 1;
+
+                // Initialize the sequence number for each slot.  The sequence number provides a ticket that
+                // allows dequeuers to know whether they can dequeue and enqueuers to know whether they can
+                // enqueue.  An enqueuer at position N can enqueue when the sequence number is N, and a dequeuer
+                // for position N can dequeue when the sequence number is N + 1.  When an enqueuer is done writing
+                // at position N, it sets the sequence number to N + 1 so that a dequeuer will be able to dequeue,
+                // and when a dequeuer is done dequeueing at position N, it sets the sequence number to N + _slots.Length,
+                // so that when an enqueuer loops around the slots, it'll find that the sequence number at
+                // position N is N.  This also means that when an enqueuer finds that at position N the sequence
+                // number is < N, there is still a value in that slot, i.e. the segment is full, and when a
+                // dequeuer finds that the value in a slot is < N + 1, there is nothing currently available to
+                // dequeue. (It is possible for multiple enqueuers to enqueue concurrently, writing into
+                // subsequent slots, and to have the first enqueuer take longer, so that the slots for 1, 2, 3, etc.
+                // may have values, but the 0th slot may still be being filled... in that case, TryDequeue will
+                // return false.)
+                for (int i = 0; i < _slots.Length; i++)
+                {
+                    _slots[i].SequenceNumber = i;
+                }
+            }
+
+            /// <summary>Gets the number of elements this segment can store.</summary>
+            internal int Capacity => _slots.Length;
+
+            /// <summary>Gets the "freeze offset" for this segment.</summary>
+            internal int FreezeOffset => _slots.Length * 2;
+
+            /// <summary>
+            /// Ensures that the segment will not accept any subsequent enqueues that aren't already underway.
+            /// </summary>
+            /// <remarks>
+            /// When we mark a segment as being frozen for additional enqueues,
+            /// we set the <see cref="_frozenForEnqueues"/> bool, but that's mostly
+            /// as a small helper to avoid marking it twice.  The real marking comes
+            /// by modifying the Tail for the segment, increasing it by this
+            /// <see cref="FreezeOffset"/>.  This effectively knocks it off the
+            /// sequence expected by future enqueuers, such that any additional enqueuer
+            /// will be unable to enqueue due to it not lining up with the expected
+            /// sequence numbers.  This value is chosen specially so that Tail will grow
+            /// to a value that maps to the same slot but that won't be confused with
+            /// any other enqueue/dequeue sequence number.
+            /// </remarks>
+            internal void EnsureFrozenForEnqueues() // must only be called while queue's segment lock is held
+            {
+                if (!_frozenForEnqueues) // flag used to ensure we don't increase the Tail more than once if frozen more than once
+                {
+                    _frozenForEnqueues = true;
+
+                    // Increase the tail by FreezeOffset, spinning until we're successful in doing so.
+                    while (true)
+                    {
+                        int tail = Thread.VolatileRead(ref _headAndTail.Tail);
+                        if (Interlocked.CompareExchange(ref _headAndTail.Tail, tail + FreezeOffset, tail) == tail)
+                        {
+                            break;
+                        }
+                        Thread.SpinWait(1);
+                    }
+                }
+            }
+
+            /// <summary>Tries to dequeue an element from the queue.</summary>
+            public bool TryDequeue(out T item)
+            {
+                // Loop in case of contention...
+                while (true)
+                {
+                    // Get the head at which to try to dequeue.
+                    int currentHead = Thread.VolatileRead(ref _headAndTail.Head);
+                    int slotsIndex = currentHead & _slotsMask;
+
+                    // Read the sequence number for the head position.
+                    int sequenceNumber = Thread.VolatileRead(ref _slots[slotsIndex].SequenceNumber);
+
+                    // We can dequeue from this slot if it's been filled by an enqueuer, which
+                    // would have left the sequence number at pos+1.
+                    int diff = sequenceNumber - (currentHead + 1);
+                    if (diff == 0)
+                    {
+                        // We may be racing with other dequeuers.  Try to reserve the slot by incrementing
+                        // the head.  Once we've done that, no one else will be able to read from this slot,
+                        // and no enqueuer will be able to read from this slot until we've written the new
+                        // sequence number. WARNING: The next few lines are not reliable on a runtime that
+                        // supports thread aborts. If a thread abort were to sneak in after the CompareExchange
+                        // but before the Volatile.Write, enqueuers trying to enqueue into this slot would
+                        // spin indefinitely.  If this implementation is ever used on such a platform, this
+                        // if block should be wrapped in a finally / prepared region.
+                        if (Interlocked.CompareExchange(ref _headAndTail.Head, currentHead + 1, currentHead) == currentHead)
+                        {
+                            // Successfully reserved the slot.  Note that after the above CompareExchange, other threads
+                            // trying to dequeue from this slot will end up spinning until we do the subsequent Write.
+                            item = _slots[slotsIndex].Item;
+                            if (Thread.VolatileRead(ref _preservedForObservation) == 0)
+                            {
+                                // If we're preserving, though, we don't zero out the slot, as we need it for
+                                // enumerations, peeking, ToArray, etc.  And we don't update the sequence number,
+                                // so that an enqueuer will see it as full and be forced to move to a new segment.
+                                _slots[slotsIndex].Item = default(T);
+                                Thread.VolatileWrite(ref _slots[slotsIndex].SequenceNumber, currentHead + _slots.Length);
+                            }
+                            return true;
+                        }
+                    }
+                    else if (diff < 0)
+                    {
+                        // The sequence number was less than what we needed, which means this slot doesn't
+                        // yet contain a value we can dequeue, i.e. the segment is empty.  Technically it's
+                        // possible that multiple enqueuers could have written concurrently, with those
+                        // getting later slots actually finishing first, so there could be elements after
+                        // this one that are available, but we need to dequeue in order.  So before declaring
+                        // failure and that the segment is empty, we check the tail to see if we're actually
+                        // empty or if we're just waiting for items in flight or after this one to become available.
+                        bool frozen = _frozenForEnqueues;
+                        int currentTail = Thread.VolatileRead(ref _headAndTail.Tail);
+                        if (currentTail - currentHead <= 0 || (frozen && (currentTail - FreezeOffset - currentHead <= 0)))
+                        {
+                            item = default(T);
+                            return false;
+                        }
+
+                        // It's possible it could have become frozen after we checked _frozenForEnqueues
+                        // and before reading the tail.  That's ok: in that rare race condition, we just
+                        // loop around again.
+                    }
+
+                    // Lost a race. Spin a bit, then try again.
+                    Thread.SpinWait(1);
+                }
+            }
+
+            /// <summary>Tries to peek at an element from the queue, without removing it.</summary>
+            public bool TryPeek(out T result, bool resultUsed)
+            {
+                if (resultUsed)
+                {
+                    // In order to ensure we don't get a torn read on the value, we mark the segment
+                    // as preserving for observation.  Additional items can still be enqueued to this
+                    // segment, but no space will be freed during dequeues, such that the segment will
+                    // no longer be reusable.
+                    _preservedForObservation = 1;
+                    Thread.MemoryBarrier();
+                }
+
+                // Loop in case of contention...
+                while (true)
+                {
+                    // Get the head at which to try to peek.
+                    int currentHead = Thread.VolatileRead(ref _headAndTail.Head);
+                    int slotsIndex = currentHead & _slotsMask;
+
+                    // Read the sequence number for the head position.
+                    int sequenceNumber = Thread.VolatileRead(ref _slots[slotsIndex].SequenceNumber);
+
+                    // We can peek from this slot if it's been filled by an enqueuer, which
+                    // would have left the sequence number at pos+1.
+                    int diff = sequenceNumber - (currentHead + 1);
+                    if (diff == 0)
+                    {
+                        result = resultUsed ? _slots[slotsIndex].Item : default(T);
+                        return true;
+                    }
+                    else if (diff < 0)
+                    {
+                        // The sequence number was less than what we needed, which means this slot doesn't
+                        // yet contain a value we can peek, i.e. the segment is empty.  Technically it's
+                        // possible that multiple enqueuers could have written concurrently, with those
+                        // getting later slots actually finishing first, so there could be elements after
+                        // this one that are available, but we need to peek in order.  So before declaring
+                        // failure and that the segment is empty, we check the tail to see if we're actually
+                        // empty or if we're just waiting for items in flight or after this one to become available.
+                        bool frozen = _frozenForEnqueues;
+                        int currentTail = Thread.VolatileRead(ref _headAndTail.Tail);
+                        if (currentTail - currentHead <= 0 || (frozen && (currentTail - FreezeOffset - currentHead <= 0)))
+                        {
+                            result = default(T);
+                            return false;
+                        }
+
+                        // It's possible it could have become frozen after we checked _frozenForEnqueues
+                        // and before reading the tail.  That's ok: in that rare race condition, we just
+                        // loop around again.
+                    }
+
+                    // Lost a race. Spin a bit, then try again.
+                    Thread.SpinWait(1);
+                }
+            }
+
+            /// <summary>
+            /// Attempts to enqueue the item.  If successful, the item will be stored
+            /// in the queue and true will be returned; otherwise, the item won't be stored, and false
+            /// will be returned.
+            /// </summary>
+            public bool TryEnqueue(T item)
+            {
+                // Loop in case of contention...
+                while (true)
+                {
+                    // Get the tail at which to try to return.
+                    int currentTail = Thread.VolatileRead(ref _headAndTail.Tail);
+                    int slotsIndex = currentTail & _slotsMask;
+
+                    // Read the sequence number for the tail position.
+                    int sequenceNumber = Thread.VolatileRead(ref _slots[slotsIndex].SequenceNumber);
+
+                    // The slot is empty and ready for us to enqueue into it if its sequence
+                    // number matches the slot.
+                    int diff = sequenceNumber - currentTail;
+                    if (diff == 0)
+                    {
+                        // We may be racing with other enqueuers.  Try to reserve the slot by incrementing
+                        // the tail.  Once we've done that, no one else will be able to write to this slot,
+                        // and no dequeuer will be able to read from this slot until we've written the new
+                        // sequence number. WARNING: The next few lines are not reliable on a runtime that
+                        // supports thread aborts. If a thread abort were to sneak in after the CompareExchange
+                        // but before the Volatile.Write, other threads will spin trying to access this slot.
+                        // If this implementation is ever used on such a platform, this if block should be
+                        // wrapped in a finally / prepared region.
+                        if (Interlocked.CompareExchange(ref _headAndTail.Tail, currentTail + 1, currentTail) == currentTail)
+                        {
+                            // Successfully reserved the slot.  Note that after the above CompareExchange, other threads
+                            // trying to return will end up spinning until we do the subsequent Write.
+                            _slots[slotsIndex].Item = item;
+                            Thread.VolatileWrite(ref _slots[slotsIndex].SequenceNumber, currentTail + 1);
+                            return true;
+                        }
+                    }
+                    else if (diff < 0)
+                    {
+                        // The sequence number was less than what we needed, which means this slot still
+                        // contains a value, i.e. the segment is full.  Technically it's possible that multiple
+                        // dequeuers could have read concurrently, with those getting later slots actually
+                        // finishing first, so there could be spaces after this one that are available, but
+                        // we need to enqueue in order.
+                        return false;
+                    }
+
+                    // Lost a race. Spin a bit, then try again.
+                    Thread.SpinWait(1);
+                }
+            }
+
+            /// <summary>Represents a slot in the queue.</summary>
+            [StructLayout(LayoutKind.Auto)]
+            [DebuggerDisplay("Item = {Item}, SequenceNumber = {SequenceNumber}")]
+            internal struct Slot
+            {
+                /// <summary>The item.</summary>
+                public T Item;
+                /// <summary>The sequence number for this slot, used to synchronize between enqueuers and dequeuers.</summary>
+                public int SequenceNumber;
+            }
+        }
+    }
+    /// <summary>Padded head and tail indices, to avoid false sharing between producers and consumers.</summary>
+    [DebuggerDisplay("Head = {Head}, Tail = {Tail}")]
+    [StructLayout(LayoutKind.Explicit, Size = 192)] // padding before/between/after fields based on typical cache line size of 64
+    internal struct PaddedHeadAndTail
+    {
+        [FieldOffset(64)] public int Head;
+        [FieldOffset(128)] public int Tail;
+    }
+}

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -162,6 +162,8 @@
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyResources.cs" />
+    <Compile Include="Concurrent\ConcurrentDictionary.cs" />
+    <Compile Include="Concurrent\ConcurrentQueue.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TypeLoader.cs" />
     <Compile Include="..\MSBuild\LogMessagePacket.cs">

--- a/src/MSBuildTaskHost/TypeLoader.cs
+++ b/src/MSBuildTaskHost/TypeLoader.cs
@@ -12,7 +12,9 @@ using System.Reflection;
 using System.Collections;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 
 namespace Microsoft.Build.Shared
 {
@@ -21,35 +23,16 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal class TypeLoader
     {
-        /// <summary>
-        /// Lock for initializing the dictionary
-        /// </summary>
-        private static readonly Object s_cacheOfLoadedTypesByFilterLock = new Object();
-
-        /// <summary>
-        /// Lock for initializing the dictionary
-        /// </summary>
-        private static readonly Object s_cacheOfReflectionOnlyLoadedTypesByFilterLock = new Object();
-
-        /// <summary>
-        /// Lock for initializing the dictionary
-        /// </summary>
-        private static readonly Object s_loadInfoToTypeLock = new Object();
-
-        /// <summary>
-        /// Lock for initializing the dictionary
-        /// </summary>
-        private static readonly Object s_reflectionOnlyloadInfoToTypeLock = new Object();
 
         /// <summary>
         /// Cache to keep track of the assemblyLoadInfos based on a given typeFilter.
         /// </summary>
-        private static IDictionary<TypeFilter, IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> s_cacheOfLoadedTypesByFilter = new Dictionary<TypeFilter, IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>>();
+        private static Concurrent.ConcurrentDictionary<TypeFilter, Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> s_cacheOfLoadedTypesByFilter = new Concurrent.ConcurrentDictionary<TypeFilter, Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>>();
 
         /// <summary>
-        /// Cache to keep track of the assemblyLoadInfos based on a given typeFilter for assemblies which are to be loaded for reflectionOnlyLoads.
+        /// Cache to keep track of the assemblyLoadInfos based on a given type filter for assemblies which are to be loaded for reflectionOnlyLoads.
         /// </summary>
-        private static IDictionary<TypeFilter, IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> s_cacheOfReflectionOnlyLoadedTypesByFilter = new Dictionary<TypeFilter, IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>>();
+        private static Concurrent.ConcurrentDictionary<TypeFilter, Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> s_cacheOfReflectionOnlyLoadedTypesByFilter = new Concurrent.ConcurrentDictionary<TypeFilter, Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>>();
 
         /// <summary>
         /// Typefilter for this typeloader
@@ -158,7 +141,7 @@ namespace Microsoft.Build.Shared
             AssemblyLoadInfo assembly
         )
         {
-            return GetLoadedType(s_cacheOfLoadedTypesByFilterLock, s_loadInfoToTypeLock, s_cacheOfLoadedTypesByFilter, typeName, assembly);
+            return GetLoadedType(s_cacheOfLoadedTypesByFilter, typeName, assembly);
         }
 
         /// <summary>
@@ -173,7 +156,7 @@ namespace Microsoft.Build.Shared
             AssemblyLoadInfo assembly
         )
         {
-            return GetLoadedType(s_cacheOfReflectionOnlyLoadedTypesByFilterLock, s_reflectionOnlyloadInfoToTypeLock, s_cacheOfReflectionOnlyLoadedTypesByFilter, typeName, assembly);
+            return GetLoadedType(s_cacheOfReflectionOnlyLoadedTypesByFilter, typeName, assembly);
         }
 
         /// <summary>
@@ -181,30 +164,16 @@ namespace Microsoft.Build.Shared
         /// any) is unambiguous; otherwise, if there are multiple types with the same name in different namespaces, the first type
         /// found will be returned.
         /// </summary>
-        private LoadedType GetLoadedType(object cacheLock, object loadInfoToTypeLock, IDictionary<TypeFilter, IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> cache, string typeName, AssemblyLoadInfo assembly)
+        private LoadedType GetLoadedType(Concurrent.ConcurrentDictionary<TypeFilter, Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>> cache, string typeName, AssemblyLoadInfo assembly)
         {
-            // A given typefilter have been used on a number of assemblies, Based on the typefilter we will get another dictionary which 
+            // A given type filter have been used on a number of assemblies, Based on the type filter we will get another dictionary which 
             // will map a specific AssemblyLoadInfo to a AssemblyInfoToLoadedTypes class which knows how to find a typeName in a given assembly.
-            IDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes> loadInfoToType = null;
-            lock (cacheLock)
-            {
-                if (!cache.TryGetValue(_isDesiredType, out loadInfoToType))
-                {
-                    loadInfoToType = new Dictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>();
-                    cache.Add(_isDesiredType, loadInfoToType);
-                }
-            }
+            Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes> loadInfoToType =
+                cache.GetOrAdd(_isDesiredType, (_) => new Concurrent.ConcurrentDictionary<AssemblyLoadInfo, AssemblyInfoToLoadedTypes>());
 
             // Get an object which is able to take a typename and determine if it is in the assembly pointed to by the AssemblyInfo.
-            AssemblyInfoToLoadedTypes typeNameToType = null;
-            lock (loadInfoToTypeLock)
-            {
-                if (!loadInfoToType.TryGetValue(assembly, out typeNameToType))
-                {
-                    typeNameToType = new AssemblyInfoToLoadedTypes(_isDesiredType, assembly);
-                    loadInfoToType.Add(assembly, typeNameToType);
-                }
-            }
+            AssemblyInfoToLoadedTypes typeNameToType =
+                loadInfoToType.GetOrAdd(assembly, (_) => new AssemblyInfoToLoadedTypes(_isDesiredType, _));
 
             return typeNameToType.GetLoadedTypeByTypeName(typeName);
         }
@@ -236,7 +205,7 @@ namespace Microsoft.Build.Shared
             /// <summary>
             /// What is the type for the given type name, this may be null if the typeName does not map to a type.
             /// </summary>
-            private Dictionary<string, Type> _typeNameToType;
+            private Concurrent.ConcurrentDictionary<string, Type> _typeNameToType;
 
             /// <summary>
             /// List of public types in the assembly which match the typefilter and their corresponding types
@@ -246,7 +215,7 @@ namespace Microsoft.Build.Shared
             /// <summary>
             /// Have we scanned the public types for this assembly yet.
             /// </summary>
-            private bool _haveScannedPublicTypes;
+            private long _haveScannedPublicTypes;
 
             /// <summary>
             /// If we loaded an assembly for this type.
@@ -265,7 +234,7 @@ namespace Microsoft.Build.Shared
 
                 _isDesiredType = typeFilter;
                 _assemblyLoadInfo = loadInfo;
-                _typeNameToType = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+                _typeNameToType = new Concurrent.ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
                 _publicTypeNameToType = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
             }
 
@@ -277,78 +246,53 @@ namespace Microsoft.Build.Shared
                 ErrorUtilities.VerifyThrowArgumentNull(typeName, "typeName");
 
                 // Only one thread should be doing operations on this instance of the object at a time.
-                lock (_lockObject)
+
+                Type type = _typeNameToType.GetOrAdd(typeName, (key) =>
                 {
-                    Type type = null;
-
-                    // Maybe we've already cracked open this assembly before. Check to see if the typeName is in the list we dont look for partial matches here
-                    // this is an optimization.
-                    bool foundType = _typeNameToType.TryGetValue(typeName, out type);
-                    if (!foundType)
+                    if ((_assemblyLoadInfo.AssemblyName != null) && (typeName.Length > 0))
                     {
-                        // We could still not find the type, lets try and resolve it by doing a get type.
-                        if ((_assemblyLoadInfo.AssemblyName != null) && (typeName.Length > 0))
+                        try
                         {
-                            try
+                            // try to load the type using its assembly qualified name
+                            Type t2 = Type.GetType(typeName + "," + _assemblyLoadInfo.AssemblyName, false /* don't throw on error */, true /* case-insensitive */);
+                            if (t2 != null)
                             {
-                                // try to load the type using its assembly qualified name
-                                type = Type.GetType(typeName + "," + _assemblyLoadInfo.AssemblyName, false /* don't throw on error */, true /* case-insensitive */);
-                            }
-                            catch (ArgumentException)
-                            {
-                                // Type.GetType() will throw this exception if the type name is invalid -- but we have no idea if it's the
-                                // type or the assembly name that's the problem -- so just ignore the exception, because we're going to
-                                // check the existence/validity of the assembly and type respectively, below anyway
-                            }
-
-                            // if we found the type, it means its assembly qualified name was also its fully qualified name
-                            if (type != null)
-                            {
-                                // if it's not the right type, bail out -- there's no point searching further since we already matched on the
-                                // fully qualified name
-                                if (!_isDesiredType(type, null))
-                                {
-                                    _typeNameToType.Add(typeName, null);
-                                    return null;
-                                }
-                                else
-                                {
-                                    _typeNameToType.Add(typeName, type);
-                                }
+                                return !_isDesiredType(t2, null) ? null : t2;
                             }
                         }
-
-                        // We could not find the type based on the passed in type name, we now need to see if there is a type which 
-                        // will match based on partially matching the typename. To do this partial matching we need to get the public types in the assembly
-                        if (type == null && !_haveScannedPublicTypes)
+                        catch (ArgumentException)
                         {
-                            ScanAssemblyForPublicTypes();
-                            _haveScannedPublicTypes = true;
+                            // Type.GetType() will throw this exception if the type name is invalid -- but we have no idea if it's the
+                            // type or the assembly name that's the problem -- so just ignore the exception, because we're going to
+                            // check the existence/validity of the assembly and type respectively, below anyway
                         }
+                    }
 
-                        // Could not find the type we need to look through the types in the assembly or in our cache.
-                        if (type == null)
+                    if (Interlocked.Read(ref _haveScannedPublicTypes) == 0)
+                    {
+                        lock (_lockObject)
                         {
-                            foreach (KeyValuePair<string, Type> desiredTypeInAssembly in _publicTypeNameToType)
+                            if (Interlocked.Read(ref _haveScannedPublicTypes) == 0)
                             {
-                                // if type matches partially on its name
-                                if (typeName.Length == 0 || TypeLoader.IsPartialTypeNameMatch(desiredTypeInAssembly.Key, typeName))
-                                {
-                                    type = desiredTypeInAssembly.Value;
-                                    _typeNameToType.Add(typeName, type);
-                                    break;
-                                }
+                                ScanAssemblyForPublicTypes();
+                                Interlocked.Exchange(ref _haveScannedPublicTypes, ~0);
                             }
                         }
                     }
 
-                    if (type != null)
+                    foreach (KeyValuePair<string, Type> desiredTypeInAssembly in _publicTypeNameToType)
                     {
-                        return new LoadedType(type, _assemblyLoadInfo, _loadedAssembly);
+                        // if type matches partially on its name
+                        if (typeName.Length == 0 || TypeLoader.IsPartialTypeNameMatch(desiredTypeInAssembly.Key, typeName))
+                        {
+                            return desiredTypeInAssembly.Value;
+                        }
                     }
 
                     return null;
-                }
+                });
+
+                return type != null ? new LoadedType(type, _assemblyLoadInfo, _loadedAssembly) : null;
             }
 
             /// <summary>

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text;
 using System.IO;
@@ -101,7 +102,7 @@ namespace Microsoft.Build.BackEnd
         /// Operations on this queue must be synchronized since it is accessible by multiple threads.
         /// Use a lock on the packetQueue itself.
         /// </remarks>
-        private Queue<INodePacket> _packetQueue;
+        private ConcurrentQueue<INodePacket> _packetQueue;
 
         /// <summary>
         /// Per-node shared read buffer.
@@ -316,11 +317,8 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrow(null != _packetQueue, "packetQueue is null");
             ErrorUtilities.VerifyThrow(null != _packetAvailable, "packetAvailable is null");
 
-            lock (_packetQueue)
-            {
-                _packetQueue.Enqueue(packet);
-                _packetAvailable.Set();
-            }
+            _packetQueue.Enqueue(packet);
+            _packetAvailable.Set();
         }
 
         /// <summary>
@@ -335,7 +333,7 @@ namespace Microsoft.Build.BackEnd
                 _packetPump.Name = "OutOfProc Endpoint Packet Pump";
                 _packetAvailable = new AutoResetEvent(false);
                 _terminatePacketPump = new AutoResetEvent(false);
-                _packetQueue = new Queue<INodePacket>();
+                _packetQueue = new ConcurrentQueue<INodePacket>();
                 _packetPump.Start();
             }
         }
@@ -358,7 +356,7 @@ namespace Microsoft.Build.BackEnd
 
             AutoResetEvent localPacketAvailable = _packetAvailable;
             AutoResetEvent localTerminatePacketPump = _terminatePacketPump;
-            Queue<INodePacket> localPacketQueue = _packetQueue;
+            ConcurrentQueue<INodePacket> localPacketQueue = _packetQueue;
 
             DateTime originalWaitStartTime = DateTime.UtcNow;
             bool gotValidConnection = false;
@@ -535,7 +533,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         private void RunReadLoop(Stream localReadPipe, Stream localWritePipe,
-            Queue<INodePacket> localPacketQueue, AutoResetEvent localPacketAvailable, AutoResetEvent localTerminatePacketPump)
+            ConcurrentQueue<INodePacket> localPacketQueue, AutoResetEvent localPacketAvailable, AutoResetEvent localTerminatePacketPump)
         {
             // Ordering of the wait handles is important.  The first signalled wait handle in the array 
             // will be returned by WaitAny if multiple wait handles are signalled.  We prefer to have the
@@ -633,17 +631,10 @@ namespace Microsoft.Build.BackEnd
                     case 2:
                         try
                         {
-                            int packetCount = localPacketQueue.Count;
-
                             // Write out all the queued packets.
-                            while (packetCount > 0)
+                            INodePacket packet;
+                            while (localPacketQueue.TryDequeue(out packet))
                             {
-                                INodePacket packet;
-                                lock (_packetQueue)
-                                {
-                                    packet = localPacketQueue.Dequeue();
-                                }
-
                                 MemoryStream packetStream = new MemoryStream();
                                 INodePacketTranslator writeTranslator = NodePacketTranslator.GetWriteTranslator(packetStream);
 
@@ -672,8 +663,6 @@ namespace Microsoft.Build.BackEnd
                                     localWritePipe.Write(packetStream.ToArray(), 0, (int)packetStream.Length);
                                 }
 #endif
-
-                                packetCount--;
                             }
                         }
                         catch (Exception e)

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -7,7 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+#if CLR2COMPATIBILITY
+using Microsoft.Build.Shared.Concurrent;
+#else
 using System.Collections.Concurrent;
+#endif
 using System.Globalization;
 using System.Text;
 using System.IO;


### PR DESCRIPTION
Those following changes improve msbuild performance at least in 2 times. The build time in our case decreased **from 31 minutes to 13 minutes**.

In CoreCLR project we faced with major performance problem in Linux environment related to msbuild where building our C# tests (more then 10000 stand-alone C#/IL projects) takes a lot of time, much more than on Windows.
I started to investigate and figured out that most of time root msbuild process spends spinning trying to acquire some locks. The perf report shows that fact:

```
  59.63%  dotnet   libcoreclr.so                         [.] Object::EnterObjMonitorHelperSpin
  18.21%  dotnet   libcoreclr.so                         [.] AwareLock::Contention
   1.05%  dotnet   libcoreclr.so                         [.] LookupMapBase::GetValueFromCompressedMap
   0.85%  dotnet   ld-2.23.so                            [.] __tls_get_addr
   0.77%  dotnet   libcoreclr.so                         [.] CMiniMd::vSearchTable
   0.71%  dotnet   libcoreclr.so                         [.] JIT_MonReliableEnter_Portable
   0.68%  dotnet   libcoreclr.so                         [.] StgBlobPoolReadOnly::GetBlob
   0.63%  dotnet   [kernel.kallsyms]                     [k] update_blocked_averages
   0.62%  dotnet   libcoreclr.so                         [.] CMiniMdBase::SearchTableForMultipleRows
   0.55%  dotnet   libcoreclr.so                         [.] ThreadPoolNative::NotifyRequestComplete
   0.49%  dotnet   libcoreclr.so                         [.] MetaDataImport::Enum
```
In total it almost 80% of CPU time. I got the exact methods that spend most of time, here they are:
```
LoadedType Microsoft.Build.Shared.TypeLoader$AssemblyInfoToLoadedTypes::GetLoadedTypeByTypeName(string)
LoadedType Microsoft.Build.Shared.TypeLoader::GetLoadedType(class System.Collections.Concurrent.ConcurrentDictionary<Func<System.Type, object ,bool>, System.Collections.Concurrent.ConcurrentDictionary<AssemblyLoadInfo, TypeLoader$AssemblyInfoToLoadedTypes>>, string, AssemblyLoadInfo)
```

In those methods there are bunch of locks which led to such problem, but there also were different methods that were using `lock` statement and `Queue<T>`.

To solve the main problem I used `ConcurrentDicrionary` that spreads workload over the number of different locks inside Dictionary.
To solve the problem with Queues I replaced all those cases with `ConcurrentQueue` which in theory may work even without any lock. I also fixed some cases of inappropriate use of locks.

With my changes perf tool shows a picture like:
```
   6.81%  dotnet   libcoreclr.so                         [.] WKS::enter_spin_lock
   4.29%  dotnet   libcoreclr.so                         [.] AwareLock::Contention
   1.85%  dotnet   libcoreclr.so                         [.] Module::FindDomainFile
   1.67%  dotnet   libcoreclr.so                         [.] JIT_GetRuntimeType
   1.64%  dotnet   libcoreclr.so                         [.] Object::EnterObjMonitorHelperSpin
   1.61%  dotnet   libcoreclr.so                         [.] CMiniMd::vSearchTable
   1.55%  dotnet   libcoreclr.so                         [.] MDInternalRO::EnumInit
   1.48%  dotnet   libcoreclr.so                         [.] MethodTable::GetModule
   1.48%  dotnet   libcoreclr.so                         [.] ModuleHandle::GetMetadataImport
   1.22%  dotnet   ld-2.23.so                            [.] __tls_get_addr
   1.17%  dotnet   libcoreclr.so                         [.] CMiniMd::vSearchTableNotGreater
```
So you can see both  `AwareLock::Contention` and `Object::EnterObjMonitorHelperSpin` take just (4.29% + 1.64%) 5.93% of CPU time instead of ~80%. The method `WKS::enter_spin_lock` is the part of GC and its top position might be explained by the memory consumption.