### PR TITLE
Avoid cloning AssemblyName

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -272,7 +272,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CULTUREINFO</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CLONE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BINARY_SERIALIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>

--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -70,10 +70,9 @@ namespace Microsoft.Build.Shared
             name.SetPublicKeyToken(assemblyNameToClone.GetPublicKeyToken());
             name.Version = assemblyNameToClone.Version;
             name.Flags = assemblyNameToClone.Flags;
-            name.ContentType = assemblyNameToClone.ContentType;
             name.ProcessorArchitecture = assemblyNameToClone.ProcessorArchitecture;
 
-#if FEATURE_ASSEMBLYNAME_CULTUREINFO
+#if !RUNTIME_TYPE_NETCORE
             name.CultureInfo = assemblyNameToClone.CultureInfo;
             name.HashAlgorithm = assemblyNameToClone.HashAlgorithm;
             name.VersionCompatibility = assemblyNameToClone.VersionCompatibility;

--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Build.Shared
 
         public static AssemblyName CloneIfPossible(this AssemblyName assemblyNameToClone)
         {
+#if CLR2COMPATIBILITY
+            return (AssemblyName) assemblyNameToClone.Clone();
+#else
+
             // NOTE: In large projects, this is called a lot. Avoid calling AssemblyName.Clone
             // because it clones the Version property (which is immutable) and the PublicKey property
             // and the PublicKeyToken property.
@@ -66,9 +70,13 @@ namespace Microsoft.Build.Shared
             name.SetPublicKeyToken(assemblyNameToClone.GetPublicKeyToken());
             name.Version = assemblyNameToClone.Version;
             name.Flags = assemblyNameToClone.Flags;
-            name.CultureName = assemblyNameToClone.CultureName;
             name.ContentType = assemblyNameToClone.ContentType;
             name.ProcessorArchitecture = assemblyNameToClone.ProcessorArchitecture;
+
+            // mono does not support CultureName
+#if !MONO
+            name.CultureName = assemblyNameToClone.CultureName;
+#endif
 
 #if FEATURE_ASSEMBLYNAME_CULTUREINFO
             name.CultureInfo = assemblyNameToClone.CultureInfo;
@@ -80,6 +88,8 @@ namespace Microsoft.Build.Shared
 #endif
 
             return name;
+#endif
+
         }
 
         public static bool CultureInfoHasGetCultures()

--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -65,12 +65,19 @@ namespace Microsoft.Build.Shared
             name.SetPublicKey(assemblyNameToClone.GetPublicKey());
             name.SetPublicKeyToken(assemblyNameToClone.GetPublicKeyToken());
             name.Version = assemblyNameToClone.Version;
+            name.Flags = assemblyNameToClone.Flags;
+            name.CultureName = assemblyNameToClone.CultureName;
+            name.ContentType = assemblyNameToClone.ContentType;
+            name.ProcessorArchitecture = assemblyNameToClone.ProcessorArchitecture;
+
+#if FEATURE_ASSEMBLYNAME_CULTUREINFO
             name.CultureInfo = assemblyNameToClone.CultureInfo;
             name.HashAlgorithm = assemblyNameToClone.HashAlgorithm;
             name.VersionCompatibility = assemblyNameToClone.VersionCompatibility;
             name.CodeBase = assemblyNameToClone.CodeBase;
-            name.Flags = assemblyNameToClone.Flags;
             name.KeyPair = assemblyNameToClone.KeyPair;
+            name.VersionCompatibility = assemblyNameToClone.VersionCompatibility;
+#endif
 
             return name;
         }

--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -73,11 +73,6 @@ namespace Microsoft.Build.Shared
             name.ContentType = assemblyNameToClone.ContentType;
             name.ProcessorArchitecture = assemblyNameToClone.ProcessorArchitecture;
 
-            // mono does not support CultureName
-#if !MONO
-            name.CultureName = assemblyNameToClone.CultureName;
-#endif
-
 #if FEATURE_ASSEMBLYNAME_CULTUREINFO
             name.CultureInfo = assemblyNameToClone.CultureInfo;
             name.HashAlgorithm = assemblyNameToClone.HashAlgorithm;
@@ -85,6 +80,10 @@ namespace Microsoft.Build.Shared
             name.CodeBase = assemblyNameToClone.CodeBase;
             name.KeyPair = assemblyNameToClone.KeyPair;
             name.VersionCompatibility = assemblyNameToClone.VersionCompatibility;
+#elif !MONO
+            // Setting the culture name creates a new CultureInfo, leading to many allocations. Only set CultureName when the CultureInfo member is not available.
+            // CultureName not available on Mono
+            name.CultureName = assemblyNameToClone.CultureName;
 #endif
 
             return name;


### PR DESCRIPTION
This is causing 11% of all allocations building Roslyn.sln.

![image](https://user-images.githubusercontent.com/1103906/31856715-ed30c384-b67c-11e7-9245-4f56e22964fb.png)
