### PR TITLE
RAR does not write to cache file on rebuilds

### DIFF
--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -27,10 +27,14 @@ namespace Microsoft.Build.Tasks
     [Serializable]
     internal sealed class SystemState : StateFileBase, ISerializable
     {
+        /// <summary>
+        /// Cache at the SystemState instance level. Has the same contents as <see cref="instanceLocalFileStateCache"/>.
+        /// It acts as a flag to enforce that an entry has been checked for staleness only once.
+        /// </summary>
         private Hashtable upToDateLocalFileStateCache = new Hashtable();
 
         /// <summary>
-        /// State information for cached files kept at the SystemState instance level.
+        /// Cache at the SystemState instance level. It is serialized and reused between instances.
         /// </summary>
         private Hashtable instanceLocalFileStateCache = new Hashtable();
 

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Build.Tasks
             if (processFileState == null && instanceLocalFileState != null)
             {
                 cacheFileState = instanceLocalFileState;
-                SystemState.s_processWideFileStateCache.TryAdd(path, instanceLocalFileState);
+                SystemState.s_processWideFileStateCache[path] = instanceLocalFileState;
             }
             else if (processFileState != null && instanceLocalFileState == null)
             {
@@ -376,7 +376,7 @@ namespace Microsoft.Build.Tasks
                 else
                 {
                     cacheFileState = instanceLocalFileState;
-                    SystemState.s_processWideFileStateCache.TryAdd(path, instanceLocalFileState);
+                    SystemState.s_processWideFileStateCache[path] = instanceLocalFileState;
                 }
             }
 
@@ -385,7 +385,7 @@ namespace Microsoft.Build.Tasks
             {
                 cacheFileState = new FileState(getLastWriteTime(path));
                 instanceLocalFileStateCache[path] = cacheFileState;
-                SystemState.s_processWideFileStateCache.TryAdd(path, cacheFileState);
+                SystemState.s_processWideFileStateCache[path] = cacheFileState;
                 isDirty = true;
             }
             else
@@ -396,7 +396,7 @@ namespace Microsoft.Build.Tasks
                 {
                     cacheFileState = new FileState(getLastWriteTime(path));
                     instanceLocalFileStateCache[path] = cacheFileState;
-                    SystemState.s_processWideFileStateCache.TryAdd(path, cacheFileState);
+                    SystemState.s_processWideFileStateCache[path] = cacheFileState;
                     isDirty = true;
                 }
             }


### PR DESCRIPTION
Closes #2687

Cause of the issue: 
- RAR uses two caches: a process wide cache and a project specific cache
- The project specific cache is serialized and reused between processes, whereas the process wide cache is not serialized. The process wide cache aggregates the project specific caches as projects are built.
- On every RAR execution, the project specific cache is loaded from disk, and compared against the value process wide cache: https://github.com/Microsoft/msbuild/blob/99d4c838624293725bfbfd1ae75405ec1bb99c4a/src/Tasks/SystemState.cs#L343-L351
- since the project wide cache is deserialized each time, its entries' are different instances from the entries in the process wide cache. This makes the reference equality check fail, and leads to dirtying the cache.

Fix: I chose to reuse the old code, wrap it with a guarding collection (to ensure an entry is checked for staleness only once), and ported over the change to replace stale entries from the process wide cache. Did this because the old code had an extra optimization: if the process wide cache had a more recent entry than the project specific cache, it would update the project specific cache from the process cache.

Before / After memory

![image](https://user-images.githubusercontent.com/2255729/32352352-25a743d6-bfde-11e7-8015-44e2a07b322b.png)

Before / After CPU
![image](https://user-images.githubusercontent.com/2255729/32352465-91665f76-bfde-11e7-99e8-a46baf2031a7.png)

