### PR TITLE
Include Sdk Resolver in bootstrapped MSBuild

### DIFF
--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -31,6 +31,7 @@
     <ItemGroup>
       <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.targets" />
       <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.props" />
+      <SdkResolverFiles Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\SdkResolvers\**\*.*" />
       <InstalledSdks Include="$(MSBuildExtensionsPath)\Sdks\**\*.*" />
       <InstalledStaticAnalysisTools Include="$(VsInstallRoot)\Team Tools\Static Analysis Tools\**\*.*" />
 
@@ -59,6 +60,8 @@
     <!-- Copy in props and targets from the machine-installed MSBuildExtensionsPath -->
     <Copy SourceFiles="@(InstalledVersionedExtensions)"
           DestinationFiles="@(InstalledVersionedExtensions->'$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(SdkResolverFiles)"
+          DestinationFiles="@(SdkResolverFiles->'$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(InstalledMicrosoftExtensions)"
           DestinationFiles="@(InstalledMicrosoftExtensions->'$(BootstrapDestination)Microsoft\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(InstalledSdks)"


### PR DESCRIPTION
- Include Sdk Resolver in bootstrapped MSBuild.  This should mean the bootstrapped MSBuild can successfully build SDK-Style projects that use the 2.0 SDK or higher
- Add binary logging to build scripts

@AndyGerlicher @cdmihai @jeffkl for review