### PR TITLE
Optimizations for FileMatcher.GetFiles 

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -15,6 +15,7 @@
     <tags>MSBuild</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.3">
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Tasks.Core.nuspec
@@ -56,6 +56,7 @@
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
         <dependency id="System.Xml.XDocument" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Utilities.Core.nuspec
@@ -21,6 +21,7 @@
         <dependency id="System.AppContext" version="4.1.0" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />
+        <dependency id="System.Collections.Immutable" version="1.2.0" />
         <dependency id="System.Collections.NonGeneric" version="4.0.1" />
         <dependency id="System.Console" version="4.0.0" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
@@ -47,6 +48,7 @@
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
         <dependency id="System.Threading.Timer" version="4.0.1" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />
@@ -54,6 +56,7 @@
       </group>
       <group targetFramework=".NETFramework4.6">
         <dependency id="Microsoft.Build.Framework" version="[$version$]" />
+        <dependency id="System.Collections.Immutable" version="1.3.1" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
       </group>
     </dependencies>

--- a/build/NuGetPackages/Microsoft.Build.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.nuspec
@@ -56,6 +56,7 @@
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
         <dependency id="System.Threading.Tasks.Dataflow" version="4.6.0" />
+        <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
         <dependency id="System.Threading.ThreadPool" version="4.0.10" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -249,6 +249,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />

--- a/src/Build.UnitTests/project.json
+++ b/src/Build.UnitTests/project.json
@@ -10,6 +10,7 @@
   "frameworks": {
     "net46": {
       "Microsoft.Net.Compilers": "2.3.1",
+      "System.Collections.Immutable": "1.3.1",
       "System.Threading.Tasks.Dataflow": "4.5.24.0"
     },
     "netstandard1.3": {
@@ -17,6 +18,7 @@
         "System.Net.NetworkInformation": "4.1.0",
         "Microsoft.NETCore": "5.0.1",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
         "System.Diagnostics.Contracts": "4.0.1",

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Build.Evaluation
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
                             _rootDirectory,
                             glob,
-                            excludePatternsForGlobs
+                            excludePatternsForGlobs,
+                            entriesCache: EntriesCache
                             );
 
                         // itemsToAdd might grow 0 or more times during the following iteration. Proactively increase its capacity to ensure only one growth happens

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -43,6 +44,11 @@ namespace Microsoft.Build.Evaluation
 
                 _itemSpec.Expander = _expander;
             }
+
+            /// <summary>
+            /// Cache used for caching IO operation results
+            /// </summary>
+            protected ConcurrentDictionary<string, ImmutableArray<string>> EntriesCache => _lazyEvaluator._entriesCache;
 
             public virtual void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Debugging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -44,6 +45,11 @@ namespace Microsoft.Build.Evaluation
         private Dictionary<string, LazyItemList> _itemLists = Traits.Instance.EscapeHatches.UseCaseSensitiveItemNames ?
             new Dictionary<string, LazyItemList>() :
             new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Cache used for caching IO operation results
+        /// </summary>
+        private readonly ConcurrentDictionary<string, ImmutableArray<string>> _entriesCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
 
         public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext)
         {

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -32,6 +32,7 @@
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Text.Encoding.CodePages" : "4.0.1",
         "System.Threading.Tasks.Dataflow": "4.6.0.0",
+        "System.Threading.Tasks.Parallel": "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Threading.ThreadPool": "4.0.10",
         "System.Xml.XmlDocument": "4.0.1",

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -8,6 +8,7 @@
         "SourceLink.Create.CommandLine": "2.1.2",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "System.Text.Encoding.CodePages" : "4.0.1",
+        "System.Threading.Tasks.Parallel": "4.0.1",
         "System.Threading.Thread": "4.0.0"
       }
     }

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -6,9 +6,14 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Security;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -19,13 +24,398 @@ namespace Microsoft.Build.UnitTests
 {
     public class FileMatcherTest
     {
+        [Fact]
+        public void GetFilesPatternMatching()
+        {
+            var workingPath = Path.Combine(Path.GetTempPath(), "Test");
+            var files = new string[]
+            {
+                "Foo.cs",
+                "Foo2.cs",
+                "file.txt",
+                "file1.txt",
+                "file1.txtother",
+                "fie1.txt",
+                "fire1.txt"
+            };
+
+            try
+            {
+                Directory.CreateDirectory(workingPath);
+                foreach (var file in files)
+                {
+                    File.WriteAllBytes(Path.Combine(workingPath, file), new byte[5000]);
+                }
+
+                var patterns = new Dictionary<string, int>
+                {
+                    {"*.txt", 4},
+                    { "???.cs", 1},
+                    { "????.cs", 1},
+                    {"file?.txt", 1},
+                    {"fi?e?.txt", 2},
+                    { "???.*", 1},
+                    { "????.*", 3},
+                    { "*.???", 4},
+                    { "f??e1.txt", 2}
+                };
+                foreach (var pattern in patterns)
+                {
+                    try
+                    {
+                        Assert.Equal(pattern.Value, FileMatcher.GetFiles(workingPath, pattern.Key).Length);
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine($"Pattern {pattern} failed");
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPath, true);
+            }
+        }
+
+        [Theory]
+        [InlineData(
+            @"src\**\inner\**\*.cs", // Include
+            new string[] { }, // Excludes
+            new[] // Expected matchings
+            {
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\foo\foo.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\baz\baz.cs",
+                @"src\bar\inner\foo\foo.cs"
+            }
+        )]
+        [InlineData(
+            @"src\**\inner\**\*.cs", // Include
+            new[] // Excludes
+            {
+                @"**\foo\**"
+            },
+            new[] // Expected matchings
+            {
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\baz\baz.cs"
+            }
+        )]
+        [InlineData(
+            @"src\**\inner\**\*.cs", // Include
+            new[] // Excludes
+            {
+                @"src\bar\inner\baz\**"
+            },
+            new[] // Expected matchings
+            {
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\foo\foo.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\foo\foo.cs"
+            }
+        )]
+        [InlineData(
+            @"src\foo\**\*.cs", // Include
+            new[] // Excludes
+            {
+                @"src\foo\**\foo\**"
+            },
+            new[] // Expected matchings
+            {
+                @"src\foo\foo.cs",
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\bar\bar.cs"
+            }
+        )]
+        [InlineData(
+            @"src\foo\inner\**\*.cs", // Include
+            new[] // Excludes
+            {
+                @"src\foo\**\???\**"
+            },
+            new[] // Expected matchings
+            {
+                @"src\foo\inner\foo.cs"
+            }
+        )]
+        [InlineData(
+            @"**\???\**\*.cs", // Include
+            new string[] { }, // Excludes
+            new[] // Expected matchings
+            {
+                @"src\foo.cs",
+                @"src\bar.cs",
+                @"src\baz.cs",
+                @"src\foo\foo.cs",
+                @"src\bar\bar.cs",
+                @"src\baz\baz.cs",
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\foo\foo.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\baz\baz.cs",
+                @"src\bar\inner\foo\foo.cs",
+                @"build\baz\foo.cs"
+            }
+        )]
+        [InlineData(
+            @"**\*.*", // Include
+            new[] // Excludes
+            {
+                @"**\???\**\*.cs"
+            },
+            new[] // Expected matchings
+            {
+                @"readme.txt",
+                @"licence.md"
+            }
+        )]
+        [InlineData(
+            @"**\?a?\**\?a?\*.c?", // Include
+            new string[] { }, // Excludes
+            new[] // Expected matchings
+            {
+                @"src\bar\inner\baz\baz.cs"
+            }
+        )]
+        [InlineData(
+            @"**\?a?\**\?a?.c?", // Include
+            new[] // Excludes
+            {
+                @"**\?a?\**\?a?\*.c?"
+            },
+            new[] // Expected matchings
+            {
+                @"src\bar\bar.cs",
+                @"src\baz\baz.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs"
+            }
+        )]
+        public void GetFilesComplexGlobbingMatching(string includePattern, string[] excludePatterns, string[] expectedMatchings)
+        {
+            var workingPath = Path.Combine(Path.GetTempPath(), "Globbing");
+            var files = new []
+            {
+                @"src\foo.cs",
+                @"src\bar.cs",
+                @"src\baz.cs",
+                @"src\foo\foo.cs",
+                @"src\bar\bar.cs",
+                @"src\baz\baz.cs",
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\foo\foo.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\baz\baz.cs",
+                @"src\bar\inner\foo\foo.cs",
+                @"build\baz\foo.cs",
+                @"readme.txt",
+                @"licence.md"
+            };
+            Action<string, string[], bool> match = (include, excludes, hasNoMatches) =>
+            {
+                string[] matchedFiles = null;
+                try
+                {
+                    matchedFiles = FileMatcher.GetFiles(workingPath, include, excludes);
+                    if (hasNoMatches)
+                    {
+                        Assert.Equal(0, matchedFiles.Length);
+                        return;
+                    }
+                    // We have to lower file paths as the result could be in uppercase e.g. "SRC\foo.cs"
+                    var normMatchedFiles = matchedFiles
+                        .Select(o => o.Replace(Path.DirectorySeparatorChar, '\\').ToLowerInvariant()).ToArray();
+                    foreach (var matchedFile in normMatchedFiles)
+                    {
+                        Assert.Contains(matchedFile, expectedMatchings);
+                    }
+                    Assert.Equal(expectedMatchings.Length, matchedFiles.Length);
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine($"Globbing failed for include {include} with excludes {string.Join(",", excludes)}, " +
+                                      $"should have no matches: {hasNoMatches}, " +
+                                      $"returned files: {(matchedFiles != null ? string.Join(",", matchedFiles) : null)}");
+                    throw;
+                }
+            };
+
+            try
+            {
+                // Create directories and files
+                foreach (var file in files)
+                {
+                    var normFile = file.Replace('\\', Path.DirectorySeparatorChar);
+                    var dirPath = Path.Combine(workingPath, Path.GetDirectoryName(normFile));
+
+                    Directory.CreateDirectory(dirPath);
+                    File.WriteAllBytes(Path.Combine(dirPath, Path.GetFileName(normFile)), new byte[5000]);
+                }
+
+                // Normal matching
+                match(includePattern, excludePatterns, false);
+                // Include forward slash
+                match(includePattern.Replace('\\', '/'), excludePatterns, false);
+                // Excludes forward slash
+                match(includePattern, excludePatterns.Select(o => o.Replace('\\', '/')).ToArray(), false);
+
+                // Backward compatibilities:
+                // 1. When an include or exclude starts with a fixed directory part e.g. "src/foo/**",
+                //    then matching should be case-sensitive on Linux, as the directory was checked for its existance
+                //    by using Directory.Exists, which is case-sensitive on Linux (on OSX is not).
+                // 2. On Unix, when an include uses a simple ** wildcard e.g. "**\*.cs", the file pattern e.g. "*.cs",
+                //    should be matched case-sensitive, as files were retrieved by using the searchPattern parameter
+                //    of Directory.GetFiles, which is case-sensitive on Unix.
+                var shouldHaveNoMatches = false;
+
+                // Do not test uppercase excludes on Linux, as it is not simple to figure out which files shall
+                // be excluded
+                if (!NativeMethodsShared.IsLinux)
+                {
+                    // Excludes uppercase
+                    match(includePattern, excludePatterns.Select(o => o.ToUpperInvariant()).ToArray(), false);
+                }
+                else
+                {
+                    // On Linux, we will have no matches for an uppercase include, when it starts with a fixed directory part
+                    // e.g. "SRC/FOO"
+                    shouldHaveNoMatches = !includePattern.StartsWith("**");
+                }
+                if (NativeMethodsShared.IsUnixLike)
+                {
+                    // On Unix, we will have no matches for an uppercase include, that has a simple ** wildcard and a file pattern
+                    // e.g. "**\*.CS"
+                    string fixedDirectoryPart;
+                    string wildcardDirectoryPart;
+                    string filenamePart;
+                    string matchFileExpression;
+                    bool needsRecursion;
+                    bool isLegalFileSpec;
+                    FileMatcher.GetFileSpecInfo(includePattern,
+                        out fixedDirectoryPart,
+                        out wildcardDirectoryPart,
+                        out filenamePart,
+                        out matchFileExpression,
+                        out needsRecursion,
+                        out isLegalFileSpec,
+                        FileMatcher.s_defaultGetFileSystemEntries);
+                    bool matchWithRegex =
+                        // if we have a directory specification that uses wildcards, and
+                        (wildcardDirectoryPart.Length > 0) &&
+                        // the specification is not a simple "**"
+                        (wildcardDirectoryPart != ("**" + new string(Path.DirectorySeparatorChar, 1)));
+                    shouldHaveNoMatches |= !matchWithRegex && filenamePart.Any(char.IsLetter);
+                }
+
+                // Include uppercase
+                match(includePattern.ToUpperInvariant(), excludePatterns, shouldHaveNoMatches);
+            }
+            finally
+            {
+                FileUtilities.DeleteWithoutTrailingBackslash(workingPath, true);
+            }
+        }
+
+        [Fact]
+        public void WildcardMatching()
+        {
+            var inputs = new List<Tuple<string, string, bool>>
+            {
+                // No wildcards
+                new Tuple<string, string, bool>("a", "a", true),
+                new Tuple<string, string, bool>("a", "", false),
+                new Tuple<string, string, bool>("", "a", false),
+
+                // Non ASCII characters
+                new Tuple<string, string, bool>("šđčćž", "šđčćž", true),
+
+                // * wildcard
+                new Tuple<string, string, bool>("abc", "*bc", true),
+                new Tuple<string, string, bool>("abc", "a*c", true),
+                new Tuple<string, string, bool>("abc", "ab*", true),
+                new Tuple<string, string, bool>("ab", "*ab", true),
+                new Tuple<string, string, bool>("ab", "a*b", true),
+                new Tuple<string, string, bool>("ab", "ab*", true),
+                new Tuple<string, string, bool>("", "*", true),
+
+                // ? wildcard
+                new Tuple<string, string, bool>("abc", "?bc", true),
+                new Tuple<string, string, bool>("abc", "a?c", true),
+                new Tuple<string, string, bool>("abc", "ab?", true),
+                new Tuple<string, string, bool>("ab", "?ab", false),
+                new Tuple<string, string, bool>("ab", "a?b", false),
+                new Tuple<string, string, bool>("ab", "ab?", false),
+                new Tuple<string, string, bool>("", "?", false),
+
+                // Mixed wildcards
+                new Tuple<string, string, bool>("a", "*?", true),
+                new Tuple<string, string, bool>("a", "?*", true),
+                new Tuple<string, string, bool>("ab", "*?", true),
+                new Tuple<string, string, bool>("ab", "?*", true),
+                new Tuple<string, string, bool>("abc", "*?", true),
+                new Tuple<string, string, bool>("abc", "?*", true),
+
+                // Multiple mixed wildcards
+                new Tuple<string, string, bool>("a", "??", false),
+                new Tuple<string, string, bool>("ab", "?*?", true),
+                new Tuple<string, string, bool>("ab", "*?*?*", true),
+                new Tuple<string, string, bool>("abc", "?**?*?", true),
+                new Tuple<string, string, bool>("abc", "?**?*c?", false),
+                new Tuple<string, string, bool>("abcd", "?b*??", true),
+                new Tuple<string, string, bool>("abcd", "?a*??", false),
+                new Tuple<string, string, bool>("abcd", "?**?c?", true),
+                new Tuple<string, string, bool>("abcd", "?**?d?", false),
+                new Tuple<string, string, bool>("abcde", "?*b*?*d*?", true),
+
+                // ? wildcard in the input string
+                new Tuple<string, string, bool>("?", "?", true),
+                new Tuple<string, string, bool>("?a", "?a", true),
+                new Tuple<string, string, bool>("a?", "a?", true),
+                new Tuple<string, string, bool>("a?b", "a?", false),
+                new Tuple<string, string, bool>("a?ab", "a?aab", false),
+                new Tuple<string, string, bool>("aa?bbbc?d", "aa?bbc?dd", false),
+
+                // * wildcard in the input string
+                new Tuple<string, string, bool>("*", "*", true),
+                new Tuple<string, string, bool>("*a", "*a", true),
+                new Tuple<string, string, bool>("a*", "a*", true),
+                new Tuple<string, string, bool>("a*b", "a*", true),
+                new Tuple<string, string, bool>("a*ab", "a*aab", false),
+                new Tuple<string, string, bool>("a*abab", "a*b", true),
+                new Tuple<string, string, bool>("aa*bbbc*d", "aa*bbc*dd", false),
+                new Tuple<string, string, bool>("aa*bbbc*d", "a*bbc*d", true)
+            };
+            foreach (var input in inputs)
+            {
+                try
+                {
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2, false));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2, true));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1.ToUpperInvariant(), input.Item2, true));
+                    Assert.Equal(input.Item3, FileMatcher.IsMatch(input.Item1, input.Item2.ToUpperInvariant(), true));
+                }
+                catch (Exception)
+                {
+                    Console.WriteLine($"Input {input.Item1} with pattern {input.Item2} failed");
+                    throw;
+                }
+            }
+        }
+
         /*
          * Method:  GetFileSystemEntries
          *
          * Simulate Directories.GetFileSystemEntries where file names are short.
          *
          */
-        private static string[] GetFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static ImmutableArray<string> GetFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
             if
             (
@@ -33,7 +423,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\" == path || @"\\server\share\" == path || path.Length == 0)
             )
             {
-                return new string[] { Path.Combine(path, "LongDirectoryName") };
+                return ImmutableArray.Create(Path.Combine(path, "LongDirectoryName"));
             }
             else if
             (
@@ -41,7 +431,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\LongDirectoryName" == path || @"\\server\share\LongDirectoryName" == path || @"LongDirectoryName" == path)
             )
             {
-                return new string[] { Path.Combine(path, "LongSubDirectory") };
+                return ImmutableArray.Create(Path.Combine(path, "LongSubDirectory"));
             }
             else if
             (
@@ -49,7 +439,7 @@ namespace Microsoft.Build.UnitTests
                 && (@"D:\LongDirectoryName\LongSubDirectory" == path || @"\\server\share\LongDirectoryName\LongSubDirectory" == path || @"LongDirectoryName\LongSubDirectory" == path)
             )
             {
-                return new string[] { Path.Combine(path, "LongFileName.txt") };
+                return ImmutableArray.Create(Path.Combine(path, "LongFileName.txt"));
             }
             else if
             (
@@ -57,7 +447,7 @@ namespace Microsoft.Build.UnitTests
                 && @"c:\apple\banana\tomato" == path
             )
             {
-                return new string[] { Path.Combine(path, "pomegranate") };
+                return ImmutableArray.Create(Path.Combine(path, "pomegranate"));
             }
             else if
             (
@@ -65,14 +455,14 @@ namespace Microsoft.Build.UnitTests
             )
             {
                 // No files exist here. This is an empty directory.
-                return new string[0];
+                return ImmutableArray<string>.Empty;
             }
             else
             {
                 Console.WriteLine("GetFileSystemEntries('{0}', '{1}')", path, pattern);
                 Assert.True(false, "Unexpected input into GetFileSystemEntries");
             }
-            return new string[] { "<undefined>" };
+            return ImmutableArray.Create("<undefined>");
         }
 
         private static readonly char S = Path.DirectorySeparatorChar;
@@ -845,45 +1235,45 @@ namespace Microsoft.Build.UnitTests
         public void RemoveProjectDirectory()
         {
             string[] strings = new string[1] { NativeMethodsShared.IsWindows ? "c:\\1.file" : "/1.file" };
-            FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\" : "/");
+            strings = FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\" : "/").ToArray();
             Assert.Equal(strings[0], "1.file");
 
             strings = new string[1] { NativeMethodsShared.IsWindows ? "c:\\directory\\1.file" : "/directory/1.file"};
-            FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\" : "/");
+            strings = FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\" : "/").ToArray();
             Assert.Equal(strings[0], NativeMethodsShared.IsWindows ? "directory\\1.file" : "directory/1.file");
 
             strings = new string[1] { NativeMethodsShared.IsWindows ? "c:\\directory\\1.file" : "/directory/1.file" };
-            FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory");
+            strings = FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory").ToArray();
             Assert.Equal(strings[0], "1.file");
 
             strings = new string[1] { NativeMethodsShared.IsWindows ? "c:\\1.file" : "/1.file" };
-            FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory" );
+            strings = FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory" ).ToArray();
             Assert.Equal(strings[0], NativeMethodsShared.IsWindows ? "c:\\1.file" : "/1.file");
 
             strings = new string[1] { NativeMethodsShared.IsWindows ? "c:\\directorymorechars\\1.file" : "/directorymorechars/1.file" };
-            FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory");
+            strings = FileMatcher.RemoveProjectDirectory(strings, NativeMethodsShared.IsWindows ? "c:\\directory" : "/directory").ToArray();
             Assert.Equal(strings[0], NativeMethodsShared.IsWindows ? "c:\\directorymorechars\\1.file" : "/directorymorechars/1.file" );
 
             if (NativeMethodsShared.IsWindows)
             {
                 strings = new string[1] { "\\Machine\\1.file" };
-                FileMatcher.RemoveProjectDirectory(strings, "\\Machine");
+                strings = FileMatcher.RemoveProjectDirectory(strings, "\\Machine").ToArray();
                 Assert.Equal(strings[0], "1.file");
 
                 strings = new string[1] { "\\Machine\\directory\\1.file" };
-                FileMatcher.RemoveProjectDirectory(strings, "\\Machine");
+                strings = FileMatcher.RemoveProjectDirectory(strings, "\\Machine").ToArray();
                 Assert.Equal(strings[0], "directory\\1.file");
 
                 strings = new string[1] { "\\Machine\\directory\\1.file" };
-                FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory");
+                strings = FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory").ToArray();
                 Assert.Equal(strings[0], "1.file");
 
                 strings = new string[1] { "\\Machine\\1.file" };
-                FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory");
+                strings = FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory").ToArray();
                 Assert.Equal(strings[0], "\\Machine\\1.file");
 
                 strings = new string[1] { "\\Machine\\directorymorechars\\1.file" };
-                FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory");
+                strings = FileMatcher.RemoveProjectDirectory(strings, "\\Machine\\directory").ToArray();
                 Assert.Equal(strings[0], "\\Machine\\directorymorechars\\1.file");
             }
         }
@@ -1057,6 +1447,36 @@ namespace Microsoft.Build.UnitTests
                 @"src\Common\Properties\AssemblyInfo.cs",
             }
             )]
+        [InlineData(
+            @"**\*.cs", // Include Pattern
+            new[] // Exclude patterns
+            {
+                @"**\bin\**\*.cs",
+                @"src\Co??on\**",
+            },
+            new[] // Matching files
+            {
+                @"foo.cs",
+                @"src\Framework\Properties\AssemblyInfo.cs",
+                @"src\Framework\Foo\Bar\Baz\Buzz.cs"
+            },
+            new[] // Non matching files
+            {
+                @"foo.txt",
+                @"src\Framework\Readme.md",
+                @"src\Common\foo.cs",
+
+                // Ideally these would be untouchable
+                @"src\Framework\bin\foo.cs",
+                @"src\Framework\bin\Debug",
+                @"src\Framework\bin\Debug\foo.cs",
+                @"src\Common\Properties\AssemblyInfo.cs"
+            },
+            new[] // Non matching files that shouldn't be touched
+            {
+                @"src\Common\Properties\"
+            }
+        )]
         [InlineData(
             @"src\**\proj\**\*.cs", // Include Pattern
             new[] // Exclude patterns
@@ -1326,7 +1746,7 @@ namespace Microsoft.Build.UnitTests
             /// <param name="path">The path to search.</param>
             /// <param name="pattern">The pattern to search (may be null)</param>
             /// <returns>The matched files or folders.</returns>
-            internal string[] GetAccessibleFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+            internal ImmutableArray<string> GetAccessibleFileSystemEntries(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
             {
                 string normalizedPath = Normalize(path);
 
@@ -1345,7 +1765,7 @@ namespace Microsoft.Build.UnitTests
                     GetMatchingDirectories(_fileSet3, normalizedPath, pattern, files);
                 }
 
-                return files.ToArray();
+                return files.ToImmutableArray();
             }
 
             /// <summary>
@@ -1601,9 +2021,9 @@ namespace Microsoft.Build.UnitTests
         /// <param name="path"></param>
         /// <param name="pattern"></param>
         /// <returns>Array of matching file system entries (can be empty).</returns>
-        private static string[] GetFileSystemEntriesLoopBack(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static ImmutableArray<string> GetFileSystemEntriesLoopBack(FileMatcher.FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
-            return new string[] { Path.Combine(path, pattern) };
+            return ImmutableArray.Create(Path.Combine(path, pattern));
         }
 
         /*************************************************************************************

--- a/src/Tasks.UnitTests/project.json
+++ b/src/Tasks.UnitTests/project.json
@@ -12,6 +12,7 @@
     "net46": {
       "dependencies": {
         "xunit.runner.visualstudio": "2.1.0",
+        "System.Collections.Immutable": "1.3.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
@@ -20,6 +21,7 @@
         "System.Net.NetworkInformation": "4.1.0",
         "Microsoft.NETCore": "5.0.1",
         "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Console": "4.0.0",
         "System.Diagnostics.TraceSource": "4.0.0",

--- a/src/Tasks/project.json
+++ b/src/Tasks/project.json
@@ -26,6 +26,7 @@
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.Algorithms": "4.2.0",
         "System.Text.Encoding.CodePages" : "4.0.1",
+        "System.Threading.Tasks.Parallel": "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1",
         "System.Xml.XPath": "4.0.1",

--- a/src/Utilities/project.json
+++ b/src/Utilities/project.json
@@ -5,12 +5,14 @@
         "Microsoft.VisualStudio.Setup.Configuration.Interop":  "1.14.114",
         "PdbGit": "3.0.41",
         "SourceLink.Create.CommandLine": "2.1.2",
+        "System.Collections.Immutable": "1.3.1",
         "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
       }
     },
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "System.Collections.Immutable": "1.2.0",
         "System.Collections.NonGeneric": "4.0.1",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TraceSource": "4.0.0",
@@ -20,6 +22,7 @@
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
         "System.Security.Cryptography.X509Certificates": "4.1.0",
         "System.Text.Encoding.CodePages" : "4.0.1",
+        "System.Threading.Tasks.Parallel": "4.0.1",
         "System.Threading.Thread": "4.0.0",
         "System.Xml.XmlDocument": "4.0.1"
       }


### PR DESCRIPTION
Here are the optimization changes that were discussed in #2392, which are divided into three commits:

1. Usage of `Directory.EnumerateFiles` and `Directory.EnumerateDirectories` and checking excludes with a custom wildcard matching algorithm.
2. Adding directory caching passed by `LazyItemEvaluator`
3. Traversing subdirectories in parallel by using `Parallel.ForEach`

For the parallel change I did some modifications in order to prevent spawning too much threads. With the old modification the traversing created up to 9 threads on my computer, with the new one, it creates up to 4 threads. I found this to be a good balance between performance and threads being used, at least on my computer (Intel I7 860).

[This](https://github.com/maca88/msbuild/commit/24ccceeafb1d7969107fc02c272bcd29909eea4d#diff-7a21f5e73644f08fe8b0dc9763a632aaR30) test was used on [NHibernate.Test](https://github.com/nhibernate/nhibernate-core/tree/master/src/NHibernate.Test) project and [Roslyn](https://github.com/dotnet/roslyn) root folder. For NHibernate also the evaluation was tested by using the [Project](https://github.com/Microsoft/msbuild/blob/master/src/Build/Definition/Project.cs#L50) class.

Latest master:
```
NH:
File spec: **/*, Call time: 2650ms, Returned files: 14
File spec: **/*.cs, Call time: 1556ms, Returned files: 3509
File spec: **/*.resx, Call time: 1548ms, Returned files: 0
File spec: **\*.hbm.xml, Call time: 258ms, Returned files: 827
File spec: **\*.jpg, Call time: 246ms, Returned files: 1
Total time: 6261ms

NHibernate.Test Project Evaluation: Total time: 7391ms

Roslyn:
File spec: **/*, Call time: 5572ms, Returned files: 5485
File spec: **/*.cs, Call time: 3398ms, Returned files: 8631
File spec: **/*.resx, Call time: 3187ms, Returned files: 70
File spec: **\*.hbm.xml, Call time: 516ms, Returned files: 0
File spec: **\*.jpg, Call time: 524ms, Returned files: 0
Total time: 13199ms
```

This PR:
```
NH:
File spec: **/*, Call time: 172ms, Returned files: 14
File spec: **/*.cs, Call time: 114ms, Returned files: 3509
File spec: **/*.resx, Call time: 63ms, Returned files: 0
File spec: **\*.hbm.xml, Call time: 68ms, Returned files: 827
File spec: **\*.jpg, Call time: 64ms, Returned files: 1
Total time: 483ms

NHibernate.Test Project Evaluation: Total time: 2097ms

Roslyn:
File spec: **/*, Call time: 748ms, Returned files: 5485
File spec: **/*.cs, Call time: 373ms, Returned files: 8631
File spec: **/*.resx, Call time: 186ms, Returned files: 70
File spec: **\*.hbm.xml, Call time: 170ms, Returned files: 0
File spec: **\*.jpg, Call time: 177ms, Returned files: 0
Total time: 1656ms
```

All tests were ran in Release configuration on Intel I7 860 processor and the average of 5 runs was taken.