### PR TITLE
Ensure ResolveProjectReferences runs before RAR

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2046,6 +2046,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <PropertyGroup>
     <ResolveAssemblyReferencesDependsOn>
+      ResolveProjectReferences;
+      FindInvalidProjectReferences;
       GetFrameworkPaths;
       GetReferenceAssemblyPaths;
       PrepareForBuild;


### PR DESCRIPTION
Fixes a case where RAR was called early in the build before project
references were resolved. As far as I know this only happened in
design-time builds, but this makes the dependency explicit (if
ResolveProjectReferences has not run all project dependencies will not
be correctly resolved in RAR).

Fixes #2591