### PR TITLE
Fix issue with list of warnings or errors to treat differently can be added to the list multiple times

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -503,6 +503,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 if (_filterEventSource.WarningsAsErrorsByProject.ContainsKey(projectInstanceId))
                 {
+                    // The same project instance can be built multiple times with different targets.  In this case the codes have already been added
                     return;
                 }
 
@@ -521,6 +522,7 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 if (_filterEventSource.WarningsAsMessagesByProject.ContainsKey(projectInstanceId))
                 {
+                    // The same project instance can be built multiple times with different targets.  In this case the codes have already been added
                     return;
                 }
 

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -501,7 +501,12 @@ namespace Microsoft.Build.BackEnd.Logging
                     _filterEventSource.WarningsAsErrorsByProject = new ConcurrentDictionary<int, ISet<string>>();
                 }
 
-                _filterEventSource.WarningsAsErrorsByProject.Add(projectInstanceId, new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase));
+                if (_filterEventSource.WarningsAsErrorsByProject.ContainsKey(projectInstanceId))
+                {
+                    return;
+                }
+
+                _filterEventSource.WarningsAsErrorsByProject[projectInstanceId] = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -514,7 +519,12 @@ namespace Microsoft.Build.BackEnd.Logging
                     _filterEventSource.WarningsAsMessagesByProject = new ConcurrentDictionary<int, ISet<string>>();
                 }
 
-                _filterEventSource.WarningsAsMessagesByProject.Add(projectInstanceId, new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase));
+                if (_filterEventSource.WarningsAsMessagesByProject.ContainsKey(projectInstanceId))
+                {
+                    return;
+                }
+
+                _filterEventSource.WarningsAsMessagesByProject[projectInstanceId] = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -408,14 +408,18 @@ namespace Microsoft.Build.Engine.UnitTests
 
         internal MockLogger BuildProjectExpectFailure(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
         {
-            BuildProject(globalProperties, toolsVersion, out MockLogger logger).ShouldBeFalse();
+            MockLogger logger;
+
+            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeFalse();
 
             return logger;
         }
 
         internal MockLogger BuildProjectExpectSuccess(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
         {
-            BuildProject(globalProperties, toolsVersion, out MockLogger logger).ShouldBeTrue();
+            MockLogger logger;
+
+            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeTrue();
 
             return logger;
         }

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,7 +8,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
-using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -192,7 +191,7 @@ namespace Microsoft.Build.Engine.UnitTests
         /// <param name="files">Files to be created.</param>
         /// <param name="relativePathFromRootToProject">Path for the specified files to be created in relative to 
         /// the root of the project directory.</param>
-        public TransientTestProjectWithFiles CreateTestProjectWithFiles(string projectContents, string[] files,
+        public TransientTestProjectWithFiles CreateTestProjectWithFiles(string projectContents, string[] files = null,
             string relativePathFromRootToProject = ".")
         {
             return WithTransientTestState(
@@ -407,9 +406,35 @@ namespace Microsoft.Build.Engine.UnitTests
             CreatedFiles = Helpers.CreateFilesInDirectory(TestRoot, files);
         }
 
+        internal MockLogger BuildProjectExpectFailure(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
+        {
+            BuildProject(globalProperties, toolsVersion, out MockLogger logger).ShouldBeFalse();
+
+            return logger;
+        }
+
+        internal MockLogger BuildProjectExpectSuccess(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
+        {
+            BuildProject(globalProperties, toolsVersion, out MockLogger logger).ShouldBeTrue();
+
+            return logger;
+        }
+
         public override void Revert()
         {
             _folder.Revert();
+        }
+
+        private bool BuildProject(IDictionary<string, string> globalProperties, string toolsVersion, out MockLogger logger)
+        {
+            logger = new MockLogger();
+
+            using (ProjectCollection projectCollection = new ProjectCollection())
+            {
+                Project project = new Project(ProjectFile, globalProperties, toolsVersion, projectCollection);
+
+                return project.Build(logger);
+            }
         }
     }
 


### PR DESCRIPTION
When building two or more projects in the same build episode, the list of warnings to treat as errors or warnings to treat as messages is parsed multiple times.

This fixes the issue by checking if the list is already populated for a given project instance.

Fixes #2667