### PR TITLE
Remove unneeded ToArray

### DIFF
--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Build.BackEnd.Logging
                 configurationId,
                 parentBuildEventContext,
                 projectFullPath,
-                String.Join(";", targets.ToArray()),
+                String.Join(";", targets),
                 properties,
                 items
                 );

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2159,7 +2159,7 @@ namespace Microsoft.Build.BackEnd
                 String.Format(CultureInfo.InvariantCulture, "{0:0.000}", request.GetTimeSpentInState(SchedulableRequestState.Executing).TotalSeconds),
                 String.Format(CultureInfo.InvariantCulture, "{0:0.000}", request.GetTimeSpentInState(SchedulableRequestState.Executing).TotalSeconds + request.GetTimeSpentInState(SchedulableRequestState.Blocked).TotalSeconds + request.GetTimeSpentInState(SchedulableRequestState.Ready).TotalSeconds),
                 _configCache[request.BuildRequest.ConfigurationId].ProjectFullPath,
-                String.Join(", ", request.BuildRequest.Targets.ToArray())
+                String.Join(", ", request.BuildRequest.Targets)
             );
 
             List<SchedulableRequest> childRequests = new List<SchedulableRequest>(_schedulingData.GetRequestsByHierarchy(request));

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1675,8 +1675,8 @@ namespace Microsoft.Build.Execution
         {
             ProjectRootElement rootElement = ProjectRootElement.Create();
 
-            rootElement.InitialTargets = String.Join(";", InitialTargets.ToArray());
-            rootElement.DefaultTargets = String.Join(";", DefaultTargets.ToArray());
+            rootElement.InitialTargets = String.Join(";", InitialTargets);
+            rootElement.DefaultTargets = String.Join(";", DefaultTargets);
             rootElement.ToolsVersion = ToolsVersion;
 
             // Add all of the item definitions.            

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -2472,10 +2472,10 @@ namespace Microsoft.Build.Utilities
             string registryRoot = NativeMethodsShared.IsWindows ? GetTargetPlatformMonikerRegistryRoots(registrySearchLocation) : string.Empty;
 
             string cachedTargetPlatformsKey = String.Join("|",
-                String.Join(";", sdkDiskRoots.ToArray()),
+                String.Join(";", sdkDiskRoots),
                 registryRoot);
 
-            string cachedExtensionSdksKey = extensionDiskRoots == null ? String.Empty : String.Join(";", extensionDiskRoots.ToArray());
+            string cachedExtensionSdksKey = extensionDiskRoots == null ? String.Empty : String.Join(";", extensionDiskRoots);
 
             lock (s_locker)
             {


### PR DESCRIPTION
String.Join added an IEnumerable<string> overload in 4.0. This doesn't reduce the # allocations, but it does reduce the size of the allocations and prevent the copying.