### PR TITLE
Only import NuGet.targets when it exists

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5875,7 +5875,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildToolsPath)\NuGet.targets</NuGetRestoreTargets>
   </PropertyGroup>
 
-  <Import Project="$(NuGetRestoreTargets)" />
+  <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
 
   <Import Project="$(CustomAfterMicrosoftCommonTargets)" Condition="'$(CustomAfterMicrosoftCommonTargets)' != '' and Exists('$(CustomAfterMicrosoftCommonTargets)')"/>
 


### PR DESCRIPTION
Workaround might be needed until a better solution is found.

* Some scenarios may not have NuGet.targets (e.g. C++ only workload in VS)