### PR TITLE
Don't add OriginalItemSpec when it already exists

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1368,6 +1368,11 @@ namespace Microsoft.Build.Execution
                         {
                             // Utilities.TaskItem's don't know about item definition metadata. So merge that into the values.
                             destinationItem.SetMetadata(metadatum.Name, GetMetadataEscaped(metadatum.Name));
+                            if (metadatum.Name == "OriginalItemSpec")
+                            {
+                                // We copied OriginalItemSpec, don't re-apply it later.
+                                addOriginalItemSpec = false;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Not positive this is the best way to fix this issue, but it seems to solve this class of issue. Not 100% sure that this wouldn't subtly change behavior though. But it seems like if you have `OriginalItemSpec` you probably don't want it reset every time you alter the item.

There is special logic to add OriginalItemSpec as metadata when copying
items. When that metadata already exists, don't overwrite it.

Closes #2649