### PR TITLE
Target item includes use same code as Project item includes

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Xml;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.Engine.UnitTests.Globbing;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Shared;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -559,126 +560,11 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             TestIncludeExclude(projectContents, inputFiles, expectedInclude, includeString, excludeString, normalizeSlashes: false);
         }
 
+        public static IEnumerable<object[]> IncludesAndExcludesWithWildcardsTestData => GlobbingTestData.IncludesAndExcludesWithWildcardsTestData;
+
         [Theory]
-        [InlineData(
-            "a.*",
-            "*.1",
-            new[] { "a.1", "a.2", "a.1" },
-            new[] { "a.2" },
-            false)]
-        [InlineData(
-            @"**\*.cs",
-            @"a\**",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs" },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"**\b\**",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs", @"a\2.cs", "build.proj" },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"**\b\**\*.cs",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs", @"a\b\c\5.txt" },
-            new[] { "1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj" },
-            false)]
-        [InlineData(
-            @"src\**\proj\**\*.cs",
-            @"src\**\proj\**\none\**\*",
-            new[]
-            {
-                "1.cs",
-                @"src\2.cs",
-                @"src\a\3.cs",
-                @"src\proj\4.cs",
-                @"src\proj\a\5.cs",
-                @"src\a\proj\6.cs",
-                @"src\a\proj\a\7.cs",
-                @"src\proj\none\8.cs",
-                @"src\proj\a\none\9.cs",
-                @"src\proj\a\none\a\10.cs",
-                @"src\a\proj\a\none\11.cs",
-                @"src\a\proj\a\none\a\12.cs"
-            },
-            new[]
-            {
-                @"src\a\proj\6.cs",
-                @"src\a\proj\a\7.cs",
-                @"src\proj\4.cs",
-                @"src\proj\a\5.cs"
-            },
-            false)]
-        [InlineData(
-            @"**\*",
-            "foo",
-            new[]
-            {
-                "foo",
-                @"a\foo",
-                @"a\a\foo",
-                @"a\b\foo",
-            },
-            new[]
-            {
-                @"a\a\foo",
-                @"a\b\foo",
-                @"a\foo",
-                "build.proj"
-            },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"a\af*\*",
-            new[]
-            {
-                @"a\foo",
-                @"a\a\foo",
-                @"a\b\foo",
-            },
-            new[]
-            {
-                @"a\a\foo",
-                @"a\b\foo",
-                @"a\foo",
-                "build.proj"
-            },
-            false)]
-        [InlineData(
-            @"$(MSBuildThisFileDirectory)\**\*",
-            @"$(MSBuildThisFileDirectory)\a\foo.txt",
-            new[]
-            {
-                @"a\foo",
-                @"a\foo.txt",
-            },
-            new[]
-            {
-                @"a\foo",
-                "build.proj"
-            },
-            true)]
-        [InlineData(
-            @"$(MSBuildThisFileDirectory)\**\*",
-            @"$(MSBuildThisFileDirectory)\a\**\*",
-            new[]
-            {
-                @"a\a",
-                @"a\b\ab",
-                @"b\b",
-                @"c\c",
-                @"c\d\cd",
-            },
-            new[]
-            {
-                "build.proj",
-                @"b\b",
-                @"c\c",
-                @"c\d\cd",
-            },
-            true)]
-        public void ExcludeVectorWithWildCards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
+        [MemberData(nameof(IncludesAndExcludesWithWildcardsTestData))]
+        public void ExcludeVectorWithWildCards(string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
         {
             TestIncludeExcludeWithDifferentSlashes(ItemWithIncludeAndExclude, includeString, excludeString, inputFiles, expectedInclude, makeExpectedIncludeAbsolute);
         }

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -560,27 +560,31 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Theory]
-        [InlineData(ItemWithIncludeAndExclude,
+        [InlineData(
             "a.*",
             "*.1",
             new[] { "a.1", "a.2", "a.1" },
-            new[] { "a.2" })]
-        [InlineData(ItemWithIncludeAndExclude,
+            new[] { "a.2" },
+            false)]
+        [InlineData(
             @"**\*.cs",
             @"a\**",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs" })]
-        [InlineData(ItemWithIncludeAndExclude,
+            new[] { "1.cs" },
+            false)]
+        [InlineData(
             @"**\*",
             @"**\b\**",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs", @"a\2.cs", "build.proj" })]
-        [InlineData(ItemWithIncludeAndExclude,
+            new[] { "1.cs", @"a\2.cs", "build.proj" },
+            false)]
+        [InlineData(
             @"**\*",
             @"**\b\**\*.cs",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs", @"a\b\c\5.txt" },
-            new[] { "1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj" })]
-        [InlineData(ItemWithIncludeAndExclude,
+            new[] { "1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj" },
+            false)]
+        [InlineData(
             @"src\**\proj\**\*.cs",
             @"src\**\proj\**\none\**\*",
             new[]
@@ -604,8 +608,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 @"src\a\proj\a\7.cs",
                 @"src\proj\4.cs",
                 @"src\proj\a\5.cs"
-            })]
-        [InlineData(ItemWithIncludeAndExclude,
+            },
+            false)]
+        [InlineData(
             @"**\*",
             "foo",
             new[]
@@ -615,14 +620,15 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 @"a\a\foo",
                 @"a\b\foo",
             },
-            new []
+            new[]
             {
                 @"a\a\foo",
                 @"a\b\foo",
                 @"a\foo",
                 "build.proj"
-            })]
-        [InlineData(ItemWithIncludeAndExclude,
+            },
+            false)]
+        [InlineData(
             @"**\*",
             @"a\af*\*",
             new[]
@@ -637,10 +643,44 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 @"a\b\foo",
                 @"a\foo",
                 "build.proj"
-            })]
-        public void ExcludeVectorWithWildCards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
+            },
+            false)]
+        [InlineData(
+            @"$(MSBuildThisFileDirectory)\**\*",
+            @"$(MSBuildThisFileDirectory)\a\foo.txt",
+            new[]
+            {
+                @"a\foo",
+                @"a\foo.txt",
+            },
+            new[]
+            {
+                @"a\foo",
+                "build.proj"
+            },
+            true)]
+        [InlineData(
+            @"$(MSBuildThisFileDirectory)\**\*",
+            @"$(MSBuildThisFileDirectory)\a\**\*",
+            new[]
+            {
+                @"a\a",
+                @"a\b\ab",
+                @"b\b",
+                @"c\c",
+                @"c\d\cd",
+            },
+            new[]
+            {
+                "build.proj",
+                @"b\b",
+                @"c\c",
+                @"c\d\cd",
+            },
+            true)]
+        public void ExcludeVectorWithWildCards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
         {
-            TestIncludeExcludeWithDifferentSlashes(projectContents, includeString, excludeString, inputFiles, expectedInclude);
+            TestIncludeExcludeWithDifferentSlashes(ItemWithIncludeAndExclude, includeString, excludeString, inputFiles, expectedInclude, makeExpectedIncludeAbsolute);
         }
 
         [Theory]
@@ -791,11 +831,11 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             TestIncludeExclude(projectContents, inputFiles, expectedInclude, includeString, "");
         }
 
-        private static void TestIncludeExcludeWithDifferentSlashes(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude)
+        private static void TestIncludeExcludeWithDifferentSlashes(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute = false)
         {
             Action<string, string> runTest = (include, exclude) =>
             {
-                TestIncludeExclude(projectContents, inputFiles, expectedInclude, include, exclude, normalizeSlashes: true);
+                TestIncludeExclude(projectContents, inputFiles, expectedInclude, include, exclude, normalizeSlashes: true, makeExpectedIncludeAbsolute:makeExpectedIncludeAbsolute);
             };
 
             var includeWithForwardSlash = Helpers.ToForwardSlash(includeString);
@@ -807,10 +847,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             runTest(includeWithForwardSlash, excludeString);
         }
 
-        private static void TestIncludeExclude(string projectContents, string[] inputFiles, string[] expectedInclude, string include, string exclude, bool normalizeSlashes = false)
+        private static void TestIncludeExclude(string projectContents, string[] inputFiles, string[] expectedInclude, string include, string exclude, bool normalizeSlashes = false, bool makeExpectedIncludeAbsolute = false)
         {
             var formattedProjectContents = string.Format(projectContents, include, exclude);
-            ObjectModelHelpers.AssertItemEvaluationFromProject(formattedProjectContents, inputFiles, expectedInclude, expectedMetadataPerItem: null, normalizeSlashes: normalizeSlashes);
+            ObjectModelHelpers.AssertItemEvaluationFromProject(formattedProjectContents, inputFiles, expectedInclude, expectedMetadataPerItem: null, normalizeSlashes: normalizeSlashes, makeExpectedIncludeAbsolute: makeExpectedIncludeAbsolute);
         }
 
         [Theory]

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -810,7 +810,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         private static void TestIncludeExclude(string projectContents, string[] inputFiles, string[] expectedInclude, string include, string exclude, bool normalizeSlashes = false)
         {
             var formattedProjectContents = string.Format(projectContents, include, exclude);
-            ObjectModelHelpers.AssertItemEvaluation(formattedProjectContents, inputFiles, expectedInclude, expectedMetadataPerItem: null, normalizeSlashes: normalizeSlashes);
+            ObjectModelHelpers.AssertItemEvaluationFromProject(formattedProjectContents, inputFiles, expectedInclude, expectedMetadataPerItem: null, normalizeSlashes: normalizeSlashes);
         }
 
         [Theory]
@@ -2717,7 +2717,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         public void UpdateAndRemoveShouldWorkWithEscapedCharacters(string projectContents, string include, string update, string remove, string[] expectedInclude, Dictionary<string, string>[] expectedMetadata)
         {
             var formattedProjectContents = string.Format(projectContents, include, update, remove);
-            ObjectModelHelpers.AssertItemEvaluation(formattedProjectContents, new string[0], expectedInclude, expectedMetadata);
+            ObjectModelHelpers.AssertItemEvaluationFromProject(formattedProjectContents, new string[0], expectedInclude, expectedMetadata);
         }
 
         [Theory]

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -267,31 +267,31 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 ";
 
         [Theory]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             "a.*",
             "*.1",
             new[] { "a.1", "a.2", "a.1" },
             new[] { "a.2" },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"**\*.cs",
             @"a\**",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
             new[] { "1.cs" },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"**\*",
             @"**\b\**",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
             new[] { "1.cs", @"a\2.cs", "build.proj" },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"**\*",
             @"**\b\**\*.cs",
             new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs", @"a\b\c\5.txt" },
             new[] { "1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj" },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"src\**\proj\**\*.cs",
             @"src\**\proj\**\none\**\*",
             new[]
@@ -317,7 +317,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 @"src\proj\a\5.cs"
             },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"**\*",
             "foo",
             new[]
@@ -335,7 +335,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "build.proj"
             },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"**\*",
             @"a\af*\*",
             new[]
@@ -352,7 +352,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "build.proj"
             },
             false)]
-        [InlineData(TargetitemwithIncludeAndExclude,
+        [InlineData(
             @"$(MSBuildThisFileDirectory)\**\*",
             @"$(MSBuildThisFileDirectory)\a\foo.txt",
             new[]
@@ -366,9 +366,28 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "build.proj"
             },
             true)]
+        [InlineData(
+            @"$(MSBuildThisFileDirectory)\**\*",
+            @"$(MSBuildThisFileDirectory)\a\**\*",
+            new[]
+            {
+                @"a\a",
+                @"a\b\ab",
+                @"b\b",
+                @"c\c",
+                @"c\d\cd",
+            },
+            new[]
+            {
+                "build.proj",
+                @"b\b",
+                @"c\c",
+                @"c\d\cd",
+            },
+            true)]
         public void ItemsWithWildcards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
         {
-            projectContents = string.Format(projectContents, includeString, excludeString).Cleanup();
+            projectContents = string.Format(TargetitemwithIncludeAndExclude, includeString, excludeString).Cleanup();
 
             AssertItemEvaluationFromTarget(projectContents, "t", "i", inputFiles, expectedInclude, makeExpectedIncludeAbsolute);
         }

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             var projectContents = string.Format(TargetitemwithIncludeAndExclude, includeString, excludeString).Cleanup();
 
-            AssertItemEvaluationFromTarget(projectContents, "t", "i", inputFiles, expectedInclude, makeExpectedIncludeAbsolute);
+            AssertItemEvaluationFromTarget(projectContents, "t", "i", inputFiles, expectedInclude, makeExpectedIncludeAbsolute, normalizeSlashes: true);
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.Engine.UnitTests.Globbing;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -266,128 +267,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     </Project>
                 ";
 
+        public static IEnumerable<object[]> IncludesAndExcludesWithWildcardsTestData => GlobbingTestData.IncludesAndExcludesWithWildcardsTestData;
+
         [Theory]
-        [InlineData(
-            "a.*",
-            "*.1",
-            new[] { "a.1", "a.2", "a.1" },
-            new[] { "a.2" },
-            false)]
-        [InlineData(
-            @"**\*.cs",
-            @"a\**",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs" },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"**\b\**",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs" },
-            new[] { "1.cs", @"a\2.cs", "build.proj" },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"**\b\**\*.cs",
-            new[] { "1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs", @"a\b\c\5.txt" },
-            new[] { "1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj" },
-            false)]
-        [InlineData(
-            @"src\**\proj\**\*.cs",
-            @"src\**\proj\**\none\**\*",
-            new[]
-            {
-                "1.cs",
-                @"src\2.cs",
-                @"src\a\3.cs",
-                @"src\proj\4.cs",
-                @"src\proj\a\5.cs",
-                @"src\a\proj\6.cs",
-                @"src\a\proj\a\7.cs",
-                @"src\proj\none\8.cs",
-                @"src\proj\a\none\9.cs",
-                @"src\proj\a\none\a\10.cs",
-                @"src\a\proj\a\none\11.cs",
-                @"src\a\proj\a\none\a\12.cs"
-            },
-            new[]
-            {
-                @"src\a\proj\6.cs",
-                @"src\a\proj\a\7.cs",
-                @"src\proj\4.cs",
-                @"src\proj\a\5.cs"
-            },
-            false)]
-        [InlineData(
-            @"**\*",
-            "foo",
-            new[]
-            {
-                "foo",
-                @"a\foo",
-                @"a\a\foo",
-                @"a\b\foo",
-            },
-            new[]
-            {
-                @"a\a\foo",
-                @"a\b\foo",
-                @"a\foo",
-                "build.proj"
-            },
-            false)]
-        [InlineData(
-            @"**\*",
-            @"a\af*\*",
-            new[]
-            {
-                @"a\foo",
-                @"a\a\foo",
-                @"a\b\foo",
-            },
-            new[]
-            {
-                @"a\a\foo",
-                @"a\b\foo",
-                @"a\foo",
-                "build.proj"
-            },
-            false)]
-        [InlineData(
-            @"$(MSBuildThisFileDirectory)\**\*",
-            @"$(MSBuildThisFileDirectory)\a\foo.txt",
-            new[]
-            {
-                @"a\foo",
-                @"a\foo.txt",
-            },
-            new[]
-            {
-                @"a\foo",
-                "build.proj"
-            },
-            true)]
-        [InlineData(
-            @"$(MSBuildThisFileDirectory)\**\*",
-            @"$(MSBuildThisFileDirectory)\a\**\*",
-            new[]
-            {
-                @"a\a",
-                @"a\b\ab",
-                @"b\b",
-                @"c\c",
-                @"c\d\cd",
-            },
-            new[]
-            {
-                "build.proj",
-                @"b\b",
-                @"c\c",
-                @"c\d\cd",
-            },
-            true)]
-        public void ItemsWithWildcards(string projectContents, string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
+        [MemberData(nameof(IncludesAndExcludesWithWildcardsTestData))]
+        public void ItemsWithWildcards(string includeString, string excludeString, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute)
         {
-            projectContents = string.Format(TargetitemwithIncludeAndExclude, includeString, excludeString).Cleanup();
+            var projectContents = string.Format(TargetitemwithIncludeAndExclude, includeString, excludeString).Cleanup();
 
             AssertItemEvaluationFromTarget(projectContents, "t", "i", inputFiles, expectedInclude, makeExpectedIncludeAbsolute);
         }

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -1158,7 +1158,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// <param name="itemMetadata"></param>
         private void CreateComplexPropertiesItemsMetadata
             (
-            out ReadOnlyLookup readOnlyLookup,
+            out Lookup readOnlyLookup,
             out StringMetadataTable itemMetadata
             )
         {
@@ -1212,7 +1212,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             lookup.PopulateWithItems("IntermediateAssembly", intermediateAssemblyItemGroup);
             lookup.PopulateWithItems("Content", contentItemGroup);
 
-            readOnlyLookup = new ReadOnlyLookup(lookup);
+            readOnlyLookup = lookup;
         }
 
         /// <summary>
@@ -1221,7 +1221,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoTaskItemsComplex()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1253,7 +1253,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringComplexPiecemeal()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1306,7 +1306,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringEmpty()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1332,7 +1332,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringComplex()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1354,7 +1354,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringLeaveEscapedComplex()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1376,7 +1376,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringExpectIdenticalReference()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1407,7 +1407,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringExpanderOptions()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
@@ -1430,7 +1430,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void ExpandAllIntoStringListLeaveEscapedComplex()
         {
-            ReadOnlyLookup lookup;
+            Lookup lookup;
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 

--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                         env.SetEnvironmentVariable("MsBuildCacheFileEnumerations", "1");
                     }
 
-                    ObjectModelHelpers.AssertItemEvaluation(
+                    ObjectModelHelpers.AssertItemEvaluationFromProject(
                         projectContents,
                         inputFiles: new[] {"a.cs", "b.cs", "c.cs"},
                         expectedInclude: new[] {"a.cs", "b.cs", "c.cs", "b.cs", "c.cs", "b.cs"});

--- a/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             _metadata = metadata;
-            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_lookup.ReadOnlyLookup, _lookup.ReadOnlyLookup, new StringMetadataTable(metadata));
+            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_lookup, _lookup, new StringMetadataTable(metadata));
 
             _bucketSequenceNumber = bucketSequenceNumber;
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.BackEnd
     /// 
     /// For sensible semantics, only the current primary scope can be modified at any point.
     /// </summary>
-    internal class Lookup
+    internal class Lookup : IPropertyProvider<ProjectPropertyInstance>, IItemProvider<ProjectItemInstance>
     {
         #region Fields
 
@@ -455,7 +455,7 @@ namespace Microsoft.Build.BackEnd
         /// If no match is found, returns null.
         /// Caller must not modify the property returned.
         /// </summary>
-        internal ProjectPropertyInstance GetProperty(string name, int startIndex, int endIndex)
+        public ProjectPropertyInstance GetProperty(string name, int startIndex, int endIndex)
         {
             // Walk down the tables and stop when the first 
             // property with this name is found
@@ -493,7 +493,7 @@ namespace Microsoft.Build.BackEnd
         /// If no match is found, returns null.
         /// Caller must not modify the property returned.
         /// </summary>
-        internal ProjectPropertyInstance GetProperty(string name)
+        public ProjectPropertyInstance GetProperty(string name)
         {
             ErrorUtilities.VerifyThrowInternalLength(name, "name");
 
@@ -505,7 +505,7 @@ namespace Microsoft.Build.BackEnd
         /// If no match is found, returns an empty list.
         /// Caller must not modify the group returned.
         /// </summary>
-        internal ICollection<ProjectItemInstance> GetItems(string itemType)
+        public ICollection<ProjectItemInstance> GetItems(string itemType)
         {
             // The visible items consist of the adds (accumulated as we go down)
             // plus the first set of regular items we encounter

--- a/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/Lookup.cs
@@ -85,11 +85,6 @@ namespace Microsoft.Build.BackEnd
         private Dictionary<ProjectItemInstance, ProjectItemInstance> _cloneTable;
 
         /// <summary>
-        /// Read-only wrapper around this lookup.
-        /// </summary>
-        private ReadOnlyLookup _readOnlyLookup;
-
-        /// <summary>
         /// A dictionary of named values for debugger display only. If 
         /// not debugging, this should be null.
         /// </summary>
@@ -136,21 +131,6 @@ namespace Microsoft.Build.BackEnd
         #endregion
 
         #region Properties
-
-        /// <summary>
-        /// Returns a read-only wrapper around this lookup
-        /// </summary>
-        internal ReadOnlyLookup ReadOnlyLookup
-        {
-            get
-            {
-                if (_readOnlyLookup == null)
-                {
-                    _readOnlyLookup = new ReadOnlyLookup(this);
-                }
-                return _readOnlyLookup;
-            }
-        }
 
         // Convenience private properties
         // "Primary" is the "top" or "innermost" scope
@@ -1484,39 +1464,5 @@ namespace Microsoft.Build.BackEnd
                 _owningLookup.LeaveScope(this);
             }
         }
-    }
-
-    #region Related Types
-
-    /// <summary>
-    /// Read-only wrapper around a lookup.
-    /// Passed to Expander and ItemExpander, which only need to
-    /// use a lookup in a read-only fashion, thus increasing 
-    /// encapsulation of the data in the Lookup.
-    /// </summary>
-    internal class ReadOnlyLookup : IPropertyProvider<ProjectPropertyInstance>, IItemProvider<ProjectItemInstance>
-    {
-        private Lookup _lookup;
-
-        internal ReadOnlyLookup(Lookup lookup)
-        {
-            _lookup = lookup;
-        }
-
-        public ICollection<ProjectItemInstance> GetItems(string itemType)
-        {
-            return _lookup.GetItems(itemType);
-        }
-
-        public ProjectPropertyInstance GetProperty(string name)
-        {
-            return _lookup.GetProperty(name);
-        }
-
-        public ProjectPropertyInstance GetProperty(string name, int startIndex, int endIndex)
-        {
-            return _lookup.GetProperty(name, startIndex, endIndex);
-        }
-        #endregion
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Build.BackEnd
             _targetBuilderCallback = targetBuilderCallback;
             _targetSpecification = targetSpecification;
             _parentTarget = parentTarget;
-            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(baseLookup.ReadOnlyLookup, baseLookup.ReadOnlyLookup);
+            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(baseLookup, baseLookup);
             _state = TargetEntryState.Dependencies;
             _baseLookup = baseLookup;
             _host = host;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // expand the properties
-            var expandedItemSpec = new EvaluationItemSpec(itemSpec, expander, elementLocation, projectDirectory, expandProperties: true);
+            var expandedItemSpec = new EvaluationItemSpec(itemSpec, expander, elementLocation, projectDirectory, ExpanderOptions.ExpandProperties);
             var numberOfMatches = ItemMatchesInItemSpec(itemToMatch, expandedItemSpec, out provenance);
 
             // Result is inconclusive if properties are present

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -44,17 +44,17 @@ namespace Microsoft.Build.Evaluation
         /// <param name="expander">Expects the expander to have a default item factory set</param>
         /// <param name="itemSpecLocation">The xml location the itemspec comes from</param>
         /// <param name="projectDirectory">The directory that the project is in.</param>
-        /// <param name="expandProperties">Expand properties before breaking down fragments. Defaults to true</param>
-        public ItemSpec(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation, string projectDirectory, bool expandProperties = true)
+        /// <param name="expandOptions">Expander options for expanding the itemspec before breaking down fragments. Defaults to <see cref="ExpanderOptions.ExpandProperties"/>. Use null to express no expansion.</param>
+        public ItemSpec(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation, string projectDirectory, ExpanderOptions? expandOptions = ExpanderOptions.ExpandProperties)
         {
             ItemSpecString = itemSpec;
             Expander = expander;
             ItemSpecLocation = itemSpecLocation;
 
-            Fragments = BuildItemFragments(itemSpecLocation, projectDirectory, expandProperties);
+            Fragments = BuildItemFragments(itemSpecLocation, projectDirectory, expandOptions);
         }
 
-        private ImmutableList<ItemFragment> BuildItemFragments(IElementLocation itemSpecLocation, string projectDirectory, bool expandProperties)
+        private ImmutableList<ItemFragment> BuildItemFragments(IElementLocation itemSpecLocation, string projectDirectory, ExpanderOptions? expandOptions)
         {
             var builder = ImmutableList.CreateBuilder<ItemFragment>();
 
@@ -67,9 +67,9 @@ namespace Microsoft.Build.Evaluation
             }
 
             // STEP 1: Expand properties in Include
-            if (expandProperties)
+            if (expandOptions != null)
             {
-                evaluatedItemspecEscaped = Expander.ExpandIntoStringLeaveEscaped(ItemSpecString, ExpanderOptions.ExpandProperties, itemSpecLocation);
+                evaluatedItemspecEscaped = Expander.ExpandIntoStringLeaveEscaped(ItemSpecString, expandOptions.Value, itemSpecLocation);
             }
 
             // STEP 2: Split Include on any semicolons, and take each split in turn

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Evaluation
 {
     internal partial class LazyItemEvaluator<P, I, M, D>
     {
-        class EvaluatorData : IEvaluatorData<P, I, M, D>
+        internal class EvaluatorData : IEvaluatorData<P, I, M, D>
         {
             IEvaluatorData<P, I, M, D> _wrappedData;
             Func<string, ICollection<I>> _itemGetter;

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Build.Evaluation
             {
                 var itemsToAdd = ImmutableList.CreateBuilder<I>();
 
-
                 Lazy<Func<string, bool>> excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
                 if (excludes != null)

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
@@ -13,7 +15,7 @@ namespace Microsoft.Build.Evaluation
 {
     internal partial class LazyItemEvaluator<P, I, M, D>
     {
-        class IncludeOperation : LazyItemOperation
+        internal class IncludeOperation : LazyItemOperation
         {
             readonly int _elementOrder;
             
@@ -35,37 +37,68 @@ namespace Microsoft.Build.Evaluation
 
             protected override ImmutableList<I> SelectItems(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
+                return ComputeItemsFromElement(
+                    _itemSpec,
+                    _excludes,
+                    _itemElement.IncludeLocation,
+                    _itemElement.ExcludeLocation,
+                    globsToIgnore,
+                    _rootDirectory,
+                    _itemElement.ContainingProject.FullPath,
+                    _expander,
+                    _evaluatorData,
+                    _itemFactory,
+                    EntriesCache);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static ImmutableList<I> ComputeItemsFromElement(
+                ItemSpec<P, I> itemSpec,
+                ImmutableList<string> excludes,
+                IElementLocation includeLocation,
+                IElementLocation excludeLocation,
+                ImmutableHashSet<string> globsToIgnore,
+                string rootDirectory, string projectPath,
+                Expander<P, I> expander,
+                IItemProvider<I> itemProvider,
+                IItemFactory<I, I> itemFactory,
+                ConcurrentDictionary<string, ImmutableArray<string>> entriesCache)
+            {
                 var itemsToAdd = ImmutableList.CreateBuilder<I>();
+
 
                 Lazy<Func<string, bool>> excludeTester = null;
                 ImmutableList<string>.Builder excludePatterns = ImmutableList.CreateBuilder<string>();
-                if (_excludes != null)
+                if (excludes != null)
                 {
                     // STEP 4: Evaluate, split, expand and subtract any Exclude
-                    foreach (string exclude in _excludes)
+                    foreach (string exclude in excludes)
                     {
-                        string excludeExpanded = _expander.ExpandIntoStringLeaveEscaped(exclude, ExpanderOptions.ExpandPropertiesAndItems, _itemElement.ExcludeLocation);
+                        string excludeExpanded = expander.ExpandIntoStringLeaveEscaped(exclude,
+                            ExpanderOptions.ExpandPropertiesAndItems, excludeLocation);
                         var excludeSplits = ExpressionShredder.SplitSemiColonSeparatedList(excludeExpanded);
                         excludePatterns.AddRange(excludeSplits);
                     }
 
                     if (excludePatterns.Count > 0)
                     {
-                        excludeTester = new Lazy<Func<string, bool>>(() => EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, _rootDirectory));
+                        excludeTester = new Lazy<Func<string, bool>>(() =>
+                            EngineFileUtilities.GetFileSpecMatchTester(excludePatterns, rootDirectory));
                     }
                 }
 
                 ISet<string> excludePatternsForGlobs = null;
 
-                foreach (var fragment in _itemSpec.Fragments)
+                foreach (var fragment in itemSpec.Fragments)
                 {
                     if (fragment is ItemExpressionFragment<P, I>)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                         bool throwaway;
-                        var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            ((ItemExpressionFragment<P, I>)fragment).Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
-                            false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
+                        var itemsFromExpression = expander.ExpandExpressionCaptureIntoItems(
+                            ((ItemExpressionFragment<P, I>) fragment).Capture, itemProvider, itemFactory,
+                            ExpanderOptions.ExpandItems,
+                            false /* do not include null expansion results */, out throwaway, includeLocation);
 
                         if (excludeTester != null)
                         {
@@ -78,18 +111,18 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is ValueFragment)
                     {
-                        string value = ((ValueFragment)fragment).ItemSpecFragment;
+                        string value = ((ValueFragment) fragment).ItemSpecFragment;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(EscapingUtilities.UnescapeAll(value)))
                         {
-                            var item = _itemFactory.CreateItem(value, value, _itemElement.ContainingProject.FullPath);
+                            var item = itemFactory.CreateItem(value, value, projectPath);
                             itemsToAdd.Add(item);
                         }
                     }
                     else if (fragment is GlobFragment)
                     {
-                        string glob = ((GlobFragment)fragment).ItemSpecFragment;
+                        string glob = ((GlobFragment) fragment).ItemSpecFragment;
 
                         if (excludePatternsForGlobs == null)
                         {
@@ -97,15 +130,16 @@ namespace Microsoft.Build.Evaluation
                         }
 
                         string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
-                            _rootDirectory,
+                            rootDirectory,
                             glob,
                             excludePatternsForGlobs,
-                            entriesCache: EntriesCache
-                            );
+                            entriesCache: entriesCache
+                        );
 
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
                         {
-                            itemsToAdd.Add(_itemFactory.CreateItem(includeSplitFileEscaped, glob, _itemElement.ContainingProject.FullPath));
+                            itemsToAdd.Add(itemFactory.CreateItem(includeSplitFileEscaped, glob,
+                                projectPath));
                         }
                     }
                     else
@@ -117,6 +151,7 @@ namespace Microsoft.Build.Evaluation
                 return itemsToAdd.ToImmutable();
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableList<string>.Builder excludePatterns)
             {
                 var anyExcludes = excludePatterns.Count > 0;
@@ -144,7 +179,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        class IncludeOperationBuilder : OperationBuilderWithMetadata
+        internal class IncludeOperationBuilder : OperationBuilderWithMetadata
         {
             public int ElementOrder { get; set; }
             public string RootDirectory { get; set; }

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Evaluation
 {
     internal partial class LazyItemEvaluator<P, I, M, D>
     {
-        private abstract class LazyItemOperation : IItemOperation
+        internal abstract class LazyItemOperation : IItemOperation
         {
             private readonly string _itemType;
             private readonly ImmutableDictionary<string, LazyItemList> _referencedItemLists;

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private class LazyItemList
+        internal class LazyItemList
         {
             private readonly LazyItemList _previous;
             private readonly MemoizedOperation _memoizedOperation;
@@ -361,7 +361,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private class OperationBuilder
+        internal class OperationBuilder
         {
             // WORKAROUND: Unnecessary boxed allocation: https://github.com/dotnet/corefx/issues/24563
             private static readonly ImmutableDictionary<string, LazyItemList> s_emptyIgnoreCase = ImmutableDictionary.Create<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
@@ -384,7 +384,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private class OperationBuilderWithMetadata : OperationBuilder
+        internal class OperationBuilderWithMetadata : OperationBuilder
         {
             public ImmutableList<ProjectMetadataElement>.Builder Metadata = ImmutableList.CreateBuilder<ProjectMetadataElement>();
 

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -13,7 +13,20 @@ namespace Microsoft.Build.Utilities
     /// </summary>
     internal class Traits
     {
-        public static Traits Instance = new Traits();
+        private static Traits _instance = new Traits();
+        public static Traits Instance
+        {
+            get
+            {
+#if DEBUG
+                if (Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS") == "1")
+                {
+                    return new Traits();
+                }
+#endif
+                return _instance;
+            }
+        }
 
         public EscapeHatches EscapeHatches { get; }
 

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -117,13 +117,38 @@ namespace Microsoft.Build.UnitTests
             return items[0];
         }
 
-        internal static void AssertItemEvaluation(string projectContents, string[] inputFiles, string[] expectedInclude, Dictionary<string, string>[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
+        internal static void AssertItemEvaluationFromProject(string projectContents, string[] inputFiles, string[] expectedInclude, Dictionary<string, string>[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
+        {
+            AssertItemEvaluationFromGenericItemEvaluator((p, c) =>
+                {
+                    return new Project(p, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, c)
+                        .Items
+                        .Select(i => (TestItem) new ProjectItemTestItemAdapter(i))
+                        .ToList();
+                },
+            projectContents,
+            inputFiles,
+            expectedInclude,
+            false,
+            expectedMetadataPerItem,
+            normalizeSlashes);
+        }
+
+        internal static void AssertItemEvaluationFromGenericItemEvaluator(Func<string, ProjectCollection, IList<TestItem>> itemEvaluator, string projectContents, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute = false, TempPaths[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
         {
             using (var env = TestEnvironment.Create())
             using (var collection = new ProjectCollection())
             {
                 var testProject = env.CreateTestProjectWithFiles(projectContents, inputFiles);
-                var evaluatedItems = new Project(testProject.ProjectFile, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, collection).Items.ToList();
+                var evaluatedItems = itemEvaluator(testProject.ProjectFile, collection);
+
+                if (makeExpectedIncludeAbsolute)
+                {
+                    for (int i = 0; i < expectedInclude.Length; i++)
+                    {
+                        expectedInclude[i] = Path.Combine(testProject.TestRoot, expectedInclude[i]);
+                    }
+                }
 
                 if (expectedMetadataPerItem == null)
                 {
@@ -141,10 +166,62 @@ namespace Microsoft.Build.UnitTests
             return path.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
         }
 
+        // todo Make IItem<M> public and add these new members to it.
+        internal interface TestItem
+        {
+            string EvaluatedInclude { get; }
+            int DirectMetadataCount { get; }
+            string GetMetadataValue(string key);
+        }
+
+        internal class ProjectItemTestItemAdapter : TestItem
+        {
+            private readonly ProjectItem _projectInstance;
+
+            public ProjectItemTestItemAdapter(ProjectItem projectInstance)
+            {
+                _projectInstance = projectInstance;
+            }
+
+            public string EvaluatedInclude => _projectInstance.EvaluatedInclude;
+            public int DirectMetadataCount => _projectInstance.DirectMetadataCount;
+            public string GetMetadataValue(string key) => _projectInstance.GetMetadataValue(key);
+
+            public static implicit operator ProjectItemTestItemAdapter(ProjectItem pi)
+            {
+                return new ProjectItemTestItemAdapter(pi);
+            }
+        }
+
+        internal class ProjectItemInstanceTestItemAdapter : TestItem
+        {
+            private readonly ProjectItemInstance _projectInstance;
+
+            public ProjectItemInstanceTestItemAdapter(ProjectItemInstance projectInstance)
+            {
+                _projectInstance = projectInstance;
+            }
+
+            public string EvaluatedInclude => _projectInstance.EvaluatedInclude;
+            public int DirectMetadataCount => _projectInstance.DirectMetadataCount;
+            public string GetMetadataValue(string key) => _projectInstance.GetMetadataValue(key);
+
+            public static implicit operator ProjectItemInstanceTestItemAdapter(ProjectItemInstance pi)
+            {
+                return new ProjectItemInstanceTestItemAdapter(pi);
+            }
+        }
+
+        internal static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
+        {
+            var converteditems = items.Select(i => (TestItem) new ProjectItemTestItemAdapter(i)).ToList();
+            AssertItems(expectedItems, converteditems, expectedDirectMetadata, normalizeSlashes);
+        }
+
         /// <summary>
         /// Asserts that the list of items has the specified evaluated includes.
         /// </summary>
-        internal static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
+        internal static void AssertItems(string[] expectedItems, IList<TestItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
         {
             if (expectedDirectMetadata == null)
             {
@@ -163,6 +240,12 @@ namespace Microsoft.Build.UnitTests
         }
 
         public static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem, bool normalizeSlashes = false)
+        {
+            var convertedItems = items.Select(i => (TestItem) new ProjectItemTestItemAdapter(i)).ToList();
+            AssertItems(expectedItems, convertedItems, expectedDirectMetadataPerItem, normalizeSlashes);
+        }
+
+        public static void AssertItems(string[] expectedItems, IList<TestItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem, bool normalizeSlashes = false)
         {
             Assert.Equal(expectedItems.Length, items.Count);
 
@@ -332,7 +415,13 @@ namespace Microsoft.Build.UnitTests
                 Assert.True(false, "Items were returned in the incorrect order.  See 'Standard Out' tab for more details.");
             }
         }
+
         internal static void AssertItemHasMetadata(Dictionary<string, string> expected, ProjectItem item)
+        {
+            AssertItemHasMetadata(expected, new ProjectItemTestItemAdapter(item));
+        }
+
+        internal static void AssertItemHasMetadata(Dictionary<string, string> expected, TestItem item)
         {
             Assert.Equal(expected.Keys.Count, item.DirectMetadataCount);
 

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests
             return items[0];
         }
 
-        internal static void AssertItemEvaluationFromProject(string projectContents, string[] inputFiles, string[] expectedInclude, Dictionary<string, string>[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
+        internal static void AssertItemEvaluationFromProject(string projectContents, string[] inputFiles, string[] expectedInclude, Dictionary<string, string>[] expectedMetadataPerItem = null, bool normalizeSlashes = false, bool makeExpectedIncludeAbsolute = false)
         {
             AssertItemEvaluationFromGenericItemEvaluator((p, c) =>
                 {
@@ -129,7 +129,7 @@ namespace Microsoft.Build.UnitTests
             projectContents,
             inputFiles,
             expectedInclude,
-            false,
+            makeExpectedIncludeAbsolute,
             expectedMetadataPerItem,
             normalizeSlashes);
         }
@@ -144,19 +144,16 @@ namespace Microsoft.Build.UnitTests
 
                 if (makeExpectedIncludeAbsolute)
                 {
-                    for (int i = 0; i < expectedInclude.Length; i++)
-                    {
-                        expectedInclude[i] = Path.Combine(testProject.TestRoot, expectedInclude[i]);
-                    }
+                    expectedInclude = expectedInclude.Select(i => Path.Combine(testProject.TestRoot, i)).ToArray();
                 }
 
                 if (expectedMetadataPerItem == null)
                 {
-                    ObjectModelHelpers.AssertItems(expectedInclude, evaluatedItems, expectedDirectMetadata: null, normalizeSlashes: normalizeSlashes);
+                    AssertItems(expectedInclude, evaluatedItems, expectedDirectMetadata: null, normalizeSlashes: normalizeSlashes);
                 }
                 else
                 {
-                    ObjectModelHelpers.AssertItems(expectedInclude, evaluatedItems, expectedMetadataPerItem, normalizeSlashes);
+                    AssertItems(expectedInclude, evaluatedItems, expectedMetadataPerItem, normalizeSlashes);
                 }
             }
         }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Build.UnitTests
                 }
                 else
                 {
-                    Assert.Equal(NormalizeSlashes(expectedItems[i]), NormalizeSlashes(items[i].EvaluatedInclude));
+                    Assert.Equal(NormalizeSlashes(expectedItems[i]), items[i].EvaluatedInclude);
                 }
 
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);

--- a/src/Shared/UnitTests/TestData/GlobbingTestData.cs
+++ b/src/Shared/UnitTests/TestData/GlobbingTestData.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                 yield return new object[]
                 {
                     @"$(MSBuildThisFileDirectory)\**\*",
-                    @"$(MSBuildThisFileDirectory)\a\**\*",
+                    @"$(MSBuildThisFileDirectory)\a\**\*;build.proj",
                     new[]
                     {
                         @"a\a",
@@ -150,7 +150,6 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
                     },
                     new[]
                     {
-                        "build.proj",
                         @"b\b",
                         @"c\c",
                         @"c\d\cd"

--- a/src/Shared/UnitTests/TestData/GlobbingTestData.cs
+++ b/src/Shared/UnitTests/TestData/GlobbingTestData.cs
@@ -9,6 +9,157 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
     
     public static class GlobbingTestData
     {
+        public static IEnumerable<object[]> IncludesAndExcludesWithWildcardsTestData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    "a.*", // include string
+                    "*.1", // exclude string
+                    new[] {"a.1", "a.2", "a.1"}, // files
+                    new[] {"a.2"}, // expected include
+                    false // whether to append the project directory to the expected include items
+                };
+
+                yield return new object[]
+                {
+                    @"**\*.cs",
+                    @"a\**",
+                    new[] {"1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs"},
+                    new[] {"1.cs"},
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"**\*",
+                    @"**\b\**",
+                    new[] {"1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs"},
+                    new[] {"1.cs", @"a\2.cs", "build.proj"},
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"**\*",
+                    @"**\b\**\*.cs",
+                    new[] {"1.cs", @"a\2.cs", @"a\b\3.cs", @"a\b\c\4.cs", @"a\b\c\5.txt"},
+                    new[] {"1.cs", @"a\2.cs", @"a\b\c\5.txt", "build.proj"},
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"src\**\proj\**\*.cs",
+                    @"src\**\proj\**\none\**\*",
+                    new[]
+                    {
+                        "1.cs",
+                        @"src\2.cs",
+                        @"src\a\3.cs",
+                        @"src\proj\4.cs",
+                        @"src\proj\a\5.cs",
+                        @"src\a\proj\6.cs",
+                        @"src\a\proj\a\7.cs",
+                        @"src\proj\none\8.cs",
+                        @"src\proj\a\none\9.cs",
+                        @"src\proj\a\none\a\10.cs",
+                        @"src\a\proj\a\none\11.cs",
+                        @"src\a\proj\a\none\a\12.cs"
+                    },
+                    new[]
+                    {
+                        @"src\a\proj\6.cs",
+                        @"src\a\proj\a\7.cs",
+                        @"src\proj\4.cs",
+                        @"src\proj\a\5.cs"
+                    },
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"**\*",
+                    "foo",
+                    new[]
+                    {
+                        "foo",
+                        @"a\foo",
+                        @"a\a\foo",
+                        @"a\b\foo"
+                    },
+                    new[]
+                    {
+                        @"a\a\foo",
+                        @"a\b\foo",
+                        @"a\foo",
+                        "build.proj"
+                    },
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"**\*",
+                    @"a\af*\*",
+                    new[]
+                    {
+                        @"a\foo",
+                        @"a\a\foo",
+                        @"a\b\foo"
+                    },
+                    new[]
+                    {
+                        @"a\a\foo",
+                        @"a\b\foo",
+                        @"a\foo",
+                        "build.proj"
+                    },
+                    false
+                };
+
+                yield return new object[]
+                {
+                    @"$(MSBuildThisFileDirectory)\**\*",
+                    @"$(MSBuildThisFileDirectory)\a\foo.txt",
+                    new[]
+                    {
+                        @"a\foo",
+                        @"a\foo.txt"
+                    },
+                    new[]
+                    {
+                        @"a\foo",
+                        "build.proj"
+                    },
+                    true
+                };
+
+                yield return new object[]
+                {
+                    @"$(MSBuildThisFileDirectory)\**\*",
+                    @"$(MSBuildThisFileDirectory)\a\**\*",
+                    new[]
+                    {
+                        @"a\a",
+                        @"a\b\ab",
+                        @"b\b",
+                        @"c\c",
+                        @"c\d\cd"
+                    },
+                    new[]
+                    {
+                        "build.proj",
+                        @"b\b",
+                        @"c\c",
+                        @"c\d\cd"
+                    },
+                    true
+                };
+            }
+        }
+
         public static IEnumerable<object[]> GlobbingConesTestData
         {
             get

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Build.Engine.UnitTests
             if (!ignoreBuildErrorFiles)
                 env.WithInvariant(new BuildFailureLogInvariant());
 
+            env.SetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS", "1");
+
             return env;
         }
 
@@ -106,6 +108,7 @@ namespace Microsoft.Build.Engine.UnitTests
             WithEnvironmentVariableInvariant("MSBuildForwardPropertiesFromChild");
             WithEnvironmentVariableInvariant("MsBuildForwardAllPropertiesFromChild");
             WithEnvironmentVariableInvariant("MSBUILDDEBUGFORCECACHING");
+            WithEnvironmentVariableInvariant("MSBUILDRELOADTRAITSONEACHACCESS");
         }
 
         /// <summary>
@@ -356,13 +359,11 @@ namespace Microsoft.Build.Engine.UnitTests
             _originalValue = Environment.GetEnvironmentVariable(environmentVariableName);
 
             Environment.SetEnvironmentVariable(environmentVariableName, newValue);
-            Traits.Instance = new Traits(); // Reset the traits to re-read environment changes
         }
 
         public override void Revert()
         {
             Environment.SetEnvironmentVariable(_environmentVariableName, _originalValue);
-            Traits.Instance = new Traits(); // Reset the traits to re-read environment changes
         }
     }
 


### PR DESCRIPTION
Fixes #2621 

This brings the exclude optimization (sending excludes together with includes, rather than file walking twice and doing set difference) to target based item includes as well, so it should make target item globbing a bit faster.