### PR TITLE
Support NuGet PackageReference properly in WPF temporary assembly

### DIFF
--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -60,7 +60,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportProjectExtensionProps Condition="'$(ImportProjectExtensionProps)' == ''">true</ImportProjectExtensionProps>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <!-- WPF sometimes creates a temporary project. In order to properly import NuGet generated targets, we need to use _OriginalProjectName when set. -->
+  <Import Project="$(MSBuildProjectExtensionsPath)$(_OriginalProjectName).*.props" Condition="'$(_OriginalProjectName)' != '' and '$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.props" Condition="'$(_OriginalProjectName)' == '' and'$(ImportProjectExtensionProps)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <!-- 
         Import wildcard "ImportBefore" props files if we're actually in a 12.0+ project (rather than a project being

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -124,7 +124,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <ImportProjectExtensionTargets Condition="'$(ImportProjectExtensionTargets)' == ''">true</ImportProjectExtensionTargets>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <!-- WPF sometimes creates a temporary project. In order to properly import NuGet generated targets, we need to use _OriginalProjectName when set. -->
+  <Import Project="$(MSBuildProjectExtensionsPath)$(_OriginalProjectName).*.targets" Condition="'$(_OriginalProjectName)' != '' and '$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
+  <Import Project="$(MSBuildProjectExtensionsPath)$(MSBuildProjectFile).*.targets" Condition="'$(_OriginalProjectName)' == '' and '$(ImportProjectExtensionTargets)' == 'true' and exists('$(MSBuildProjectExtensionsPath)')" />
 
   <PropertyGroup>
     <ImportDirectoryBuildTargets Condition="'$(ImportDirectoryBuildTargets)' == ''">true</ImportDirectoryBuildTargets>

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -11,4 +11,33 @@
 
    <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
 
+   <!-- This target is to fix a problem with WPF TemporaryAssembly creation during markup compilation. Shipping fix with MsBuild, until 
+        we can get the right fix into .NET Framework and Windows.
+   -->
+
+   <Target Name="GenerateTemporaryTargetAssembly"
+               Condition="'$(_RequireMCPass2ForMainAssembly)' == 'true'" >
+
+      <Message Text="MSBuildProjectFile is $(MSBuildProjectFile)" Condition="'$(MSBuildTargetsVerbose)' == 'true'" />
+
+       <GenerateTemporaryTargetAssembly2
+                CurrentProject="$(MSBuildProjectFullPath)"
+                MSBuildBinPath="$(MSBuildBinPath)"
+                ReferencePathTypeName="ReferencePath"
+                CompileTypeName="Compile"
+                GeneratedCodeFiles="@(_GeneratedCodeFiles)"
+                ReferencePath="@(ReferencePath)"
+                IntermediateOutputPath="$(IntermediateOutputPath)"
+                AssemblyName="$(AssemblyName)"
+                CompileTargetName="$(_CompileTargetNameForLocalType)"
+                 >
+
+       </GenerateTemporaryTargetAssembly2>
+
+       <CreateItem Include="$(IntermediateOutputPath)$(TargetFileName)" >
+               <Output TaskParameter="Include" ItemName="AssemblyForLocalTypeReference" />
+       </CreateItem>
+
+  </Target>
+
 </Project>


### PR DESCRIPTION
Support NuGet PackageReference properly in WPF temporary assembly by enabling .g.targets and .g.props to be properly included, despite the project file name change.

(Right now, just shopping the approach around, and looking for feedback. Need to coordinate with WPF team as well.)

Fixes: http://github.com/NuGet/Home/issues/5894

These changes react to _OriginalProjectName that is set by the new version of the temp assembly generator code. (see nuget change)