### PR TITLE
Stop reading the ToolsVersion from project XML during build

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -833,7 +833,7 @@ namespace Microsoft.Build.Execution
                 }
 
                 // Create/Retrieve a configuration for each request
-                BuildRequestConfiguration buildRequestConfiguration = new BuildRequestConfiguration(submission.BuildRequestData, _buildParameters.DefaultToolsVersion, _buildParameters.GetToolset);
+                BuildRequestConfiguration buildRequestConfiguration = new BuildRequestConfiguration(submission.BuildRequestData, _buildParameters.DefaultToolsVersion);
                 BuildRequestConfiguration matchingConfiguration = _configCache.GetMatchingConfiguration(buildRequestConfiguration);
                 BuildRequestConfiguration newConfiguration = ResolveConfiguration(buildRequestConfiguration, matchingConfiguration, submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ReplaceExistingProjectInstance));
 
@@ -948,7 +948,7 @@ namespace Microsoft.Build.Execution
 
             if (existingConfiguration == null)
             {
-                existingConfiguration = new BuildRequestConfiguration(GetNewConfigurationId(), new BuildRequestData(newInstance, Array.Empty<string>()), null /* use the instance's tools version */, null /* shouldn't need to get toolsets because ProjectInstance's ToolsVersion overrides */);
+                existingConfiguration = new BuildRequestConfiguration(GetNewConfigurationId(), new BuildRequestData(newInstance, Array.Empty<string>()), null /* use the instance's tools version */);
             }
             else
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Build.BackEnd
                 // Otherwise let the BuildRequestConfiguration figure out what tools version will be used
                 BuildRequestData data = new BuildRequestData(projectFiles[i], properties[i].ToDictionary(), explicitToolsVersion, targets, null);
 
-                BuildRequestConfiguration config = new BuildRequestConfiguration(data, _componentHost.BuildParameters.DefaultToolsVersion, _componentHost.BuildParameters.GetToolset);
+                BuildRequestConfiguration config = new BuildRequestConfiguration(data, _componentHost.BuildParameters.DefaultToolsVersion);
 
                 requests[i] = new FullyQualifiedBuildRequest(config, targets, waitForResults,
                     flags: skipNonexistentTargets ? BuildRequestDataFlags.SkipNonexistentTargets : BuildRequestDataFlags.None);

--- a/src/Shared/XmlUtilities.cs
+++ b/src/Shared/XmlUtilities.cs
@@ -167,65 +167,6 @@ namespace Microsoft.Build.Shared
             return -1;
         }
 
-        /// <summary>
-        /// Load the xml file using XMLTextReader and locate the element and attribute specified and then 
-        /// return the value. This is a quick way to peek at the xml file whithout having the go through 
-        /// the XMLDocument (MSDN article (Chapter 9 - Improving XML Performance)).
-        /// Does not throw for IO or XML issues.
-        /// Returns null if the attribute is not present.
-        /// </summary>
-        internal static string SniffAttributeValueFromXmlFile
-            (
-            string projectFileName,
-            string elementName,
-            string attributeName
-            )
-        {
-            string attributeValue = null;
-
-            try
-            {
-                XmlReaderSettings xmlReaderSettings = new XmlReaderSettings();
-                xmlReaderSettings.DtdProcessing = DtdProcessing.Ignore;
-                using (XmlReader xmlReader = XmlReader.Create(projectFileName, xmlReaderSettings))
-                {
-                    while (xmlReader.Read())
-                    {
-                        if (xmlReader.NodeType == XmlNodeType.Element)
-                        {
-                            if (String.Compare(xmlReader.Name, elementName, StringComparison.OrdinalIgnoreCase) == 0)
-                            {
-                                if (xmlReader.HasAttributes)
-                                {
-                                    for (int i = 0; i < xmlReader.AttributeCount; i++)
-                                    {
-                                        xmlReader.MoveToAttribute(i);
-                                        if (String.Compare(xmlReader.Name, attributeName, StringComparison.OrdinalIgnoreCase) == 0)
-                                        {
-                                            attributeValue = xmlReader.Value;
-                                            break;
-                                        }
-                                    }
-                                }
-                                // if we have already located the element then we are done
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // Ignore any IO or XML exceptions as it will be caught later on
-                if (ExceptionHandling.NotExpectedIoOrXmlException(ex))
-                {
-                    throw;
-                }
-            }
-
-            return attributeValue;
-        }
-
         internal static bool IsValidInitialElementNameCharacter(char c)
         {
             return (c >= 'A' && c <= 'Z') ||


### PR DESCRIPTION
We don't use ToolsVersion and getting the attibute from XML is costly.  It has to allocate a streeam, a byte[] to read the BOM, and then read elements and attributes.

Fixes #2604