### PR TITLE
Option to not evaluate elements with false conditions

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -760,6 +760,7 @@ namespace Microsoft.Build.Evaluation
     public enum ProjectLoadSettings
     {
         Default = 0,
+        DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -748,6 +748,7 @@ namespace Microsoft.Build.Evaluation
     public enum ProjectLoadSettings
     {
         Default = 0,
+        DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,

--- a/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
@@ -10,9 +10,10 @@ using System.Collections.Generic;
 using System.Text;
 using System.Xml;
 using System.IO;
+using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
-
+using Shouldly;
 using InternalUtilities = Microsoft.Build.Internal.Utilities;
 using Xunit;
 
@@ -190,6 +191,74 @@ namespace Microsoft.Build.UnitTests.Definition
             {
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", oldValue);
                 InternalUtilities.RefreshInternalEnvironmentValues();
+            }
+        }
+
+        [Fact]
+        public void ProjectEvaluationShouldRespectConditionsIfProjectLoadSettingsSaysSo()
+        {
+            var projectContents = @"
+<Project>   
+   <ItemDefinitionGroup Condition=`1 == 2`>
+     <I>
+       <m>v</m>
+     </I>
+   </ItemDefinitionGroup>
+   
+   <PropertyGroup Condition=`1 == 2`>
+     <P1>v</P1>
+   </PropertyGroup>
+
+   <PropertyGroup>
+     <P2 Condition=`1 == 2`>v</P2>
+   </PropertyGroup>
+
+   <ItemGroup Condition=`1 == 2`>
+     <I1 Include=`i`/>
+   </ItemGroup>
+
+   <ItemGroup>
+     <I2 Condition=`1 == 2` Include=`i`/>
+   </ItemGroup>
+</Project>".Cleanup();
+
+            using (var env = TestEnvironment.Create())
+            {
+                var projectCollection = env.CreateProjectCollection().Collection;
+
+                var project = new Project(XmlReader.Create(new StringReader(projectContents)), new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, projectCollection, ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition);
+
+                var data = project.TestOnlyGetPrivateData;
+
+                project.GetProperty("P1").ShouldBeNull();
+                project.GetProperty("P2").ShouldBeNull();
+                project.Items.ShouldBeEmpty();
+                project.ItemDefinitions.ShouldBeEmpty();
+
+                data.ConditionedProperties.ShouldBeEmpty();
+                data.ItemsIgnoringCondition.ShouldBeEmpty();
+                data.AllEvaluatedItemDefinitionMetadata.ShouldBeEmpty();
+                data.AllEvaluatedItems.ShouldBeEmpty();
+
+                Should.Throw<InvalidOperationException>(() =>
+                {
+                    var c = project.ConditionedProperties;
+                });
+
+                Should.Throw<InvalidOperationException>(() =>
+                {
+                    var c = project.ItemsIgnoringCondition;
+                });
+
+                Should.Throw<InvalidOperationException>(() =>
+                {
+                    var c = project.AllEvaluatedItemDefinitionMetadata;
+                });
+
+                Should.Throw<InvalidOperationException>(() =>
+                {
+                    var c = project.AllEvaluatedItems;
+                });
             }
         }
     }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -535,6 +535,8 @@ namespace Microsoft.Build.Evaluation
             UseProjectCollectionSetting
         }
 
+        internal Data TestOnlyGetPrivateData => _data;
+
         /// <summary>
         /// Gets or sets the project collection which contains this project.
         /// Can never be null.

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2687,7 +2687,10 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
-            _data = new Data(this, globalPropertiesCollection, toolsVersion, subToolsetVersion);
+            // For back compat Project based evaluations should, by default, evaluate elements with false conditions
+            var shouldEvaluateElementsWithFalseCondition = !loadSettings.HasFlag(ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition);
+
+            _data = new Data(this, globalPropertiesCollection, toolsVersion, subToolsetVersion, shouldEvaluateElementsWithFalseCondition);
 
             _loadSettings = loadSettings;
 
@@ -2917,10 +2920,11 @@ namespace Microsoft.Build.Evaluation
             /// Constructor taking the immutable global properties and tools version.
             /// Tools version may be null.
             /// </summary>
-            internal Data(Project project, PropertyDictionary<ProjectPropertyInstance> globalProperties, string explicitToolsVersion, string explicitSubToolsetVersion)
+            internal Data(Project project, PropertyDictionary<ProjectPropertyInstance> globalProperties, string explicitToolsVersion, string explicitSubToolsetVersion, bool shouldEvaluateForDesignTime)
             {
                 _project = project;
                 _globalProperties = globalProperties;
+                ShouldEvaluateForDesignTime = shouldEvaluateForDesignTime;
                 this.ExplicitToolsVersion = explicitToolsVersion;
                 this.ExplicitSubToolsetVersion = explicitSubToolsetVersion;
             }
@@ -2930,10 +2934,7 @@ namespace Microsoft.Build.Evaluation
             /// as well as items respecting condition; and collect
             /// conditioned properties, as well as regular properties
             /// </summary>
-            bool IEvaluatorData<ProjectProperty, ProjectItem, ProjectMetadata, ProjectItemDefinition>.ShouldEvaluateForDesignTime
-            {
-                get { return true; }
-            }
+            public bool ShouldEvaluateForDesignTime { get; }
 
             /// <summary>
             /// Collection of all evaluated item definitions, one per item-type

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -31,6 +31,7 @@ using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFil
 using ProjectItemFactory = Microsoft.Build.Evaluation.ProjectItem.ProjectItemFactory;
 using System.Globalization;
 using Microsoft.Build.Globbing;
+using Microsoft.Build.Utilities;
 using EvaluationItemSpec = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
 using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemExpressionFragment<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
 
@@ -2712,7 +2713,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // For back compat Project based evaluations should, by default, evaluate elements with false conditions
-            var shouldEvaluateElementsWithFalseCondition = !loadSettings.HasFlag(ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition);
+            var shouldEvaluateElementsWithFalseCondition = Traits.Instance.EscapeHatches.EvaluateElementsWithFalseConditionInProjectEvaluation ?? !loadSettings.HasFlag(ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition);
 
             _data = new Data(this, globalPropertiesCollection, toolsVersion, subToolsetVersion, shouldEvaluateElementsWithFalseCondition);
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -704,6 +704,11 @@ namespace Microsoft.Build.Evaluation
             [DebuggerStepThrough]
             get
             {
+                if (!_data.ShouldEvaluateForDesignTime)
+                {
+                    ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(ConditionedProperties));
+                }
+
                 if (_data.ConditionedProperties == null)
                 {
                     return ReadOnlyEmptyDictionary<string, List<string>>.Instance;
@@ -747,7 +752,14 @@ namespace Microsoft.Build.Evaluation
         {
             [DebuggerStepThrough]
             get
-            { return new ReadOnlyCollection<ProjectItem>(_data.ItemsIgnoringCondition); }
+            {
+                if (!_data.ShouldEvaluateForDesignTime)
+                {
+                    ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(ItemsIgnoringCondition));
+                }
+
+                return new ReadOnlyCollection<ProjectItem>(_data.ItemsIgnoringCondition);
+            }
         }
 
         /// <summary>
@@ -853,6 +865,11 @@ namespace Microsoft.Build.Evaluation
         {
             get
             {
+                if (!_data.ShouldEvaluateForDesignTime)
+                {
+                    ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(AllEvaluatedItemDefinitionMetadata));
+                }
+
                 ICollection<ProjectMetadata> allEvaluatedItemDefinitionMetadata = _data.AllEvaluatedItemDefinitionMetadata;
 
                 if (allEvaluatedItemDefinitionMetadata == null)
@@ -877,6 +894,11 @@ namespace Microsoft.Build.Evaluation
         {
             get
             {
+                if (!_data.ShouldEvaluateForDesignTime)
+                {
+                    ErrorUtilities.ThrowInvalidOperation("OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse", nameof(AllEvaluatedItems));
+                }
+
                 ICollection<ProjectItem> allEvaluatedItems = _data.AllEvaluatedItems;
 
                 if (allEvaluatedItems == null)

--- a/src/Build/Definition/ProjectLoadSettings.cs
+++ b/src/Build/Definition/ProjectLoadSettings.cs
@@ -43,5 +43,11 @@ namespace Microsoft.Build.Evaluation
         /// Ignore empty targets files when evaluating the project
         /// </summary>
         IgnoreEmptyImports = 16,
+
+        /// <summary>
+        /// By default, evaluations performed via <see cref="Project"/> evaluate and collect elements whose conditions were false (e.g. <see cref="Project.ItemsIgnoringCondition"/>).
+        /// This flag turns off this behaviour. <see cref="Project"/> members that collect such elements will throw when accessed.
+        /// </summary>
+        DoNotEvaluateElementsWithFalseCondition = 32
     }
 }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1491,6 +1491,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="OM_ProjectInstanceImmutable">
     <value>Instance object was created as immutable.</value>    
   </data>
+  <data name="OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse">
+    <value>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</value>    
+  </data>
   <!-- #################################################################################################-->
   <!-- ############################## Execution-model-related strings #################################-->
   <!-- #################################################################################################-->

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -108,7 +108,8 @@ namespace Microsoft.Build.Utilities
                 return null;
             }
 
-            if (bool.TryParse(value, out var result))
+            bool result;
+            if (bool.TryParse(value, out result))
             {
                 return result;
             }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Force whether Project based evaluations should evaluate elements with false conditions.
         /// </summary>
-        public readonly bool? EvaluateElementsWithFalseConditionInProjectEvaluation = ParseNullableBoolFromEnvironmentVariable(nameof(EvaluateElementsWithFalseConditionInProjectEvaluation));
+        public readonly bool? EvaluateElementsWithFalseConditionInProjectEvaluation = ParseNullableBoolFromEnvironmentVariable("MSBUILDEVALUATEELEMENTSWITHFALSECONDITIONINPROJECTEVALUATION");
 
         /// <summary>
         /// Always use the accurate-but-slow CreateFile approach to timestamp extraction.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Build.Utilities
     internal class EscapeHatches
     {
         /// <summary>
+        /// Force whether Project based evaluations should evaluate elements with false conditions.
+        /// </summary>
+        public readonly bool? EvaluateElementsWithFalseConditionInProjectEvaluation = ParseNullableBoolFromEnvironmentVariable(nameof(EvaluateElementsWithFalseConditionInProjectEvaluation));
+
+        /// <summary>
         /// Always use the accurate-but-slow CreateFile approach to timestamp extraction.
         /// </summary>
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
@@ -93,6 +98,25 @@ namespace Microsoft.Build.Utilities
         // be removed (permanently set to false) after establishing that
         // it's unneeded (at least by the 16.0 timeframe).
         public readonly bool UseCaseSensitiveItemNames = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1";
+
+        private static bool? ParseNullableBoolFromEnvironmentVariable(string environmentVariable)
+        {
+            var value = Environment.GetEnvironmentVariable(environmentVariable);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            if (bool.TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            ErrorUtilities.ThrowInternalError($"Environment variable \"{environmentVariable}\" should have values \"true\", \"false\" or undefined");
+
+            return null;
+        }
 
         private static ProjectInstanceTranslationMode? ComputeProjectInstanceTranslation()
         {


### PR DESCRIPTION
Up until now project based evaluations evaluated certain elements (properties / groups, items / groups, item definition groups) even when their condition was false. This PR adds an option to turn this off.

Tested with [this project](https://github.com/jeromelaban/MicrosoftIssues/blob/master/MsBuildEarlyEvalIssue/XTargetProject/XTargetProject.csproj) and dropped a node_modules inside. Respecting conditions takes ~600ms, not respecting them takes ~1200ms.

CPS will have to turn this on via ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition

Closes #2502 