### PR TITLE
 Have MSBuild.exe search for a Directory.Build.rsp in the project directory or above

### DIFF
--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -288,33 +288,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>The full path of the directory containing the file if it is found, otherwise an empty string. </returns>
         internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
         {
-            // Canonicalize our starting location
-            string lookInDirectory = Path.GetFullPath(startingDirectory);
-
-            do
-            {
-                // Construct the path that we will use to test against
-                string possibleFileDirectory = Path.Combine(lookInDirectory, fileName);
-
-                // If we successfully locate the file in the directory that we're
-                // looking in, simply return that location. Otherwise we'll
-                // keep moving up the tree.
-                if (File.Exists(possibleFileDirectory))
-                {
-                    // We've found the file, return the directory we found it in
-                    return lookInDirectory;
-                }
-                else
-                {
-                    // GetDirectoryName will return null when we reach the root
-                    // terminating our search
-                    lookInDirectory = Path.GetDirectoryName(lookInDirectory);
-                }
-            }
-            while (lookInDirectory != null);
-
-            // When we didn't find the location, then return an empty string
-            return String.Empty;
+            return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName);
         }
 
         /// <summary>
@@ -326,16 +300,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
         internal static string GetPathOfFileAbove(string file, string startingDirectory)
         {
-            // This method does not accept a path, only a file name
-            if(file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
-            {
-                ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
-            }
-
-            // Search for a directory that contains that file
-            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
-
-            return String.IsNullOrWhiteSpace(directoryName) ? String.Empty : NormalizePath(directoryName, file);
+            return FileUtilities.GetPathOfFileAbove(file, startingDirectory);
         }
 
         /// <summary>
@@ -427,7 +392,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>A canonicalized full path with the correct directory separators.</returns>
         internal static string NormalizePath(params string[] path)
         {
-            return FileUtilities.NormalizePath(Path.Combine(path));
+            return FileUtilities.NormalizePath(path);
         }
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1805,6 +1805,11 @@ namespace Microsoft.Build.CommandLine
         private const string autoResponseFileName = "MSBuild.rsp";
 
         /// <summary>
+        /// THe name of an auto-response file to search for in the project directory and above.
+        /// </summary>
+        private const string directoryResponseFileName = "Directory.Build.rsp";
+
+        /// <summary>
         /// Whether switches from the auto-response file are being used.
         /// </summary>
         internal static bool usingSwitchesFromAutoResponseFile = false;
@@ -1817,6 +1822,11 @@ namespace Microsoft.Build.CommandLine
         private static bool GatherAutoResponseFileSwitches(string path, CommandLineSwitches switchesFromAutoResponseFile)
         {
             string autoResponseFile = Path.Combine(path, autoResponseFileName);
+            return GatherAutoResponseFileSwitchesFromFullPath(autoResponseFile, switchesFromAutoResponseFile);
+        }
+
+        private static bool GatherAutoResponseFileSwitchesFromFullPath(string autoResponseFile, CommandLineSwitches switchesFromAutoResponseFile)
+        {
             bool found = false;
 
             // if the auto-response file does not exist, only use the switches on the command line
@@ -1837,6 +1847,9 @@ namespace Microsoft.Build.CommandLine
                     // we picked up some switches from the auto-response file
                     usingSwitchesFromAutoResponseFile = true;
                 }
+
+                // Throw errors found in the response file
+                switchesFromAutoResponseFile.ThrowErrors();
             }
 
             return found;
@@ -1936,6 +1949,14 @@ namespace Microsoft.Build.CommandLine
                     {
                         // gather any switches from an msbuild.rsp that is next to the project or solution file itself
                         string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectFile));
+
+                        // gather any switches from the first Directory.Build.rsp found in the project directory or above
+                        string directoryResponseFile = FileUtilities.GetPathOfFileAbove(directoryResponseFileName, projectDirectory);
+
+                        if (!String.IsNullOrWhiteSpace(directoryResponseFile))
+                        {
+                            GatherAutoResponseFileSwitchesFromFullPath(directoryResponseFile, switchesFromAutoResponseFile);
+                        }
 
                         bool found = false;
 

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -399,6 +399,18 @@ namespace Microsoft.Build.Shared
 
         }
 
+        internal static string NormalizePath(string directory, string file)
+        {
+            return NormalizePath(Path.Combine(directory, file));
+        }
+
+#if !CLR2COMPATIBILITY
+        internal static string NormalizePath(params string[] paths)
+        {
+            return NormalizePath(Path.Combine(paths));
+        }
+#endif
+
         internal static string FixFilePath(string path)
         {
             return string.IsNullOrEmpty(path) || Path.DirectorySeparatorChar == '\\' ? path : path.Replace('\\', '/');//.Replace("//", "/");
@@ -1176,6 +1188,62 @@ namespace Microsoft.Build.Shared
             {
                 return new StreamReader(fileStream, encoding, detectEncodingFromByteOrderMarks);
             }
+        }
+
+        /// <summary>
+        /// Locate a file in either the directory specified or a location in the
+        /// directory structure above that directory.
+        /// </summary>
+        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
+        {
+            // Canonicalize our starting location
+            string lookInDirectory = Path.GetFullPath(startingDirectory);
+
+            do
+            {
+                // Construct the path that we will use to test against
+                string possibleFileDirectory = Path.Combine(lookInDirectory, fileName);
+
+                // If we successfully locate the file in the directory that we're
+                // looking in, simply return that location. Otherwise we'll
+                // keep moving up the tree.
+                if (File.Exists(possibleFileDirectory))
+                {
+                    // We've found the file, return the directory we found it in
+                    return lookInDirectory;
+                }
+                else
+                {
+                    // GetDirectoryName will return null when we reach the root
+                    // terminating our search
+                    lookInDirectory = Path.GetDirectoryName(lookInDirectory);
+                }
+            }
+            while (lookInDirectory != null);
+
+            // When we didn't find the location, then return an empty string
+            return String.Empty;
+        }
+
+        /// <summary>
+        /// Searches for a file based on the specified starting directory.
+        /// </summary>
+        /// <param name="file">The file to search for.</param>
+        /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
+        /// of the file containing the property function.</param>
+        /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
+        internal static string GetPathOfFileAbove(string file, string startingDirectory)
+        {
+            // This method does not accept a path, only a file name
+            if (file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
+            {
+                ErrorUtilities.ThrowArgument("InvalidGetPathOfFileAboveParameter", file);
+            }
+
+            // Search for a directory that contains that file
+            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
+
+            return String.IsNullOrEmpty(directoryName) ? String.Empty : NormalizePath(directoryName, file);
         }
 
         // Method is simple set of function calls and may inline;

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Build.UnitTests
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
-                Assert.Equal(null, FileUtilities.NormalizePath(null));
+                Assert.Equal(null, FileUtilities.NormalizePath(null, null));
             }
            );
         }


### PR DESCRIPTION
# Response file processing order

1. `MSBuild.rsp` next to `MSBuild.exe`
2. `Directory.Build.rsp` in project directory or above
3. 1MSBuild.rsp` in the project directory

# Other Changes
* Move `GetDirectoryNameOfFileAbove` and `GetPathOfFileAbove` to `FileUtilities` so they can be reused
* Show an error if there is an invalid switch in the response file