### PR TITLE
Remove <Link/> from OutOfProcTaskAppDomainWrapper

### DIFF
--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -190,9 +190,7 @@
     <Compile Include="..\MSBuild\OutOfProcTaskAppDomainWrapperBase.cs">
       <Link>OutOfProcTaskAppDomainWrapperBase.cs</Link>
     </Compile>
-    <Compile Include="OutOfProcTaskAppDomainWrapper.cs">
-      <Link>OutOfProcTaskAppDomainWrapperStub.cs</Link>
-    </Compile>
+    <Compile Include="OutOfProcTaskAppDomainWrapper.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>


### PR DESCRIPTION
Removes warning about it being in the project root.

```
Severity	Code	Description	Project	File	Line	Suppression State
Warning		The file 'OutOfProcTaskAppDomainWrapper.cs' could not be added to the project.  Cannot add a link to the file E:\msbuild\src\MSBuildTaskHost\OutOfProcTaskAppDomainWrapper.cs. This file is within the project directory tree.	MSBuildTaskHost			
```