### PR TITLE
Init smarter and rewrite loops

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -785,7 +785,7 @@ namespace Microsoft.Build.BackEnd
             try
             {
                 // Loop through all the TaskItems in our arraylist, and convert them.
-                ArrayList finalTaskInputs = new ArrayList();
+                ArrayList finalTaskInputs = new ArrayList(taskItems.Count);
 
                 if (parameterType != typeof(ITaskItem[]))
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Build.Evaluation
                         _expander.Metadata = metadataTable;
 
                         // Also keep a list of everything so we can get the predecessor objects correct.
-                        List<Pair<ProjectMetadataElement, string>> metadataList = new List<Pair<ProjectMetadataElement, string>>();
+                        List<Pair<ProjectMetadataElement, string>> metadataList = new List<Pair<ProjectMetadataElement, string>>(metadata.Count);
 
                         foreach (var metadataElement in metadata)
                         {


### PR DESCRIPTION
Type all fields as List<T> and then just foreach over them. This avoids the box.

Also initialize capability in a few places.