### PR TITLE
Remove LINQ operations

### DIFF
--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -147,14 +147,6 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Return the items in <param name="items"/> that match this itemspec
-        /// </summary>
-        public IEnumerable<I> FilterItems(IEnumerable<I> items)
-        {
-            return items.Where(MatchesItem);
-        }
-
-        /// <summary>
         /// Return true if the given <paramref name="item"/> matches this itemspec
         /// </summary>
         /// <param name="item">The item to attempt to find a match for.</param>

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -228,14 +228,6 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
             }
-
-            /// <summary>
-            /// Collects all the items of this item element's type that match the items (represented as operations)
-            /// </summary>
-            protected IEnumerable<I> SelectItemsMatchingItemSpec(ImmutableList<ItemData>.Builder listBuilder, IElementLocation elementLocation)
-            {
-                return _itemSpec.FilterItems(listBuilder.Select(itemData => itemData.Item));
-            }
         }
     }
 }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Evaluation
             // todo Perf: do not match against the globs: https://github.com/Microsoft/msbuild/issues/2329
             protected override ICollection<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
-                return SelectItemsMatchingItemSpec(listBuilder, _itemElement.RemoveLocation).ToImmutableHashSet();
+                return _itemSpec.FilterItems(listBuilder.Select(itemData => itemData.Item)).ToImmutableHashSet();
             }
 
             protected override void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder)

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -20,7 +20,14 @@ namespace Microsoft.Build.Evaluation
             // todo Perf: do not match against the globs: https://github.com/Microsoft/msbuild/issues/2329
             protected override ICollection<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
-                return _itemSpec.FilterItems(listBuilder.Select(itemData => itemData.Item)).ToImmutableHashSet();
+                var items = ImmutableHashSet.CreateBuilder<I>();
+                foreach (ItemData item in listBuilder)
+                {
+                    if (_itemSpec.MatchesItem(item.Item))
+                        items.Add(item.Item);
+                }
+
+                return items.ToImmutableHashSet();
             }
 
             protected override void SaveItems(ICollection<I> items, ImmutableList<ItemData>.Builder listBuilder)


### PR DESCRIPTION
LazyOperation.Apply [is very allocation hungry](https://github.com/Microsoft/msbuild/issues/2599) and requires a small refactoring to prevent the gigabytes of data that its allocating while opening a partner's solution. To make reviews as easy as possible - I'm breaking off small portions on the road to the refactoring to try reduce regressions/review pain.

Below is unlinqifying RemoveOperation.SelectItems.