### PR TITLE
Add support to skip missing targets in MSBuild task

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1000,6 +1000,7 @@ namespace Microsoft.Build.Execution
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ReplaceExistingProjectInstance = 1,
+        SkipNonexistentTargets = 16,
     }
     public partial class BuildResult
     {

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -977,6 +977,7 @@ namespace Microsoft.Build.Execution
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ReplaceExistingProjectInstance = 1,
+        SkipNonexistentTargets = 16,
     }
     public partial class BuildResult
     {

--- a/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
@@ -941,7 +941,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// Empty impl
         /// </summary>
-        Task<BuildResult[]> IRequestBuilderCallback.BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults)
+        Task<BuildResult[]> IRequestBuilderCallback.BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets)
         {
             throw new NotImplementedException();
         }

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -865,7 +865,7 @@ namespace ItemCreationTask
         /// <summary>
         /// Empty impl
         /// </summary>
-        Task<BuildResult[]> IRequestBuilderCallback.BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults)
+        Task<BuildResult[]> IRequestBuilderCallback.BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets)
         {
             throw new NotImplementedException();
         }

--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -1196,7 +1196,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             /// <summary>
             /// Mock of the BuildProjects method on the callback.
             /// </summary>
-            public Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults)
+            public Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets)
             {
                 return Task<BuildResult[]>.FromResult(_buildResultsToReturn);
             }

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -30,13 +30,13 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// When this flag is present, the existing ProjectInstance in the build will be replaced by this one.
         /// </summary>
-        ReplaceExistingProjectInstance = 0x1,
+        ReplaceExistingProjectInstance = 1 << 0,
 
         /// <summary>
         /// When this flag is present, <see cref="BuildResult"/> issued in response to this request will
         /// include <see cref="BuildResult.ProjectStateAfterBuild"/>.
         /// </summary>
-        ProvideProjectStateAfterBuild = 0x2,
+        ProvideProjectStateAfterBuild = 1 << 1,
 
         /// <summary>
         /// When this flag is present and the project has previously been built on a node whose affinity is
@@ -54,14 +54,21 @@ namespace Microsoft.Build.Execution
         /// request will not re-build that target (nor will any of the project state mutations which previously
         /// occurred as a consequence of building that target be re-applied.)
         /// </remarks>
-        IgnoreExistingProjectState = 0x4,
+        IgnoreExistingProjectState = 1 << 2,
 
         /// <summary>
         /// When this flag is present, caches including the <see cref="ProjectRootElementCache"/> will be cleared
         /// after the build request completes.  This is used when the build request is known to modify a lot of
         /// state such as restoring packages or generating parts of the import graph.
         /// </summary>
-        ClearCachesAfterBuild = 0x8,
+        ClearCachesAfterBuild = 1 << 3,
+
+        /// <summary>
+        /// When this flag is present, the top level target(s) in the build request will be skipped if those targets
+        /// are not defined in the Project to build. This only applies to this build request (if another target calls
+        /// the "missing target" at any other point this will still result in an error).
+        /// </summary>
+        SkipNonexistentTargets = 1 << 4
     }
 
     /// <summary>

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1148,7 +1148,10 @@ namespace Microsoft.Build.BackEnd
                         // waiting for results.  It is important that we tell the issuing request to wait for a result
                         // prior to issuing any necessary configuration request so that we don't get into a state where
                         // we receive the configuration response before we enter the wait state.
-                        newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(), request.Config.ConfigurationId, request.Targets, issuingEntry.Request.HostServices, issuingEntry.Request.BuildEventContext, issuingEntry.Request);
+                        newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(),
+                            request.Config.ConfigurationId, request.Targets, issuingEntry.Request.HostServices,
+                            issuingEntry.Request.BuildEventContext, issuingEntry.Request,
+                            request.BuildRequestDataFlags);
 
                         issuingEntry.WaitForResult(newRequest);
 
@@ -1162,7 +1165,10 @@ namespace Microsoft.Build.BackEnd
                     else
                     {
                         // We have a configuration, see if we already have results locally.
-                        newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(), matchingConfig.ConfigurationId, request.Targets, issuingEntry.Request.HostServices, issuingEntry.Request.BuildEventContext, issuingEntry.Request);
+                        newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(),
+                            matchingConfig.ConfigurationId, request.Targets, issuingEntry.Request.HostServices,
+                            issuingEntry.Request.BuildEventContext, issuingEntry.Request,
+                            request.BuildRequestDataFlags);
 
                         IResultsCache resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
                         ResultsCacheResponse response = resultsCache.SatisfyRequest(newRequest, matchingConfig.ProjectInitialTargets, matchingConfig.ProjectDefaultTargets, matchingConfig.GetAfterTargetsForDefaultTargets(newRequest), skippedResultsAreOK: false);

--- a/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
@@ -5,9 +5,6 @@
 // <summary>Build request which has not had its configuration resolved yet.</summary>
 //-----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.BackEnd
@@ -25,21 +22,6 @@ namespace Microsoft.Build.BackEnd
     internal class FullyQualifiedBuildRequest
     {
         /// <summary>
-        /// The request's configuration.
-        /// </summary>
-        private BuildRequestConfiguration _requestConfiguration;
-
-        /// <summary>
-        /// The set of targets to build.
-        /// </summary>
-        private string[] _targets;
-
-        /// <summary>
-        /// Whether or not we need to wait for results before completing this request.
-        /// </summary>
-        private bool _resultsNeeded;
-
-        /// <summary>
         /// Initializes a build request.
         /// </summary>
         /// <param name="config">The configuration to use for the request.</param>
@@ -50,43 +32,25 @@ namespace Microsoft.Build.BackEnd
             ErrorUtilities.VerifyThrowArgumentNull(config, "config");
             ErrorUtilities.VerifyThrowArgumentNull(targets, "targets");
 
-            _requestConfiguration = config;
-            _targets = targets;
-            _resultsNeeded = resultsNeeded;
+            Config = config;
+            Targets = targets;
+            ResultsNeeded = resultsNeeded;
         }
 
         /// <summary>
         /// Returns the configuration for this request.
         /// </summary>
-        public BuildRequestConfiguration Config
-        {
-            get
-            {
-                return _requestConfiguration;
-            }
-        }
+        public BuildRequestConfiguration Config { get; }
 
         /// <summary>
         /// Returns the set of targets to be satisfied for this request.
         /// </summary>
-        public string[] Targets
-        {
-            get
-            {
-                return _targets;
-            }
-        }
+        public string[] Targets { get; }
 
         /// <summary>
         /// Returns true if this request must wait for its results in order to complete.
         /// </summary>
-        public bool ResultsNeeded
-        {
-            get
-            {
-                return _resultsNeeded;
-            }
-        }
+        public bool ResultsNeeded { get; }
 
         /// <summary>
         /// Implementation of the equality operator.
@@ -96,28 +60,12 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the objects are equivalent, false otherwise.</returns>
         public static bool operator ==(FullyQualifiedBuildRequest left, FullyQualifiedBuildRequest right)
         {
-            if (Object.ReferenceEquals(left, null))
+            if (ReferenceEquals(left, null))
             {
-                if (Object.ReferenceEquals(right, null))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return ReferenceEquals(right, null);
             }
-            else
-            {
-                if (Object.ReferenceEquals(right, null))
-                {
-                    return false;
-                }
-                else
-                {
-                    return left.InternalEquals(right);
-                }
-            }
+
+            return !ReferenceEquals(right, null) && left.InternalEquals(right);
         }
 
         /// <summary>
@@ -132,12 +80,12 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Returns the hashcode for this object.
+        /// Returns the hash code for this object.
         /// </summary>
-        /// <returns>The hashcode</returns>
+        /// <returns>The hash code</returns>
         public override int GetHashCode()
         {
-            return _requestConfiguration.GetHashCode();
+            return Config.GetHashCode();
         }
 
         /// <summary>
@@ -147,17 +95,12 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the objects are equivalent, false otherwise.</returns>
         public override bool Equals(object obj)
         {
-            if (null == obj)
+            if (obj == null)
             {
                 return false;
             }
 
-            if (this.GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            return InternalEquals((FullyQualifiedBuildRequest)obj);
+            return GetType() == obj.GetType() && InternalEquals((FullyQualifiedBuildRequest) obj);
         }
 
         /// <summary>
@@ -167,29 +110,29 @@ namespace Microsoft.Build.BackEnd
         /// <returns>True if the objects are equivalent, false otherwise.</returns>
         private bool InternalEquals(FullyQualifiedBuildRequest other)
         {
-            if (Object.ReferenceEquals(this, other))
+            if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if (_requestConfiguration != other._requestConfiguration)
+            if (Config != other.Config)
             {
                 return false;
             }
 
-            if (_resultsNeeded != other._resultsNeeded)
+            if (ResultsNeeded != other.ResultsNeeded)
             {
                 return false;
             }
 
-            if (_targets.Length != other._targets.Length)
+            if (Targets.Length != other.Targets.Length)
             {
                 return false;
             }
 
-            for (int i = 0; i < _targets.Length; ++i)
+            for (int i = 0; i < Targets.Length; ++i)
             {
-                if (_targets[i] != other._targets[i])
+                if (Targets[i] != other.Targets[i])
                 {
                     return false;
                 }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
@@ -5,6 +5,7 @@
 // <summary>Build request which has not had its configuration resolved yet.</summary>
 //-----------------------------------------------------------------------
 
+using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.BackEnd
@@ -27,7 +28,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="config">The configuration to use for the request.</param>
         /// <param name="targets">The set of targets to build.</param>
         /// <param name="resultsNeeded">Whether or not to wait for the results of this request.</param>
-        public FullyQualifiedBuildRequest(BuildRequestConfiguration config, string[] targets, bool resultsNeeded)
+        /// <param name="flags">Flags specified for the build request.</param>
+        public FullyQualifiedBuildRequest(BuildRequestConfiguration config, string[] targets, bool resultsNeeded, BuildRequestDataFlags flags = BuildRequestDataFlags.None)
         {
             ErrorUtilities.VerifyThrowArgumentNull(config, "config");
             ErrorUtilities.VerifyThrowArgumentNull(targets, "targets");
@@ -35,6 +37,7 @@ namespace Microsoft.Build.BackEnd
             Config = config;
             Targets = targets;
             ResultsNeeded = resultsNeeded;
+            BuildRequestDataFlags = flags;
         }
 
         /// <summary>
@@ -51,6 +54,11 @@ namespace Microsoft.Build.BackEnd
         /// Returns true if this request must wait for its results in order to complete.
         /// </summary>
         public bool ResultsNeeded { get; }
+
+        /// <summary>
+        /// The set of flags specified in the BuildRequestData for this request.
+        /// </summary>
+        public BuildRequestDataFlags BuildRequestDataFlags { get; set; }
 
         /// <summary>
         /// Implementation of the equality operator.
@@ -121,6 +129,11 @@ namespace Microsoft.Build.BackEnd
             }
 
             if (ResultsNeeded != other.ResultsNeeded)
+            {
+                return false;
+            }
+
+            if (BuildRequestDataFlags != other.BuildRequestDataFlags)
             {
                 return false;
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/IRequestBuilderCallback.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IRequestBuilderCallback.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="toolsVersions">The tools version to use for each project.  Must be the same number as there are project files.</param>
         /// <param name="targets">The targets to be built.  Each project will be built with the same targets.</param>
         /// <param name="waitForResults">True to wait for the results </param>
+        /// <param name="skipNonexistentTargets">If set, skip targets that are not defined in the projects to be built.</param>
         /// <returns>An Task representing the work which will be done.</returns>
-        Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults);
+        Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets = false);
 
         /// <summary>
         /// This method instructs the request builder that the target builder is blocked on a target which is already in progress on the

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs
@@ -129,22 +129,22 @@ namespace Microsoft.Build.BackEnd
 
             ITaskItem[] singleProject = new ITaskItem[1];
             singleProject[0] = null;
+
             // Build the specified targets in the current project.
-            return MSBuild.ExecuteTargets
-                (
-                singleProject,  // project = null (current project)
-                null,           // propertiesTable = null
-                null,           // undefineProperties
-                targetLists,    // list of targets to build
-                false,          // stopOnFirstFailure = false
-                false,          // rebaseOutputs = false
-                this.BuildEngine3,
-                this.Log,
-                _targetOutputs,
-                this.UseResultsCache,
-                false,
-                null            // toolsVersion = null
-                );
+            return MSBuild.ExecuteTargets(
+                projects: singleProject,
+                propertiesTable: null,
+                undefineProperties: null,
+                targetLists: targetLists,
+                stopOnFirstFailure: false,
+                rebaseOutputs: false,
+                buildEngine: this.BuildEngine3,
+                log: this.Log,
+                targetOutputs: _targetOutputs,
+                useResultsCache: this.UseResultsCache,
+                unloadProjectsOnCompletion: false,
+                toolsVersion: null,
+                skipNonexistentTargets: false);
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/CallTarget.cs
@@ -33,38 +33,15 @@ namespace Microsoft.Build.BackEnd
 
         #region Properties
 
-        // A list of targets to build.  This is a required parameter.  If you want to build the 
-        // default targets, use the <MSBuild> task and pass in Projects=$(MSBuildProjectFile).
-        private string[] _targets = null;
-
         // outputs of all built targets
-        private ArrayList _targetOutputs = new ArrayList();
-
-        // When this is true, instead of calling the engine once to build all the targets,
-        // we would call the engine once per target.  The benefit of this is that
-        // if one target fails, you can still continue with the remaining targets.
-        private bool _runEachTargetSeparately = false;
-
-        // If true the cache will be checked for the result and the result will be stored if the operation 
-        // is run
-        private bool _useResultsCache = false;
+        private readonly ArrayList _targetOutputs = new ArrayList();
 
         /// <summary>
-        /// The targets to build.
+        /// A list of targets to build.  This is a required parameter.  If you want to build the 
+        /// default targets, use the <see cref="MSBuild"/> task and pass in Projects=$(MSBuildProjectFile).
         /// </summary>
         /// <value>Array of target names.</value>
-        public string[] Targets
-        {
-            get
-            {
-                return _targets;
-            }
-
-            set
-            {
-                _targets = value;
-            }
-        }
+        public string[] Targets { get; set; } = null;
 
         /// <summary>
         /// Outputs of the targets built in each project.
@@ -84,35 +61,14 @@ namespace Microsoft.Build.BackEnd
         /// we would call the engine once per target (for each project).  The benefit of this is that
         /// if one target fails, you can still continue with the remaining targets.
         /// </summary>
-        public bool RunEachTargetSeparately
-        {
-            get
-            {
-                return _runEachTargetSeparately;
-            }
-
-            set
-            {
-                _runEachTargetSeparately = value;
-            }
-        }
+        public bool RunEachTargetSeparately { get; set; } = false;
 
         /// <summary>
         /// If true the cached result will be returned if present and a if MSBuild
         /// task is run its result will be cached in a scope (ProjectFileName, GlobalProperties)[TargetNames]
         /// as a list of build items
         /// </summary>
-        public bool UseResultsCache
-        {
-            get
-            {
-                return _useResultsCache;
-            }
-            set
-            {
-                _useResultsCache = value;
-            }
-        }
+        public bool UseResultsCache { get; set; } = false;
 
         #endregion
 
@@ -145,15 +101,7 @@ namespace Microsoft.Build.BackEnd
 
         public TaskLoggingHelper Log
         {
-            get
-            {
-                if (_logHelper == null)
-                {
-                    _logHelper = new TaskLoggingHelper(this);
-                }
-
-                return _logHelper;
-            }
+            get { return _logHelper ?? (_logHelper = new TaskLoggingHelper(this)); }
         }
 
         public bool Execute()
@@ -170,7 +118,7 @@ namespace Microsoft.Build.BackEnd
             // Make sure the list of targets was passed in.
             if ((Targets == null) || (Targets.Length == 0))
             {
-                return Task<bool>.FromResult(true);
+                return Task.FromResult(true);
             }
 
             // This is a list of string[].  That is, each element in the list is a string[].  Each

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
@@ -41,68 +41,21 @@ namespace Microsoft.Build.BackEnd
             Build
         }
 
-        /// <summary>
-        /// Default constructor.
-        /// </summary>
-        public MSBuild()
-        {
-        }
-
         #region Properties
 
-        // projects to build
-        private ITaskItem[] _projects = null;
-        // A list of targets to build.  This is an optional parameter.  If it's omitted,
-        // the default targets are built.
-        private string[] _targets = null;
-        // A list of property name/value pairs to apply as global properties to the child project.
-        // Each string in this array should be of the form:  "propname=propvalue"
-        private string[] _properties = null;
-
-        /// <summary>
-        /// A semicolon-delimited list of global properties to undefine
-        /// </summary>
-        private string _undefineProperties = null;
-
         // outputs of all built targets
-        private ArrayList _targetOutputs = new ArrayList();
-        // indicates if the paths of target output items should be rebased relative to the calling project
-        private bool _rebaseOutputs = false;
-        // Indicates that we should stop building remaining projects as soon as one fails to build.
-        // The default is that we chug ahead despite failures.
-        private bool _stopOnFirstFailure = false;
-        // When this is true, instead of calling the engine once to build all the targets (for each project),
-        // we would call the engine once per target (for each project).  The benefit of this is that
-        // if one target fails, you can still continue with the remaining targets.
-        private bool _runEachTargetSeparately = false;
-        // When this is true we call the engine with all the projects at once instead of
-        // calling the engine once per project
-        private bool _buildInParallel = false;
-        // If true the project will be unloaded once the  operation is completed
-        private bool _unloadProjectsOnCompletion = false;
-        // If true the cache will be checked for the result and the result will be stored if the operation 
-        // is run
-        private bool _useResultsCache = true;
+        private readonly ArrayList _targetOutputs = new ArrayList();
+
         // Whether to skip project files that don't exist on disk. By default we error for such projects.
         private SkipNonexistentProjectsBehavior _skipNonexistentProjects = SkipNonexistentProjectsBehavior.Error;
-        // Value of ToolsVersion to use when building projects passed to this task.
-        private string _toolsVersion = null;
-        // Should Targets, Properties (+ properties as project metadata) be un-escaped before processing
-        private string[] _targetAndPropertyListSeparators = null;
 
-        /// <summary>
-        /// The task logging helper
-        /// </summary>
-        private TaskLoggingHelper _logHelper = null;
+        private TaskLoggingHelper _logHelper;
 
+        /// <inheritdoc />
         /// <summary>
         /// The build engine, from ITask
         /// </summary>
-        public IBuildEngine BuildEngine
-        {
-            get;
-            set;
-        }
+        public IBuildEngine BuildEngine { get; set; }
 
         public IBuildEngine2 BuildEngine2
         {
@@ -118,23 +71,16 @@ namespace Microsoft.Build.BackEnd
         {
             get
             {
-                if (_logHelper == null)
-                {
-                    _logHelper = new TaskLoggingHelperExtension(this, AssemblyResources.PrimaryResources, AssemblyResources.SharedResources, "MSBuild.");
-                }
-
-                return _logHelper;
+                return _logHelper ?? (_logHelper = new TaskLoggingHelperExtension(this,
+                           AssemblyResources.PrimaryResources, AssemblyResources.SharedResources, "MSBuild."));
             }
         }
 
+        /// <inheritdoc />
         /// <summary>
         /// The host object, from ITask
         /// </summary>
-        public ITaskHost HostObject
-        {
-            get;
-            set;
-        }
+        public ITaskHost HostObject { get; set; }
 
         /// <summary>
         /// A list of property name/value pairs to apply as global properties to 
@@ -151,69 +97,25 @@ namespace Microsoft.Build.BackEnd
         ///     <MSBuild
         ///         Properties="@(OutputPathItem->'TargetPath=%(Identity)')" />
         /// </remarks>
-        public string[] Properties
-        {
-            get
-            {
-                return _properties;
-            }
-
-            set
-            {
-                _properties = value;
-            }
-        }
+        public string[] Properties { get; set; }
 
         /// <summary>
-        /// Gets or sets the set of global properties to remove.
+        /// Gets or sets a semicolon-delimited list of global properties to remove.
         /// </summary>
-        public string RemoveProperties
-        {
-            get
-            {
-                return _undefineProperties;
-            }
-
-            set
-            {
-                _undefineProperties = value;
-            }
-        }
+        public string RemoveProperties { get; set; } = null;
 
         /// <summary>
         /// The targets to build in each project specified by the <see cref="Projects"/> property.
         /// </summary>
         /// <value>Array of target names.</value>
-        public string[] Targets
-        {
-            get
-            {
-                return _targets;
-            }
-
-            set
-            {
-                _targets = value;
-            }
-        }
+        public string[] Targets { get; set; }
 
         /// <summary>
         /// The projects to build.
         /// </summary>
         /// <value>Array of project items.</value>
         [Required]
-        public ITaskItem[] Projects
-        {
-            get
-            {
-                return _projects;
-            }
-
-            set
-            {
-                _projects = value;
-            }
-        }
+        public ITaskItem[] Projects { get; set; } = null;
 
         /// <summary>
         /// Outputs of the targets built in each project.
@@ -232,117 +134,43 @@ namespace Microsoft.Build.BackEnd
         /// Indicates if the paths of target output items should be rebased relative to the calling project.
         /// </summary>
         /// <value>true, if target output item paths should be rebased</value>
-        public bool RebaseOutputs
-        {
-            get
-            {
-                return _rebaseOutputs;
-            }
-
-            set
-            {
-                _rebaseOutputs = value;
-            }
-        }
+        public bool RebaseOutputs { get; set; } = false;
 
         /// <summary>
         /// Forces the task to stop building the remaining projects as soon as any of
         /// them fail.
         /// </summary>
-        public bool StopOnFirstFailure
-        {
-            get
-            {
-                return _stopOnFirstFailure;
-            }
-
-            set
-            {
-                _stopOnFirstFailure = value;
-            }
-        }
+        public bool StopOnFirstFailure { get; set; } = false;
 
         /// <summary>
         /// When this is true, instead of calling the engine once to build all the targets (for each project),
         /// we would call the engine once per target (for each project).  The benefit of this is that
         /// if one target fails, you can still continue with the remaining targets.
         /// </summary>
-        public bool RunEachTargetSeparately
-        {
-            get
-            {
-                return _runEachTargetSeparately;
-            }
-
-            set
-            {
-                _runEachTargetSeparately = value;
-            }
-        }
+        public bool RunEachTargetSeparately { get; set; } = false;
 
         /// <summary>
         /// Value of ToolsVersion to use when building projects passed to this task.
         /// </summary>
-        public string ToolsVersion
-        {
-            get
-            {
-                return _toolsVersion;
-            }
-
-            set
-            {
-                _toolsVersion = value;
-            }
-        }
+        public string ToolsVersion { get; set; } = null;
 
         /// <summary>
         /// When this is true we call the engine with all the projects at once instead of 
         /// calling the engine once per project
         /// </summary>
-        public bool BuildInParallel
-        {
-            get
-            {
-                return _buildInParallel;
-            }
-            set
-            {
-                _buildInParallel = value;
-            }
-        }
+        public bool BuildInParallel { get; set; }
 
         /// <summary>
         /// If true the project will be unloaded once the operation is completed
         /// </summary>
-        public bool UnloadProjectsOnCompletion
-        {
-            get
-            {
-                return _unloadProjectsOnCompletion;
-            }
-            set
-            {
-                _unloadProjectsOnCompletion = value;
-            }
-        }
+        public bool UnloadProjectsOnCompletion { get; set; } = false;
 
         /// <summary>
         /// If true the cached result will be returned if present and a if MSBuild
         /// task is run its result will be cached in a scope (ProjectFileName, GlobalProperties)[TargetNames]
         /// as a list of build items
         /// </summary>
-        public bool UseResultsCache
-        {
-            get
-            {
-                return _useResultsCache;
-            }
-            set
-            {
-                _useResultsCache = value;
-            }
-        }
+        public bool UseResultsCache { get; set; } = true;
 
         /// <summary>
         /// When this is true, project files that do not exist on the disk will be skipped. By default,
@@ -382,34 +210,17 @@ namespace Microsoft.Build.BackEnd
                 {
                     ErrorUtilities.VerifyThrowArgument(ConversionUtilities.CanConvertStringToBool(value), "MSBuild.InvalidSkipNonexistentProjectValue");
                     bool originalSkipValue = ConversionUtilities.ConvertStringToBool(value);
-                    if (originalSkipValue)
-                    {
-                        _skipNonexistentProjects = SkipNonexistentProjectsBehavior.Skip;
-                    }
-                    else
-                    {
-                        _skipNonexistentProjects = SkipNonexistentProjectsBehavior.Error;
-                    }
+                    _skipNonexistentProjects = originalSkipValue ? SkipNonexistentProjectsBehavior.Skip : SkipNonexistentProjectsBehavior.Error;
                 }
             }
         }
 
         /// <summary>
-        /// Unescape Targets, Properties (including Properties and AdditionalProperties as Project item metadata)
+        /// Un-escape Targets, Properties (including Properties and AdditionalProperties as Project item metadata)
         /// will be un-escaped before processing. e.g. %3B (an escaped ';') in the string for any of them will 
         /// be treated as if it were an un-escaped ';'
         /// </summary>
-        public string[] TargetAndPropertyListSeparators
-        {
-            get
-            {
-                return _targetAndPropertyListSeparators;
-            }
-            set
-            {
-                _targetAndPropertyListSeparators = value;
-            }
-        }
+        public string[] TargetAndPropertyListSeparators { get; set; } = null;
 
         #endregion
 
@@ -448,10 +259,10 @@ namespace Microsoft.Build.BackEnd
 
             // Parse out the properties to undefine, if any.
             string[] undefinePropertiesArray = null;
-            if (!String.IsNullOrEmpty(_undefineProperties))
+            if (!String.IsNullOrEmpty(RemoveProperties))
             {
                 Log.LogMessageFromResources(MessageImportance.Low, "General.UndefineProperties");
-                undefinePropertiesArray = _undefineProperties.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                undefinePropertiesArray = RemoveProperties.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string property in undefinePropertiesArray)
                 {
                     Log.LogMessageFromText(String.Format(CultureInfo.InvariantCulture, "  {0}", property), MessageImportance.Low);
@@ -462,9 +273,9 @@ namespace Microsoft.Build.BackEnd
             // If we are in single proc mode and stopOnFirstFailure is true, we cannot build in parallel because 
             // building in parallel sends all of the projects to the engine at once preventing us from not sending
             // any more projects after the first failure. Therefore, to preserve compatibility with whidbey if we are in this situation disable buildInParallel.
-            if (!isRunningMultipleNodes && _stopOnFirstFailure && _buildInParallel)
+            if (!isRunningMultipleNodes && StopOnFirstFailure && BuildInParallel)
             {
-                _buildInParallel = false;
+                BuildInParallel = false;
                 Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NotBuildingInParallel");
             }
 
@@ -473,7 +284,7 @@ namespace Microsoft.Build.BackEnd
             // All project files will be submitted to the engine all at once, this mean there is no stopping for failures between projects.
             // When RunEachTargetSeparately is false, all targets will be submitted to the engine at once, this means there is no way to stop between target failures.
             // therefore the first failure seen will be the only failure seen.
-            if (isRunningMultipleNodes && _buildInParallel && _stopOnFirstFailure && !_runEachTargetSeparately)
+            if (isRunningMultipleNodes && BuildInParallel && StopOnFirstFailure && !RunEachTargetSeparately)
             {
                 Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.NoStopOnFirstFailure");
             }
@@ -490,7 +301,7 @@ namespace Microsoft.Build.BackEnd
             bool[] skipProjects = null;
 
 
-            if (_buildInParallel)
+            if (BuildInParallel)
             {
                 skipProjects = new bool[Projects.Length];
                 for (int i = 0; i < skipProjects.Length; i++)
@@ -513,7 +324,7 @@ namespace Microsoft.Build.BackEnd
 
                 string projectPath = FileUtilities.AttemptToShortenPath(project.ItemSpec);
 
-                if (_stopOnFirstFailure && !success)
+                if (StopOnFirstFailure && !success)
                 {
                     // Inform the user that we skipped the remaining projects because StopOnFirstFailure=true.
                     Log.LogMessageFromResources(MessageImportance.Low, "MSBuild.SkippingRemainingProjects");
@@ -534,7 +345,7 @@ namespace Microsoft.Build.BackEnd
 
                     // If we are building in parallel we want to only make one call to
                     // ExecuteTargets once we verified that all projects exist
-                    if (!_buildInParallel)
+                    if (!BuildInParallel)
                     {
                         singleProject[0] = project;
                         bool executeResult = await ExecuteTargets(
@@ -547,8 +358,8 @@ namespace Microsoft.Build.BackEnd
                                                 BuildEngine3,
                                                 Log,
                                                 _targetOutputs,
-                                                _useResultsCache,
-                                                _unloadProjectsOnCompletion,
+                                                UseResultsCache,
+                                                UnloadProjectsOnCompletion,
                                                 ToolsVersion
                                                 );
 
@@ -578,7 +389,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             // We need to build all the projects that were not skipped
-            if (_buildInParallel)
+            if (BuildInParallel)
             {
                 success = await BuildProjectsInParallel(propertiesTable, undefinePropertiesArray, targetLists, success, skipProjects);
             }
@@ -591,7 +402,6 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private async Task<bool> BuildProjectsInParallel(Hashtable propertiesTable, string[] undefinePropertiesArray, ArrayList targetLists, bool success, bool[] skipProjects)
         {
-            ITaskItem[] projectToBuildInParallel = Projects;
             // There were some projects that were skipped so we need to recreate the
             // project array with those projects removed
             List<ITaskItem> projectsToBuildArrayList = new List<ITaskItem>();
@@ -602,31 +412,30 @@ namespace Microsoft.Build.BackEnd
                     projectsToBuildArrayList.Add(Projects[i]);
                 }
             }
-            projectToBuildInParallel = projectsToBuildArrayList.ToArray();
+            var projectToBuildInParallel = projectsToBuildArrayList.ToArray();
 
             // Make the call to build the projects
-            if (projectToBuildInParallel.Length > 0)
-            {
-                bool executeResult = await ExecuteTargets
-                                (
-                                projectToBuildInParallel,
-                                propertiesTable,
-                                undefinePropertiesArray,
-                                targetLists,
-                                StopOnFirstFailure,
-                                RebaseOutputs,
-                                BuildEngine3,
-                                Log,
-                                _targetOutputs,
-                                _useResultsCache,
-                                _unloadProjectsOnCompletion,
-                                ToolsVersion
-                                );
+            if (projectToBuildInParallel.Length <= 0) return success;
 
-                if (!executeResult)
-                {
-                    success = false;
-                }
+            bool executeResult = await ExecuteTargets
+            (
+                projectToBuildInParallel,
+                propertiesTable,
+                undefinePropertiesArray,
+                targetLists,
+                StopOnFirstFailure,
+                RebaseOutputs,
+                BuildEngine3,
+                Log,
+                _targetOutputs,
+                UseResultsCache,
+                UnloadProjectsOnCompletion,
+                ToolsVersion
+            );
+
+            if (!executeResult)
+            {
+                success = false;
             }
 
             return success;
@@ -640,36 +449,37 @@ namespace Microsoft.Build.BackEnd
             List<string> expandedProperties = new List<string>();
             List<string> expandedTargets = new List<string>();
 
-            if (this.Properties != null)
+            if (Properties != null)
             {
                 // Expand all properties
-                for (int n = 0; n < this.Properties.Length; n++)
+                for (int n = 0; n < Properties.Length; n++)
                 {
                     // Split each property according to the separators
-                    string[] expandedPropertyValues = this.Properties[n].Split(this.TargetAndPropertyListSeparators, StringSplitOptions.RemoveEmptyEntries);
+                    string[] expandedPropertyValues = Properties[n].Split(TargetAndPropertyListSeparators, StringSplitOptions.RemoveEmptyEntries);
                     // Add the resultant properties to the final list
                     foreach (string property in expandedPropertyValues)
                     {
                         expandedProperties.Add(property);
                     }
                 }
-                this.Properties = expandedProperties.ToArray();
+                Properties = expandedProperties.ToArray();
             }
 
-            if (this.Targets != null)
+            if (Targets != null)
             {
                 // Expand all targets
-                for (int n = 0; n < this.Targets.Length; n++)
+                for (int n = 0; n < Targets.Length; n++)
                 {
                     // Split each target according to the separators
-                    string[] expandedTargetValues = this.Targets[n].Split(this.TargetAndPropertyListSeparators, StringSplitOptions.RemoveEmptyEntries);
+                    string[] expandedTargetValues = Targets[n].Split(TargetAndPropertyListSeparators, StringSplitOptions.RemoveEmptyEntries);
                     // Add the resultant targets to the final list
                     foreach (string target in expandedTargetValues)
                     {
                         expandedTargets.Add(target);
                     }
                 }
-                this.Targets = expandedTargets.ToArray();
+
+                Targets = expandedTargets.ToArray();
             }
         }
 
@@ -695,7 +505,7 @@ namespace Microsoft.Build.BackEnd
                 // Separate target invocations for each individual target.
                 foreach (string targetName in targets)
                 {
-                    targetLists.Add(new string[1] { targetName });
+                    targetLists.Add(new[] { targetName });
                 }
             }
             else
@@ -867,13 +677,13 @@ namespace Microsoft.Build.BackEnd
                 {
                     for (int i = 0; i < projects.Length; i++)
                     {
-                        IEnumerable nonNullTargetList = (targetList != null) ? targetList : targetOutputsPerProject[i].Keys;
+                        IEnumerable nonNullTargetList = targetList ?? targetOutputsPerProject[i].Keys;
 
                         foreach (string targetName in nonNullTargetList)
                         {
                             if (targetOutputsPerProject[i].ContainsKey(targetName))
                             {
-                                ITaskItem[] outputItemsFromTarget = (ITaskItem[])targetOutputsPerProject[i][targetName];
+                                ITaskItem[] outputItemsFromTarget = targetOutputsPerProject[i][targetName];
 
                                 foreach (ITaskItem outputItemFromTarget in outputItemsFromTarget)
                                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -313,8 +313,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="toolsVersions">The tools version to use for each project.  Must be the same number as there are project files.</param>
         /// <param name="targets">The targets to be built.  Each project will be built with the same targets.</param>
         /// <param name="waitForResults">True to wait for the results </param>
+        /// <param name="skipNonexistentTargets">If set, skip targets that are not defined in the projects to be built.</param>
         /// <returns>True if the requests were satisfied, false if they were aborted.</returns>
-        public async Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults)
+        public async Task<BuildResult[]> BuildProjects(string[] projectFiles, PropertyDictionary<ProjectPropertyInstance>[] properties, string[] toolsVersions, string[] targets, bool waitForResults, bool skipNonexistentTargets = false)
         {
             VerifyIsNotZombie();
             ErrorUtilities.VerifyThrowArgumentNull(projectFiles, "projectFiles");
@@ -351,7 +352,8 @@ namespace Microsoft.Build.BackEnd
 
                 BuildRequestConfiguration config = new BuildRequestConfiguration(data, _componentHost.BuildParameters.DefaultToolsVersion, _componentHost.BuildParameters.GetToolset);
 
-                requests[i] = new FullyQualifiedBuildRequest(config, targets, waitForResults);
+                requests[i] = new FullyQualifiedBuildRequest(config, targets, waitForResults,
+                    flags: skipNonexistentTargets ? BuildRequestDataFlags.SkipNonexistentTargets : BuildRequestDataFlags.None);
             }
 
             // Send the requests off

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private async Task ProcessTargetStack(ITaskBuilder taskBuilder)
         {
-            // Keep building while we have targets to build and haven't been cancelled.
+            // Keep building while we have targets to build and haven't been canceled.
             bool stopProcessingStack = false;
             while
                 (

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -778,7 +778,7 @@ namespace Microsoft.Build.BackEnd
                 _targetBuilderCallback = null;
 
                 // Clear out the sponsor (who is responsible for keeping the EngineProxy remoting lease alive until the task is done)
-                // this will be null if the engineproxy was never sent across an appdomain boundry.
+                // this will be null if the engine proxy was never sent across an AppDomain boundary.
                 if (_sponsor != null)
                 {
                     ILease lease = (ILease)RemotingServices.GetLifetimeService(this);
@@ -845,8 +845,10 @@ namespace Microsoft.Build.BackEnd
 
                     if (returnTargetOutputs)
                     {
-                        targetOutputsPerProject = new List<IDictionary<string, ITaskItem[]>>(1);
-                        targetOutputsPerProject.Add(new Dictionary<string, ITaskItem[]>(StringComparer.OrdinalIgnoreCase));
+                        targetOutputsPerProject = new List<IDictionary<string, ITaskItem[]>>(1)
+                        {
+                            new Dictionary<string, ITaskItem[]>(StringComparer.OrdinalIgnoreCase)
+                        };
                     }
 
                     for (int i = 0; i < targetNames.Length; i++)
@@ -878,7 +880,7 @@ namespace Microsoft.Build.BackEnd
                         }
 
                         // Finally, remove any which were requested to be removed.
-                        if (undefineProperties != null && undefineProperties[i] != null)
+                        if (undefineProperties?[i] != null)
                         {
                             foreach (string property in undefineProperties[i])
                             {

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Build.BackEnd
         private BuildRequestDataFlags _buildRequestDataFlags;
 
         /// <summary>
+        /// If set, skip targets that are not defined in the projects to be built.
+        /// </summary>
+        private bool _skipNonexistentTargets;
+
+        /// <summary>
         /// Constructor for serialization.
         /// </summary>
         public BuildRequest()
@@ -297,6 +302,15 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// If set, skip targets that are not defined in the projects to be built.
+        /// </summary>
+        internal bool SkipNonexistentTargets
+        {
+            get { return _skipNonexistentTargets; }
+            set { _skipNonexistentTargets = value; }
+        }
+
+        /// <summary>
         /// Sets the configuration id to a resolved id.
         /// </summary>
         /// <param name="newConfigId">The new configuration id for this request.</param>
@@ -323,6 +337,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _parentBuildEventContext);
             translator.Translate(ref _buildEventContext);
             translator.TranslateEnum(ref _buildRequestDataFlags, (int)_buildRequestDataFlags);
+            translator.Translate(ref _skipNonexistentTargets);
 
             // UNDONE: (Compat) Serialize the host object.
         }

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -133,14 +133,7 @@ namespace Microsoft.Build.BackEnd
             _buildEventContext = BuildEventContext.Invalid;
             _parentBuildEventContext = parentBuildEventContext;
             _globalRequestId = InvalidGlobalRequestId;
-            if (null != parentRequest)
-            {
-                _parentGlobalRequestId = parentRequest.GlobalRequestId;
-            }
-            else
-            {
-                _parentGlobalRequestId = InvalidGlobalRequestId;
-            }
+            _parentGlobalRequestId = parentRequest?.GlobalRequestId ?? InvalidGlobalRequestId;
 
             _nodeRequestId = nodeRequestId;
             _buildRequestDataFlags = buildRequestDataFlags;
@@ -337,7 +330,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Factory for serialization.
         /// </summary>
-        static internal INodePacket FactoryForDeserialization(INodePacketTranslator translator)
+        internal static INodePacket FactoryForDeserialization(INodePacketTranslator translator)
         {
             return new BuildRequest(translator);
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -922,7 +922,11 @@
   </data>
   <data name="TargetSkippedFalseCondition" UESanitized="false" Visibility="Public">
     <value>Target "{0}" skipped, due to false condition; ({1}) was evaluated as ({2}).</value>
-  </data>  
+  </data>
+  <data name="TargetSkippedWhenSkipNonexistentTargets" UESanitized="false" Visibility="Public">
+    <value>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</value>
+    <comment>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</comment>
+  </data>
   
   <!-- ====================================================================== -->
   

--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -2474,6 +2474,7 @@ elementFormDefault="qualified">
                     <xs:attribute name="RebaseOutputs" type="msb:boolean" />
                     <xs:attribute name="RunEachTargetSeparately" type="msb:boolean" />
                     <xs:attribute name="SkipNonexistentProjects" type="msb:boolean" />
+                    <xs:attribute name="SkipNonexistentTargets" type="msb:boolean" />
                     <xs:attribute name="StopOnFirstFailure" type="msb:boolean" />
                     <xs:attribute name="TargetAndPropertyListSeparators" />
                     <xs:attribute name="Targets" />

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1235,7 +1235,7 @@ namespace Microsoft.Build.CommandLine
                 toolsVersion,
                 targetsToBuild: new[] { MSBuildConstants.RestoreTargetName },
                 hostServices: null,
-                flags: BuildRequestDataFlags.ClearCachesAfterBuild);
+                flags: BuildRequestDataFlags.ClearCachesAfterBuild | BuildRequestDataFlags.SkipNonexistentTargets);
 
             return ExecuteBuild(buildManager, restoreRequest);
         }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -806,16 +806,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                                        Restore
-
-    This empty target is defined so that all projects can run Restore.  Most package management systems like
-    NuGet will override this target.
-    ============================================================
-    -->
-  <Target Name="Restore"/>
-
-  <!--
-    ============================================================
                                         CoreBuild
 
     The core build step calls each of the build targets.


### PR DESCRIPTION
Note: Tests still to come. Since this is a lot of cascading changes I wanted to get it out for review before I spent too much time on tests.

Add optional `SkipNonexistentTargets` attribute to the `MSBuild` task. This allows for the ability to make changes to our project to project reference protocol which would be an otherwise breaking change.

Related to #2472

Closes #2471