### PR TITLE
Avoid allocating checking extension

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -886,7 +886,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool IsSolutionFilename(string filename)
         {
-            return (String.Equals(Path.GetExtension(filename), ".sln", PathComparison));
+            return HasExtension(filename, ".sln");
         }
 
         /// <summary>
@@ -894,7 +894,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool IsVCProjFilename(string filename)
         {
-            return (String.Equals(Path.GetExtension(filename), ".vcproj", PathComparison));
+            return HasExtension(filename, ".vcproj");
         }
 
         /// <summary>
@@ -902,12 +902,20 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool IsMetaprojectFilename(string filename)
         {
-            return (String.Equals(Path.GetExtension(filename), ".metaproj", PathComparison));
+            return HasExtension(filename, ".metaproj");
         }
 
         internal static bool IsBinaryLogFilename(string filename)
         {
-            return (String.Equals(Path.GetExtension(filename), ".binlog", PathComparison));
+            return HasExtension(filename, ".binlog");
+        }
+
+        private static bool HasExtension(string filename, string extension)
+        {
+            if (String.IsNullOrEmpty(filename))
+                return false;
+
+            return filename.EndsWith(extension, PathComparison);
         }
 
         /// <summary>


### PR DESCRIPTION
IsVCProjFilename was allocating 0.1% in a large solution's evaluation:

![image](https://user-images.githubusercontent.com/1103906/31064051-57f8f02c-a784-11e7-970a-1595a7ace0f7.png)
