### PR TITLE
Normalize include and exclude specs before file walking

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -739,40 +739,55 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             @"src/**/*.cs",
             new[]
             {
-                @"src\a.cs",
-                @"src\a\b\b.cs",
+                @"src/a.cs",
+                @"src/a/b/b.cs",
             },
             new[]
             {
                 @"src/a.cs",
-                @"src/a\b\b.cs",
+                @"src/a/b/b.cs",
             })]
         [InlineData(ItemWithIncludeAndExclude,
             @"src/test/**/*.cs",
             new[]
             {
-                @"src\test\a.cs",
-                @"src\test\a\b\c.cs",
+                @"src/test/a.cs",
+                @"src/test/a/b/c.cs",
             },
             new[]
             {
                 @"src/test/a.cs",
-                @"src/test/a\b\c.cs",
+                @"src/test/a/b/c.cs",
             })]
         [InlineData(ItemWithIncludeAndExclude,
             @"src/test/**/a/b/**/*.cs",
             new[]
             {
-                @"src\test\dir\a\b\a.cs",
-                @"src\test\dir\a\b\c\a.cs",
+                @"src/test/dir/a/b/a.cs",
+                @"src/test/dir/a/b/c/a.cs",
             },
             new[]
             {
-                @"src/test/dir\a\b\a.cs",
-                @"src/test/dir\a\b\c\a.cs",
+                @"src/test/dir/a/b/a.cs",
+                @"src/test/dir/a/b/c/a.cs",
             })]
-        public void IncludeWithWildcardShouldPreserveUserSlashesInFixedDirPart(string projectContents, string includeString, string[] inputFiles, string[] expectedInclude)
+        public void IncludeWithWildcardShouldNotPreserveUserSlashesInFixedDirectoryPart(string projectContents, string includeString, string[] inputFiles, string[] expectedInclude)
         {
+            Func<string, char, string> setSlashes = (s, c) => s.Replace('/', c).Replace('\\', c);
+
+            // set the include string slashes to the opposite orientation relative to the OS default slash
+            if (NativeMethodsShared.IsWindows)
+            {
+                includeString = setSlashes(includeString, '/');
+            }
+            else
+            {
+                includeString = setSlashes(includeString, '\\');
+            }
+
+            // all the slashes in the expected items should be platform specific
+            expectedInclude = expectedInclude.Select(p => setSlashes(p, Path.DirectorySeparatorChar)).ToArray();
+
             TestIncludeExclude(projectContents, inputFiles, expectedInclude, includeString, "");
         }
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1585,7 +1585,11 @@ namespace Microsoft.Build.Shared
             return SearchAction.RunSearch;
         }
 
-        // Replace all slashes to the OS slash, collapse multiple slashes into one, trim trailing slashes
+        /// <summary>
+        /// Replace all slashes to the OS slash, collapse multiple slashes into one, trim trailing slashes
+        /// </summary>
+        /// <param name="aString">A string</param>
+        /// <returns>The normalized string</returns>
         internal static string Normalize(string aString)
         {
             if (string.IsNullOrEmpty(aString))

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1586,43 +1586,99 @@ namespace Microsoft.Build.Shared
         }
 
         // Replace all slashes to the OS slash, collapse multiple slashes into one, trim trailing slashes
-        private static string Normalize(string aString)
+        internal static string Normalize(string aString)
         {
             if (string.IsNullOrEmpty(aString))
             {
                 return aString;
             }
 
-            var header = string.Empty;
+            var sb = new StringBuilder(aString.Length);
+            var index = 0;
 
-            // preserver meaningful root slashes
-            if (aString.StartsWith(@"\\"))
+            // preserve meaningful roots and their slashes
+            if (aString.Length >= 2 && IsValidDriveChar(aString[0]) && aString[1] == ':')
             {
-                header = @"\\";
+                sb.Append(aString[0]);
+                sb.Append(aString[1]);
+
+                var i = SkipCharacters(aString, 2, c => IsSlash(c));
+
+                if (index != i)
+                {
+                    sb.Append('\\');
+                }
+
+                index = i;
             }
-            else if (aString.StartsWith("/"))
+            else if (aString.StartsWith("/", StringComparison.Ordinal))
             {
-                header = "/";
+                sb.Append('/');
+                index = SkipCharacters(aString, 1, c => IsSlash(c));
             }
-            else if (aString.StartsWith(@"\"))
+            else if (aString.StartsWith(@"\\", StringComparison.Ordinal))
             {
-                header = @"\";
+                sb.Append(@"\\");
+                index = SkipCharacters(aString, 2, c => IsSlash(c));
+            }
+            else if (aString.StartsWith(@"\", StringComparison.Ordinal))
+            {
+                sb.Append(@"\");
+                index = SkipCharacters(aString, 1, c => IsSlash(c));
             }
 
-            var splits = aString.Split(directorySeparatorCharacters, StringSplitOptions.RemoveEmptyEntries);
-
-            if (splits.Length == 0)
+            while (index < aString.Length)
             {
-                splits = new string[0];
+                var afterSlashesIndex = SkipCharacters(aString, index, c => IsSlash(c));
+
+                // do not append separator at the end of the string
+                if (afterSlashesIndex >= aString.Length)
+                {
+                    break;
+                }
+                // replace multiple slashes with the OS separator
+                else if (afterSlashesIndex > index)
+                {
+                    sb.Append(s_directorySeparator);
+                }
+
+                var afterNonSlashIndex = SkipCharacters(aString, afterSlashesIndex, c => !IsSlash(c));
+
+                sb.Append(aString, afterSlashesIndex, afterNonSlashIndex - afterSlashesIndex);
+
+                index = afterNonSlashIndex;
             }
 
-            // do not loose the slash when the only split element is a drive letter
-            if (splits.Length == 1 && splits[0].Length == 2 && splits[0][1] == ':')
+            return sb.ToString();
+        }
+
+        private static bool IsSlash(char c) => c == '/' || c == '\\';
+
+        /// <summary>
+        /// Skips characters that satisfy the condition <param name="jumpOverCharacter"></param>
+        /// </summary>
+        /// <param name="aString">The working string</param>
+        /// <param name="startingIndex">Offset in string to start the search in</param>
+        /// <returns>First index that does not satisfy the condition. Returns the string's length if end of string is reached</returns>
+        private static int SkipCharacters(string aString, int startingIndex, Func<char, bool> jumpOverCharacter)
+        {
+            var index = startingIndex;
+
+            while (index < aString.Length && jumpOverCharacter(aString[index]))
             {
-                splits[0] = splits[0] + s_directorySeparator;
+                index++;
             }
 
-            return header + splits.DefaultIfEmpty().Aggregate((a, b) => $"{a}{s_directorySeparator}{b}");
+            return index;
+        }
+
+        // copied from https://github.com/dotnet/corefx/blob/master/src/Common/src/System/IO/PathInternal.Windows.cs#L77-L83
+        /// <summary>
+        /// Returns true if the given character is a valid drive letter
+        /// </summary>
+        internal static bool IsValidDriveChar(char value)
+        {
+            return ((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z'));
         }
 
         static string[] CreateArrayWithSingleItemIfNotExcluded(string filespecUnescaped, IEnumerable<string> excludeSpecsUnescaped)

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1040,12 +1040,24 @@ namespace Microsoft.Build.Shared
             return s.Replace('\\', '/');
         }
 
+        /// <summary>
+        /// Ensure all slashes are the current platform's slash
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        internal static string ToPlatformSlash(this string s)
+        {
+            var separator = Path.DirectorySeparatorChar;
+
+            return s.Replace(separator == '/' ? '\\' : '/', separator);
+        }
+
         internal static string WithTrailingSlash(this string s)
         {
             return EnsureTrailingSlash(s);
         }
 
-        internal static string NormalizeForPathComparison(this string s) => s.ToSlash().TrimTrailingSlashes();
+        internal static string NormalizeForPathComparison(this string s) => s.ToPlatformSlash().TrimTrailingSlashes();
 
         // TODO: assumption on file system case sensitivity: https://github.com/Microsoft/msbuild/issues/781
         internal static bool PathsEqual(string path1, string path2)

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -72,6 +73,130 @@ namespace Microsoft.Build.UnitTests
                 Assert.True(false, "Unexpected input into GetFileSystemEntries");
             }
             return new string[] { "<undefined>" };
+        }
+
+        private static readonly char S = Path.DirectorySeparatorChar;
+
+        public static IEnumerable<object[]> NormalizeTestData()
+        {
+            yield return new object[]
+            {
+                null,
+                null
+            };
+            yield return new object[]
+            {
+                "",
+                ""
+            };
+            yield return new object[]
+            {
+                " ",
+                " "
+            };
+
+            yield return new object[]
+            {
+                @"\\",
+                @"\\"
+            };
+            yield return new object[]
+            {
+                @"\\/\//",
+                @"\\"
+            };
+            yield return new object[]
+            {
+                @"\\a/\b/\",
+                $@"\\a{S}b"
+            };
+
+            yield return new object[]
+            {
+                @"\",
+                @"\"
+            };
+            yield return new object[]
+            {
+                @"\/\/\/",
+                @"\"
+            };
+            yield return new object[]
+            {
+                @"\a/\b/\",
+                $@"\a{S}b"
+            };
+
+            yield return new object[]
+            {
+                "/",
+                "/"
+            };
+            yield return new object[]
+            {
+                @"/\/\",
+                "/"
+            };
+            yield return new object[]
+            {
+                @"/a\/b/\\",
+                $@"/a{S}b"
+            };
+
+            yield return new object[]
+            {
+                @"c:\",
+                @"c:\"
+            };
+            yield return new object[]
+            {
+                @"c:/",
+                @"c:\"
+            };
+            yield return new object[]
+            {
+                @"c:/\/\/",
+                @"c:\"
+            };
+            yield return new object[]
+            {
+                @"c:/ab",
+                @"c:\ab"
+            };
+            yield return new object[]
+            {
+                @"c:\/\a//b",
+                $@"c:\a{S}b"
+            };
+            yield return new object[]
+            {
+                @"c:\/\a//b\/",
+                $@"c:\a{S}b"
+            };
+
+            yield return new object[]
+            {
+                @"..\/a\../.\b\/",
+                $@"..{S}a{S}..{S}.{S}b"
+            };
+            yield return new object[]
+            {
+                @"**/\foo\/**\/",
+                $@"**{S}foo{S}**"
+            };
+
+            yield return new object[]
+            {
+                "AbCd",
+                "AbCd"
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(NormalizeTestData))]
+        public void NormalizeTest(string inputString, string expectedString)
+        {
+            FileMatcher.Normalize(inputString).ShouldBe(expectedString);
         }
 
         /// <summary>


### PR DESCRIPTION
Avoids expensive string normalization on each discovered directory.

Improves performance (and probably memory) by not calling path aware comparisons and string normalizations during the recursive file walk. Instead, the user specs are normalized before the walk begins.

Also closes #1874 

Results based on building NHibernate.Test.csproj referenced in https://github.com/Microsoft/msbuild/issues/2392#issuecomment-330029024

![image](https://user-images.githubusercontent.com/2255729/30891096-d53ce618-a2e5-11e7-9d07-1cf7a0b61b7a.png)


