### PR TITLE
Reduce allocations in Lookup.GetItems

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -548,7 +548,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         if (modifies.Count != 0)
                         {
-                            allModifies = allModifies ?? new Dictionary<ProjectItemInstance, MetadataModifications>();
+                            allModifies = allModifies ?? new Dictionary<ProjectItemInstance, MetadataModifications>(modifies.Count);
 
                             // We already have some modifies for this type
                             foreach (KeyValuePair<ProjectItemInstance, MetadataModifications> modify in modifies)

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -510,8 +510,9 @@ namespace Microsoft.Build.BackEnd
             // The visible items consist of the adds (accumulated as we go down)
             // plus the first set of regular items we encounter
             // minus any removes
-            ItemDictionary<ProjectItemInstance> allAdds = null;
-            ItemDictionary<ProjectItemInstance> allRemoves = null;
+
+            List<ProjectItemInstance> allAdds = null;
+            List<ProjectItemInstance> allRemoves = null;
             Dictionary<ProjectItemInstance, MetadataModifications> allModifies = null;
             ICollection<ProjectItemInstance> groupFound = null;
 
@@ -523,8 +524,8 @@ namespace Microsoft.Build.BackEnd
                     ICollection<ProjectItemInstance> adds = scope.Adds[itemType];
                     if (adds.Count != 0)
                     {
-                        allAdds = allAdds ?? new ItemDictionary<ProjectItemInstance>();
-                        allAdds.ImportItemsOfType(itemType, adds);
+                        allAdds = allAdds ?? new List<ProjectItemInstance>(adds.Count);
+                        allAdds.AddRange(adds);
                     }
                 }
 
@@ -534,8 +535,8 @@ namespace Microsoft.Build.BackEnd
                     ICollection<ProjectItemInstance> removes = scope.Removes[itemType];
                     if (removes.Count != 0)
                     {
-                        allRemoves = allRemoves ?? new ItemDictionary<ProjectItemInstance>();
-                        allRemoves.ImportItems(removes);
+                        allRemoves = allRemoves ?? new List<ProjectItemInstance>(removes.Count);
+                        allRemoves.AddRange(removes);
                     }
                 }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -588,11 +588,19 @@ namespace Microsoft.Build.BackEnd
                 return groupFound;
             }
 
+            // Set the initial sizes to avoid resizing during import
+            int itemsTypesCount = 1;    // We're only ever importing a single item type
+            int itemsCount = groupFound?.Count ?? 0;    // Start with initial set
+            itemsCount += allAdds?.Count ?? 0;          // Add all the additions
+            itemsCount -= allRemoves?.Count ?? 0;       // Remove the removals
+            if (itemsCount < 0)
+                itemsCount = 0;
+
             // We have adds and/or removes and/or modifies to incorporate.
             // We can't modify the group, because that might
             // be visible to other batches; we have to create
             // a new one.
-            ItemDictionary<ProjectItemInstance> result = new ItemDictionary<ProjectItemInstance>();
+            ItemDictionary<ProjectItemInstance> result = new ItemDictionary<ProjectItemInstance>(itemsTypesCount, itemsCount);
 
             if (groupFound != null)
             {

--- a/src/Build/Collections/ItemDictionary.cs
+++ b/src/Build/Collections/ItemDictionary.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Build.Collections
         /// Constructor for an empty collection taking an initial capacity
         /// for the number of distinct item types
         /// </summary>
-        internal ItemDictionary(int initialItemTypesCapacity)
+        internal ItemDictionary(int initialItemTypesCapacity, int initialItemsCapacity = 0)
         {
             // Tracing.Record("new item dictionary");
             _itemLists = new Dictionary<string, LinkedList<T>>(initialItemTypesCapacity, MSBuildNameIgnoreCaseComparer.Default);
-            _nodes = new Dictionary<T, LinkedListNode<T>>();
+            _nodes = new Dictionary<T, LinkedListNode<T>>(initialItemsCapacity);
         }
 
         /// <summary>


### PR DESCRIPTION
This cuts allocations in Lookup.GetItems by half, from 2.8% -> 1.4% in a mixed .NET Standard/.NET Framework solution.

This is a minimal change to avoid introducing regressions but this code path is extremely allocation heavy, it's creating and copying collections into other collections *a lot*. ItemDictionary would be better replaced with a different collection:

Before:
![image](https://user-images.githubusercontent.com/1103906/31423445-960917d4-aea0-11e7-989f-131763d340ad.png)

After:
![image](https://user-images.githubusercontent.com/1103906/31423463-ba95cd0e-aea0-11e7-91e7-efee12379ba3.png)

