### PR TITLE
Make MSBuildNameIgnoreCaseComparer stateless

### DIFF
--- a/src/Build.UnitTests/Collections/MSBuildNameIgnoreCaseComparer_Tests.cs
+++ b/src/Build.UnitTests/Collections/MSBuildNameIgnoreCaseComparer_Tests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             Assert.Equal(true, MSBuildNameIgnoreCaseComparer.Default.Equals("", ""));
             Assert.Equal(false, MSBuildNameIgnoreCaseComparer.Default.Equals("x", null));
             Assert.Equal(false, MSBuildNameIgnoreCaseComparer.Default.Equals(null, "x"));
-            Assert.Equal(true, MSBuildNameIgnoreCaseComparer.Default.Equals(null, null));
+            Assert.Equal(true, MSBuildNameIgnoreCaseComparer.Default.Equals((string)null, (string)null));
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void MatchProperty()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Default;
             PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
 
             ProjectPropertyInstance p = ProjectPropertyInstance.Create("foo", "bar");
@@ -52,43 +52,11 @@ namespace Microsoft.Build.UnitTests.OM.Collections
             dictionary.Set(p);
 
             string s = "$(foo)";
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, s, 2, 4);
+            ProjectPropertyInstance value = dictionary.GetProperty(s, 2, 4);
 
             Assert.True(Object.ReferenceEquals(p, value)); // "Should have returned the same object as was inserted"
 
-            try
-            {
-                comparer.SetConstraintsForUnitTestingOnly(s, 2, 4);
-                Assert.Equal(MSBuildNameIgnoreCaseComparer.Default.GetHashCode("foo"), comparer.GetHashCode(s));
-            }
-            finally
-            {
-                comparer.RemoveConstraintsForUnitTestingOnly();
-            }
-        }
-
-        /// <summary>
-        /// Default comparer is immutable
-        /// </summary>
-        [Fact]
-        public void Immutable()
-        {
-            Assert.Throws<InternalErrorException>(() =>
-            {
-                Dictionary<string, Object> dictionary = new Dictionary<string, Object>(MSBuildNameIgnoreCaseComparer.Default);
-
-                MSBuildNameIgnoreCaseComparer.Default.GetValueWithConstraints(dictionary, "x", 0, 1);
-            }
-           );
-        }
-        /// <summary>
-        /// Objects work
-        /// </summary>
-        [Fact]
-        public void NonString()
-        {
-            Object o = new Object();
-            Assert.Equal(true, ((IEqualityComparer)MSBuildNameIgnoreCaseComparer.Default).Equals(o, o));
+            Assert.Equal(MSBuildNameIgnoreCaseComparer.Default.GetHashCode("foo"), comparer.GetHashCode(s, 2, 3));
         }
 
         /// <summary>
@@ -110,18 +78,6 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         }
 
         /// <summary>
-        /// Make sure we can handle the case where the dictionary is null.
-        /// </summary>
-        [Fact]
-        public void NullDictionary()
-        {
-            Assert.Throws<InternalErrorException>(() =>
-            {
-                MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<Object>(null, "s", 0, 1);
-            }
-           );
-        }
-        /// <summary>
         /// Invalid start 
         /// </summary>
         [Fact]
@@ -129,8 +85,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             Assert.Throws<InternalErrorException>(() =>
             {
-                PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
-                MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "x", -1, 0);
+                MSBuildNameIgnoreCaseComparer.Default.Equals("x", "y", -1, 0);
             }
            );
         }
@@ -142,8 +97,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             Assert.Throws<InternalErrorException>(() =>
             {
-                PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
-                MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "x", 0, -1);
+                MSBuildNameIgnoreCaseComparer.Default.Equals("x", "y", 0, -1);
             }
            );
         }
@@ -155,8 +109,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         {
             Assert.Throws<InternalErrorException>(() =>
             {
-                PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>();
-                MSBuildNameIgnoreCaseComparer.Mutable.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "x", 0, 2);
+                MSBuildNameIgnoreCaseComparer.Default.Equals("x", "y", 0, 2);
             }
            );
         }
@@ -166,15 +119,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsEndPastEnd1()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p = ProjectPropertyInstance.Create("bbb", "value");
-            dictionary.Set(p);
-
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "abbbaaa", 1, 3);
-
-            Assert.True(Object.ReferenceEquals(p, value)); // "Should have returned the same object as was inserted"
+            Assert.True(MSBuildNameIgnoreCaseComparer.Default.Equals("bbb", "abbbaaa", 1, 3));
         }
 
         /// <summary>
@@ -183,18 +128,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd1()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("A", "value1");
-            ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("B", "value2");
-
-            dictionary.Set(p1);
-            dictionary.Set(p2);
-
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "babbbb", 1, 1);
-
-            Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'A' value"
+            Assert.True(MSBuildNameIgnoreCaseComparer.Default.Equals("A", "babbbb", 1, 1));
         }
 
         /// <summary>
@@ -203,18 +137,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd2()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("a", "value1");
-            ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("b", "value2");
-
-            dictionary.Set(p1);
-            dictionary.Set(p2);
-
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 2, 2);
-
-            Assert.True(Object.ReferenceEquals(p2, value)); // "Should have returned the 'b' value"
+            Assert.True(MSBuildNameIgnoreCaseComparer.Default.Equals("b", "aabaa", 2, 1));
         }
 
         /// <summary>
@@ -223,18 +146,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsSameStartEnd3()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("a", "value1");
-            ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("b", "value2");
-
-            dictionary.Set(p1);
-            dictionary.Set(p2);
-
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "ab", 0, 0);
-
-            Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'a' value"
+            Assert.True(MSBuildNameIgnoreCaseComparer.Default.Equals("a", "ab", 0, 1));
         }
 
         /// <summary>
@@ -243,65 +155,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void EqualsStartZero()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("aab", "value1");
-            ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("aba", "value2");
-
-            dictionary.Set(p1);
-            dictionary.Set(p2);
-
-            ProjectPropertyInstance value = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, "aabaa", 0, 2);
-
-            Assert.True(Object.ReferenceEquals(p1, value)); // "Should have returned the 'aab' value"
-        }
-
-        /// <summary>
-        /// End at end
-        /// </summary>
-        [Fact]
-        public void EqualsEndEnd()
-        {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            PropertyDictionary<ProjectPropertyInstance> dictionary = new PropertyDictionary<ProjectPropertyInstance>(comparer);
-
-            ProjectPropertyInstance p1 = ProjectPropertyInstance.Create("aabaaaa", "value1");
-            ProjectPropertyInstance p2 = ProjectPropertyInstance.Create("baaaa", "value2");
-            dictionary.Set(p1);
-            dictionary.Set(p2);
-
-            string constraint = "aabaaa";
-
-            ProjectPropertyInstance p3 = ProjectPropertyInstance.Create("abaaa", "value3");
-            dictionary.Set(p3);
-
-            // Should match o3
-            ProjectPropertyInstance value1 = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
-
-            Assert.True(Object.ReferenceEquals(p3, value1)); // "Should have returned the 'abaaa' value"
-
-            dictionary.Remove("abaaa"); // get rid of o3
-
-            ProjectPropertyInstance value2 = comparer.GetValueWithConstraints<ProjectPropertyInstance>(dictionary, constraint, 1, 5);
-
-            Assert.Null(value2); // "Should not have been a match in the dictionary"
-
-            // Even if the string is exactly the same, if only a substring is being compared, then although it 
-            // will be judged equal, the hash codes will NOT be the same, and for that reason, a lookup in the 
-            // dictionary will fail.  
-            int originalHashCode = comparer.GetHashCode("aabaaa");
-            try
-            {
-                comparer.SetConstraintsForUnitTestingOnly(constraint, 1, 5);
-
-                Assert.True(comparer.Equals("aabaaa", constraint)); // same on both sides
-                Assert.NotEqual(originalHashCode, comparer.GetHashCode(constraint));
-            }
-            finally
-            {
-                comparer.RemoveConstraintsForUnitTestingOnly();
-            }
+            Assert.True(MSBuildNameIgnoreCaseComparer.Default.Equals("aab", "aabaa", 0, 3));
         }
 
         /// <summary>
@@ -310,7 +164,7 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void DefaultGetHashcode()
         {
-            Assert.Equal(true, 0 == MSBuildNameIgnoreCaseComparer.Default.GetHashCode(null));
+            Assert.Equal(true, 0 == MSBuildNameIgnoreCaseComparer.Default.GetHashCode((string)null));
 
             MSBuildNameIgnoreCaseComparer.Default.GetHashCode(""); // doesn't throw            
             Assert.Equal(MSBuildNameIgnoreCaseComparer.Default.GetHashCode("aBc"), MSBuildNameIgnoreCaseComparer.Default.GetHashCode("AbC"));
@@ -322,23 +176,13 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void IndexedGetHashcode1()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            string s = "xyz";
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Default;
 
-            try
-            {
-                comparer.SetConstraintsForUnitTestingOnly(s, 0, 0);
+            comparer.GetHashCode(""); // does not crash
 
-                comparer.GetHashCode(""); // does not crash
-
-                Assert.Equal(true, 0 == comparer.GetHashCode(null));
-                Assert.Equal(comparer.GetHashCode("aBc"), comparer.GetHashCode("AbC"));
-                Assert.Equal(comparer.GetHashCode(s), comparer.GetHashCode("x"));
-            }
-            finally
-            {
-                comparer.RemoveConstraintsForUnitTestingOnly();
-            }
+            Assert.Equal(true, 0 == comparer.GetHashCode((string)null));
+            Assert.Equal(comparer.GetHashCode("aBc"), comparer.GetHashCode("AbC"));
+            Assert.Equal(comparer.GetHashCode("xyz", 0, 1), comparer.GetHashCode("x"));
         }
 
         /// <summary>
@@ -347,19 +191,9 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void IndexedGetHashcode2()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            string s = "xyz";
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Default;
 
-            try
-            {
-                comparer.SetConstraintsForUnitTestingOnly(s, 1, 2);
-
-                Assert.Equal(comparer.GetHashCode(s), comparer.GetHashCode("YZ"));
-            }
-            finally
-            {
-                comparer.RemoveConstraintsForUnitTestingOnly();
-            }
+            Assert.Equal(comparer.GetHashCode("xyz", 1, 2), comparer.GetHashCode("YZ"));
         }
 
         /// <summary>
@@ -368,19 +202,9 @@ namespace Microsoft.Build.UnitTests.OM.Collections
         [Fact]
         public void IndexedGetHashcode3()
         {
-            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            string s = "abcd";
+            MSBuildNameIgnoreCaseComparer comparer = MSBuildNameIgnoreCaseComparer.Default;
 
-            try
-            {
-                comparer.SetConstraintsForUnitTestingOnly(s, 0, 2);
-
-                Assert.Equal(comparer.GetHashCode(s), comparer.GetHashCode("abc"));
-            }
-            finally
-            {
-                comparer.RemoveConstraintsForUnitTestingOnly();
-            }
+            Assert.Equal(comparer.GetHashCode("abcd", 0, 3), comparer.GetHashCode("abc"));
         }
     }
 }

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Collections
     /// </remarks>
     /// <typeparam name="T">Property or Metadata class type to store</typeparam>
     [DebuggerDisplay("#Entries={Count}")]
-    internal sealed class CopyOnWritePropertyDictionary<T> : IEnumerable<T>, IEquatable<CopyOnWritePropertyDictionary<T>>, IPropertyProvider<T>, IDictionary<string, T>
+    internal sealed class CopyOnWritePropertyDictionary<T> : IEnumerable<T>, IEquatable<CopyOnWritePropertyDictionary<T>>, IDictionary<string, T>
         where T : class, IKeyed, IValued, IEquatable<T>, IImmutable
     {
         /// <summary>
@@ -58,17 +58,12 @@ namespace Microsoft.Build.Collections
         private readonly CopyOnWriteDictionary<string, T> _properties;
 
         /// <summary>
-        /// Comparer whose start and end indexes we can manipulate as necessary.
-        /// </summary>
-        private readonly MSBuildNameIgnoreCaseComparer _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-
-        /// <summary>
         /// Creates empty dictionary
         /// </summary>
         public CopyOnWritePropertyDictionary()
         {
             // Tracing.Record("New COWD1");
-            _properties = new CopyOnWriteDictionary<string, T>(_comparer);
+            _properties = new CopyOnWriteDictionary<string, T>(MSBuildNameIgnoreCaseComparer.Mutable);
         }
 
         /// <summary>
@@ -77,7 +72,7 @@ namespace Microsoft.Build.Collections
         public CopyOnWritePropertyDictionary(int capacity)
         {
             // Tracing.Record("New COWD2");
-            _properties = new CopyOnWriteDictionary<string, T>(capacity, _comparer);
+            _properties = new CopyOnWriteDictionary<string, T>(capacity, MSBuildNameIgnoreCaseComparer.Mutable);
         }
 
         /// <summary>
@@ -314,32 +309,6 @@ namespace Microsoft.Build.Collections
         }
 
         #endregion
-
-        /// <summary>
-        /// Get the property with the specified name or null if it is not present
-        /// </summary>
-        T IPropertyProvider<T>.GetProperty(string name)
-        {
-            return this[name];
-        }
-
-        /// <summary>
-        /// Get the property with the specified name or null if it is not present.
-        /// Name is the segment of the provided string with the provided start and end indexes.
-        /// </summary>
-        T IPropertyProvider<T>.GetProperty(string name, int startIndex, int endIndex)
-        {
-            lock (_properties)
-            {
-                if (startIndex == 0 && endIndex == name.Length - 1)
-                {
-                    return this[name];
-                }
-
-                T returnValue = _comparer.GetValueWithConstraints<T>(this, name, startIndex, endIndex);
-                return returnValue;
-            }
-        }
 
         #region IDictionary<string,T> Members
 

--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Collections
         public CopyOnWritePropertyDictionary()
         {
             // Tracing.Record("New COWD1");
-            _properties = new CopyOnWriteDictionary<string, T>(MSBuildNameIgnoreCaseComparer.Mutable);
+            _properties = new CopyOnWriteDictionary<string, T>(MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Collections
         public CopyOnWritePropertyDictionary(int capacity)
         {
             // Tracing.Record("New COWD2");
-            _properties = new CopyOnWriteDictionary<string, T>(capacity, MSBuildNameIgnoreCaseComparer.Mutable);
+            _properties = new CopyOnWriteDictionary<string, T>(capacity, MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>

--- a/src/Build/Collections/PropertyDictionary.cs
+++ b/src/Build/Collections/PropertyDictionary.cs
@@ -49,17 +49,11 @@ namespace Microsoft.Build.Collections
         private RetrievableEntryHashSet<T> _properties;
 
         /// <summary>
-        /// Comparer whose start and end indexes we can manipulate as necessary.
-        /// </summary>
-        private MSBuildNameIgnoreCaseComparer _comparer;
-
-        /// <summary>
         /// Creates empty dictionary
         /// </summary>
         public PropertyDictionary()
         {
-            _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            _properties = new RetrievableEntryHashSet<T>(_comparer);
+            _properties = new RetrievableEntryHashSet<T>(MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>
@@ -67,8 +61,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal PropertyDictionary(int capacity)
         {
-            _comparer = MSBuildNameIgnoreCaseComparer.Mutable;
-            _properties = new RetrievableEntryHashSet<T>(capacity, _comparer);
+            _properties = new RetrievableEntryHashSet<T>(capacity, MSBuildNameIgnoreCaseComparer.Default);
         }
 
         /// <summary>
@@ -88,8 +81,7 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal PropertyDictionary(MSBuildNameIgnoreCaseComparer comparer)
         {
-            _comparer = comparer;
-            _properties = new RetrievableEntryHashSet<T>(_comparer);
+            _properties = new RetrievableEntryHashSet<T>(comparer);
         }
 
         /// <summary>
@@ -340,14 +332,7 @@ namespace Microsoft.Build.Collections
         {
             lock (_properties)
             {
-                if (startIndex == 0 && endIndex == name.Length - 1)
-                {
-                    return this[name];
-                }
-
-                T returnValue = _comparer.GetValueWithConstraints<T>(this, name, startIndex, endIndex);
-
-                return returnValue;
+                return _properties.Get(name, startIndex, endIndex - startIndex + 1);
             }
         }
 

--- a/src/Build/Collections/RetrievableEntryHashSet/HashSet.cs
+++ b/src/Build/Collections/RetrievableEntryHashSet/HashSet.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Build.Collections
                 throw new ArgumentOutOfRangeException("index");
 
             if (_constrainedComparer == null)
-                throw new InvalidOperationException("Cannot do a constrained lookup on this colleciton.");
+                throw new InvalidOperationException("Cannot do a constrained lookup on this collection.");
         
             return Get(new KeyedObject(key), index, length);
         }

--- a/src/Build/Collections/RetrievableEntryHashSet/HashSet.cs
+++ b/src/Build/Collections/RetrievableEntryHashSet/HashSet.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Build.Collections
         private int _lastIndex;
         private int _freeList;
         private IEqualityComparer<IKeyed> _comparer;
+        private IConstrainedEqualityComparer<IKeyed> _constrainedComparer;
         private int _version;
         private bool _readOnly;
 
@@ -146,6 +147,7 @@ namespace Microsoft.Build.Collections
             }
 
             _comparer = comparer;
+            _constrainedComparer = comparer as IConstrainedEqualityComparer<IKeyed>;
             _lastIndex = 0;
             _count = 0;
             _freeList = -1;
@@ -348,7 +350,28 @@ namespace Microsoft.Build.Collections
         /// <returns>true if item contained; false if not</returns>
         public T Get(string key)
         {
-            return Get(new KeyedObject(key));
+            return Get(new KeyedObject(key), 0, key?.Length ?? 0);
+        }
+
+        /// <summary>
+        /// Gets the item if any with the given name
+        /// </summary>
+        /// <param name="key">key to check for containment</param>
+        /// <param name="index">The position of the substring within <paramref name="key"/>.</param>
+        /// <param name="length">The maximum number of characters in the <paramref name="key"/> to lookup.</param>
+        /// <returns>true if item contained; false if not</returns>
+        public T Get(string key, int index, int length)
+        {
+            if (length < 0)
+                throw new ArgumentOutOfRangeException("length");
+
+            if (index < 0 || index > (key == null ? 0 : key.Length) - length)
+                throw new ArgumentOutOfRangeException("index");
+
+            if (_constrainedComparer == null)
+                throw new InvalidOperationException("Cannot do a constrained lookup on this colleciton.");
+        
+            return Get(new KeyedObject(key), index, length);
         }
 
         /// <summary>
@@ -358,13 +381,25 @@ namespace Microsoft.Build.Collections
         /// <returns>true if item contained; false if not</returns>
         public T Get(IKeyed item)
         {
+            return Get(item, 0, item?.Key?.Length ?? 0);
+        }
+
+        /// <summary>
+        /// Gets the item if any with the given name
+        /// </summary>
+        /// <param name="item">item to check for containment</param>
+        /// <param name="index">The position of the substring within <paramref name="item"/>.</param>
+        /// <param name="length">The maximum number of characters in the <paramref name="item"/> to lookup.</param>
+        /// <returns>true if item contained; false if not</returns>
+        private T Get(IKeyed item, int index, int length)
+        {
             if (_buckets != null)
             {
-                int hashCode = InternalGetHashCode(item);
+                int hashCode = InternalGetHashCode(item, index, length);
                 // see note at "HashSet" level describing why "- 1" appears in for loop
                 for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = _slots[i].next)
                 {
-                    if (_slots[i].hashCode == hashCode && _comparer.Equals(_slots[i].value, item))
+                    if (_slots[i].hashCode == hashCode && _constrainedComparer != null ? _constrainedComparer.Equals(_slots[i].value, item, index, length) : _comparer.Equals(_slots[i].value, item))
                     {
                         return _slots[i].value;
                     }
@@ -558,6 +593,7 @@ namespace Microsoft.Build.Collections
 
             int capacity = _siInfo.GetInt32(CapacityName);
             _comparer = (IEqualityComparer<IKeyed>)_siInfo.GetValue(ComparerName, typeof(IEqualityComparer<IKeyed>));
+            _constrainedComparer = _comparer as IConstrainedEqualityComparer<IKeyed>;
             _freeList = -1;
 
             if (capacity != 0)
@@ -1708,6 +1744,16 @@ namespace Microsoft.Build.Collections
                                                                                                                                                                 return set1.Comparer.Equals(set2.Comparer);
         }
 #endif
+       
+        private int InternalGetHashCode(IKeyed item, int index, int length)
+        {
+            // No need to check for null 'item' as we own all comparers
+            if (_constrainedComparer != null)
+                return _constrainedComparer.GetHashCode(item, index, length) & Lower31BitMask;
+
+            return InternalGetHashCode(item);
+        }
+
         /// <summary>
         /// Workaround Comparers that throw ArgumentNullException for GetHashCode(null).
         /// </summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -1305,7 +1305,7 @@ namespace Microsoft.Build.Evaluation
 
                 object propertyValue;
 
-                if (property == null && MSBuildNameIgnoreCaseComparer.Equals("MSBuild", propertyName, startIndex, 7))
+                if (property == null && ((endIndex - startIndex) >= 7) && MSBuildNameIgnoreCaseComparer.Default.Equals("MSBuild", propertyName, startIndex, 7))
                 {
                     // It could be one of the MSBuildThisFileXXXX properties,
                     // whose values vary according to the file they are in.
@@ -1330,7 +1330,7 @@ namespace Microsoft.Build.Evaluation
                     if (usedUninitializedProperties.Warn && usedUninitializedProperties.CurrentlyEvaluatingPropertyElementName != null)
                     {
                         // Check to see if the property name does not match the property we are currently evaluating, note the property we are currently evaluating in the element name, this means no $( or )
-                        if (!MSBuildNameIgnoreCaseComparer.Equals(usedUninitializedProperties.CurrentlyEvaluatingPropertyElementName, propertyName, startIndex, endIndex - startIndex + 1))
+                        if (!MSBuildNameIgnoreCaseComparer.Default.Equals(usedUninitializedProperties.CurrentlyEvaluatingPropertyElementName, propertyName, startIndex, endIndex - startIndex + 1))
                         {
                             string propertyTrimed = propertyName.Substring(startIndex, endIndex - startIndex + 1);
                             if (!usedUninitializedProperties.Properties.ContainsKey(propertyTrimed))

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -124,6 +124,9 @@
     <Compile Include="..\Shared\HybridDictionary.cs">
       <Link>Collections\HybridDictionary.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
+      <Link>IConstrainedEqualityComparer.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\NGen.cs">
       <Link>SharedUtilities\NGen.cs</Link>
     </Compile>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -86,6 +86,9 @@
       <Link>FileUtilitiesRegex.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
+      <Link>IConstrainedEqualityComparer.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\QuotingUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Shared/IConstrainedEqualityComparer.cs
+++ b/src/Shared/IConstrainedEqualityComparer.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Collections
+{
+    /// <summary>
+    ///     Defines methods to support the comparison of <see cref="IKeyed"/> objects for
+    ///     equality over constrained inputs.
+    /// </summary>
+    internal interface IConstrainedEqualityComparer<in T> : IEqualityComparer<T> where T : IKeyed 
+    {
+        /// <summary>
+        /// Determines whether the specified objects are equal, factoring in the specified bounds when comparing <paramref name="y"/>.
+        /// </summary>
+        bool Equals(T x, T y, int indexY, int length);
+
+        /// <summary>
+        /// Returns a hash code for the specified object factoring in the specified bounds.
+        /// </summary>
+        int GetHashCode(T obj, int index, int length);
+    }
+}

--- a/src/Shared/MSBuildNameIgnoreCaseComparer.cs
+++ b/src/Shared/MSBuildNameIgnoreCaseComparer.cs
@@ -24,47 +24,12 @@ namespace Microsoft.Build.Collections
 #if FEATURE_BINARY_SERIALIZATION
     [Serializable]
 #endif
-    internal class MSBuildNameIgnoreCaseComparer : EqualityComparer<string>, IEqualityComparer<IKeyed>
+    internal class MSBuildNameIgnoreCaseComparer : IConstrainedEqualityComparer<IKeyed>, IEqualityComparer<string>
     {
-        /// <summary>
-        /// The default immutable comparer instance operating on the whole string that can be used instead of creating once each time
-        /// </summary>
-        private static MSBuildNameIgnoreCaseComparer s_immutableComparer = new MSBuildNameIgnoreCaseComparer(true /* immutable */);
-
         /// <summary>
         /// The processor architecture on which we are running, but default it will be x86
         /// </summary>
         private static NativeMethodsShared.ProcessorArchitectures s_runningProcessorArchitecture = NativeMethodsShared.ProcessorArchitectures.X86;
-
-        /// <summary>
-        /// Object used to lock the internal state s.t. we know that only one person is modifying
-        /// it at any one time.  
-        /// This is necessary to prevent, e.g., someone from reading the comparer (through GetHashCode when setting 
-        /// a property, for example) at the same time that someone else is writing to it. 
-        /// </summary>
-        private Object lockObject = new Object();
-
-        /// <summary>
-        /// String to be constrained. 
-        /// If null, comparer is unconstrained.
-        /// If empty string, comparer is unconstrained and immutable.
-        /// </summary>
-        private string constraintString;
-
-        /// <summary>
-        /// Start of constraint
-        /// </summary>
-        private int startIndex;
-
-        /// <summary>
-        /// End of constraint
-        /// </summary>
-        private int endIndex;
-
-        /// <summary>
-        /// True if the comparer is immutable; false otherwise.
-        /// </summary>
-        private bool immutable;
 
         /// <summary>
         /// We need a static constructor to retrieve the running ProcessorArchitecture that way we can
@@ -76,31 +41,55 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Constructor. If specified, comparer is immutable and operates on the whole string.
-        /// </summary>
-        private MSBuildNameIgnoreCaseComparer(bool immutable)
-        {
-            this.immutable = immutable;
-        }
-
-        /// <summary>
         /// The default immutable comparer instance.
         /// </summary>
-        internal static new MSBuildNameIgnoreCaseComparer Default
+        internal static MSBuildNameIgnoreCaseComparer Default { get; } = new MSBuildNameIgnoreCaseComparer();
+
+        public bool Equals(IKeyed x, IKeyed y)
         {
-            get { return s_immutableComparer; }
+            return Equals(x?.Key, y?.Key);
         }
 
-        /// <summary>
-        /// The default mutable comparer instance.
-        /// </summary>
-        internal static MSBuildNameIgnoreCaseComparer Mutable => new MSBuildNameIgnoreCaseComparer(immutable: false);
+        public bool Equals(IKeyed x, IKeyed y, int indexY, int length)
+        {
+            return Equals(x.Key, y.Key, indexY, length);
+        }
+
+        public bool Equals(string x, string y)
+        {
+            return Equals(x, y, 0, y?.Length ?? 0);
+        }
+
+        public int GetHashCode(IKeyed obj)
+        {
+            return GetHashCode(obj?.Key);
+        }
+
+        public int GetHashCode(IKeyed obj, int index, int length)
+        {
+            return GetHashCode(obj?.Key, index, length);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return GetHashCode(obj, 0, obj?.Length ?? 0);
+        }
 
         /// <summary>
         /// Performs the "Equals" operation on two MSBuild property, item or metadata names
         /// </summary>
-        public static bool Equals(string compareToString, string constrainedString, int start, int lengthToCompare)
+        public bool Equals(string compareToString, string constrainedString, int start, int lengthToCompare)
         {
+            if (lengthToCompare < 0)
+            {
+                ErrorUtilities.ThrowInternalError("Invalid lengthToCompare '{0}' {1} {2}", constrainedString, start, lengthToCompare);
+            }
+
+            if (start < 0 || start > (constrainedString == null ? 0 : constrainedString.Length) - lengthToCompare)
+            {
+                ErrorUtilities.ThrowInternalError("Invalid start '{0}' {1} {2}", constrainedString, start, lengthToCompare);
+            }
+
             if (Object.ReferenceEquals(compareToString, constrainedString))
             {
                 return true;
@@ -154,184 +143,13 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
-        /// Given a set of constraints and a dictionary for which we are the comparer, return the value for the given key. 
-        /// The key is also used as the string for the constraint. 
-        /// </summary>
-        /// <typeparam name="T">The value type of the dictionary being looked up</typeparam>
-        public T GetValueWithConstraints<T>(IDictionary<string, T> dictionary, string key, int startIndex, int endIndex)
-            where T : class
-        {
-            if (immutable)
-            {
-                ErrorUtilities.ThrowInternalError("immutable");
-            }
-
-            ErrorUtilities.VerifyThrowInternalNull(dictionary, "dictionary");
-
-#if DEBUG
-            // doing this rather than checking the strong type because otherwise, I would have to define T to be several other things 
-            // (IKeyed, IValued, IImmutable, IEquatable<T>), some of which are not compiled into Microsoft.Build.Utilities, which also 
-            // uses the MSBuildNameIgnoreCaseComparer. 
-            ErrorUtilities.VerifyThrow(dictionary.GetType().Name.Contains("PropertyDictionary"), "Needs to be PropertyDictionary or CopyOnWritePropertyDictionary");
-#endif
-            if (startIndex < 0)
-            {
-                ErrorUtilities.ThrowInternalError("Invalid start index '{0}' {1} {2}", key, startIndex, endIndex);
-            }
-
-            if (key != null && (endIndex > key.Length || endIndex < startIndex))
-            {
-                ErrorUtilities.ThrowInternalError("Invalid end index '{0}' {1} {2}", key, startIndex, endIndex);
-            }
-
-            T returnValue;
-            lock (lockObject)
-            {
-                constraintString = key;
-                this.startIndex = startIndex;
-                this.endIndex = endIndex;
-
-                try
-                {
-                    returnValue = dictionary[key];
-                }
-                finally
-                {
-                    // Make sure we always reset the constraint
-                    constraintString = null;
-                    this.startIndex = 0;
-                    this.endIndex = 0;
-                }
-            }
-
-            return returnValue;
-        }
-
-        /// <summary>
-        /// Compare keyed operands
-        /// </summary>
-        public bool Equals(IKeyed x, IKeyed y)
-        {
-            if (x == null && y == null)
-            {
-                return true;
-            }
-            else if (x == null || y == null)
-            {
-                return false;
-            }
-
-            return Equals(x.Key, y.Key);
-        }
-
-        /// <summary>
-        /// Performs the "Equals" operation on two MSBuild property, item or metadata names
-        /// </summary>
-        public override bool Equals(string x, string y)
-        {
-            if (x == null && y == null)
-            {
-                return true;
-            }
-            else if (x == null || y == null)
-            {
-                return false;
-            }
-
-            string compareToString;
-            string constrainedString;
-            int start;
-            int lengthToCompare;
-
-            if (immutable)
-            {
-                // by definition we don't have a constraint
-                if (Object.ReferenceEquals(x, y))
-                {
-                    return true;
-                }
-
-                compareToString = x;
-                constrainedString = y;
-                start = 0;
-                lengthToCompare = y.Length;
-            }
-            else
-            {
-                lock (lockObject)
-                {
-                    if (constraintString != null)
-                    {
-                        bool constraintInX = Object.ReferenceEquals(x, constraintString);
-                        bool constraintInY = Object.ReferenceEquals(y, constraintString);
-
-                        if (!constraintInX && !constraintInY)
-                        {
-                            ErrorUtilities.ThrowInternalError("Expected to compare to constraint");
-                        }
-
-                        // Put constrained string in 'y', regular in 'x'
-                        compareToString = constraintInX ? y : x;
-                        constrainedString = constraintInY ? y : x;
-
-                        start = startIndex;
-                        lengthToCompare = endIndex - startIndex + 1;
-                    }
-                    else
-                    {
-                        if (Object.ReferenceEquals(x, y))
-                        {
-                            return true;
-                        }
-
-                        // Manually setup the "constraints" for the comparison
-                        compareToString = x;
-                        constrainedString = y;
-                        start = 0;
-                        lengthToCompare = y.Length;
-                    }
-                }
-            }
-
-            return Equals(compareToString, constrainedString, start, lengthToCompare);
-        }
-
-        /// <summary>
-        /// Get case insensitive hashcode for key
-        /// </summary>
-        public int GetHashCode(IKeyed keyed)
-        {
-            if (keyed == null)
-            {
-                return 0; // per BCL convention
-            }
-
-            return GetHashCode(keyed.Key);
-        }
-
-        /// <summary>
         /// Getting a case insensitive hash code for the msbuild property, item or metadata name
         /// </summary>
-        public override int GetHashCode(string obj)
+        public int GetHashCode(string obj, int start, int length)
         {
             if (obj == null)
             {
                 return 0; // per BCL convention
-            }
-
-            int start = 0;
-            int length = obj.Length;
-
-            if (!immutable)
-            {
-                lock (lockObject)
-                {
-                    if (constraintString != null && Object.ReferenceEquals(obj, constraintString))
-                    {
-                        start = startIndex;
-                        length = endIndex - startIndex + 1;
-                    }
-                }
             }
 
             if ((s_runningProcessorArchitecture != NativeMethodsShared.ProcessorArchitectures.IA64)
@@ -388,52 +206,6 @@ namespace Microsoft.Build.Collections
             else
             {
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Substring(start, length));
-            }
-        }
-
-        /// <summary>
-        /// Set the constraints in the comparer explicitly -- should ONLY be used for unit tests
-        /// </summary>
-        internal void SetConstraintsForUnitTestingOnly(string constraintString, int startIndex, int endIndex)
-        {
-            if (immutable)
-            {
-                ErrorUtilities.ThrowInternalError("immutable");
-            }
-
-            if (startIndex < 0)
-            {
-                ErrorUtilities.ThrowInternalError("Invalid start index '{0}' {1} {2}", constraintString, startIndex, endIndex);
-            }
-
-            if (constraintString != null && (endIndex > constraintString.Length || endIndex < startIndex))
-            {
-                ErrorUtilities.ThrowInternalError("Invalid end index '{0}' {1} {2}", constraintString, startIndex, endIndex);
-            }
-
-            lock (lockObject)
-            {
-                this.constraintString = constraintString;
-                this.startIndex = startIndex;
-                this.endIndex = endIndex;
-            }
-        }
-
-        /// <summary>
-        /// Companion to SetConstraintsForUnitTestingOnly -- makes the comparer unconstrained again. 
-        /// </summary>
-        internal void RemoveConstraintsForUnitTestingOnly()
-        {
-            if (immutable)
-            {
-                ErrorUtilities.ThrowInternalError("immutable");
-            }
-
-            lock (lockObject)
-            {
-                constraintString = null;
-                startIndex = 0;
-                endIndex = 0;
             }
         }
     }

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -111,6 +111,9 @@
     <Compile Include="..\Shared\HybridDictionary.cs">
       <Link>Collections\HybridDictionary.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IConstrainedEqualityComparer.cs">
+      <Link>IConstrainedEqualityComparer.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\InternalErrorException.cs">
       <Link>InternalErrorException.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes: #2434
Partially fixes: #2429

MSBuildNameIgnoreCaseComparer has complicated logic/state for comparing partial strings ("constrained lookups") to avoid allocations when evaluating projects. This required it to have fields remembering the index/length to compare, and lock around said state to avoid multiple threads partying on it at same time. To avoid the contention https://github.com/microsoft/msbuild/commit/cc1e115c138dde4e72585c7b7fa77b83d57847a2#diff-92c6141b604c1dbb4e995702a79391ab introduced a change where we ended up creating unique comparers for every collection, causing [a bunch of allocations](https://github.com/Microsoft/msbuild/issue/2434). This also did not reduce the CPU overhead of [calling Monitor.Enter itself](https://github.com/Microsoft/msbuild/issues/2429). 

This change removes all state from the comparer, and instead makes RetrievableEntryHashSet aware of constrained lookups via a new comparer called "IConstrainedEqualityComparer" - if one is specified as the comparer, then it calls through it, this has the benefit of:

- Removing all allocations of the comparer (there is now only ever 1) - saves ~1% of allocations across a solution-wide design-time build
- Removing locking within Equals/GetHashCode - saves ~0.2% of CPU

This ended up saving approx 300ms (from 10.45 secs -> 10.15 sec) running a single-proc design-time called out in dotnet/project-system#2789.

Notes:

- The IPropertyProvider<T> implementation on CopyOnWritePropertyDictionary was never used. To make this new IConstrainedEqualityComparer work for it was a significant amount of work because it wraps framework collections instead of it own. To avoid making changes around that, I just removed the implementation.
- I stopped deriving from StringComparer which removed support for comparing object instances. It wasn't used.
