### PR TITLE
Remove boxing of enumerator

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Evaluation
                         excludePatterns.AddRange(excludeSplits);
                     }
 
-                    if (excludePatterns.Any())
+                    if (excludePatterns.Count > 0)
                     {
                         excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
                     }


### PR DESCRIPTION
This saves 0.1% of allocations in a solution I'm testing with:

![image](https://user-images.githubusercontent.com/1103906/30860738-86c344a2-a30b-11e7-962c-c2c45171ef19.png)
