### PR TITLE
Fix NullReferenceException in SdkResolution

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolution.cs
@@ -63,7 +63,12 @@ namespace Microsoft.Build.BackEnd
                     try
                     {
                         var result = (SdkResultImpl)sdkResolver.Resolve(sdk, context, resultFactory);
-                        if (result != null && result.Success)
+                        if (result == null)
+                        {
+                            continue;
+                        }
+
+                        if (result.Success)
                         {
                             LogWarnings(loggingContext, sdkReferenceLocation, result);
                             return result.Path;

--- a/src/Framework/Sdk/SdkResolver.cs
+++ b/src/Framework/Sdk/SdkResolver.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.Framework
         /// <param name="factory">Factory class to create an <see cref="SdkResult" /></param>
         /// <returns>
         ///     An <see cref="SdkResult" /> containing the resolved SDKs or associated error / reason
-        ///     the SDK could not be resolved.
+        ///     the SDK could not be resolved.  Return <code>null</code> if the resolver is not
+        ///     applicable for a particular <see cref="SdkReference"/>.
         ///     <remarks>
         ///         Note: You must use the <see cref="SdkResultFactory" /> to return a result.
         ///     </remarks>


### PR DESCRIPTION
If an SdkResolver returns null, then we throw a NullReferenceException

Also cleaned up the test a little