### PR TITLE
Reduce allocations of HashSet<AssemblyNameExtension>

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -78,7 +78,6 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private AssemblyNameExtension()
         {
-            InitializeRemappedFrom();
         }
 
         /// <summary>


### PR DESCRIPTION
Reduces overall allocations during a build by 4.4%. Measured on building `dotnet new mvc`.

All the accesses of the field were already protected by a call to the lazy instantiation method.

![image](https://user-images.githubusercontent.com/2255729/31980926-a7f4f940-b904-11e7-914d-39483d723b1c.png)
