### PR TITLE
Reduce AssemblyName allocations

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -271,6 +271,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CULTUREINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BINARY_SERIALIZATION</DefineConstants>

--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -19,6 +20,13 @@ namespace Microsoft.Build.Engine.UnitTests
 #else
         private const string MSBuildExeName = "MSBuild.exe";
 #endif
+
+        [Fact]
+        public void ShouldBeRunningInTests()
+        {
+            BuildEnvironmentHelper.Instance.RunningTests.ShouldBeTrue();
+        }
+
         [Fact]
         public void GetExecutablePath()
         {

--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -22,12 +22,6 @@ namespace Microsoft.Build.Engine.UnitTests
 #endif
 
         [Fact]
-        public void ShouldBeRunningInTests()
-        {
-            BuildEnvironmentHelper.Instance.RunningTests.ShouldBeTrue();
-        }
-
-        [Fact]
         public void GetExecutablePath()
         {
             var msbuildPath = Path.GetDirectoryName(FileUtilities.ExecutingAssemblyPath);
@@ -272,11 +266,7 @@ namespace Microsoft.Build.Engine.UnitTests
             }
         }
 
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/669")]
-#else
         [Fact]
-#endif
         public void BuildEnvironmentDetectsRunningTests()
         {
             BuildEnvironmentHelper.Instance.RunningTests.ShouldBeTrue();

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -740,7 +740,7 @@ namespace Microsoft.Build.Shared
 #if FEATURE_ASSEMBLYNAME_CULTUREINFO
             return a?.CultureInfo?.LCID == b?.CultureInfo?.LCID;
 #else
-            return a?.CultureInfo?.Name == b?.CultureInfo?.Name;
+            return a?.CultureName == b?.CultureName;
 #endif
         }
 

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Build.Shared
                 return false;
             }
 
-            if (!CompareCulture(that))
+            if (!CompareCultures(AssemblyName, that.AssemblyName))
             {
                 return false;
             }
@@ -734,29 +734,13 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Allows the comparison of the culture.
         /// </summary>
-        internal bool CompareCulture(AssemblyNameExtension that)
+        internal static bool CompareCultures(AssemblyName a, AssemblyName b)
         {
             // Do the Cultures match?
 #if FEATURE_ASSEMBLYNAME_CULTUREINFO
-            CultureInfo aCulture = CultureInfo;
-            CultureInfo bCulture = that.CultureInfo;
-            if (aCulture == null)
-            {
-                aCulture = CultureInfo.InvariantCulture;
-            }
-            if (bCulture == null)
-            {
-                bCulture = CultureInfo.InvariantCulture;
-            }
-
-            if (aCulture.LCID != bCulture.LCID)
-            {
-                return false;
-            }
-
-            return true;
+            return a?.CultureInfo?.LCID == b?.CultureInfo?.LCID;
 #else
-            return CultureInfo?.Name == that.CultureInfo?.Name;
+            return a?.CultureInfo?.Name == b?.CultureInfo?.Name;
 #endif
         }
 
@@ -774,7 +758,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Compare two public key tokens.
         /// </summary>
-        private static bool ComparePublicKeyTokens(byte[] aPKT, byte[] bPKT)
+        internal static bool ComparePublicKeyTokens(byte[] aPKT, byte[] bPKT)
         {
             // Some assemblies (real case was interop assembly) may have null PKTs.
             if (aPKT == null)
@@ -926,7 +910,7 @@ namespace Microsoft.Build.Shared
                 return false;
             }
 
-            if ((comparisonFlags & PartialComparisonFlags.Culture) != 0 && CultureInfo != null && (that.CultureInfo == null || !CompareCulture(that)))
+            if ((comparisonFlags & PartialComparisonFlags.Culture) != 0 && CultureInfo != null && (that.CultureInfo == null || !CompareCultures(AssemblyName, that.AssemblyName)))
             {
                 return false;
             }

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -738,9 +738,41 @@ namespace Microsoft.Build.Shared
         {
             // Do the Cultures match?
 #if FEATURE_ASSEMBLYNAME_CULTUREINFO
-            return a?.CultureInfo?.LCID == b?.CultureInfo?.LCID;
+            CultureInfo aCulture = a.CultureInfo;
+            CultureInfo bCulture = b.CultureInfo;
+            if (aCulture == null)
+            {
+                aCulture = CultureInfo.InvariantCulture;
+            }
+            if (bCulture == null)
+            {
+                bCulture = CultureInfo.InvariantCulture;
+            }
+
+            if (aCulture.LCID != bCulture.LCID)
+            {
+                return false;
+            }
+
+            return true;
 #else
-            return a?.CultureName == b?.CultureName;
+            string aCulture = a.CultureName;
+            string bCulture = b.CultureName;
+            if (aCulture == null)
+            {
+                aCulture = CultureInfo.InvariantCulture.Name;
+            }
+            if (bCulture == null)
+            {
+                bCulture = CultureInfo.InvariantCulture.Name;
+            }
+
+            if (aCulture != bCulture)
+            {
+                return false;
+            }
+
+            return true;
 #endif
         }
 

--- a/src/Shared/AssemblyUtilities.cs
+++ b/src/Shared/AssemblyUtilities.cs
@@ -19,13 +19,17 @@ namespace Microsoft.Build.Shared
         // Cached method info
         private static PropertyInfo s_assemblylocationProperty;
         private static MethodInfo s_cultureInfoGetCultureMethod;
-        private static Lazy<Assembly> s_entryAssembly = new Lazy<Assembly>(() => GetEntryAssembly());
 
 #if !FEATURE_CULTUREINFO_GETCULTURES
         private static Lazy<CultureInfo[]> s_validCultures = new Lazy<CultureInfo[]>(() => GetValidCultures(), true);
 #endif
 
+#if !CLR2COMPATIBILITY
+        private static Lazy<Assembly> s_entryAssembly = new Lazy<Assembly>(() => GetEntryAssembly());
         public static Assembly EntryAssembly => s_entryAssembly.Value;
+#else
+        public static Assembly EntryAssembly = GetEntryAssembly();
+#endif
 
         public static string GetAssemblyLocation(Assembly assembly)
         {

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -335,7 +335,11 @@ namespace Microsoft.Build.Shared
 
         private static string GetProcessFromRunningProcess()
         {
+#if RUNTIME_TYPE_NETCORE
+            return AssemblyUtilities.GetAssemblyLocation(AssemblyUtilities.EntryAssembly);
+#else
             return Process.GetCurrentProcess().MainModule.FileName;
+#endif
         }
 
         private static string GetExecutingAssemblyPath()

--- a/src/Shared/InternalErrorException.cs
+++ b/src/Shared/InternalErrorException.cs
@@ -147,52 +147,6 @@ namespace Microsoft.Build.Shared
         }
         #endregion
 
-        private static bool RunningTests()
-        {
-            // Copied logic from BuildEnvironmentHelper. Removed reference for single use due
-            // to additional dependencies. Update both if needed.
-            string[] testRunners =
-            {
-                "XUNIT", "NUNIT", "MSTEST", "VSTEST", "TASKRUNNER", "VSTESTHOST", "QTAGENT32",
-                "CONCURRENT", "RESHARPER", "MDHOST", "TE.PROCESSHOST"
-            };
-
-            string[] testAssemblies =
-            {
-                "Microsoft.Build.Tasks.UnitTests", "Microsoft.Build.Engine.UnitTests",
-                "Microsoft.Build.Utilities.UnitTests", "Microsoft.Build.CommandLine.UnitTests",
-                "Microsoft.Build.Engine.OM.UnitTests", "Microsoft.Build.Framework.UnitTests"
-            };
-
-#if FEATURE_GET_COMMANDLINE
-            var processNameCommandLine = Environment.GetCommandLineArgs()[0];
-#else
-            string processNameCommandLine = null;
-#endif
-            var processNameCurrentProcess = Process.GetCurrentProcess().MainModule.FileName;
-
-            // First check if we're running in a known test runner.
-            if (IsProcessInList(processNameCommandLine, testRunners) ||
-                IsProcessInList(processNameCurrentProcess, testRunners))
-            {
-#if FEATURE_APPDOMAIN
-                // If we are, then ensure we're running MSBuild's tests by seeing if any of our assemblies are loaded.
-                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-                {
-                    if (testAssemblies.Any(item => item.Equals(assembly.GetName().Name, StringComparison.InvariantCultureIgnoreCase)))
-                        return true;
-                }
-#else
-                return true;
-#endif
-            }
-
-            return false;
-        }
-
-        private static bool IsProcessInList(string processName, string[] processList)
-        {
-            return processList.Any(s => Path.GetFileNameWithoutExtension(processName)?.IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0);
-        }
+        private static bool RunningTests() => BuildEnvironmentHelper.Instance.RunningTests;
     }
 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Utilities
             get
             {
 #if DEBUG
-                if (Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS") == "1")
+                if (BuildEnvironmentHelper.Instance.RunningTests && Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS") == "1")
                 {
                     return new Traits();
                 }

--- a/src/Tasks/AppConfig/DependentAssembly.cs
+++ b/src/Tasks/AppConfig/DependentAssembly.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// The partial <see cref="AssemblyName"/>, there should be no version.
+        /// Setter and Getter clone the incoming / outgoing assembly
         /// </summary>
         internal AssemblyName PartialAssemblyName
         {
@@ -39,6 +40,17 @@ namespace Microsoft.Build.Tasks
             get
             {
                 return _partialAssemblyName?.CloneIfPossible();
+            }
+        }
+
+        /// <summary>
+        /// The full <see cref="AssemblyName"/>. It is not cloned. Callers should not mutate this object.
+        /// </summary>
+        internal AssemblyName AssemblyNameReadOnly
+        {
+            get
+            {
+                return _partialAssemblyName;
             }
         }
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2372,7 +2372,7 @@ namespace Microsoft.Build.Tasks
                 foreach (DependentAssembly remappedAssembly in _remappedAssemblies)
                 {
                     // First, exclude anything without the simple name match
-                    AssemblyNameExtension comparisonAssembly = new AssemblyNameExtension(remappedAssembly.PartialAssemblyName.CloneIfPossible());
+                    AssemblyNameExtension comparisonAssembly = new AssemblyNameExtension(remappedAssembly.PartialAssemblyName);
                     if (assemblyName.CompareBaseNameTo(comparisonAssembly) == 0)
                     {
                         // Comparison assembly is a partial name. Give it our version.


### PR DESCRIPTION
In mvc rebuild (133mb total allocations), reduces AssemblyName allocations 18.3% ->  0.5% and AssemblyNameExtensions 4.5% -> 0.3%. In a Roslyn rebuild (3.2gb total allocations), it reduces AssemblyName 2.3% -> 0.2% and AsssemblyNameExtension 0.6% -> 0.1%.

Commit [#1](https://github.com/Microsoft/msbuild/commit/8d5b139b9fabe58d288a65d4c34fe887fe812ae5) is safe to do, because the AssemblyName was double cloned ...
Commit [#2](https://github.com/Microsoft/msbuild/pull/2676/commits/b292563136731a53858defbac2fda9b1d056d7af) replaces calls to [AssemblyNameExtension.EqualsImpl](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L670-L733) and [AssemblyNameExtension.CompareBaseNameToImpl](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L516-L546) with a simple name, culture, and key comparison. This _looks_ safe to do because:
- the versions don't matter because both assemblies [get the same version](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Tasks/AssemblyDependency/ReferenceTable.cs#L2379)
- [AssemblyNameExtension.asString](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L63) does not matter because the comparison assembly [is instantiated](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Tasks/AssemblyDependency/ReferenceTable.cs#L2375) via a constructor that leaves `asString` null
- [ignoreVersion ](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L712)and [considerRetargetableFlag ](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L727) are [false](https://github.com/Microsoft/msbuild/blob/0a47f62a138b32cb406d058fe7f49c0494aa6c84/src/Shared/AssemblyNameExtension.cs#L646)
