### PR TITLE
Remove unused features of expression capture

### DIFF
--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Build.Evaluation
                     // Create an expression capture that encompases the entire expression between the @( and the )
                     // with the item name and any separator contained within it
                     // and each transform expression contained within it (i.e. each ->XYZ)
-                    ItemExpressionCapture expressionCapture = new ItemExpressionCapture(startPoint, endPoint - startPoint, expression.Substring(startPoint, endPoint - startPoint), itemName, separator, separatorStart, separatorLength, transformExpressions);
+                    ItemExpressionCapture expressionCapture = new ItemExpressionCapture(startPoint, endPoint - startPoint, expression.Substring(startPoint, endPoint - startPoint), itemName, separator, separatorStart, transformExpressions);
                     subExpressions.Add(expressionCapture);
 
                     continue;
@@ -738,11 +738,6 @@ namespace Microsoft.Build.Evaluation
             private int _separatorStart;
 
             /// <summary>
-            /// The length of the separator
-            /// </summary>
-            private int _separatorLength;
-
-            /// <summary>
             /// The function name, if any, within this expression
             /// </summary>
             private string _functionName;
@@ -756,7 +751,7 @@ namespace Microsoft.Build.Evaluation
             /// Create an Expression Capture instance
             /// Represents a sub expression, shredded from a larger expression
             /// </summary>
-            public ItemExpressionCapture(int index, int length, string subExpression) : this(index, length, subExpression, null, null, -1, -1, null)
+            public ItemExpressionCapture(int index, int length, string subExpression) : this(index, length, subExpression, null, null, -1, null)
             {
             }
 
@@ -764,7 +759,7 @@ namespace Microsoft.Build.Evaluation
             /// Create an Expression Capture instance
             /// Represents a sub expression, shredded from a larger expression
             /// </summary>
-            public ItemExpressionCapture(int index, int length, string subExpression, string itemType, string separator, int separatorStart, int separatorLength, List<ItemExpressionCapture> captures)
+            public ItemExpressionCapture(int index, int length, string subExpression, string itemType, string separator, int separatorStart, List<ItemExpressionCapture> captures)
             {
                 _index = index;
                 _length = length;
@@ -772,7 +767,6 @@ namespace Microsoft.Build.Evaluation
                 _itemType = itemType;
                 _separator = separator;
                 _separatorStart = separatorStart;
-                _separatorLength = separatorLength;
                 _captures = captures;
             }
 
@@ -834,14 +828,6 @@ namespace Microsoft.Build.Evaluation
             public int SeparatorStart
             {
                 get { return _separatorStart; }
-            }
-
-            /// <summary>
-            /// The length of the separator.
-            /// </summary>
-            public int SeparatorLength
-            {
-                get { return _separatorLength; }
             }
 
             /// <summary>

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -776,7 +776,6 @@ namespace Microsoft.Build.Evaluation
             public List<ItemExpressionCapture> Captures
             {
                 get { return _captures; }
-                set { _captures = value; }
             }
 
             /// <summary>
@@ -810,7 +809,6 @@ namespace Microsoft.Build.Evaluation
             public string ItemType
             {
                 get { return _itemType; }
-                set { _itemType = value; }
             }
 
             /// <summary>
@@ -819,7 +817,6 @@ namespace Microsoft.Build.Evaluation
             public string Separator
             {
                 get { return _separator; }
-                set { _separator = value; }
             }
 
             /// <summary>

--- a/src/Build/Evaluation/ExpressionShredder.cs
+++ b/src/Build/Evaluation/ExpressionShredder.cs
@@ -704,38 +704,38 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Captures within this capture
             /// </summary>
-            private List<ItemExpressionCapture> _captures;
+            private readonly List<ItemExpressionCapture> _captures;
 
             /// <summary>
             /// The position in the original string where the first character of the captured
             /// substring was found.
             /// </summary>
-            private int _index;
+            private readonly int _index;
 
             /// <summary>
             /// The length of the captured substring.
             /// </summary>
-            private int _length;
+            private readonly int _length;
 
             /// <summary>
             /// The captured substring from the input string.
             /// </summary>
-            private string _value;
+            private readonly string _value;
 
             /// <summary>
             /// The type of the item within this expression
             /// </summary>
-            private string _itemType;
+            private readonly string _itemType;
 
             /// <summary>
             /// The separator, if any, within this expression
             /// </summary>
-            private string _separator;
+            private readonly string _separator;
 
             /// <summary>
             /// The starting character of the separator within the expression
             /// </summary>
-            private int _separatorStart;
+            private readonly int _separatorStart;
 
             /// <summary>
             /// The function name, if any, within this expression


### PR DESCRIPTION
ItemExpressionCapture represents four types of expressions; function call, a normal transform, separator transform and the entire outer expression. All expressions pay for the fields of the other regardless of whether they use them. 

This is a tiny little cleanup to reduce the diff when I attempt to split them up into their appropriate expressions.