### PR TITLE
Add back the parameter to FormatResourceString

### DIFF
--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Shared
 
         [Obsolete("Use GetResourceString instead.", true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static string FormatResourceString()
+        internal static string FormatResourceString(string resourceName)
         {   // Avoids an accidental dependency on FormatResourceString(string, params object[])
             return null;
         }


### PR DESCRIPTION
Accidentally removed it when adding obsolete therefore defeating the purpose of it existing (to catch accident calls to FormatResourceString without any args). As pointed out by @pilchie: https://github.com/Microsoft/msbuild/pull/2609#discussion_r143490068.