### PR TITLE
Set document full path sooner to reduce allocations

### DIFF
--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -2093,7 +2093,11 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowInternalRooted(fullPath);
 
-            var document = new XmlDocumentWithLocation {PreserveWhitespace = preserveFormatting};
+            var document = new XmlDocumentWithLocation
+            {
+                FullPath = fullPath,
+                PreserveWhitespace = preserveFormatting
+            };
 #if (!STANDALONEBUILD)
             using (new CodeMarkerStartEnd(CodeMarkerEvent.perfMSBuildProjectLoadFromFileBegin, CodeMarkerEvent.perfMSBuildProjectLoadFromFileEnd))
 #endif
@@ -2110,7 +2114,6 @@ namespace Microsoft.Build.Construction
                         document.Load(xtr.Reader);
                     }
 
-                    document.FullPath = fullPath;
                     _projectFileLocation = ElementLocation.Create(fullPath);
                     _directory = Path.GetDirectoryName(fullPath);
 


### PR DESCRIPTION
Building a single project I saw 17,537 `ElementLocation` objects being created.  It turns out that code in `XmlElementWithLocation` and `XmlAttributeWithLocation` was making new objects because the document full path is not set in time.

This change sets the document full path sooner.  This reduced the number of ElementLocation objects being created from 17,537 to just 9,237 (47% less)

FYI @davkean 