### PR TITLE
Cache directory exists in rar

### DIFF
--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2070,6 +2070,7 @@ namespace Microsoft.Build.Tasks
                     getAssemblyName = _cache.CacheDelegate(getAssemblyName);
                     getAssemblyMetadata = _cache.CacheDelegate(getAssemblyMetadata);
                     fileExists = _cache.CacheDelegate(fileExists);
+                    directoryExists = _cache.CacheDelegate(directoryExists);
                     getDirectories = _cache.CacheDelegate(getDirectories);
                     getRuntimeVersion = _cache.CacheDelegate(getRuntimeVersion);
 #endif

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -2,21 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Diagnostics;
-using Microsoft.Build.Tasks;
-using Microsoft.Build.Utilities;
-using Microsoft.Build.Shared;
-using System.Reflection;
 using System.Collections;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Runtime.Serialization;
-using System.Security.Permissions;
-using System.Globalization;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.Serialization;
 using System.Runtime.Versioning;
+using System.Security.Permissions;
+using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks.AssemblyDependency;
 
 namespace Microsoft.Build.Tasks
@@ -63,47 +57,47 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// XML tables of installed assemblies.
         /// </summary>
-        private RedistList redistList = null;
+        private RedistList redistList;
 
         /// <summary>
         /// True if the contents have changed.
         /// </summary>
-        private bool isDirty = false;
+        private bool isDirty;
 
         /// <summary>
         /// Delegate used internally.
         /// </summary>
-        private GetLastWriteTime getLastWriteTime = null;
+        private GetLastWriteTime getLastWriteTime;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetAssemblyName getAssemblyName = null;
+        private GetAssemblyName getAssemblyName;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetAssemblyMetadata getAssemblyMetadata = null;
+        private GetAssemblyMetadata getAssemblyMetadata;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private FileExists fileExists = null;
+        private FileExists fileExists;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private DirectoryExists directoryExists = null;
+        private DirectoryExists directoryExists;
 
         /// <summary>
         /// Cached delegate.
         /// </summary>
-        private GetDirectories getDirectories = null;
+        private GetDirectories getDirectories;
 
         /// <summary>
         /// Cached delegate
         /// </summary>
-        private GetAssemblyRuntimeVersion getAssemblyRuntimeVersion = null;
+        private GetAssemblyRuntimeVersion getAssemblyRuntimeVersion;
 
         /// <summary>
         /// Class that holds the current file state.
@@ -119,27 +113,27 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// The fusion name of this file.
             /// </summary>
-            private AssemblyNameExtension assemblyName = null;
+            private AssemblyNameExtension assemblyName;
 
             /// <summary>
             /// The assemblies that this file depends on.
             /// </summary>
-            internal AssemblyNameExtension[] dependencies = null;
+            internal AssemblyNameExtension[] dependencies;
 
             /// <summary>
             /// The scatter files associated with this assembly.
             /// </summary>
-            internal string[] scatterFiles = null;
+            internal string[] scatterFiles;
 
             /// <summary>
             /// FrameworkName the file was built against
             /// </summary>
-            internal FrameworkName frameworkName = null;
+            internal FrameworkName frameworkName;
 
             /// <summary>
             /// The CLR runtime version for the assembly.
             /// </summary>
-            internal string runtimeVersion = null;
+            internal string runtimeVersion;
 
             /// <summary>
             /// Default construct.
@@ -167,7 +161,7 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// Serialize the contents of the class.
             /// </summary>
-            [SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
+            [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
             public void GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 ErrorUtilities.VerifyThrowArgumentNull(info, "info");
@@ -205,8 +199,8 @@ namespace Microsoft.Build.Tasks
             /// <value></value>
             internal string RuntimeVersion
             {
-                get { return this.runtimeVersion; }
-                set { this.runtimeVersion = value; }
+                get { return runtimeVersion; }
+                set { runtimeVersion = value; }
             }
 
             /// <summary>
@@ -215,8 +209,8 @@ namespace Microsoft.Build.Tasks
             [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Could be used in other assemblies")]
             internal FrameworkName FrameworkNameAttribute
             {
-                get { return this.frameworkName; }
-                set { this.frameworkName = value; }
+                get { return frameworkName; }
+                set { frameworkName = value; }
             }
         }
 
@@ -256,7 +250,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Serialize the contents of the class.
         /// </summary>
-        [SecurityPermissionAttribute(SecurityAction.Demand, SerializationFormatter = true)]
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             ErrorUtilities.VerifyThrowArgumentNull(info, "info");
@@ -290,7 +284,7 @@ namespace Microsoft.Build.Tasks
         internal GetAssemblyName CacheDelegate(GetAssemblyName getAssemblyNameValue)
         {
             getAssemblyName = getAssemblyNameValue;
-            return new GetAssemblyName(this.GetAssemblyName);
+            return GetAssemblyName;
         }
 
         /// <summary>
@@ -301,7 +295,7 @@ namespace Microsoft.Build.Tasks
         internal GetAssemblyMetadata CacheDelegate(GetAssemblyMetadata getAssemblyMetadataValue)
         {
             getAssemblyMetadata = getAssemblyMetadataValue;
-            return new GetAssemblyMetadata(this.GetAssemblyMetadata);
+            return GetAssemblyMetadata;
         }
 
         /// <summary>
@@ -312,13 +306,13 @@ namespace Microsoft.Build.Tasks
         internal FileExists CacheDelegate(FileExists fileExistsValue)
         {
             fileExists = fileExistsValue;
-            return new FileExists(this.FileExists);
+            return FileExists;
         }
 
         public DirectoryExists CacheDelegate(DirectoryExists directoryExistsValue)
         {
             directoryExists = directoryExistsValue;
-            return new DirectoryExists(this.DirectoryExists);
+            return DirectoryExists;
         }
 
         /// <summary>
@@ -329,7 +323,7 @@ namespace Microsoft.Build.Tasks
         internal GetDirectories CacheDelegate(GetDirectories getDirectoriesValue)
         {
             getDirectories = getDirectoriesValue;
-            return new GetDirectories(this.GetDirectories);
+            return GetDirectories;
         }
 
         /// <summary>
@@ -340,7 +334,7 @@ namespace Microsoft.Build.Tasks
         internal GetAssemblyRuntimeVersion CacheDelegate(GetAssemblyRuntimeVersion getAssemblyRuntimeVersion)
         {
             this.getAssemblyRuntimeVersion = getAssemblyRuntimeVersion;
-            return new GetAssemblyRuntimeVersion(this.GetRuntimeVersion);
+            return GetRuntimeVersion;
         }
 
         private FileState GetFileState(string path)


### PR DESCRIPTION
The cache is local to one RAR execution, just like the file existence cache.

(times below are relative to all RAR invocations on a Roslyn build)

Before:
![image](https://user-images.githubusercontent.com/2255729/32396931-a55d56da-c0a4-11e7-89a1-a354383b65dc.png)

After:
![image](https://user-images.githubusercontent.com/2255729/32396946-b2cabd94-c0a4-11e7-87ac-859ff67ffbb7.png)

Second commit is a code cleanup change that makes everything hard to read.