### PR TITLE
Import NuGet.targets in CrossTargeting build

### DIFF
--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -131,17 +131,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="Rebuild" DependsOnTargets="Clean;Build" />
 
   <!--
-    This will import NuGet restore targets, which is a special case separate from the package -> project extension 
-    mechanism below. For obvious reasons,  we need restore to work before any package assets are available.
-
-    TODO: https://github.com/Microsoft/msbuild/issues/1061: This is now generalized with less coupling to nuget, 
-          but this codepath should remain as a compat shim until NuGet and the CLI use the CrossTargeting imports.
+    This will import NuGet restore targets. We need restore to work before any package assets are available.
   -->
   <PropertyGroup>
-    <ImportByWildcardAfterMicrosoftCommonTargets Condition="'$(ImportByWildcardAfterMicrosoftCommonTargets)' == ''">true</ImportByWildcardAfterMicrosoftCommonTargets>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'=='' and '$([MSBuild]::IsRunningFromVisualStudio())'=='true'">$(MSBuildToolsPath32)\..\..\..\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targets</NuGetRestoreTargets>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath)\NuGet.targets</NuGetRestoreTargets>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter\*.NuGet.*.targets"
-          Condition="'$(ImportByWildcardAfterMicrosoftCommonTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.targets\ImportAfter')"/>
+
+  <Import Project="$(NuGetRestoreTargets)" />
 
   <Import Project="$(CustomAfterMicrosoftCommonCrossTargetingTargets)" Condition="'$(CustomAfterMicrosoftCommonCrossTargetingTargets)' != '' and Exists('$(CustomAfterMicrosoftCommonCrossTargetingTargets)')"/>
 


### PR DESCRIPTION
This case was missed and is failing CI for https://github.com/dotnet/cli/pull/7914

When doing a CrossTargeting build, we need to import NuGet for Restore. This was done by importing the file that used to be dropped with the CLI which would import the real NuGet.targets.