### PR TITLE
Add MsBuild.Engine.Corext package

### DIFF
--- a/setup/MsBuild.Engine.Corext/.readme.txt
+++ b/setup/MsBuild.Engine.Corext/.readme.txt
@@ -1,0 +1,7 @@
+This package includes the files that MSBuild ships into Visual Studio via its .vsix.
+Paths are adjusted to match the corext package MsBuild.Corext.
+
+Files in the MSBuild vsix which are not in this package:
+- msbuild satellite assemblies (no translation needed for corext)
+- MSBuild.exe.config (MsBuild.Corext has manual edits to this file)
+- *pkgdef (VS specific)

--- a/setup/MsBuild.Engine.Corext/MSBuild.Engine.Corext.cxspec
+++ b/setup/MsBuild.Engine.Corext/MSBuild.Engine.Corext.cxspec
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<package>
+  <aggregate id="MsBuild.Corext" version="15.0"/>
+</package>

--- a/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>MsBuild.Engine.Corext</id>
+    <summary>Aggregate of MsBuild.Corext with the latest MSBuild team deliverables</summary>
+    <description>Use this package to update your existing MsBuild.Corext package to the latest MSBuild binaries and core build files.</description>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>msbtm@microsoft.com</authors>
+    <version>$version$</version>
+  </metadata>
+
+  <files>
+    <file src="$repoRoot$setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.cxspec" target=""/>
+    <file src="$repoRoot$setup/MsBuild.Engine.Corext/.readme.txt" target=""/>
+    <file src="$repoRoot$THIRDPARTYNOTICES" target="v15.0/bin/THIRDPARTYNOTICES" />
+    <file src="$X86BinPath$Microsoft.Common.props" target="\Extensions\15.0" />
+    <file src="$X86BinPath$Microsoft.VisualStudioVersion.v15.Common.props" target="\Extensions\15.0" />
+
+    <file src="$X86BinPath$MSBuild.exe" target="v15.0/bin" />
+    <file src="$X86BinPath$MSBuildTaskHost.exe" target="v15.0/bin" />
+    <file src="$X86BinPath$MSBuildTaskHost.exe.config" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Conversion.Core.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Engine.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Framework.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Build.Core.xsd" target="v15.0/bin/MSBuild" />
+    <file src="$X86BinPath$Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/MSBuild" />
+    <file src="$X86BinPath$Microsoft.CSharp.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Common.CrossTargeting.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Common.CurrentVersion.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Common.overridetasks" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Common.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Common.tasks" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.CSharp.CrossTargeting.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.CSharp.CurrentVersion.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Data.Entity.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.ServiceModel.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.CrossTargeting.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.CurrentVersion.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.WinFx.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.WorkflowBuildExtensions.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.Xaml.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Workflow.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Workflow.VisualBasic.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.NetFramework.CurrentVersion.props" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.NetFramework.CurrentVersion.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.NetFramework.props" target="v15.0/bin" />
+    <file src="$X86BinPath$Microsoft.NetFramework.targets" target="v15.0/bin" />
+
+    <file src="$X64BinPath$MSBuild.exe" target="v15.0/bin/amd64" />
+    <file src="$X64BinPath$MSBuildTaskHost.exe" target="v15.0/bin/amd64" />
+    <file src="$X64BinPath$MSBuildTaskHost.exe.config" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Conversion.Core.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Engine.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Framework.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Build.Core.xsd" target="v15.0/bin/amd64/MSBuild" />
+    <file src="$X86BinPath$Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/amd64/MSBuild" />
+    <file src="$X86BinPath$Microsoft.CSharp.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Common.CrossTargeting.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Common.CurrentVersion.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Common.overridetasks" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Common.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Common.tasks" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.CSharp.CrossTargeting.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.CSharp.CurrentVersion.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Data.Entity.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.ServiceModel.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.CrossTargeting.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.VisualBasic.CurrentVersion.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.WinFx.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.WorkflowBuildExtensions.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.Xaml.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Workflow.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Workflow.VisualBasic.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.NetFramework.CurrentVersion.props" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.NetFramework.CurrentVersion.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.NetFramework.props" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$Microsoft.NetFramework.targets" target="v15.0/bin/amd64" />
+  </files>
+</package>

--- a/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -16,6 +16,8 @@
     <file src="$X86BinPath$Microsoft.Common.props" target="\Extensions\15.0" />
     <file src="$X86BinPath$Microsoft.VisualStudioVersion.v15.Common.props" target="\Extensions\15.0" />
 
+    <!-- x86 -->
+
     <file src="$X86BinPath$MSBuild.exe" target="v15.0/bin" />
     <file src="$X86BinPath$MSBuildTaskHost.exe" target="v15.0/bin" />
     <file src="$X86BinPath$MSBuildTaskHost.exe.config" target="v15.0/bin" />
@@ -25,9 +27,24 @@
     <file src="$X86BinPath$Microsoft.Build.Framework.dll" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Collections.Immutable.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Console.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Diagnostics.Process.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.IO.Compression.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.IO.FileSystem.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.IO.FileSystem.Primitives.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.IO.Pipes.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Runtime.InteropServices.RuntimeInformation.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Security.AccessControl.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Security.Cryptography.Algorithms.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Security.Cryptography.Primitives.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Security.Principal.Windows.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Threading.Thread.dll" target="v15.0/bin" />
+
     <file src="$X86BinPath$Microsoft.Build.Core.xsd" target="v15.0/bin/MSBuild" />
     <file src="$X86BinPath$Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/MSBuild" />
+    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.CSharp.targets" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.VisualBasic.targets" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.Common.CrossTargeting.targets" target="v15.0/bin" />
@@ -51,6 +68,8 @@
     <file src="$X86BinPath$Microsoft.NetFramework.props" target="v15.0/bin" />
     <file src="$X86BinPath$Microsoft.NetFramework.targets" target="v15.0/bin" />
 
+    <!-- x64 -->
+
     <file src="$X64BinPath$MSBuild.exe" target="v15.0/bin/amd64" />
     <file src="$X64BinPath$MSBuildTaskHost.exe" target="v15.0/bin/amd64" />
     <file src="$X64BinPath$MSBuildTaskHost.exe.config" target="v15.0/bin/amd64" />
@@ -60,9 +79,24 @@
     <file src="$X86BinPath$Microsoft.Build.Framework.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
-    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Collections.Immutable.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$System.Console.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Diagnostics.Process.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.IO.Compression.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.IO.FileSystem.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.IO.FileSystem.Primitives.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.IO.Pipes.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Runtime.InteropServices.RuntimeInformation.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Security.AccessControl.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Security.Cryptography.Algorithms.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Security.Cryptography.Primitives.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Security.Principal.Windows.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$System.Threading.Thread.dll" target="v15.0/bin/amd64" />
+
     <file src="$X86BinPath$Microsoft.Build.Core.xsd" target="v15.0/bin/amd64/MSBuild" />
     <file src="$X86BinPath$Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/amd64/MSBuild" />
+    <file src="$X86BinPath$MSBuild.rsp" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.CSharp.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.VisualBasic.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.Common.CrossTargeting.targets" target="v15.0/bin/amd64" />
@@ -85,5 +119,6 @@
     <file src="$X86BinPath$Microsoft.NetFramework.CurrentVersion.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.NetFramework.props" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$Microsoft.NetFramework.targets" target="v15.0/bin/amd64" />
+    
   </files>
 </package>

--- a/setup/MsBuild.Engine.Corext/TestBuild.cmd
+++ b/setup/MsBuild.Engine.Corext/TestBuild.cmd
@@ -1,0 +1,11 @@
+
+set repoRoot=%~dp0..\..\
+
+pushd %repoRoot%
+set repoRoot=%CD%\
+popd
+
+set X86BinPath=%repoRoot%bin\Release\x86\Windows_NT\Output\
+set X64BinPath=%repoRoot%bin\Release\x64\Windows_NT\Output\
+
+nuget pack -Properties "version=2.3.4.5;repoRoot=%repoRoot%;X86BinPath=%X86BinPath%;X64BinPath=%X64BinPath%" -noPackageAnalysis


### PR DESCRIPTION
This package aggregates to MsBuild.Corext. Because MsBuild.Corext is hand made, updating it to new versions is difficult. MsBuild.Engine.Corext alleviates this issue by upgrading the master package with the deliverables of this repo (engine binaries and the common build files)