### PR TITLE
Don't enumerate GAC directories if the GAC path doesn't exist

### DIFF
--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -1532,14 +1532,21 @@ typedef enum _tagAssemblyComparisonResult
                 }
                 else
                 {
-                    if (!string.IsNullOrWhiteSpace(assemblyName))
+                    if (Directory.Exists(s_gacPath))
                     {
-                        _assemblyNameVersion = new AssemblyName(assemblyName);
-                        _gacDirectories = Directory.EnumerateDirectories(s_gacPath, _assemblyNameVersion.Name);
+                        if (!string.IsNullOrWhiteSpace(assemblyName))
+                        {
+                            _assemblyNameVersion = new AssemblyName(assemblyName);
+                            _gacDirectories = Directory.EnumerateDirectories(s_gacPath, _assemblyNameVersion.Name);
+                        }
+                        else
+                        {
+                            _gacDirectories = Directory.EnumerateDirectories(s_gacPath);
+                        }
                     }
                     else
                     {
-                        _gacDirectories = Directory.EnumerateDirectories(s_gacPath);
+                        _gacDirectories = Array.Empty<string>();
                     }
                 }
             }


### PR DESCRIPTION
Fixes #2673

On non-Windows, MSBuild assumes that the GAC path is the location of the assembly containing `System.String` plus `"/gac"`. This works fine on a standard Mono layout. However, on a non-standard Mono layout (such as the one used by OmniSharp), this throws a `System.IO.DirectoryNotFoundException` when trying enumerate the GAC directories.

This PR fixes the issue by checking with the GAC path exists before enumerating directories within it. If it doesn't, it is assumed that there are no GAC directories to search.