### PR TITLE
Cleanup bootstrap build

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,7 +11,7 @@
     <add key="nuget.org v2" value="https://nuget.org/api/v2/" />
     <add key="myget.org roslyn nightly" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="dotnet.myget.org buildtools v3" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <!-- <add key="myget.org nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" /> -->
+    <add key="myget.org nugetbuild" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="dotnet.myget.org dotnet-core v3" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org aspnet vnext v3" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
     <add key="myget.org aspnet vnext" value="https://www.myget.org/F/aspnetvnext/" />

--- a/dir.props
+++ b/dir.props
@@ -43,6 +43,7 @@
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <GitVersioningVersion>1.6.35</GitVersioningVersion>
     <NuSpecReferenceGeneratorVersion>1.4.2</NuSpecReferenceGeneratorVersion>
+    <NuGetVersion>4.5.0-preview1-4518</NuGetVersion>
   </PropertyGroup>
 
    <!-- Common repo directories -->
@@ -56,8 +57,10 @@
     <GitVersioningDir>$(PackagesDir)\Nerdbank.GitVersioning\$(GitVersioningVersion)\build\</GitVersioningDir>
 
     <!-- Tell build tools to use the full framework dlls that contain build tasks (like the nuget assets task) -->
-    <BuildToolsTaskDir>$(ToolsDir)net45/</BuildToolsTaskDir>
-    <PackagingTaskDir>$(ToolsDir)net45/</PackagingTaskDir>
+    <BuildToolsTaskDir Condition="'$(OsEnvironment)'=='Windows_NT'">$(ToolsDir)net45\</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(OsEnvironment)'!='Windows_NT'">$(ToolsDir)</BuildToolsTaskDir>
+    <PackagingTaskDir Condition="'$(OsEnvironment)'=='Windows_NT'">$(ToolsDir)net45\</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(OsEnvironment)'!='Windows_NT'">$(ToolsDir)</PackagingTaskDir>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>

--- a/dir.props
+++ b/dir.props
@@ -57,10 +57,10 @@
     <GitVersioningDir>$(PackagesDir)\Nerdbank.GitVersioning\$(GitVersioningVersion)\build\</GitVersioningDir>
 
     <!-- Tell build tools to use the full framework dlls that contain build tasks (like the nuget assets task) -->
-    <BuildToolsTaskDir Condition="'$(OsEnvironment)'=='Windows_NT'">$(ToolsDir)net45\</BuildToolsTaskDir>
-    <BuildToolsTaskDir Condition="'$(OsEnvironment)'!='Windows_NT'">$(ToolsDir)</BuildToolsTaskDir>
-    <PackagingTaskDir Condition="'$(OsEnvironment)'=='Windows_NT'">$(ToolsDir)net45\</PackagingTaskDir>
-    <PackagingTaskDir Condition="'$(OsEnvironment)'!='Windows_NT'">$(ToolsDir)</PackagingTaskDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)'=='Full'">$(ToolsDir)net45\</BuildToolsTaskDir>
+    <BuildToolsTaskDir Condition="'$(MSBuildRuntimeType)'!='Full'">$(ToolsDir)</BuildToolsTaskDir>
+    <PackagingTaskDir Condition="'$(MSBuildRuntimeType)'=='Full'">$(ToolsDir)net45\</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(MSBuildRuntimeType)'!='Full'">$(ToolsDir)</PackagingTaskDir>
 
     <!-- Output directories -->
     <BinDir>$(RepoRoot)bin$([System.IO.Path]::DirectorySeparatorChar)</BinDir>

--- a/src/.nuget/project.json
+++ b/src/.nuget/project.json
@@ -5,7 +5,8 @@
     "NuSpec.ReferenceGenerator": "1.4.2",
     "Microsoft.Net.Compilers": "2.3.1",
     "MicroBuild.Core": "0.2.0",
-    "Microsoft.DotNet.BuildTools.GenAPI": "1.0.0-beta2-00731-01"
+    "Microsoft.DotNet.BuildTools.GenAPI": "1.0.0-beta2-00731-01",
+    "NuGet.Build.Tasks": "4.5.0-preview1-4518"
   },
   "frameworks": {
     "net46": {}

--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -46,7 +46,23 @@
       <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
-      <NuGetCommonExtensions Include="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\NuGet\**\*.*" />
+      <!--<NuGetCommonExtensions Include="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\NuGet\**\*.*" />-->
+      <!-- TODO: Need NuGet.Build.Tasks.dll, would be not to not list out all of its dependencies! -->
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\runtimes\any\native\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.commands\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.common\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.configuration\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.dependencyresolver.core\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.frameworks\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.librarymodel\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.packaging\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.packaging.core\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.projectmodel\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.protocol\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.versioning\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuspec.referencegenerator\$(NuGetVersion)\lib\net45\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\Newtonsoft.Json\9.0.1\lib\net45\**\*.*" />
 
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.dll" />
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.exe" />

--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -46,8 +46,8 @@
       <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
-      <!--<NuGetCommonExtensions Include="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\NuGet\**\*.*" />-->
-      <!-- TODO: Need NuGet.Build.Tasks.dll, would be not to not list out all of its dependencies! -->
+
+      <!-- TODO: Automate getting NuGet.Build.Tasks.dll + all dependencies. -->
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\lib\net45\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\runtimes\any\native\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.commands\$(NuGetVersion)\lib\net45\**\*.*" />
@@ -107,7 +107,8 @@
   <Target Name="BootstrapNetCore">
     <ItemGroup>
       <DeployedItems Include="$(DeploymentDir)\**\*.*"/>
-      <!-- TODO: Need NuGet.Build.Tasks.dll, would be not to not list out all of its dependencies! -->
+
+      <!-- TODO: Automate getting NuGet.Build.Tasks.dll + all dependencies. -->
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\runtimes\any\native\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.commands\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />

--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -107,19 +107,37 @@
   <Target Name="BootstrapNetCore">
     <ItemGroup>
       <DeployedItems Include="$(DeploymentDir)\**\*.*"/>
+      <!-- TODO: Need NuGet.Build.Tasks.dll, would be not to not list out all of its dependencies! -->
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\runtimes\any\native\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.commands\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.common\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.configuration\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.dependencyresolver.core\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.frameworks\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.librarymodel\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.packaging\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.packaging.core\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.projectmodel\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.protocol\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.versioning\$(NuGetVersion)\lib\netstandard1.0\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\nuspec.referencegenerator\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\Newtonsoft.Json\9.0.1\lib\netstandard1.0\**\*.*" />
     </ItemGroup>
 
     <RemoveDir
             Directories="$(BootstrapDestination)"
-            ContinueOnError="true"/>
+            ContinueOnError="true" />
 
     <RemoveDir
             Directories="$(BootstrapDestination)"
-            ContinueOnError="true"/>
+            ContinueOnError="true" />
 
     <Copy SourceFiles="@(DeployedItems)"
-          DestinationFolder="$(BootstrapDestination)\%(RecursiveDir)"
-          />
+          DestinationFolder="$(BootstrapDestination)\%(RecursiveDir)" />
+
+    <Copy SourceFiles="@(NuGetCommonExtensions)"
+          DestinationFiles="@(NuGetCommonExtensions -> '$(BootstrapDestination)%(RecursiveDir)%(FileName)%(Extension)')" />
 
     <!-- Microsoft.Portable.CSharp.targets imports this file with a capital T -->
     <Copy SourceFiles="$(DeploymentDir)\Microsoft.CSharp.targets"

--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -46,6 +46,7 @@
       <InstalledMicrosoftExtensions Include="$(MSBuildExtensionsPath)\Microsoft\**\*.*" />
 
       <InstalledNuGetFiles Include="$(MSBuildExtensionsPath)\Microsoft\NuGet\*" />
+      <NuGetCommonExtensions Include="$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\NuGet\**\*.*" />
 
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.dll" />
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.exe" />
@@ -71,6 +72,8 @@
 
     <Copy SourceFiles="@(InstalledNuGetFiles)"
           DestinationFiles="@(InstalledNuGetFiles->'$(BootstrapDestination)Microsoft\NuGet\%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(NuGetCommonExtensions)"
+          DestinationFiles="@(NuGetCommonExtensions -> '$(BootstrapDestination)..\Common7\IDE\CommonExtensions\Microsoft\NuGet\%(RecursiveDir)%(FileName)%(Extension)')" />
 
     <!-- Delete shim projects, because they point where we can't follow. -->
     <!-- It would be better to just not copy these. -->
@@ -88,9 +91,6 @@
   <Target Name="BootstrapNetCore">
     <ItemGroup>
       <DeployedItems Include="$(DeploymentDir)\**\*.*"/>
-      <!-- Work around https://github.com/Microsoft/msbuild/issues/658
-           by making sure NuGet DLLs are next to MSBuild.exe -->
-      <DeployedItems Include="$(ToolsDir)\NuGet*.dll" />
     </ItemGroup>
 
     <RemoveDir

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -75,7 +75,7 @@
           />
   </Target>
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)net45/Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <!--At build time, we target netstandard to be runnable on many runtimes.

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -21,30 +21,6 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Copy content of BuildTools package to deployment folders -->
-  <!--<Target Name="CopyBuildTools">
-    <PropertyGroup>
-      <BuildToolsVersionFile>$(RepoRoot)BuildToolsVersion.txt</BuildToolsVersionFile>
-    </PropertyGroup>
-    <ReadLinesFromFile File="$(BuildToolsVersionFile)">
-      <Output TaskParameter="Lines" ItemName="BuildToolsVersion" />
-    </ReadLinesFromFile>
-    <PropertyGroup>
-      <BuildToolsVersion>@(BuildToolsVersion)</BuildToolsVersion>
-    </PropertyGroup>
-    <ItemGroup>
-      <BuildToolsFiles Include="$(ToolPackagesDir)Microsoft.DotNet.BuildTools\$(BuildToolsVersion)\lib\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildToolsFiles)"
-          DestinationFolder="$(DeploymentDir)"
-          SkipUnchangedFiles="true"
-          />
-    <Copy SourceFiles="@(BuildToolsFiles)"
-          DestinationFolder="$(TestDeploymentDir)"
-          SkipUnchangedFiles="true"
-          />
-  </Target>-->
-
   <Target Name="CopyPackageContent">
     <ItemGroup>
       <!-- We want the list of files *after* restore, which happens
@@ -208,8 +184,7 @@
         SourceFiles="$(TestDeploymentDir)\dotnet"
         DestinationFiles="$(TestDeploymentDir)\dotnet.exe"
         Condition="'$(MonoBuild)' != 'true'"
-        />        
-        
+        />
   </Target>
 
   <Target Name="DeployDependencies"

--- a/targets/DeployDependencies.proj
+++ b/targets/DeployDependencies.proj
@@ -22,7 +22,7 @@
   </Target>
 
   <!-- Copy content of BuildTools package to deployment folders -->
-  <Target Name="CopyBuildTools">
+  <!--<Target Name="CopyBuildTools">
     <PropertyGroup>
       <BuildToolsVersionFile>$(RepoRoot)BuildToolsVersion.txt</BuildToolsVersionFile>
     </PropertyGroup>
@@ -43,7 +43,7 @@
           DestinationFolder="$(TestDeploymentDir)"
           SkipUnchangedFiles="true"
           />
-  </Target>
+  </Target>-->
 
   <Target Name="CopyPackageContent">
     <ItemGroup>
@@ -185,7 +185,7 @@
   </Target>
   
   <Target Name="FixupFilenames"
-          DependsOnTargets="CopyBuildTools;DeployRuntime"
+          DependsOnTargets="DeployRuntime"
           Condition="'$(OsEnvironment)'!='Windows_NT'">
           
     <!-- Portable targets package has mismatched casing for Microsoft.CSharp.Targets -->
@@ -213,6 +213,6 @@
   </Target>
 
   <Target Name="DeployDependencies"
-          DependsOnTargets="CopyBuildTools;CopyPackageContent;CopyCompilerTools;DeployRuntime;FixupFilenames" />
+          DependsOnTargets="CopyPackageContent;CopyCompilerTools;DeployRuntime;FixupFilenames" />
 
 </Project>


### PR DESCRIPTION
Needed for #2595 

* Download NuGet.Build.Tasks from package (myget feed).
* Cleanup bootstrap. Avoid copying BuildTools blindly into the output folder.
* Correct some path properties. A lot of things just worked because we copied so much.