### PR TITLE
Stop boxing in CompileDirectories

### DIFF
--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal static Resolver[] CompileDirectories
         (
-            IEnumerable<string> directories,
+            List<string> directories,
             FileExists fileExists,
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -209,12 +209,13 @@ namespace Microsoft.Build.Tasks
             Version targetedRuntimeVersion
         )
         {
-            List<Resolver> resolvers = new List<Resolver>();
-            foreach (string directory in directories)
+            var resolvers = new Resolver[directories.Count];
+            for (int i = 0; i < directories.Count; i++)
             {
-                resolvers.Add(new DirectoryResolver(directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion));
+                resolvers[i] = new DirectoryResolver(directories[i], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion);
             }
-            return resolvers.ToArray();
+
+            return resolvers;
         }
     }
 }


### PR DESCRIPTION
Stop boxing in CompileDirectories and avoid extra List<T> overhead.

This was about 0.1% in a mixed .NET Framework/.NET Standard solution.