### PR TITLE
Remove the disable intrinsic MSBuild tasks escape hatch

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -23,7 +23,6 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.BackEnd.Logging;
 using System.Globalization;
 using System.Reflection;
-using Microsoft.Build.Utilities;
 #if FEATURE_APPDOMAIN
 using System.Runtime.Remoting;
 #endif

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Build.BackEnd
         private const int CancelWarningWaitInterval = 15000;
 
         /// <summary>
+        /// True if intrinsic MSBuild tasks, MSBuild and CallTarget, are supported.
+        /// </summary>
+        private static readonly bool s_supportsIntrinsicMSBuildTasks = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDISABLEINTRINSICMSBUILDTASK"));
+
+        /// <summary>
         /// Whether to log task input parameters.  Can either be set through an environment variable 
         /// or by the BuildParameters.
         /// </summary>
@@ -980,7 +985,7 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDISABLEINTRINSICMSBUILDTASK")))
+                if (s_supportsIntrinsicMSBuildTasks)
                 {
                     // Map to an intrinsic task, if necessary.
                     if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.MSBuild", StringComparison.OrdinalIgnoreCase))

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -981,19 +981,16 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                if (!Traits.Instance.EscapeHatches.DisableIntrinsicMSBuildTasks)
+                // Map to an intrinsic task, if necessary.
+                if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.MSBuild", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Map to an intrinsic task, if necessary.
-                    if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.MSBuild", StringComparison.OrdinalIgnoreCase))
-                    {
-                        returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(MSBuild)), new LoadedType(typeof(MSBuild), AssemblyLoadInfo.Create(typeof(TaskExecutionHost).GetTypeInfo().Assembly.FullName, null)), _taskName, null);
-                        _intrinsicTasks[_taskName] = returnClass;
-                    }
-                    else if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.CallTarget", StringComparison.OrdinalIgnoreCase))
-                    {
-                        returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(CallTarget)), new LoadedType(typeof(CallTarget), AssemblyLoadInfo.Create(typeof(TaskExecutionHost).GetTypeInfo().Assembly.FullName, null)), _taskName, null);
-                        _intrinsicTasks[_taskName] = returnClass;
-                    }
+                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(MSBuild)), new LoadedType(typeof(MSBuild), AssemblyLoadInfo.Create(typeof(TaskExecutionHost).GetTypeInfo().Assembly.FullName, null)), _taskName, null);
+                    _intrinsicTasks[_taskName] = returnClass;
+                }
+                else if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.CallTarget", StringComparison.OrdinalIgnoreCase))
+                {
+                    returnClass = new TaskFactoryWrapper(new IntrinsicTaskFactory(typeof(CallTarget)), new LoadedType(typeof(CallTarget), AssemblyLoadInfo.Create(typeof(TaskExecutionHost).GetTypeInfo().Assembly.FullName, null)), _taskName, null);
+                    _intrinsicTasks[_taskName] = returnClass;
                 }
             }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -23,6 +23,7 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.BackEnd.Logging;
 using System.Globalization;
 using System.Reflection;
+using Microsoft.Build.Utilities;
 #if FEATURE_APPDOMAIN
 using System.Runtime.Remoting;
 #endif
@@ -47,11 +48,6 @@ namespace Microsoft.Build.BackEnd
         /// Time interval in miliseconds between subsequent warnings that a non-cancelable task has not finished
         /// </summary>
         private const int CancelWarningWaitInterval = 15000;
-
-        /// <summary>
-        /// True if intrinsic MSBuild tasks, MSBuild and CallTarget, are supported.
-        /// </summary>
-        private static readonly bool s_supportsIntrinsicMSBuildTasks = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDISABLEINTRINSICMSBUILDTASK"));
 
         /// <summary>
         /// Whether to log task input parameters.  Can either be set through an environment variable 
@@ -985,7 +981,7 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
 
-                if (s_supportsIntrinsicMSBuildTasks)
+                if (!Traits.Instance.EscapeHatches.DisableIntrinsicMSBuildTasks)
                 {
                     // Map to an intrinsic task, if necessary.
                     if (String.Equals(returnClass.TaskFactory.TaskType.FullName, "Microsoft.Build.Tasks.MSBuild", StringComparison.OrdinalIgnoreCase))

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -94,6 +94,11 @@ namespace Microsoft.Build.Utilities
         // it's unneeded (at least by the 16.0 timeframe).
         public readonly bool UseCaseSensitiveItemNames = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1";
 
+        /// <summary>
+        /// True (MSBUILDDISABLEINTRINSICMSBUILDTASK=1), ff intrinsic MSBuild tasks, MSBuild and CallTarget, are disabled.
+        /// </summary>
+        public readonly bool DisableIntrinsicMSBuildTasks = Environment.GetEnvironmentVariable("MSBUILDDISABLEINTRINSICMSBUILDTASK") == "1";
+
         private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
         {
             var mode = Environment.GetEnvironmentVariable("MSBUILD_PROJECTINSTANCE_TRANSLATION_MODE");

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -94,11 +94,6 @@ namespace Microsoft.Build.Utilities
         // it's unneeded (at least by the 16.0 timeframe).
         public readonly bool UseCaseSensitiveItemNames = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1";
 
-        /// <summary>
-        /// True (MSBUILDDISABLEINTRINSICMSBUILDTASK=1), ff intrinsic MSBuild tasks, MSBuild and CallTarget, are disabled.
-        /// </summary>
-        public readonly bool DisableIntrinsicMSBuildTasks = Environment.GetEnvironmentVariable("MSBUILDDISABLEINTRINSICMSBUILDTASK") == "1";
-
         private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
         {
             var mode = Environment.GetEnvironmentVariable("MSBUILD_PROJECTINSTANCE_TRANSLATION_MODE");


### PR DESCRIPTION
This took 0.2% of CPU, and 0.1% of allocations in a .NET Standard/.NET Framework mixed project.