### PR TITLE
Allow references to specify metadata to skip finding dependencies in RAR

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -849,6 +849,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] FilesWritten { get { throw null; } set { } }
         public bool FindDependencies { get { throw null; } set { } }
+        public bool FindDependenciesOfExternallyResolvedReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool FindRelatedFiles { get { throw null; } set { } }
         public bool FindSatellites { get { throw null; } set { } }
         public bool FindSerializationAssemblies { get { throw null; } set { } }

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -498,6 +498,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] FilesWritten { get { throw null; } set { } }
         public bool FindDependencies { get { throw null; } set { } }
+        public bool FindDependenciesOfExternallyResolvedReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool FindRelatedFiles { get { throw null; } set { } }
         public bool FindSatellites { get { throw null; } set { } }
         public bool FindSerializationAssemblies { get { throw null; } set { } }

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -355,6 +355,37 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         [Fact]
+        public void SystemRuntimeDepends_Yes_Indirect_ExternallyResolved()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("Portable"),
+            };
+
+            t.Assemblies[0].SetMetadata("ExternallyResolved", "true");
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\SystemRuntime\Portable.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during intellibuild."
+        }
+
+        [Fact]
         public void NETStandardDepends_Yes()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -414,6 +445,38 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during intellibuild."
         }
 
+
+        [Fact]
+        public void NETStandardDepends_Yes_Indirect_ExternallyResolved()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("netstandardlibrary"),
+            };
+
+            t.Assemblies[0].SetMetadata("ExternallyResolved", "true");
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandardlibrary.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during intellibuild."
+        }
+
         [Fact]
         public void DependsOn_NETStandard_and_SystemRuntime()
         {
@@ -428,6 +491,42 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             };
 
             t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandardlibrary.dll");
+            t.Assemblies[1].SetMetadata("HintPath", @"C:\SystemRuntime\Portable.dll");
+
+            t.SearchPaths = DefaultPaths;
+
+            // build mode
+            t.FindDependencies = true;
+
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during build."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                   "Expected netstandard dependency found during build."
+
+            // intelli build mode
+            t.FindDependencies = false;
+            Assert.True(t.Execute(fileExists, directoryExists, getDirectories, getAssemblyName, getAssemblyMetadata, getRegistrySubKeyNames, getRegistrySubKeyDefaultValue, getLastWriteTime, getRuntimeVersion, openBaseKey, checkIfAssemblyIsInGac, isWinMDFile, readMachineTypeFromPEHeader));
+
+            Assert.True(string.Equals(t.DependsOnSystemRuntime, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected System.Runtime dependency found during intellibuild."
+            Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                   "Expected netstandard dependency found during intellibuild."
+        }
+
+        [Fact]
+        public void DependsOn_NETStandard_and_SystemRuntime_ExternallyResolved()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("netstandardlibrary"),
+                new TaskItem("Portable"),
+            };
+
+            t.Assemblies[0].SetMetadata("ExternallyResolved", "true");
+            t.Assemblies[0].SetMetadata("HintPath", @"C:\NetStandard\netstandardlibrary.dll");
+            t.Assemblies[1].SetMetadata("ExternallyResolved", "true");
             t.Assemblies[1].SetMetadata("HintPath", @"C:\SystemRuntime\Portable.dll");
 
             t.SearchPaths = DefaultPaths;

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -871,7 +871,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <summary>
         /// Externally resolved references do not get their related files identified by RAR. In the common
         /// nuget assets case, RAR cannot be the one to identify what to copy because RAR sees only the
-        /// compile-time assets and not the 
+        /// compile-time assets and not the runtime assets.
         /// </summary>
         [Theory]
         [InlineData(true)]

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -869,6 +869,47 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         /// <summary>
+        /// Externally resolved references do not get their related files identified by RAR. In the common
+        /// nuget assets case, RAR cannot be the one to identify what to copy because RAR sees only the
+        /// compile-time assets and not the 
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RelatedFilesAreNotFoundForExternallyResolvedReferences(bool findDependenciesOfExternallyResolvedReferences)
+        {
+            // This WriteLine is a hack.  On a slow machine, the Tasks unittest fails because remoting
+            // times out the object used for remoting console writes.  Adding a write in the middle of
+            // keeps remoting from timing out the object.
+            Console.WriteLine("Performing Miscellaneous.DefaultRelatedFileExtensionsAreUsed() test");
+
+            // Create the engine.
+            MockEngine engine = new MockEngine();
+
+            // Construct a list of assembly files.
+            ITaskItem[] assemblies = new TaskItem[]
+            {
+                new TaskItem(@"c:\AssemblyFolder\SomeAssembly.dll")
+            };
+
+            assemblies[0].SetMetadata("ExternallyResolved", "true");
+
+            // Now, pass feed resolved primary references into ResolveAssemblyReference.
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = engine;
+            t.Assemblies = assemblies;
+            t.TargetFrameworkDirectories = new string[] { s_myVersion20Path };
+            t.SearchPaths = DefaultPaths;
+            t.FindDependenciesOfExternallyResolvedReferences = findDependenciesOfExternallyResolvedReferences; // does not impact related file search
+            Execute(t);
+
+            Assert.Equal(1, t.ResolvedFiles.Length);
+            Assert.True(t.ResolvedFiles[0].ItemSpec.EndsWith(@"AssemblyFolder\SomeAssembly.dll"));
+            Assert.Equal(0, t.RelatedFiles.Length);
+        }
+
+        /// <summary>
         /// RAR should use any given related file extensions.
         /// </summary>
         [Fact]
@@ -1161,6 +1202,31 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(@"c:\MyWeaklyNamed\A.dll", t.ResolvedDependencyFiles[0].ItemSpec);
+        }
+
+        /// <summary>
+        /// When a reference is marked as externally resolved, it is supposed to have provided
+        /// everything needed as primary references and dependencies are therefore not searched
+        /// as an optimization. This is a contrived case of a dangling dependency off of an
+        /// externally resolved reference, so that we can observe that the dependency search is
+        /// not performed in a test.
+        /// </summary>
+        [Fact]
+        public void DependenciesOfExternallyResolvedReferencesAreNotSearched()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            t.BuildEngine = new MockEngine();
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("DependsOnSimpleA")
+            };
+
+            t.Assemblies[0].SetMetadata("ExternallyResolved", "true");
+
+            t.SearchPaths = new string[] { s_myAppRootPath, @"c:\MyStronglyNamed", @"c:\MyWeaklyNamed" };
+            Execute(t);
+            Assert.Equal(0, t.ResolvedDependencyFiles.Length);
         }
 
         /// <summary>
@@ -7999,6 +8065,44 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, e.Warnings);
         }
 
+        /// <summary>
+        /// Consider this dependency chain:
+        ///
+        /// (1) Primary reference A v 2.0.0.0 is found and marked externally resolved.
+        /// (2) Primary reference B is externally resolved and depends on A v 1.0.0.0
+        ///
+        /// When AutoGenerateBindingRedirects is used, we need to find the redirect
+        /// in the externally resolved graph.
+        /// </summary>
+        [Fact]
+        public void RedirectsAreSuggestedInExternallyResolvedGraph()
+        {
+            ResolveAssemblyReference t = new ResolveAssemblyReference();
+
+            MockEngine e = new MockEngine();
+            t.BuildEngine = e;
+
+            // NB: These are what common targets would set when AutoGenerateBindingRedirects is enabled.
+            t.AutoUnify = true;
+            t.FindDependenciesOfExternallyResolvedReferences = true;
+
+            t.Assemblies = new ITaskItem[]
+            {
+                new TaskItem("A", new Dictionary<string, string> { ["ExternallyResolved"] = "true" } ),
+                new TaskItem("B", new Dictionary<string, string> { ["ExternallyResolved"] = "true" } ),
+            };
+
+            t.SearchPaths = new string[]
+            {
+                @"c:\Regress442570",
+            };
+
+            Execute(t);
+
+            // Expect a suggested redirect with no warning.
+            Assert.Equal(1, t.SuggestedRedirects.Length);
+            Assert.Equal(0, e.Warnings);
+        }
 
         /// Consider this dependency chain:
         ///

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -1043,6 +1043,16 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// Indicates that the reference is primary and has ExternallyResolved=true metadata to denote that 
+        /// it was resolved by an external system (commonly from nuget). Such a system has already provided a
+        /// resolved closure as primary references and therefore we can skip the expensive closure walk.
+        internal bool ExternallyResolved
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Make this reference an assembly that is a dependency of 'sourceReference'
         ///
         /// For example, if 'sourceReference' is MyAssembly.dll then a dependent assembly file
@@ -1106,6 +1116,9 @@ namespace Microsoft.Build.Tasks
 
             // This is an assembly file, so we'll need to find dependencies later.
             DependenciesFound = false;
+
+            string externallyResolved = sourceItem.GetMetadata("ExternallyResolved");
+            ExternallyResolved = string.Equals(externallyResolved, "true", StringComparison.OrdinalIgnoreCase);
 
             // Add source items from the original item.
             AddSourceItem(sourceItem);

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -1049,7 +1049,7 @@ namespace Microsoft.Build.Tasks
         internal bool ExternallyResolved
         {
             get;
-            set;
+            private set;
         }
 
         /// <summary>
@@ -1117,8 +1117,7 @@ namespace Microsoft.Build.Tasks
             // This is an assembly file, so we'll need to find dependencies later.
             DependenciesFound = false;
 
-            string externallyResolved = sourceItem.GetMetadata("ExternallyResolved");
-            ExternallyResolved = string.Equals(externallyResolved, "true", StringComparison.OrdinalIgnoreCase);
+            ExternallyResolved = MetadataConversionUtilities.TryConvertItemMetadataToBool(sourceItem, "ExternallyResolved");
 
             // Add source items from the original item.
             AddSourceItem(sourceItem);

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1648,6 +1648,8 @@ namespace Microsoft.Build.Tasks
 #endif
             {
                 _references.Clear();
+                SkippedFindingExternallyResolvedDependencies = false;
+
                 _remappedAssemblies = remappedAssembliesValue;
                 SetPrimaryItems(referenceAssemblyFiles, referenceAssemblyNames, exceptions);
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -357,6 +357,26 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// Indicates that at least one reference was <see cref="Reference.ExternallyResolved"/> and
+        /// we skipped finding its dependencies as a result.
+        /// </summary>
+        /// <remarks>
+        /// This is currently used to perform a shallow search for System.Runtime/netstandard usage
+        /// within the externally resolved graph.
+        /// </remarks>
+        internal bool SkippedFindingExternallyResolvedDependencies { get; private set; }
+
+        /// <summary>
+        /// Force dependencies to be walked even when a reference is marked with ExternallyResolved=true
+        /// metadata.
+        /// </summary>
+        /// <remarks>
+        /// This is currently used to ensure that we suggest appropriate binding redirects for
+        /// assembly version conflicts within an externally resolved graph.
+        /// </remarks>
+        internal bool FindDependenciesOfExternallyResolvedReferences { get; set; }
+
+        /// <summary>
         /// Adds a reference to the table.
         /// </summary>
         /// <param name="assemblyName">The assembly name to be used as a key.</param>
@@ -1721,32 +1741,41 @@ namespace Microsoft.Build.Tasks
                         // We do not want to find dependencies of framework assembles, embedded interoptypes or assemblies in sdks.
                         if (!hasFrameworkPath && !reference.EmbedInteropTypes && reference.SDKName.Length == 0)
                         {
-                            // Look for companion files like pdbs and xmls that ride along with 
-                            // assemblies.
-                            if (_findRelatedFiles)
+                            if (!reference.ExternallyResolved)
                             {
-                                FindRelatedFiles(reference);
+                                // Look for companion files like pdbs and xmls that ride along with 
+                                // assemblies.
+                                if (_findRelatedFiles)
+                                {
+                                    FindRelatedFiles(reference);
+                                }
+
+                                // Satellite assemblies are named <CultureDir>\<AppBaseName>.resources.dll
+                                // where <CultureDir> is like 'en', 'fr', etc.
+                                if (_findSatellites)
+                                {
+                                    FindSatellites(reference);
+                                }
+
+                                // Look for serialization assemblies.
+                                if (_findSerializationAssemblies)
+                                {
+                                    FindSerializationAssemblies(reference);
+                                }
                             }
 
-                            // Satellite assemblies are named <CultureDir>\<AppBaseName>.resources.dll
-                            // where <CultureDir> is like 'en', 'fr', etc.
-                            if (_findSatellites)
+                            if (!reference.ExternallyResolved || FindDependenciesOfExternallyResolvedReferences)
                             {
-                                FindSatellites(reference);
+                                // Look for dependent assemblies.
+                                if (_findDependencies)
+                                {
+                                    FindDependenciesAndScatterFiles(reference, newEntries);
+                                }
                             }
-
-                            // Look for serialization assemblies.
-                            if (_findSerializationAssemblies)
+                            else
                             {
-                                FindSerializationAssemblies(reference);
+                                SkippedFindingExternallyResolvedDependencies = true;
                             }
-
-                            // Look for dependent assemblies.
-                            if (_findDependencies)
-                            {
-                                FindDependenciesAndScatterFiles(reference, newEntries);
-                            }
-
 
                             // If something was found, then break out and start fresh.
                             if (newEntries.Count > 0)

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2038,6 +2038,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       </Reference>
     </ItemGroup>
 
+    <!--
+      Normally, as an optimization, finding dependencies of references marked with ExternallyResolved=true metadata is skipped.
+      However, skipping that step breaks binding redirect generation when there are conflicting versions within the externally
+      resolved graph.
+    -->
+    <PropertyGroup Condition="'$(FindDependenciesOfExternallyResolvedReferences)' == ''">
+       <FindDependenciesOfExternallyResolvedReferences>false</FindDependenciesOfExternallyResolvedReferences>
+       <FindDependenciesOfExternallyResolvedReferences Condition="'$(AutoGenerateBindingRedirects)' == 'true'">true</FindDependenciesOfExternallyResolvedReferences>
+    </PropertyGroup>
+
     <ResolveAssemblyReference
         Assemblies="@(Reference)"
         AssemblyFiles="@(_ResolvedProjectReferencePaths);@(_ExplicitReference)"
@@ -2076,6 +2086,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ResolvedSDKReferences="@(ResolvedSDKReference)"
         WarnOrErrorOnTargetArchitectureMismatch="$(ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch)"
         IgnoreTargetFrameworkAttributeVersionMismatch ="$(ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch)"
+        FindDependenciesOfExternallyResolvedReferences="$(FindDependenciesOfExternallyResolvedReferences)"
         ContinueOnError="$(ContinueOnError)"
         Condition="'@(Reference)'!='' or '@(_ResolvedProjectReferencePaths)'!='' or '@(_ExplicitReference)' != ''"
         >


### PR DESCRIPTION
SDK half: https://github.com/dotnet/sdk/pull/1725

See there for perf numbers
