### PR TITLE
GetAllGlobs optimizations

### DIFF
--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -1385,10 +1385,10 @@ namespace Microsoft.Build.Globbing
     public partial class MSBuildGlob : Microsoft.Build.Globbing.IMSBuildGlob
     {
         internal MSBuildGlob() { }
-        public string FilenamePart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string FixedDirectoryPart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool IsLegal { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string WildcardDirectoryPart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FilenamePart { get { throw null; } }
+        public string FixedDirectoryPart { get { throw null; } }
+        public bool IsLegal { get { throw null; } }
+        public string WildcardDirectoryPart { get { throw null; } }
         public bool IsMatch(string stringToMatch) { throw null; }
         public Microsoft.Build.Globbing.MSBuildGlob.MatchInfoResult MatchInfo(string stringToMatch) { throw null; }
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string fileSpec) { throw null; }

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -1362,10 +1362,10 @@ namespace Microsoft.Build.Globbing
     public partial class MSBuildGlob : Microsoft.Build.Globbing.IMSBuildGlob
     {
         internal MSBuildGlob() { }
-        public string FilenamePart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string FixedDirectoryPart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool IsLegal { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string WildcardDirectoryPart { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string FilenamePart { get { throw null; } }
+        public string FixedDirectoryPart { get { throw null; } }
+        public bool IsLegal { get { throw null; } }
+        public string WildcardDirectoryPart { get { throw null; } }
         public bool IsMatch(string stringToMatch) { throw null; }
         public Microsoft.Build.Globbing.MSBuildGlob.MatchInfoResult MatchInfo(string stringToMatch) { throw null; }
         public static Microsoft.Build.Globbing.MSBuildGlob Parse(string fileSpec) { throw null; }

--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         {
             var glob = MSBuildGlob.Parse(globRoot, "*");
 
-            Assert.Equal(glob._globRoot.LastOrDefault(), Path.DirectorySeparatorChar);
+            Assert.Equal(glob.TestOnlyGlobRoot.LastOrDefault(), Path.DirectorySeparatorChar);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             var glob = MSBuildGlob.Parse(globRoot, "*");
 
             var expectedRoot = Path.Combine(Directory.GetCurrentDirectory(), globRoot).WithTrailingSlash();
-            Assert.Equal(expectedRoot, glob._globRoot);
+            Assert.Equal(expectedRoot, glob.TestOnlyGlobRoot);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         {
             var glob = MSBuildGlob.Parse(string.Empty, "*");
 
-            Assert.Equal(Directory.GetCurrentDirectory().WithTrailingSlash(), glob._globRoot);
+            Assert.Equal(Directory.GetCurrentDirectory().WithTrailingSlash(), glob.TestOnlyGlobRoot);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             var glob = MSBuildGlob.Parse(globRoot, "*");
 
             var expectedRoot = NormalizeRelativePathForGlobRepresentation(globRoot);
-            Assert.Equal(expectedRoot, glob._globRoot);
+            Assert.Equal(expectedRoot, glob.TestOnlyGlobRoot);
         }
 
         [Fact]
@@ -118,11 +118,11 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             var expectedFixedDirectory = Path.Combine(globRoot, "b").WithTrailingSlash();
 
             Assert.True(glob.IsLegal);
-            Assert.Equal(true, glob._needsRecursion);
-            Assert.Equal(fileSpec, glob._fileSpec);
+            Assert.Equal(true, glob.TestOnlyNeedsRecursion);
+            Assert.Equal(fileSpec, glob.TestOnlyFileSpec);
 
-            Assert.Equal(globRoot.WithTrailingSlash(), glob._globRoot);
-            Assert.True(glob.FixedDirectoryPart.StartsWith(glob._globRoot));
+            Assert.Equal(globRoot.WithTrailingSlash(), glob.TestOnlyGlobRoot);
+            Assert.True(glob.FixedDirectoryPart.StartsWith(glob.TestOnlyGlobRoot));
 
             Assert.Equal(expectedFixedDirectory, glob.FixedDirectoryPart);
             Assert.Equal("**/", glob.WildcardDirectoryPart);
@@ -137,14 +137,16 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             var glob = MSBuildGlob.Parse(globRoot, illegalFileSpec);
 
             Assert.False(glob.IsLegal);
-            Assert.Equal(false, glob._needsRecursion);
-            Assert.Equal(illegalFileSpec, glob._fileSpec);
+            Assert.Equal(false, glob.TestOnlyNeedsRecursion);
+            Assert.Equal(illegalFileSpec, glob.TestOnlyFileSpec);
 
-            Assert.Equal(globRoot.WithTrailingSlash(), glob._globRoot);
+            Assert.Equal(globRoot.WithTrailingSlash(), glob.TestOnlyGlobRoot);
 
             Assert.Equal(string.Empty, glob.FixedDirectoryPart);
             Assert.Equal(string.Empty, glob.WildcardDirectoryPart);
             Assert.Equal(string.Empty, glob.FilenamePart);
+
+            Assert.False(glob.IsMatch($"b/.../c/d.cs"));
         }
 
         [Fact]

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -207,22 +207,25 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public IEnumerable<string> FlattenFragmentsAsStrings()
         {
-            foreach (var valueString in Fragments.OfType<ValueFragment>().Select(v => v.ItemSpecFragment))
+            foreach (var fragment in Fragments)
             {
-                yield return valueString;
-            }
+                if (fragment is ValueFragment || fragment is GlobFragment)
+                {
+                    yield return fragment.ItemSpecFragment;
+                }
+                else if (fragment is ItemExpressionFragment<P, I>)
+                {
+                    var itemExpression = (ItemExpressionFragment<P, I>) fragment;
 
-            foreach (var globString in Fragments.OfType<GlobFragment>().Select(g => g.ItemSpecFragment))
-            {
-                yield return globString;
-            }
-
-            foreach (
-                var referencedItemString in
-                Fragments.OfType<ItemExpressionFragment<P, I>>().SelectMany(f => f.ReferencedItems).Select(v => v.ItemSpecFragment)
-            )
-            {
-                yield return referencedItemString;
+                    foreach (var referencedItem in itemExpression.ReferencedItems)
+                    {
+                        yield return referencedItem.ItemSpecFragment;
+                    }
+                }
+                else
+                {
+                    ErrorUtilities.ThrowInternalErrorUnreachable();
+                }
             }
         }
 		


### PR DESCRIPTION
GetAllGlobs has become part of the VS solution load critical path. This PR does a couple of optimizations:
- makes MsBuildGlob computation lazy, so VS computes it on the first use, not when the solution opens
- reduces allocations

Numbers from GetAllGlobs when simulating the Roslyn.sln solution load:

![image](https://user-images.githubusercontent.com/2255729/31743420-f6952948-b40f-11e7-972c-fdd9de6294cf.png)
Not including the lazy glob change:
![image](https://user-images.githubusercontent.com/2255729/31743178-fe893d7a-b40e-11e7-9811-20d1912b223d.png)
Including the lazy glob change:
![image](https://user-images.githubusercontent.com/2255729/31744179-b41f1102-b412-11e7-8ab2-65f41d0959ab.png)

Closes #2647