### PR TITLE
Avoid iterator/list allocations when parsing projects

### DIFF
--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -620,6 +620,7 @@
     <Compile Include="Utilities\Utilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Xml\ProjectXmlUtilities.XmlElementChildIterator.cs" />
     <Compile Include="Xml\ProjectXmlUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Xml;
+using Microsoft.Build.Construction;
+
+namespace Microsoft.Build.Internal
+{
+    partial class ProjectXmlUtilities
+    {
+        // Iterating an element's nodes allocates an non-trivial amount of data in certain
+        // large solutions with lots of targets, so we have our own struct-based iterator
+        // that avoids unneeded GC pressure.
+        //
+        // Deliberately not implement IEnumerable/IEnumerator to avoid accidental boxing
+        internal struct XmlElementChildIterator
+        {
+            private readonly XmlElementWithLocation _element;
+            private readonly bool _throwForInvalidNodeTypes;
+            private XmlElementWithLocation _current;
+            private bool _isFirst;
+
+            internal XmlElementChildIterator(XmlElementWithLocation element, bool throwForInvalidNodeTypes)
+            {
+                _element = element;
+                _throwForInvalidNodeTypes = throwForInvalidNodeTypes;
+                _current = null;
+                _isFirst = true;
+            }
+
+            public bool MoveNext()
+            {
+                if (_isFirst)
+                {
+                    _isFirst = false;
+                    _current = GetNextNode(_element.FirstChild);
+                }
+                else if (_current != null)
+                {
+                    _current = GetNextNode(_current.NextSibling);
+                }
+
+                return _current != null;
+            }
+
+            public XmlElementChildIterator GetEnumerator()
+            {
+                return this;
+            }
+
+            public XmlElementWithLocation Current
+            {
+                get
+                {
+                    if (_isFirst || _current == null)
+                        throw new InvalidOperationException();
+
+                    return _current;
+                }
+            }
+
+            public void Reset()
+            {
+                throw new NotSupportedException();
+            }
+
+            private XmlElementWithLocation GetNextNode(XmlNode child)
+            {
+                while (child != null)
+                {
+                    switch (child.NodeType)
+                    {
+                        case XmlNodeType.Comment:
+                        case XmlNodeType.Whitespace:
+                            // These are legal, and ignored
+                            break;
+
+                        case XmlNodeType.Element:
+                            return (XmlElementWithLocation)child;
+
+                        default:
+                            if (child.NodeType == XmlNodeType.Text && String.IsNullOrWhiteSpace(child.InnerText))
+                            {
+                                // If the text is greather than 4k and only contains whitespace, the XML reader will assume it's a text node
+                                // instead of ignoring it.  Our call to String.IsNullOrWhiteSpace() can be a little slow if the text is
+                                // large but this should be extremely rare.
+                                break;
+                            }
+                            if (_throwForInvalidNodeTypes)
+                            {
+                                ThrowProjectInvalidChildElement(child.Name, _element.Name, _element.Location);
+                            }
+                            break;
+                    }
+
+                    child = child.NextSibling;
+                }
+
+                // We're done
+                return null;
+            }
+        }
+    }
+}

--- a/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.XmlElementChildIterator.cs
@@ -61,11 +61,6 @@ namespace Microsoft.Build.Internal
                 }
             }
 
-            public void Reset()
-            {
-                throw new NotSupportedException();
-            }
-
             private XmlElementWithLocation GetNextNode(XmlNode child)
             {
                 while (child != null)

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element)
         {
-            var iterator = GetVerifyThrowProjectChildElements(element);
-            if (iterator.MoveNext())
+            var enumerator = GetVerifyThrowProjectChildElements(element).GetEnumerator();
+            if (enumerator.MoveNext())
             {
                 ThrowProjectInvalidChildElement(element.FirstChild.Name, element.Name, element.Location);
             }

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Internal
     /// <summary>
     /// Project-related Xml utilities
     /// </summary>
-    internal class ProjectXmlUtilities
+    internal static class ProjectXmlUtilities
     {
         /// <summary>
         /// Gets child elements, ignoring whitespace and comments.

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Build.Internal
     {
         /// <summary>
         /// Gets child elements, ignoring whitespace and comments.
-        /// Verifies xml namespace of elements is the MSBuild namespace.
-        /// Throws InvalidProjectFileException for elements in the wrong namespace, and unexpected XML node types
+        /// Throws InvalidProjectFileException for unexpected XML node types.
         /// </summary>
         internal static List<XmlElementWithLocation> GetVerifyThrowProjectChildElements(XmlElementWithLocation element)
         {
@@ -27,8 +26,7 @@ namespace Microsoft.Build.Internal
 
         /// <summary>
         /// Gets child elements, ignoring whitespace and comments.
-        /// Verifies xml namespace of elements is the MSBuild namespace.
-        /// Throws InvalidProjectFileException for elements in the wrong namespace, and (if parameter is set) unexpected XML node types
+        /// Throws InvalidProjectFileException for unexpected XML node types if parameter is set.
         /// </summary>
         private static List<XmlElementWithLocation> GetChildElements(XmlElementWithLocation element, bool throwForInvalidNodeTypes)
         {

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Build.Internal
     /// <summary>
     /// Project-related Xml utilities
     /// </summary>
-    internal static class ProjectXmlUtilities
+    internal static partial class ProjectXmlUtilities
     {
         /// <summary>
         /// Gets child elements, ignoring whitespace and comments.
         /// Throws InvalidProjectFileException for unexpected XML node types.
         /// </summary>
-        internal static List<XmlElementWithLocation> GetVerifyThrowProjectChildElements(XmlElementWithLocation element)
+        internal static XmlElementChildIterator GetVerifyThrowProjectChildElements(XmlElementWithLocation element)
         {
             return GetChildElements(element, true /*throw for unexpected node types*/);
         }
@@ -28,40 +28,9 @@ namespace Microsoft.Build.Internal
         /// Gets child elements, ignoring whitespace and comments.
         /// Throws InvalidProjectFileException for unexpected XML node types if parameter is set.
         /// </summary>
-        private static List<XmlElementWithLocation> GetChildElements(XmlElementWithLocation element, bool throwForInvalidNodeTypes)
+        private static XmlElementChildIterator GetChildElements(XmlElementWithLocation element, bool throwForInvalidNodeTypes)
         {
-            List<XmlElementWithLocation> children = new List<XmlElementWithLocation>();
-
-            foreach (XmlNode child in element)
-            {
-                switch (child.NodeType)
-                {
-                    case XmlNodeType.Comment:
-                    case XmlNodeType.Whitespace:
-                        // These are legal, and ignored
-                        break;
-
-                    case XmlNodeType.Element:
-                        XmlElementWithLocation childElement = (XmlElementWithLocation)child;
-                        children.Add(childElement);
-                        break;
-
-                    default:
-                        if (child.NodeType == XmlNodeType.Text && String.IsNullOrWhiteSpace(child.InnerText))
-                        {
-                            // If the text is greather than 4k and only contains whitespace, the XML reader will assume it's a text node
-                            // instead of ignoring it.  Our call to String.IsNullOrWhiteSpace() can be a little slow if the text is
-                            // large but this should be extremely rare.
-                            break;
-                        }
-                        if (throwForInvalidNodeTypes)
-                        {
-                            ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
-                        }
-                        break;
-                }
-            }
-            return children;
+            return new XmlElementChildIterator(element, throwForInvalidNodeTypes);
         }
 
         /// <summary>
@@ -69,8 +38,8 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element)
         {
-            List<XmlElementWithLocation> childElements = GetVerifyThrowProjectChildElements(element);
-            if (childElements.Count > 0)
+            var iterator = GetVerifyThrowProjectChildElements(element);
+            if (iterator.MoveNext())
             {
                 ThrowProjectInvalidChildElement(element.FirstChild.Name, element.Name, element.Location);
             }

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -38,10 +38,9 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void VerifyThrowProjectNoChildElements(XmlElementWithLocation element)
         {
-            var enumerator = GetVerifyThrowProjectChildElements(element).GetEnumerator();
-            if (enumerator.MoveNext())
+            foreach (var child in GetVerifyThrowProjectChildElements(element))
             {
-                ThrowProjectInvalidChildElement(element.FirstChild.Name, element.Name, element.Location);
+                ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
             }
         }
 


### PR DESCRIPTION
For each project and for every container construct in a project (ItemGroup, ImportGroup, etc) we were allocating a `List<XmlElementWithLocation>` and a `XmlChildEnumerator`. In large solutions with large import graphs this was adding up to a non-trivial amount of allocations (1.7% of all allocations during evaluation in one trace).

Replaces these with a struct-based enumerable/enumerator that manually walks the child elements.