### PR TITLE
Allow SignType=public

### DIFF
--- a/PublishToBlob.proj
+++ b/PublishToBlob.proj
@@ -1,0 +1,29 @@
+<Project>
+
+  <!--
+
+  This is for the internal orchestrated build scenarios and will likely never be run on a
+  developer's machine.  The official build definition builds this file directly.
+
+  -->
+
+  <PropertyGroup>
+    <FeedTasksPackage>Microsoft.DotNet.Build.Tasks.Feed</FeedTasksPackage>
+    <!-- This version should be kept in sync with `project.json` -->
+    <FeedTasksPackageVersion>1.0.0-prerelease-02121-01</FeedTasksPackageVersion>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)packages\$(FeedTasksPackage)\$(FeedTasksPackageVersion)\build\$(FeedTasksPackage).targets" />
+
+  <ItemGroup>
+    <ItemsToPush Include="$(MSBuildThisFileDirectory)bin\Packages\*.nupkg" />
+  </ItemGroup>
+
+  <Target Name="Build">
+    <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
+                    AccountKey="$(AccountKey)"
+                    ItemsToPush="@(ItemsToPush)"
+                    Overwrite="$(PublishOverwrite)" />
+  </Target>
+
+</Project>

--- a/dir.props
+++ b/dir.props
@@ -437,6 +437,20 @@
     <Languages Include="cs;de;en;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant"/>
   </ItemGroup>
 
+  <!-- Workaround for Orchestrated .NET Core product build
+
+       The buildtools signing/microbuild targets currently used by the msbuild project are very old.
+       They do not have support for 'SignType' == 'public'.  This block of code deals with this by
+       translating the 'public' sign type into 'oss' which will be usable by the buildtools version
+       at this point.  To avoid the problem of the global command line parameter passed in being set to
+       'public' permanantly, we use 'MSSignType' instead as the input.
+       UseOpenSourceSign is used internally to denote OSS signing. -->
+  <PropertyGroup>
+    <UseOpenSourceSign Condition="'$(MSSignType)'=='public'">true</UseOpenSourceSign>
+    <SignType Condition="'$(MSSignType)'=='public'">oss</SignType>
+    <SignType Condition="'$(MSSignType)'!='public'">$(MSSignType)</SignType>
+  </PropertyGroup>
+
   <Import Project="$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.props" Condition="'$(IsTestProject)' != 'true' And '$(DebugType)' == 'full' And Exists('$(PackagesDir)\pdbgit\3.0.41\build\PdbGit.props')" />
 
 </Project>

--- a/src/.nuget/project.json
+++ b/src/.nuget/project.json
@@ -6,7 +6,8 @@
     "Microsoft.Net.Compilers": "2.3.1",
     "MicroBuild.Core": "0.2.0",
     "Microsoft.DotNet.BuildTools.GenAPI": "1.0.0-beta2-00731-01",
-    "NuGet.Build.Tasks": "4.5.0-preview2-4529"
+    "NuGet.Build.Tasks": "4.5.0-preview2-4529",
+    "Microsoft.DotNet.Build.Tasks.Feed":"1.0.0-prerelease-02121-01"
   },
   "frameworks": {
     "net46": {}

--- a/src/UpdateLocalizedResources.targets
+++ b/src/UpdateLocalizedResources.targets
@@ -104,25 +104,6 @@
 
   </Target>
 
-  <!-- Copy paste and modify OpenSourceSign from sign.targets because it only signs the main assembly 
-  and provides no extension mechanism to add more assemblies to it
-  
-  If satellite assemblies do not get their delay sign bit switched off, the main assemblies won't load them
-  -->
-  <Target Name="OpenSourceSignSatelliteAssemblies"
-          Condition="'$(DelaySign)' == 'true' and '@(IntermediateSatelliteAssembliesWithTargetPath)' != '' and '$(SkipSigning)' != 'true' and '$(SignType)' == 'oss'"
-          DependsOnTargets="ComputeIntermediateSatelliteAssemblies"
-          BeforeTargets="CopyFilesToOutputDirectory"
-          Inputs="@(IntermediateSatelliteAssembliesWithTargetPath)"
-          Outputs="%(IntermediateSatelliteAssembliesWithTargetPath.Identity).oss_signed"
-          >
-    <OpenSourceSign AssemblyPath="%(IntermediateSatelliteAssembliesWithTargetPath.Identity)" />
-    <Touch Files="%(IntermediateSatelliteAssembliesWithTargetPath.Identity).oss_signed" AlwaysCreate="true" />
-    <ItemGroup>
-       <FileWrites Include="%(IntermediateSatelliteAssembliesWithTargetPath.Identity).oss_signed" />
-    </ItemGroup>
-  </Target>
-
   <!-- Target SignFiles from MicroBuild.Plugins.Signing.targets signs @(FilesToSign) -->
   <Target Name="AddSatelliteAssembliesToFilesToSignItem"
           Condition="('$(SignType)' == 'real' OR '$(SignType)' == 'test')"


### PR DESCRIPTION
SignType=public is functionally equivalent to SignType=oss.  It is what will be passed through the orchestrated build.

Here it implies that oss signing doesn't mean anything without delay signing.  Does this go the other way?
Does this also mean that delay signing is only useful for oss signing?  If so, can I change this to enable delay signing under public/oss?