### PR TITLE
Remove unneeded StringBuilder alloc

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -354,52 +354,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void LogUniqueInputsAndOutputs()
         {
-            string inputs = null;
-            string outputs = null;
-
-            if (_uniqueTargetInputs.Count > 0)
-            {
-                StringBuilder inputsBuilder = new StringBuilder();
-                foreach (string input in _uniqueTargetInputs.Keys)
-                {
-                    inputsBuilder.Append(input);
-                    inputsBuilder.Append(";");
-                }
-
-                // We don't want the trailing ; so remove it
-                inputs = inputsBuilder.ToString(0, inputsBuilder.Length - 1);
-            }
-            else
-            {
-                inputs = String.Empty;
-            }
-
-            if (_uniqueTargetOutputs.Count > 0)
-            {
-                StringBuilder outputsBuilder = new StringBuilder();
-                foreach (string input in _uniqueTargetOutputs.Keys)
-                {
-                    outputsBuilder.Append(input);
-                    outputsBuilder.Append(";");
-                }
-
-                // We don't want the trailing ; so remove it
-                outputs = outputsBuilder.ToString(0, outputsBuilder.Length - 1);
-            }
-            else
-            {
-                outputs = String.Empty;
-            }
-
-            if (inputs != null)
-            {
-                _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SkipTargetUpToDateInputs", inputs);
-            }
-
-            if (outputs != null)
-            {
-                _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SkipTargetUpToDateOutputs", outputs);
-            }
+            _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SkipTargetUpToDateInputs", string.Join(";", _uniqueTargetInputs.Keys));
+            _loggingService.LogComment(_buildEventContext, MessageImportance.Low, "SkipTargetUpToDateOutputs", string.Join(";", _uniqueTargetOutputs.Keys));
         }
 
         /// <summary>


### PR DESCRIPTION
Note, I left the behavior "as is" which is that it always logs inputs/outputs regardless of whether they exist, ie the previous null checks would never have returned false because they were always assigned a value.

While this uses a StringBuilder under the covers, it pulls it from mscorlib's pool.