### PR TITLE
Include .NET Framework facades if there is a reference to netstandard.dll

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -840,6 +840,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
+        public string DependsOnNETStandard { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public string DependsOnSystemRuntime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public bool DoNotCopyLocalIfInGac { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -489,6 +489,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] CopyLocalFiles { get { throw null; } }
         [Microsoft.Build.Framework.OutputAttribute]
+        public string DependsOnNETStandard { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        [Microsoft.Build.Framework.OutputAttribute]
         public string DependsOnSystemRuntime { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public bool DoNotCopyLocalIfInGac { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -280,12 +280,14 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
 
             Assert.True(string.Equals(t.DependsOnSystemRuntime, "false", StringComparison.OrdinalIgnoreCase)); //                 "Expected no System.Runtime dependency found during build."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "false", StringComparison.OrdinalIgnoreCase)); //                   "Expected no netstandard dependency found during build."
 
             // intelli build mode
             t.FindDependencies = false;
             Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
 
             Assert.True(string.Equals(t.DependsOnSystemRuntime, "false", StringComparison.OrdinalIgnoreCase)); //                 "Expected no System.Runtime dependency found during intellibuild."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "false", StringComparison.OrdinalIgnoreCase)); //                   "Expected no netstandard dependency found during intellibuild."
         }
 
 
@@ -350,6 +352,66 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
 
             Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during intellibuild."
+        }
+
+        [Fact]
+        public void NETStandardDepends_Yes()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("netstandard"),
+            };
+
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandard.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during intellibuild."
+        }
+
+        [Fact]
+        public void NETStandardDepends_Yes_Indirect()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("netstandardlibrary"),
+            };
+
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandardlibrary.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during intellibuild."
         }
 
         #region HelperDelegates

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -414,6 +414,40 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during intellibuild."
         }
 
+        [Fact]
+        public void DependsOn_NETStandard_and_SystemRuntime()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("netstandardlibrary"),
+                new TaskItem("Portable"),
+            };
+
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandardlibrary.dll");
+            t.Assemblies[1].SetMetadata("HintPath", @"C:\SystemRuntime\Portable.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during build."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                   "Expected netstandard dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during intellibuild."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                   "Expected netstandard dependency found during intellibuild."
+        }
+
         #region HelperDelegates
 
         private static string MockGetRuntimeVersion(string path)

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -560,6 +560,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             @"C:\DirectoryContainstwoWinmd\c.winmd",
             @"C:\SystemRuntime\System.Runtime.dll",
             @"C:\SystemRuntime\Portable.dll",
+            @"C:\NetStandard\netstandardlibrary.dll",
+            @"C:\NetStandard\netstandard.dll",
             @"C:\SystemRuntime\Regular.dll",
         };
 
@@ -2401,13 +2403,21 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             if (String.Compare(path, @"C:\SystemRuntime\Portable.dll", StringComparison.OrdinalIgnoreCase) == 0)
             {
-                // Simulate a strongly named assembly.
+                // Simulate a portable assembly with a reference to System.Runtime
                 return new AssemblyNameExtension[]
                 {
                     GetAssemblyName(@"C:\SystemRuntime\System.Runtime.dll")
                 };
             }
 
+            if (String.Compare(path, @"C:\NetStandard\netstandardlibrary.dll", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                // Simulate a .NET Standard assembly
+                return new AssemblyNameExtension[]
+                {
+                    GetAssemblyName(@"C:\NetStandard\netstandard.dll")
+                };
+            }
 
             // Use a default list.
             return new AssemblyNameExtension[]

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2040,7 +2040,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="SuggestedRedirects" ItemName="SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="DependsOnSystemRuntime" PropertyName="DependsOnSystemRuntime"/>
-      <Output TaskParameter="DependsOnNETStandard" PropertyName="DependsOnNETStandard"/>
+      <Output TaskParameter="DependsOnNETStandard" PropertyName="_DependsOnNETStandard"/>
     </ResolveAssemblyReference>
   </Target>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2040,6 +2040,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="SuggestedRedirects" ItemName="SuggestedBindingRedirects"/>
       <Output TaskParameter="FilesWritten" ItemName="FileWrites"/>
       <Output TaskParameter="DependsOnSystemRuntime" PropertyName="DependsOnSystemRuntime"/>
+      <Output TaskParameter="DependsOnNETStandard" PropertyName="DependsOnNETStandard"/>
     </ResolveAssemblyReference>
   </Target>
 

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -93,14 +93,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
       <_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true'">true</_HasReferenceToSystemRuntime>
-      <_HasReferenceToSystemRuntime Condition="'$(DependsOnNETStandard)' == 'true'">true</_HasReferenceToSystemRuntime>
+
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &lt; '2.0'">true</_HasReferenceToSystemRuntime>
+
+      <_HasReferenceToNETStandard Condition="'$(DependsOnNETStandard)' == 'true'">true</_HasReferenceToNETStandard>
+      <_HasReferenceToNETStandard Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &gt;= '2.0'">true</_HasReferenceToNETStandard>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true'">
       <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
-
+    </ItemGroup>
+    <ItemGroup Condition="'$(_HasReferenceToNETStandard)' == 'true' And '$(_HasReferenceToSystemRuntime)' != 'true'">
+      <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)netstandard.dll"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' Or '$(_HasReferenceToNETStandard)' == 'true' ">
       <_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">
           <OriginalIdentity>%(_DesignTimeFacadeAssemblies.Identity)</OriginalIdentity>
       </_DesignTimeFacadeAssemblies_Names>

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -97,7 +97,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &lt; '2.0'">true</_HasReferenceToSystemRuntime>
 
-      <_HasReferenceToNETStandard Condition="'$(DependsOnNETStandard)' == 'true'">true</_HasReferenceToNETStandard>
+      <_HasReferenceToNETStandard Condition="'$(_DependsOnNETStandard)' == 'true'">true</_HasReferenceToNETStandard>
       <_HasReferenceToNETStandard Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &gt;= '2.0'">true</_HasReferenceToNETStandard>
     </PropertyGroup>
 

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -93,6 +93,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PropertyGroup>
       <!-- Does one of our dependencies reference a System.Runtime-based portable library? -->
       <_HasReferenceToSystemRuntime Condition="'$(DependsOnSystemRuntime)' == 'true'">true</_HasReferenceToSystemRuntime>
+      <_HasReferenceToSystemRuntime Condition="'$(DependsOnNETStandard)' == 'true'">true</_HasReferenceToSystemRuntime>
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetPlatformIdentifier)' == 'Portable'">true</_HasReferenceToSystemRuntime>
       <_HasReferenceToSystemRuntime Condition="'%(_ResolvedProjectReferencePaths.TargetFrameworkIdentifier)' == '.NETStandard' and '%(_ResolvedProjectReferencePaths.TargetFrameworkVersion)' &lt; '2.0'">true</_HasReferenceToSystemRuntime>
     </PropertyGroup>

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -105,7 +105,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)*.dll"/>
     </ItemGroup>
     <ItemGroup Condition="'$(_HasReferenceToNETStandard)' == 'true' And '$(_HasReferenceToSystemRuntime)' != 'true'">
-      <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)netstandard.dll"/>
+      <_DesignTimeFacadeAssemblies Include="%(DesignTimeFacadeDirectories.Identity)netstandard.dll"
+                                   Condition="Exists('%(DesignTimeFacadeDirectories.Identity)netstandard.dll')"/>
     </ItemGroup>
     <ItemGroup Condition="'$(_HasReferenceToSystemRuntime)' == 'true' Or '$(_HasReferenceToNETStandard)' == 'true' ">
       <_DesignTimeFacadeAssemblies_Names Include="@(_DesignTimeFacadeAssemblies->'%(FileName)')">


### PR DESCRIPTION
Fixes #2199.  This is needed for .NET 4.7.1 to support references to .NET Standard 2.0 libraries.

@AndyGerlicher @cdmihai @jeffkl @nguerrera @ericstj for review