### PR TITLE
Remove short-lived List<T> allocations from SplitSemiColonSeparatedList

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1439,7 +1439,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string value = "@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; " +
                 "$(OutputPath) ; $(TargetPath) ; %(Language)_%(Culture)";
 
-            IList<string> expanded = expander.ExpandIntoStringListLeaveEscaped(value, ExpanderOptions.ExpandAll, MockElementLocation.Instance);
+            IList<string> expanded = expander.ExpandIntoStringListLeaveEscaped(value, ExpanderOptions.ExpandAll, MockElementLocation.Instance).ToList();
 
             Assert.Equal(9, expanded.Count);
             Assert.Equal(@"string$(p)", expanded[0]);

--- a/src/Build.UnitTests/Evaluation/ExpressionShredder_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ExpressionShredder_Tests.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <param name="expected"></param>
         private void VerifySplitSemiColonSeparatedList(string input, params string[] expected)
         {
-            IList<string> actual = ExpressionShredder.SplitSemiColonSeparatedList(input);
+            var actual = ExpressionShredder.SplitSemiColonSeparatedList(input);
             Console.WriteLine(input);
 
             if (null == expected)
@@ -448,12 +448,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 expected = new string[] { };
             }
 
-            Assert.Equal(actual.Count, expected.Length); // "Expected " + expected.Length + " items but got " + actual.Count
-
-            for (int i = 0; i < expected.Length; i++)
-            {
-                Assert.Equal(expected[i], actual[i]);
-            }
+            Assert.Equal(actual, expected, StringComparer.Ordinal);
         }
 
         private void VerifyExpression(string test)

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Build.BackEnd
                             HashSet<string> removeMetadata = null;
                             if (!String.IsNullOrEmpty(child.KeepMetadata))
                             {
-                                var keepMetadataEvaluated = bucket.Expander.ExpandIntoStringListLeaveEscaped(child.KeepMetadata, ExpanderOptions.ExpandAll, child.KeepMetadataLocation);
+                                var keepMetadataEvaluated = bucket.Expander.ExpandIntoStringListLeaveEscaped(child.KeepMetadata, ExpanderOptions.ExpandAll, child.KeepMetadataLocation).ToList();
                                 if (keepMetadataEvaluated.Count > 0)
                                 {
                                     keepMetadata = new HashSet<string>(keepMetadataEvaluated);
@@ -92,7 +92,7 @@ namespace Microsoft.Build.BackEnd
 
                             if (!String.IsNullOrEmpty(child.RemoveMetadata))
                             {
-                                var removeMetadataEvaluated = bucket.Expander.ExpandIntoStringListLeaveEscaped(child.RemoveMetadata, ExpanderOptions.ExpandAll, child.RemoveMetadataLocation);
+                                var removeMetadataEvaluated = bucket.Expander.ExpandIntoStringListLeaveEscaped(child.RemoveMetadata, ExpanderOptions.ExpandAll, child.RemoveMetadataLocation).ToList();
                                 if (removeMetadataEvaluated.Count > 0)
                                 {
                                     removeMetadata = new HashSet<string>(removeMetadataEvaluated);
@@ -469,7 +469,7 @@ namespace Microsoft.Build.BackEnd
             HashSet<string> specificationsToFind = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Split by semicolons
-            IList<string> specificationPieces = expander.ExpandIntoStringListLeaveEscaped(specification, ExpanderOptions.ExpandAll, specificationLocation);
+            var specificationPieces = expander.ExpandIntoStringListLeaveEscaped(specification, ExpanderOptions.ExpandAll, specificationLocation);
 
             foreach (string piece in specificationPieces)
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Build.BackEnd
             // STEP 2: Split Include on any semicolons, and take each split in turn
             if (evaluatedInclude.Length > 0)
             {
-                IList<string> includeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedInclude);
+                var includeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedInclude);
                 ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(this.Project, originalItem.ItemType);
 
                 foreach (string includeSplit in includeSplits)
@@ -387,7 +387,7 @@ namespace Microsoft.Build.BackEnd
 
                     if (evaluatedExclude.Length > 0)
                     {
-                        IList<string> excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
+                        var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
                         HashSet<string> excludesUnescapedForComparison = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                         foreach (string excludeSplit in excludeSplits)

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -369,8 +369,8 @@ namespace Microsoft.Build.BackEnd
                 return new List<TargetSpecification>();
             }
 
-            IList<string> dependencies = _expander.ExpandIntoStringListLeaveEscaped(_target.DependsOnTargets, ExpanderOptions.ExpandPropertiesAndItems, _target.DependsOnTargetsLocation);
-            List<TargetSpecification> dependencyTargets = new List<TargetSpecification>(dependencies.Count);
+            var dependencies = _expander.ExpandIntoStringListLeaveEscaped(_target.DependsOnTargets, ExpanderOptions.ExpandPropertiesAndItems, _target.DependsOnTargetsLocation);
+            List<TargetSpecification> dependencyTargets = new List<TargetSpecification>();
             foreach (string escapedDependency in dependencies)
             {
                 string dependencyTargetName = EscapingUtilities.UnescapeAll(escapedDependency);
@@ -694,7 +694,7 @@ namespace Microsoft.Build.BackEnd
 
                 if (condition)
                 {
-                    IList<string> errorTargets = _expander.ExpandIntoStringListLeaveEscaped(errorTargetInstance.ExecuteTargets, ExpanderOptions.ExpandPropertiesAndItems, errorTargetInstance.ExecuteTargetsLocation);
+                    var errorTargets = _expander.ExpandIntoStringListLeaveEscaped(errorTargetInstance.ExecuteTargets, ExpanderOptions.ExpandPropertiesAndItems, errorTargetInstance.ExecuteTargetsLocation);
 
                     foreach (string escapedErrorTarget in errorTargets)
                     {

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -425,8 +425,8 @@ namespace Microsoft.Build.BackEnd
         {
             // break down the input/output specifications along the standard separator, after expanding all embedded properties
             // and item metadata
-            IList<string> targetInputs = bucket.Expander.ExpandIntoStringListLeaveEscaped(TargetInputSpecification, ExpanderOptions.ExpandPropertiesAndMetadata, _targetToAnalyze.InputsLocation);
-            IList<string> targetOutputs = bucket.Expander.ExpandIntoStringListLeaveEscaped(TargetOutputSpecification, ExpanderOptions.ExpandPropertiesAndMetadata, _targetToAnalyze.OutputsLocation);
+            var targetInputs = bucket.Expander.ExpandIntoStringListLeaveEscaped(TargetInputSpecification, ExpanderOptions.ExpandPropertiesAndMetadata, _targetToAnalyze.InputsLocation);
+            var targetOutputs = bucket.Expander.ExpandIntoStringListLeaveEscaped(TargetOutputSpecification, ExpanderOptions.ExpandPropertiesAndMetadata, _targetToAnalyze.OutputsLocation);
 
             itemVectorTransformsInTargetInputs = new ItemVectorPartitionCollection(MSBuildNameIgnoreCaseComparer.Default);
 
@@ -820,7 +820,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="elementLocation"></param>
         private void SeparateItemVectorsFromDiscreteItems
         (
-            IList<string> items,
+            SemiColonTokenizer items,
             ItemBucket bucket,
             out ItemVectorPartitionCollection itemVectors,
             ItemVectorPartitionCollection itemVectorTransforms,

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     // This is an output item.
                     // Expand only with properties first, so that expressions like Include="@(foo)" will transfer the metadata of the "foo" items as well, not just their item specs.
-                    IList<string> outputItemSpecs = bucket.Expander.ExpandIntoStringListLeaveEscaped(taskParameterAttribute, ExpanderOptions.ExpandPropertiesAndMetadata, taskItemInstance.TaskParameterLocation);
+                    var outputItemSpecs = bucket.Expander.ExpandIntoStringListLeaveEscaped(taskParameterAttribute, ExpanderOptions.ExpandPropertiesAndMetadata, taskItemInstance.TaskParameterLocation);
                     ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(_buildRequestEntry.RequestConfiguration.Project, itemName);
 
                     foreach (string outputItemSpec in outputItemSpecs)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -968,17 +968,13 @@ namespace Microsoft.Build.Evaluation
         private void PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
         {
             // We accumulate InitialTargets from the project and each import
-            IList<string> initialTargets = _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.InitialTargets, ExpanderOptions.ExpandProperties, currentProjectOrImport.InitialTargetsLocation);
+            var initialTargets = _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.InitialTargets, ExpanderOptions.ExpandProperties, currentProjectOrImport.InitialTargetsLocation);
             _initialTargetsList.AddRange(initialTargets);
 
             if (!Traits.Instance.EscapeHatches.IgnoreTreatAsLocalProperty)
             {
-                IList<string> globalPropertiesToTreatAsLocals = _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.TreatAsLocalProperty, ExpanderOptions.ExpandProperties, currentProjectOrImport.TreatAsLocalPropertyLocation);
-                // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
-                var globalPropertiesToTreatAsLocalsCount = globalPropertiesToTreatAsLocals.Count;
-                for (var i = 0; i < globalPropertiesToTreatAsLocalsCount; i++)
-                {
-                    var propertyName = globalPropertiesToTreatAsLocals[i];
+                foreach (string propertyName in _expander.ExpandIntoStringListLeaveEscaped(currentProjectOrImport.TreatAsLocalProperty, ExpanderOptions.ExpandProperties, currentProjectOrImport.TreatAsLocalPropertyLocation))
+                { 
                     XmlUtilities.VerifyThrowProjectValidElementName(propertyName, currentProjectOrImport.Location);
                     _data.GlobalPropertiesToTreatAsLocal.Add(propertyName);
                 }
@@ -1376,8 +1372,8 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private void AddBeforeAndAfterTargetMappings(ProjectTargetElement targetElement, Dictionary<string, LinkedListNode<ProjectTargetElement>> activeTargets, Dictionary<string, List<TargetSpecification>> targetsWhichRunBeforeByTarget, Dictionary<string, List<TargetSpecification>> targetsWhichRunAfterByTarget)
         {
-            IList<string> beforeTargets = _expander.ExpandIntoStringListLeaveEscaped(targetElement.BeforeTargets, ExpanderOptions.ExpandPropertiesAndItems, targetElement.BeforeTargetsLocation);
-            IList<string> afterTargets = _expander.ExpandIntoStringListLeaveEscaped(targetElement.AfterTargets, ExpanderOptions.ExpandPropertiesAndItems, targetElement.AfterTargetsLocation);
+            var beforeTargets = _expander.ExpandIntoStringListLeaveEscaped(targetElement.BeforeTargets, ExpanderOptions.ExpandPropertiesAndItems, targetElement.BeforeTargetsLocation);
+            var afterTargets = _expander.ExpandIntoStringListLeaveEscaped(targetElement.AfterTargets, ExpanderOptions.ExpandPropertiesAndItems, targetElement.AfterTargetsLocation);
 
             foreach (string beforeTarget in beforeTargets)
             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Build.Evaluation
             // STEP 2: Split Include on any semicolons, and take each split in turn
             if (evaluatedIncludeEscaped.Length > 0)
             {
-                IList<string> includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
+                var includeSplitsEscaped = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedIncludeEscaped);
 
                 foreach (string includeSplitEscaped in includeSplitsEscaped)
                 {
@@ -1800,7 +1800,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (evaluatedExclude.Length > 0)
                 {
-                    IList<string> excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
+                    var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
 
                     HashSet<string> excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -292,11 +292,11 @@ namespace Microsoft.Build.Evaluation
         /// Use this form when the result is going to be processed further, for example by matching against the file system,
         /// so literals must be distinguished, and you promise to unescape after that.
         /// </summary>
-        internal IList<string> ExpandIntoStringListLeaveEscaped(string expression, ExpanderOptions options, IElementLocation elementLocation)
+        internal SemiColonTokenizer ExpandIntoStringListLeaveEscaped(string expression, ExpanderOptions options, IElementLocation elementLocation)
         {
             ErrorUtilities.VerifyThrow((options & ExpanderOptions.BreakOnNotEmpty) == 0, "not supported");
 
-            return ExpressionShredder.SplitSemiColonSeparatedList(ExpandIntoStringLeaveEscaped(expression, options, elementLocation)).ToList();
+            return ExpressionShredder.SplitSemiColonSeparatedList(ExpandIntoStringLeaveEscaped(expression, options, elementLocation));
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -296,7 +296,7 @@ namespace Microsoft.Build.Evaluation
         {
             ErrorUtilities.VerifyThrow((options & ExpanderOptions.BreakOnNotEmpty) == 0, "not supported");
 
-            return ExpressionShredder.SplitSemiColonSeparatedList(ExpandIntoStringLeaveEscaped(expression, options, elementLocation));
+            return ExpressionShredder.SplitSemiColonSeparatedList(ExpandIntoStringLeaveEscaped(expression, options, elementLocation)).ToList();
         }
 
         /// <summary>
@@ -341,13 +341,9 @@ namespace Microsoft.Build.Evaluation
                 return result;
             }
 
-            IList<string> splits = ExpressionShredder.SplitSemiColonSeparatedList(expression);
-
-            // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
-            var splitsCount = splits.Count;
-            for (var i = 0; i < splitsCount; i++)
+            var splits = ExpressionShredder.SplitSemiColonSeparatedList(expression);
+            foreach (string split in splits)
             {
-                var split = splits[i];
                 bool isTransformExpression;
                 IList<T> itemsToAdd = ItemExpander.ExpandSingleItemVectorExpressionIntoItems<I, T>(this, split, _items, itemFactory, options, false /* do not include null items */, out isTransformExpression, elementLocation);
 
@@ -2239,7 +2235,7 @@ namespace Microsoft.Build.Evaluation
                                 // that case.
                                 if (s_invariantCompareInfo.IndexOf(metadataValue, ';') >= 0)
                                 {
-                                    IList<string> splits = ExpressionShredder.SplitSemiColonSeparatedList(metadataValue);
+                                    var splits = ExpressionShredder.SplitSemiColonSeparatedList(metadataValue);
 
                                     foreach (string itemSpec in splits)
                                     {

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -67,77 +67,16 @@ namespace Microsoft.Build.Evaluation
         /// <returns>Array of non-empty strings from split list.</returns>
         internal static IList<string> SplitSemiColonSeparatedList(string expression)
         {
-            expression = expression.Trim();
-
-            if (expression.Length == 0)
+            List<string> splitList = null;
+            foreach (string segment in new SemicolonTokenizer(expression))
             {
-                return Array.Empty<string>();
-            }
+                if (splitList == null)
+                    splitList = new List<string>(1);
 
-            List<string> splitList = new List<string>(1);
-            int segmentStart = 0;
-            bool insideItemList = false;
-            bool insideQuotedPart = false;
-            string segment;
-
-            // Walk along the string, keeping track of whether we are in an item list expression.
-            // If we hit a semi-colon or the end of the string and we aren't in an item list, 
-            // add the segment to the list.
-            for (int current = 0; current < expression.Length; current++)
-            {
-                switch (expression[current])
-                {
-                    case ';':
-                        if (!insideItemList)
-                        {
-                            // End of segment, so add it to the list
-                            segment = expression.Substring(segmentStart, current - segmentStart).Trim();
-                            if (segment.Length > 0)
-                            {
-                                splitList.Add(segment);
-                            }
-
-                            // Move past this semicolon
-                            segmentStart = current + 1;
-                        }
-
-                        break;
-                    case '@':
-                        // An '@' immediately followed by a '(' is the start of an item list
-                        if (expression.Length > current + 1 && expression[current + 1] == '(')
-                        {
-                            // Start of item expression
-                            insideItemList = true;
-                        }
-
-                        break;
-                    case ')':
-                        if (insideItemList && !insideQuotedPart)
-                        {
-                            // End of item expression
-                            insideItemList = false;
-                        }
-
-                        break;
-                    case '\'':
-                        if (insideItemList)
-                        {
-                            // Start or end of quoted expression in item expression
-                            insideQuotedPart = !insideQuotedPart;
-                        }
-
-                        break;
-                }
-            }
-
-            // Reached the end of the string: what's left is another segment
-            segment = expression.Substring(segmentStart, expression.Length - segmentStart).Trim();
-            if (segment.Length > 0)
-            {
                 splitList.Add(segment);
             }
 
-            return splitList;
+            return (IList<string>)splitList ?? Array.Empty<string>();
         }
 
         /// <summary>

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -57,18 +57,14 @@ namespace Microsoft.Build.Evaluation
         /// Fragments are trimmed and empty fragments discarded.
         /// </summary>
         /// <remarks>
-        /// These complex cases prevent us from doing a simple split on ';':
-        ///  (1) Macro expression: @(foo->'xxx;xxx')
-        ///  (2) Separator expression: @(foo, 'xxx;xxx')
-        ///  (3) Combination: @(foo->'xxx;xxx', 'xxx;xxx')
-        ///  We must not split on semicolons in macro or separator expressions like these.
+        /// See <see cref="SemiColonTokenizer"/> for rules.
         /// </remarks>
         /// <param name="expression">List expression to split</param>
         /// <returns>Array of non-empty strings from split list.</returns>
         internal static IList<string> SplitSemiColonSeparatedList(string expression)
         {
             List<string> splitList = null;
-            foreach (string segment in new SemicolonTokenizer(expression))
+            foreach (string segment in new SemiColonTokenizer(expression))
             {
                 if (splitList == null)
                     splitList = new List<string>(1);

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -61,18 +61,9 @@ namespace Microsoft.Build.Evaluation
         /// </remarks>
         /// <param name="expression">List expression to split</param>
         /// <returns>Array of non-empty strings from split list.</returns>
-        internal static IList<string> SplitSemiColonSeparatedList(string expression)
+        internal static SemiColonTokenizer SplitSemiColonSeparatedList(string expression)
         {
-            List<string> splitList = null;
-            foreach (string segment in new SemiColonTokenizer(expression))
-            {
-                if (splitList == null)
-                    splitList = new List<string>(1);
-
-                splitList.Add(segment);
-            }
-
-            return (IList<string>)splitList ?? Array.Empty<string>();
+            return new SemiColonTokenizer(expression);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Evaluation
                     foreach (string exclude in _excludes)
                     {
                         string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
-                        IList<string> excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
+                        var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
                         excludePatterns.AddRange(excludeSplits);
                     }
 

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -469,12 +469,11 @@ namespace Microsoft.Build.Evaluation
 
                 if (evaluatedExclude.Length > 0)
                 {
-                    IList<string> excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
-
-                    operationBuilder.Excludes.AddRange(excludeSplits);
+                    var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(evaluatedExclude);
 
                     foreach (var excludeSplit in excludeSplits)
                     {
+                        operationBuilder.Excludes.Add(excludeSplit);
                         AddItemReferences(excludeSplit, operationBuilder, itemElement.ExcludeLocation);
                     }
                 }

--- a/src/Build/Evaluation/SemiColonTokenizer.cs
+++ b/src/Build/Evaluation/SemiColonTokenizer.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Splits an expression into fragments at semicolons, except where the
+    /// semicolons are in a macro or separator expression.
+    /// Fragments are trimmed and empty fragments discarded.
+    /// </summary>
+    /// <remarks>
+    /// These complex cases prevent us from doing a simple split on ';':
+    ///  (1) Macro expression: @(foo->'xxx;xxx')
+    ///  (2) Separator expression: @(foo, 'xxx;xxx')
+    ///  (3) Combination: @(foo->'xxx;xxx', 'xxx;xxx')
+    ///  We must not split on semicolons in macro or separator expressions like these.
+    /// </remarks>
+    internal struct SemicolonTokenizer : IEnumerable<string>
+    {
+        private readonly string _expression;
+
+        public SemicolonTokenizer(string expression)
+        {
+            _expression = expression;
+        }
+
+        public Enumerator GetEnumerator() => new Enumerator(_expression);
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        internal struct Enumerator : IEnumerator<string>
+        {
+            private readonly string _expression;
+            private string _current;
+            private int _index;
+
+            public Enumerator(string expression)
+            {
+                _expression = expression;
+                _index = 0;
+                _current = default(string);
+            }
+
+            public string Current
+            {
+                get { return _current; }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                int segmentStart = _index;
+                bool insideItemList = false;
+                bool insideQuotedPart = false;
+                string segment;
+
+                // Walk along the string, keeping track of whether we are in an item list expression.
+                // If we hit a semi-colon or the end of the string and we aren't in an item list, 
+                // add the segment to the list.
+                for (; _index < _expression.Length; _index++)
+                {
+                    switch (_expression[_index])
+                    {
+                        case ';':
+                            if (!insideItemList)
+                            {
+                                // End of segment, so add it to the list
+                                segment = _expression.Substring(segmentStart, _index - segmentStart).Trim();
+                                if (segment.Length > 0)
+                                {
+                                    _current = segment;
+                                    return true;
+                                }
+
+                                // Move past this semicolon
+                                segmentStart = _index + 1;
+                            }
+
+                            break;
+                        case '@':
+                            // An '@' immediately followed by a '(' is the start of an item list
+                            if (_expression.Length > _index + 1 && _expression[_index + 1] == '(')
+                            {
+                                // Start of item expression
+                                insideItemList = true;
+                            }
+
+                            break;
+                        case ')':
+                            if (insideItemList && !insideQuotedPart)
+                            {
+                                // End of item expression
+                                insideItemList = false;
+                            }
+
+                            break;
+                        case '\'':
+                            if (insideItemList)
+                            {
+                                // Start or end of quoted expression in item expression
+                                insideQuotedPart = !insideQuotedPart;
+                            }
+
+                            break;
+                    }
+                }
+
+                // Reached the end of the string: what's left is another segment
+                segment = _expression.Substring(segmentStart, _expression.Length - segmentStart).Trim();
+                if (segment.Length > 0)
+                {
+                    _current = segment;
+                    return true;
+                }
+
+                _current = null;
+                return false;
+            }
+
+            public void Reset()
+            {
+                _current = default(string);
+                _index = 0;
+            }
+        }
+    }
+}

--- a/src/Build/Evaluation/SemiColonTokenizer.cs
+++ b/src/Build/Evaluation/SemiColonTokenizer.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Build.Evaluation
     ///  (3) Combination: @(foo->'xxx;xxx', 'xxx;xxx')
     ///  We must not split on semicolons in macro or separator expressions like these.
     /// </remarks>
-    internal struct SemicolonTokenizer : IEnumerable<string>
+    internal struct SemiColonTokenizer : IEnumerable<string>
     {
         private readonly string _expression;
 
-        public SemicolonTokenizer(string expression)
+        public SemiColonTokenizer(string expression)
         {
             _expression = expression;
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -527,6 +527,7 @@
     <Compile Include="Evaluation\ProjectParser.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
     <Compile Include="Evaluation\ProjectStringCache.cs" />
+    <Compile Include="Evaluation\SemiColonTokenizer.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />
     <Compile Include="Evaluation\ExpressionShredder.cs" />
     <Compile Include="Evaluation\Evaluator.cs" />


### PR DESCRIPTION
This replaces SplitSemiColonSeparatedList's implementation with a struct-based enumerator. This avoids two types of allocations:

- Removes the need for short-lived `List<string>` just to collect the results (up to 1% of allocations)
- Removes the boxing of the enumerator in most cases when iterating the results (due to the `IList<T>` return type) (up to 0.6% of allocations)

This takes some of the changes @benaadams made in https://github.com/Microsoft/msbuild/pull/2401 and takes it further.

Future changes in later PRs:
- ~Make the same change to ExpandIntoStringListLeaveEscaped~ https://github.com/Microsoft/msbuild/pull/2586/commits/2cc0ade98bd4198a3c9bb26ecf1f8296783054fb
- Introduce a "string segment" to reduce short-lived string allocations such as Trim and Substring.

Running numbers.