### PR TITLE
Check schema when performing a sln build.

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -304,8 +304,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 ProjectInSolution project2 = solution.ProjectsByGuid["{DEA89696-F42B-4B58-B7EE-017FF40817D1}"];
 
                 project1.CanBeMSBuildProjectFile(out error).ShouldBe(false);
-                // TODO: https://github.com/Microsoft/msbuild/issues/2064
-                //project2.CanBeMSBuildProjectFile(out error).ShouldBe(false);
+                project2.CanBeMSBuildProjectFile(out error).ShouldBe(false);
             }
         }
 

--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -7,10 +7,9 @@ using System.Collections.Generic;
 using System.IO;
 
 using Microsoft.Build.Construction;
+using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Shared;
-
-
-
+using Shouldly;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using Xunit;
 
@@ -256,6 +255,57 @@ namespace Microsoft.Build.UnitTests.Construction
             {
                 File.Delete(proj1Path);
                 File.Delete(proj2Path);
+            }
+        }
+
+        /// <summary>
+        /// Test CanBeMSBuildFile
+        /// </summary>
+        [Fact]
+        public void CanBeMSBuildFileRejectsMSBuildLikeFiles()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                string rptprojProjContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                    <Project xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" ToolsVersion=""2.0"">
+                      <DataSources />
+                      <Reports />
+                    </Project>";
+                string dwprojProjContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                    <Project xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:ddl2=""http://schemas.microsoft.com/analysisservices/2003/engine/2"" xmlns:ddl2_2=""http://schemas.microsoft.com/analysisservices/2003/engine/2/2"" xmlns:ddl100_100=""http://schemas.microsoft.com/analysisservices/2008/engine/100/100"" xmlns:ddl200=""http://schemas.microsoft.com/analysisservices/2010/engine/200"" xmlns:ddl200_200=""http://schemas.microsoft.com/analysisservices/2010/engine/200/200"" xmlns:dwd=""http://schemas.microsoft.com/DataWarehouse/Designer/1.0"">
+                      <ProductVersion />
+                      <SchemaVersion />
+                      <State />
+                      <Database />
+                      <Cubes />
+                    </Project>";
+
+                string rptprojPath = env.CreateFile(".rptproj").Path;
+                File.WriteAllText(rptprojPath, rptprojProjContent);
+                string dqprojPath = env.CreateFile(".dwproj").Path;
+                File.WriteAllText(dqprojPath, dwprojProjContent);
+
+                // Create the SolutionFile object
+                string solutionFileContents =
+                    @"
+                    Microsoft Visual Studio Solution File, Format Version 8.00
+                        Project('{F14B399A-7131-4C87-9E4B-1186C45EF12D}') = 'PrtProj', '" + Path.GetFileName(rptprojPath) + @"', '{CCCCCCCC-9925-4D57-9DAF-E0A9D936ABDB}'
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
+                        EndProject
+                        Project('{D2ABAB84-BF74-430A-B69E-9DC6D40DDA17}') = 'DwProj', '" + Path.GetFileName(dqprojPath) + @"', '{DEA89696-F42B-4B58-B7EE-017FF40817D1}'
+                            ProjectSection(ProjectDependencies) = postProject
+                            EndProjectSection
+                        EndProject";
+
+                string error = null;
+                SolutionFile solution = ParseSolutionHelper(solutionFileContents);
+                ProjectInSolution project1 = solution.ProjectsByGuid["{CCCCCCCC-9925-4D57-9DAF-E0A9D936ABDB}"];
+                ProjectInSolution project2 = solution.ProjectsByGuid["{DEA89696-F42B-4B58-B7EE-017FF40817D1}"];
+
+                project1.CanBeMSBuildProjectFile(out error).ShouldBe(false);
+                // TODO: https://github.com/Microsoft/msbuild/issues/2064
+                //project2.CanBeMSBuildProjectFile(out error).ShouldBe(false);
             }
         }
 


### PR DESCRIPTION
Note this doesn't fix the `.dwproj` case. I need to figure out something slightly different for that, but I wanted to send this out because I need to move on for now.

* Check that the schema matches either empty or the MSBuild default schema
when building a solution file.

* Special case .rptproj files. This file format looks like a standard
MSBuild file but specifies ToolsVersion=2.0 and a default XML schema.
Since the XML parser treats that schema as equivalent to empty and empty
is now allowed, there's no good way to determine if it's an MSBuild file
until we try to parse. This results in an error in MSBuild 15 rather
than a warning in MSBuild 14 for solutions with a .rptproj file. To
solve this, the sln build will now allow projects where the schema is
the default MSBuild schema or empty and ToolsVersion is not 2.0.

Partial fix for #2064