### PR TITLE
Remove unnecessary List<T> instantiation

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -837,7 +837,7 @@ namespace Microsoft.Build.Evaluation
             if (lazyEvaluator != null)
             {
                 // Tell the lazy evaluator to compute the items and add them to _data
-                foreach (var itemData in lazyEvaluator.GetAllItems())
+                foreach (var itemData in lazyEvaluator.GetAllItemsDeferred())
                 {
                     if (itemData.ConditionResult)
                     {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -837,12 +837,8 @@ namespace Microsoft.Build.Evaluation
             if (lazyEvaluator != null)
             {
                 // Tell the lazy evaluator to compute the items and add them to _data
-                IList<LazyItemEvaluator<P, I, M, D>.ItemData> items = lazyEvaluator.GetAllItems();
-                // Don't box via IEnumerator and foreach; cache count so not to evaluate via interface each iteration
-                var itemsCount = items.Count;
-                for (var i = 0; i < itemsCount; i++)
+                foreach (var itemData in lazyEvaluator.GetAllItems())
                 {
-                    var itemData = items[i];
                     if (itemData.ConditionResult)
                     {
                         _data.AddItem(itemData.Item);

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.Evaluation
             return ret;
         }
 
-        public IEnumerable<ItemData> GetAllItems()
+        public IEnumerable<ItemData> GetAllItemsDeferred()
         {
             return _itemLists.Values.SelectMany(itemList => itemList.GetItems(ImmutableHashSet<string>.Empty))
                                     .OrderBy(itemData => itemData.ElementOrder);

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -401,13 +401,10 @@ namespace Microsoft.Build.Evaluation
             return ret;
         }
 
-        public IList<ItemData> GetAllItems()
+        public IEnumerable<ItemData> GetAllItems()
         {
-            var ret = _itemLists.Values.SelectMany(itemList => itemList.GetItems(ImmutableHashSet<string>.Empty))
-                .OrderBy(itemData => itemData.ElementOrder)
-                .ToList();
-
-            return ret;
+            return _itemLists.Values.SelectMany(itemList => itemList.GetItems(ImmutableHashSet<string>.Empty))
+                                    .OrderBy(itemData => itemData.ElementOrder);
         }
 
         public void ProcessItemElement(string rootDirectory, ProjectItemElement itemElement, bool conditionResult)


### PR DESCRIPTION
This was the cause of a large amount (1.2%) of allocations in a large project, some of which end up on the large object heap.

Large project from a partner:
![image](https://user-images.githubusercontent.com/1103906/31217790-eb5fae2e-aa03-11e7-952e-6c776853ac0d.png)

Smaller project with mix of .NET Framework/.NET Standard projects:
![image](https://user-images.githubusercontent.com/1103906/31217856-199abb80-aa04-11e7-8c10-8f9c495c2ebd.png)

