### PR TITLE
Reduce more allocations in CreateFileMatcher

### DIFF
--- a/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
@@ -3,6 +3,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
 using Microsoft.Build.UnitTests.BackEnd;
@@ -11,6 +12,7 @@ using ProjectInstanceItemSpec =
     Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Execution.ProjectPropertyInstance, Microsoft.Build.Execution.ProjectItemInstance>;
 using ProjectInstanceExpander =
     Microsoft.Build.Evaluation.Expander<Microsoft.Build.Execution.ProjectPropertyInstance, Microsoft.Build.Execution.ProjectItemInstance>;
+
 
 namespace Microsoft.Build.UnitTests.OM.Evaluation
 {
@@ -52,7 +54,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
         private ProjectInstanceItemSpec CreateItemSpecFrom(string itemSpec, ProjectInstanceExpander expander)
         {
-            return new ProjectInstanceItemSpec(itemSpec, expander, MockElementLocation.Instance, "ProjectDirectory");
+            return new ProjectInstanceItemSpec(itemSpec, expander, MockElementLocation.Instance, Path.GetDirectoryName(MockElementLocation.Instance.File));
         }
 
         private ProjectInstanceExpander CreateExpander(Dictionary<string, string[]> items)

--- a/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
 
         private ProjectInstanceItemSpec CreateItemSpecFrom(string itemSpec, ProjectInstanceExpander expander)
         {
-            return new ProjectInstanceItemSpec(itemSpec, expander, MockElementLocation.Instance);
+            return new ProjectInstanceItemSpec(itemSpec, expander, MockElementLocation.Instance, "ProjectDirectory");
         }
 
         private ProjectInstanceExpander CreateExpander(Dictionary<string, string[]> items)

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -101,14 +101,14 @@ namespace Microsoft.Build.Evaluation
                         {
 
                             // Just return the original string.
-                            builder.Add(new ValueFragment(splitEscaped, itemSpecLocation.File));
+                            builder.Add(new ValueFragment(splitEscaped, projectDirectory));
                         }
                         else if (!containsEscapedWildcards && containsRealWildcards)
                         {
                             // Unescape before handing it to the filesystem.
                             var filespecUnescaped = EscapingUtilities.UnescapeAll(splitEscaped);
 
-                            builder.Add(new GlobFragment(filespecUnescaped, itemSpecLocation.File));
+                            builder.Add(new GlobFragment(filespecUnescaped, projectDirectory));
                         }
                         else
                         {
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Evaluation
                             // escaping ... it should already be escaped appropriately since it came directly
                             // from the project file
 
-                            builder.Add(new ValueFragment(splitEscaped, itemSpecLocation.File));
+                            builder.Add(new ValueFragment(splitEscaped, projectDirectory));
                         }
                     }
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Build.Evaluation
             OperationBuilderWithMetadata operationBuilder = new OperationBuilderWithMetadata(itemElement, conditionResult);
 
             // Proces Update attribute
-            ProcessItemSpec(itemElement.Update, itemElement.UpdateLocation, operationBuilder);
+            ProcessItemSpec(rootDirectory, itemElement.Update, itemElement.UpdateLocation, operationBuilder);
 
             ProcessMetadataElements(itemElement, operationBuilder);
 
@@ -456,7 +456,7 @@ namespace Microsoft.Build.Evaluation
             operationBuilder.ConditionResult = conditionResult;
 
             // Process include
-            ProcessItemSpec(itemElement.Include, itemElement.IncludeLocation, operationBuilder);
+            ProcessItemSpec(rootDirectory, itemElement.Include, itemElement.IncludeLocation, operationBuilder);
 
             //  Code corresponds to Evaluator.EvaluateItemElement
 
@@ -490,14 +490,14 @@ namespace Microsoft.Build.Evaluation
         {
             OperationBuilder operationBuilder = new OperationBuilder(itemElement, conditionResult);
 
-            ProcessItemSpec(itemElement.Remove, itemElement.RemoveLocation, operationBuilder);
+            ProcessItemSpec(rootDirectory, itemElement.Remove, itemElement.RemoveLocation, operationBuilder);
 
             return new RemoveOperation(operationBuilder, this);
         }
 
-        private void ProcessItemSpec(string itemSpec, IElementLocation itemSpecLocation, OperationBuilder builder)
+        private void ProcessItemSpec(string rootDirectory, string itemSpec, IElementLocation itemSpecLocation, OperationBuilder builder)
         {
-            builder.ItemSpec = new ItemSpec<P, I>(itemSpec, _outerExpander, itemSpecLocation);
+            builder.ItemSpec = new ItemSpec<P, I>(itemSpec, _outerExpander, itemSpecLocation, rootDirectory);
 
             var itemCaptures = builder.ItemSpec.Fragments.OfType<ItemExpressionFragment<P, I>>().Select(i => i.Capture);
             AddReferencedItemLists(builder, itemCaptures);

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -620,6 +620,7 @@
     <Compile Include="Utilities\EngineFileUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Utilities\FileSpecMatchTester.cs" />
     <Compile Include="Utilities\RegistryKeyWrapper.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.EscapingStringExtensions;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Internal
+{
+    internal struct FileSpecMatcherTester
+    {
+        private readonly string _currentDirectory;
+        private readonly string _unescapedFileSpec;
+        private readonly Regex _regex;
+        
+        private FileSpecMatcherTester(string currentDirectory, string unescapedFileSpec, Regex regex)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(unescapedFileSpec));
+
+            _currentDirectory = currentDirectory;
+            _unescapedFileSpec = unescapedFileSpec;
+            _regex = regex;
+        }
+
+        public static FileSpecMatcherTester Parse(string currentDirectory, string fileSpec)
+        {
+            string unescapedFileSpec = fileSpec.Unescape();
+            Regex regex = EngineFileUtilities.FilespecHasWildcards(fileSpec) ? CreateRegex(unescapedFileSpec, currentDirectory) : null;
+
+            return new FileSpecMatcherTester(currentDirectory, unescapedFileSpec, regex);
+        }
+
+        public bool IsMatch(string fileToMatch)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(fileToMatch));
+
+            // check if there is a regex matching the file
+            if (_regex != null)
+            {
+                var normalizedFileToMatch = FileUtilities.GetFullPathNoThrow(Path.Combine(_currentDirectory, fileToMatch));
+                return _regex.IsMatch(normalizedFileToMatch);
+            }
+
+            return FileUtilities.ComparePathsNoThrow(_unescapedFileSpec, fileToMatch, _currentDirectory);
+        }
+
+        // this method parses the glob and extracts the fixed directory part in order to normalize it and make it absolute
+        // without this normalization step, strings pointing outside the globbing cone would still match when they shouldn't
+        // for example, we dont want "**/*.cs" to match "../Shared/Foo.cs"
+        // todo: glob rooting partially duplicated with MSBuildGlob.Parse
+        private static Regex CreateRegex(string unescapedFileSpec, string currentDirectory)
+        {
+            Regex regex = null;
+            string fixedDirPart = null;
+            string wildcardDirectoryPart = null;
+            string filenamePart = null;
+
+            FileMatcher.SplitFileSpec(
+                unescapedFileSpec,
+                out fixedDirPart,
+                out wildcardDirectoryPart,
+                out filenamePart,
+                FileMatcher.s_defaultGetFileSystemEntries);
+
+            if (FileUtilities.PathIsInvalid(fixedDirPart))
+            {
+                return null;
+            }
+
+            var absoluteFixedDirPart = Path.Combine(currentDirectory, fixedDirPart);
+            var normalizedFixedDirPart = string.IsNullOrEmpty(absoluteFixedDirPart)
+                // currentDirectory is empty for some in-memory projects
+                ? Directory.GetCurrentDirectory()
+                : FileUtilities.GetFullPathNoThrow(absoluteFixedDirPart);
+
+            normalizedFixedDirPart = FileUtilities.EnsureTrailingSlash(normalizedFixedDirPart);
+
+            var recombinedFileSpec = string.Join("", normalizedFixedDirPart, wildcardDirectoryPart, filenamePart);
+
+            bool isRecursive;
+            bool isLegal;
+
+            FileMatcher.GetFileSpecInfoWithRegexObject(
+                recombinedFileSpec,
+                out regex,
+                out isRecursive,
+                out isLegal,
+                FileMatcher.s_defaultGetFileSystemEntries);
+
+            return isLegal ? regex : null;
+        }
+    }
+}


### PR DESCRIPTION
This includes https://github.com/Microsoft/msbuild/pull/2590, so be sure to only review the last commit https://github.com/Microsoft/msbuild/commit/16be8a35614dabf16c4e1e15c9f53ae14b7d368f.

This removes the capture class from CreateFileMatcher which was 0.3% of allocations (74 MB) in a large partner's solution:

![image](https://user-images.githubusercontent.com/1103906/31264956-f86a0dc6-aab7-11e7-9d50-745060f87bd9.png)
