### PR TITLE
Clear more caches after /restore if necessary

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -995,7 +995,7 @@ namespace Microsoft.Build.Execution
     [System.FlagsAttribute]
     public enum BuildRequestDataFlags
     {
-        ClearProjectRootElementCacheAfterBuild = 8,
+        ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
         None = 0,
         ProvideProjectStateAfterBuild = 2,

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -972,7 +972,7 @@ namespace Microsoft.Build.Execution
     [System.FlagsAttribute]
     public enum BuildRequestDataFlags
     {
-        ClearProjectRootElementCacheAfterBuild = 8,
+        ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
         None = 0,
         ProvideProjectStateAfterBuild = 2,

--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -623,7 +623,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
             finally
             {
-                FileMatcher.TestClearCaches();
+                FileMatcher.ClearFileEnumerationsCache();
             }
         }
     }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1656,6 +1656,10 @@ namespace Microsoft.Build.Execution
                         // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
                         // part of the import graph.
                         _buildParameters?.ProjectRootElementCache?.Clear();
+
+                        FileMatcher.ClearFileEnumerationsCache();
+
+                        FileUtilities.ClearFileExistenceCache();
                     }
 
                     _noActiveSubmissionsEvent.Set();

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1650,7 +1650,7 @@ namespace Microsoft.Build.Execution
 
                 if (_buildSubmissions.Count == 0)
                 {
-                    if (submission.BuildRequestData != null && submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ClearProjectRootElementCacheAfterBuild))
+                    if (submission.BuildRequestData != null && submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ClearCachesAfterBuild))
                     {
                         // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
                         // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1658,8 +1658,9 @@ namespace Microsoft.Build.Execution
                         _buildParameters?.ProjectRootElementCache?.Clear();
 
                         FileMatcher.ClearFileEnumerationsCache();
-
+#if !CLR2COMPATIBILITY
                         FileUtilities.ClearFileExistenceCache();
+#endif
                     }
 
                     _noActiveSubmissionsEvent.Set();

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -57,11 +57,11 @@ namespace Microsoft.Build.Execution
         IgnoreExistingProjectState = 0x4,
 
         /// <summary>
-        /// When this flag is present, the <see cref="ProjectRootElementCache"/> will be cleared after the
-        /// build request completes.  This is used when the build request is known to modify a lot of state
-        /// such as restoring packages or generating parts of the import graph.
+        /// When this flag is present, caches including the <see cref="ProjectRootElementCache"/> will be cleared
+        /// after the build request completes.  This is used when the build request is known to modify a lot of
+        /// state such as restoring packages or generating parts of the import graph.
         /// </summary>
-        ClearProjectRootElementCacheAfterBuild = 0x8,
+        ClearCachesAfterBuild = 0x8,
     }
 
     /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1235,7 +1235,7 @@ namespace Microsoft.Build.CommandLine
                 toolsVersion,
                 targetsToBuild: new[] { MSBuildConstants.RestoreTargetName },
                 hostServices: null,
-                flags: BuildRequestDataFlags.ClearProjectRootElementCacheAfterBuild);
+                flags: BuildRequestDataFlags.ClearCachesAfterBuild);
 
             return ExecuteBuild(buildManager, restoreRequest);
         }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -74,10 +74,17 @@ namespace Microsoft.Build.Shared
         /// <returns>The array of filesystem entries.</returns>
         internal delegate string[] GetFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory);
 
-        internal static void TestClearCaches()
+        internal static void ClearFileEnumerationsCache()
         {
-            s_cachedFileEnumerations.Value.Clear();
-            s_cachedFileEnumerationsLock.Value.Clear();
+            if (s_cachedFileEnumerations.IsValueCreated)
+            {
+                s_cachedFileEnumerations.Value.Clear();
+            }
+
+            if (s_cachedFileEnumerationsLock.IsValueCreated)
+            {
+                s_cachedFileEnumerationsLock.Value.Clear();
+            }
         }
 
         /// <summary>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1180,12 +1180,14 @@ namespace Microsoft.Build.Shared
             return false;
         }
 
+#if !CLR2COMPATIBILITY
         /// <summary>
-        /// 
+        /// Clears the file existence cache.
         /// </summary>
         internal static void ClearFileExistenceCache()
         {
             FileExistenceCache.Clear();
         }
+#endif
     }
 }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1179,5 +1179,13 @@ namespace Microsoft.Build.Shared
 
             return false;
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        internal static void ClearFileExistenceCache()
+        {
+            FileExistenceCache.Clear();
+        }
     }
 }

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -712,7 +712,7 @@ namespace Microsoft.Build.UnitTests
             }
             finally
             {
-                FileMatcher.TestClearCaches();
+                FileMatcher.ClearFileEnumerationsCache();
             }
         }
 


### PR DESCRIPTION
1. Clear file enumerations cache because when the environment variable `MsBuildCacheFileEnumerations` is set, wild card expansions are cached.
2. Clear file existence cache because when the environment variable `MsBuildCacheFileExistence` is set, file existence is cached

/cc @dfederm 

