### PR TITLE
Unlinqify ProcessItemSpec

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -501,7 +501,8 @@ namespace Microsoft.Build.Evaluation
 
             foreach (ItemFragment fragment in builder.ItemSpec.Fragments)
             {
-                if (fragment is ItemExpressionFragment<P, I> itemExpression)
+                ItemExpressionFragment<P, I> itemExpression = fragment as ItemExpressionFragment<P, I>;
+                if (itemExpression != null)
                 {
                     AddReferencedItemLists(builder, itemExpression.Capture);
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -499,8 +499,13 @@ namespace Microsoft.Build.Evaluation
         {
             builder.ItemSpec = new ItemSpec<P, I>(itemSpec, _outerExpander, itemSpecLocation);
 
-            var itemCaptures = builder.ItemSpec.Fragments.OfType<ItemExpressionFragment<P, I>>().Select(i => i.Capture);
-            AddReferencedItemLists(builder, itemCaptures);
+            foreach (ItemFragment fragment in builder.ItemSpec.Fragments)
+            {
+                if (fragment is ItemExpressionFragment<P, I> itemExpression)
+                {
+                    AddReferencedItemLists(builder, itemExpression.Capture);
+                }
+            }
         }
 
         private void ProcessMetadataElements(ProjectItemElement itemElement, OperationBuilderWithMetadata operationBuilder)
@@ -557,14 +562,6 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 AddReferencedItemLists(operationBuilder, match);
-            }
-        }
-
-        private void AddReferencedItemLists(OperationBuilder operationBuilder, IEnumerable<ExpressionShredder.ItemExpressionCapture> captures)
-        {
-            foreach (var capture in captures)
-            {
-                AddReferencedItemLists(operationBuilder, capture);
             }
         }
 


### PR DESCRIPTION
Remove 4 allocations:

- Boxed Enumerator
- WhereSelectEnumerableIterator
- OfTypeIterator
- Func<T, TResult>

This removes 2% of allocations in a large partner's solution.

![image](https://user-images.githubusercontent.com/1103906/31219199-4bd171bc-aa08-11e7-858b-bcb0da370a7b.png)
