### PR TITLE
Fix NullReferenceException in ProjectItemInstance.SetMetadataObject

### DIFF
--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -456,11 +456,24 @@ namespace Microsoft.Build.Collections
         /// </summary>
         internal bool Remove(string name)
         {
+            return Remove(name, clearIfEmpty: false);
+        }
+
+        /// <summary>
+        /// Removes any property with the specified name.
+        /// Returns true if the property was in the collection, otherwise false.
+        /// </summary>
+        internal bool Remove(string name, bool clearIfEmpty)
+        {
             ErrorUtilities.VerifyThrowArgumentLength(name, "name");
 
             lock (_properties)
             {
                 bool result = _properties.Remove(name);
+                if (clearIfEmpty && _properties.Count == 0)
+                {
+                    _properties.Clear();
+                }
                 return result;
             }
         }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1235,7 +1235,6 @@ namespace Microsoft.Build.Execution
 
                 if (_directMetadata != null)
                 {
-                    Debug.Assert(_directMetadata.Count != 0, "We should not waste a dictionary for no metadata");
                     metadatum = _directMetadata[metadataName];
                     if (metadatum != null)
                     {
@@ -1345,8 +1344,7 @@ namespace Microsoft.Build.Execution
                     ProjectInstance.VerifyThrowNotImmutable(destinationAsTaskItem._isImmutable);
 
                     // This optimized path is hit most often
-                    Debug.Assert(_directMetadata == null || _directMetadata.Count != 0, "We should not waste a dictionary for no metadata");
-                    destinationAsTaskItem._directMetadata = (_directMetadata == null) ? null : _directMetadata.DeepClone(); // copy on write!
+                    destinationAsTaskItem._directMetadata = _directMetadata?.DeepClone(); // copy on write!
 
                     // If the destination item already has item definitions then we want to maintain them
                     // But ours will be of less precedence than those already on the item

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1296,16 +1296,8 @@ namespace Microsoft.Build.Execution
             {
                 ProjectInstance.VerifyThrowNotImmutable(_isImmutable);
 
-                if (_directMetadata != null)
-                {
-                    _directMetadata.Remove(metadataName);
-
-                    // If the metadata was all removed, toss the dictionary
-                    if (_directMetadata.Count == 0)
-                    {
-                        _directMetadata = null;
-                    }
-                }
+                // If the metadata was all removed, toss the dictionary
+                _directMetadata?.Remove(metadataName, clearIfEmpty: true);
             }
 
             /// <summary>


### PR DESCRIPTION
Sometimes when `SetMetadataObject` is executing, `RemoveMetadata` can set the backing collection to `null` which causes a `NullReferenceException`.  This change adds an atomic "remove if empty" operation to the `CopyOnWritePropertyDictionary<T>` which will clear the dictionary without resetting the reference to null.

Fixes #2264