### PR TITLE
Add flag to ignore faulted imports

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -16,11 +16,11 @@
     <dependencies>
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -16,11 +16,11 @@
     <dependencies>
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -762,7 +762,7 @@ namespace Microsoft.Build.Evaluation
         Default = 0,
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
-        IgnoreFaultedImports = 64,
+        IgnoreInvalidImports = 64,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/ref/net46/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/net46/Microsoft.Build/Microsoft.Build.cs
@@ -762,6 +762,7 @@ namespace Microsoft.Build.Evaluation
         Default = 0,
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
+        IgnoreFaultedImports = 64,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -750,6 +750,7 @@ namespace Microsoft.Build.Evaluation
         Default = 0,
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
+        IgnoreFaultedImports = 64,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
+++ b/ref/netstandard1.3/Microsoft.Build/Microsoft.Build.cs
@@ -750,7 +750,7 @@ namespace Microsoft.Build.Evaluation
         Default = 0,
         DoNotEvaluateElementsWithFalseCondition = 32,
         IgnoreEmptyImports = 16,
-        IgnoreFaultedImports = 64,
+        IgnoreInvalidImports = 64,
         IgnoreMissingImports = 1,
         RecordDuplicateButNotCircularImports = 2,
         RecordEvaluatedItemElements = 8,

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4060,33 +4060,20 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                     Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreFaultedImports);
 
-                    IEnumerable<ProjectImportedEventArgs> eventArgs = logger.AllBuildEvents.Where(i => i is ProjectImportedEventArgs).Cast<ProjectImportedEventArgs>();
+                    ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
-                    ProjectImportedEventArgs ignoreImportArg = eventArgs.FirstOrDefault();
-                    ProjectImportedEventArgs faultArg = eventArgs.LastOrDefault();
+                    Assert.NotNull(eventArgs);
 
-                    Assert.NotNull(ignoreImportArg);
-                    Assert.NotNull(faultArg);
-                    Assert.NotSame(ignoreImportArg, faultArg);
+                    Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
-                    Assert.Equal(import.Project, ignoreImportArg.UnexpandedProject);
-                    Assert.Equal(import.Project, faultArg.UnexpandedProject);
+                    Assert.Null(eventArgs.ImportedProjectFile);
 
-                    Assert.Null(ignoreImportArg.ImportedProjectFile);
-                    Assert.Null(faultArg.ImportedProjectFile);
+                    Assert.Equal(pre.FullPath, eventArgs.ProjectFile);
 
-                    Assert.Equal(pre.FullPath, ignoreImportArg.ProjectFile);
-                    Assert.Equal(pre.FullPath, faultArg.ProjectFile);
+                    Assert.Equal(6, eventArgs.LineNumber);
+                    Assert.Equal(3, eventArgs.ColumnNumber);
 
-                    Assert.Equal(6, ignoreImportArg.LineNumber);
-                    Assert.Equal(3, ignoreImportArg.ColumnNumber);
-
-                    Assert.Equal(2, faultArg.LineNumber);
-                    Assert.Equal(1, faultArg.ColumnNumber);
-
-                    logger.AssertLogContains(
-                        $"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({ignoreImportArg.LineNumber},{ignoreImportArg.ColumnNumber}), due to the file being faulted.",
-                        $"The element <#text> beneath element <Project> is unrecognized.  {import.Project}");
+                    logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to the file being faulted.");
                 }
             }
         }

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4000,11 +4000,12 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 const string contents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 ";
-                string importPath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents, Encoding.UTF8);
+                var importFile = env.CreateFile(".targets");
+                File.WriteAllText(importFile.Path, contents);
                 ProjectRootElement pre = ProjectRootElement.Create(env.CreateFile(".proj").Path);
 
                 pre.AddPropertyGroup().AddProperty("NotUsed", "");
-                var import = pre.AddImport(importPath);
+                var import = pre.AddImport(importFile.Path);
 
                 pre.Save();
                 pre.Reload();
@@ -4044,11 +4045,13 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 const string contents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project>BROKEN</Project>
 ";
-                string importPath = ObjectModelHelpers.CreateFileInTempProjectDirectory(Guid.NewGuid().ToString("N"), contents, Encoding.UTF8);
+
+                var importFile = env.CreateFile(".targets");
+                File.WriteAllText(importFile.Path, contents);
                 ProjectRootElement pre = ProjectRootElement.Create(env.CreateFile(".proj").Path);
 
                 pre.AddPropertyGroup().AddProperty("NotUsed", "");
-                var import = pre.AddImport(importPath);
+                var import = pre.AddImport(importFile.Path);
 
                 pre.Save();
                 pre.Reload();

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4035,7 +4035,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
-        public void ProjectImportedEventFaultedFile()
+        public void ProjectImportedEventInvalidFile()
         {
             using (var env = TestEnvironment.Create(_output))
             {
@@ -4058,7 +4058,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     MockLogger logger = new MockLogger();
                     collection.RegisterLogger(logger);
 
-                    Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreFaultedImports);
+                    Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreInvalidImports);
 
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
@@ -4073,7 +4073,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     Assert.Equal(6, eventArgs.LineNumber);
                     Assert.Equal(3, eventArgs.ColumnNumber);
 
-                    logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to the file being faulted.");
+                    logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to the file being invalid.");
                 }
             }
         }

--- a/src/Build/Definition/ProjectLoadSettings.cs
+++ b/src/Build/Definition/ProjectLoadSettings.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Build.Evaluation
         DoNotEvaluateElementsWithFalseCondition = 32,
 
         /// <summary>
-        /// Ignore faulted target files when evaluating the project
+        /// Ignore invalid target files when evaluating the project
         /// </summary>
-        IgnoreFaultedImports = 64,
+        IgnoreInvalidImports = 64,
     }
 }

--- a/src/Build/Definition/ProjectLoadSettings.cs
+++ b/src/Build/Definition/ProjectLoadSettings.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Build.Evaluation
         /// By default, evaluations performed via <see cref="Project"/> evaluate and collect elements whose conditions were false (e.g. <see cref="Project.ItemsIgnoringCondition"/>).
         /// This flag turns off this behaviour. <see cref="Project"/> members that collect such elements will throw when accessed.
         /// </summary>
-        DoNotEvaluateElementsWithFalseCondition = 32
+        DoNotEvaluateElementsWithFalseCondition = 32,
+
+        /// <summary>
+        /// Ignore faulted target files when evaluating the project
+        /// </summary>
+        IgnoreFaultedImports = 64,
     }
 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2670,7 +2670,7 @@ namespace Microsoft.Build.Evaluation
 
                             // If IgnoreFaultedImports is enabled, log all other non-handled exceptions and continue
                             //
-                            if (((_loadSettings & ProjectLoadSettings.IgnoreFaultedImports) != 0))
+                            if (((_loadSettings & ProjectLoadSettings.IgnoreInvalidImports) != 0))
                             {
                                 atleastOneImportIgnored = true;
 
@@ -2678,7 +2678,7 @@ namespace Microsoft.Build.Evaluation
                                 ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                                     importElement.Location.Line,
                                     importElement.Location.Column,
-                                    ResourceUtilities.GetResourceString("ProjectImportSkippedFaultedFile"),
+                                    ResourceUtilities.GetResourceString("ProjectImportSkippedInvalidFile"),
                                     importFileUnescaped,
                                     importElement.ContainingProject.FullPath,
                                     importElement.Location.Line,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2668,7 +2668,7 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
-                            // If IgnoreFaultedImports is enabled, log all other non-handled exceptions and continue
+                            // If IgnoreInvalidImports is enabled, log all other non-handled exceptions and continue
                             //
                             if (((_loadSettings & ProjectLoadSettings.IgnoreInvalidImports) != 0))
                             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2668,6 +2668,43 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
+                            if (((_loadSettings & ProjectLoadSettings.IgnoreFaultedImports) != 0))
+                            {
+                                atleastOneImportIgnored = true;
+
+                                // Log message for import skipped
+                                ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
+                                    importElement.Location.Line,
+                                    importElement.Location.Column,
+                                    ResourceUtilities.GetResourceString("ProjectImportSkippedFaultedFile"),
+                                    importFileUnescaped,
+                                    importElement.ContainingProject.FullPath,
+                                    importElement.Location.Line,
+                                    importElement.Location.Column)
+                                {
+                                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                                    UnexpandedProject = importElement.Project,
+                                    ProjectFile = importElement.ContainingProject.FullPath,
+                                };
+
+                                _evaluationLoggingContext.LogBuildEvent(eventArgs);
+
+                                // Log message for the fault that caused the import to be skipped
+                                eventArgs = new ProjectImportedEventArgs(
+                                    ex.LineNumber,
+                                    ex.ColumnNumber,
+                                    ex.Message)
+                                {
+                                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                                    UnexpandedProject = importElement.Project,
+                                    ProjectFile = importElement.ContainingProject.FullPath,
+                                };
+
+                                _evaluationLoggingContext.LogBuildEvent(eventArgs);
+
+                                continue;
+                            }
+
                             // If this exception is a wrapped exception (like IOException or XmlException) then wrap it as an invalid import instead
                             if (ex.InnerException != null)
                             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2668,6 +2668,8 @@ namespace Microsoft.Build.Evaluation
                                 continue;
                             }
 
+                            // If IgnoreFaultedImports is enabled, log all other non-handled exceptions and continue
+                            //
                             if (((_loadSettings & ProjectLoadSettings.IgnoreFaultedImports) != 0))
                             {
                                 atleastOneImportIgnored = true;
@@ -2681,19 +2683,6 @@ namespace Microsoft.Build.Evaluation
                                     importElement.ContainingProject.FullPath,
                                     importElement.Location.Line,
                                     importElement.Location.Column)
-                                {
-                                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
-                                    UnexpandedProject = importElement.Project,
-                                    ProjectFile = importElement.ContainingProject.FullPath,
-                                };
-
-                                _evaluationLoggingContext.LogBuildEvent(eventArgs);
-
-                                // Log message for the fault that caused the import to be skipped
-                                eventArgs = new ProjectImportedEventArgs(
-                                    ex.LineNumber,
-                                    ex.ColumnNumber,
-                                    ex.Message)
                                 {
                                     BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                                     UnexpandedProject = importElement.Project,

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1623,7 +1623,11 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="ProjectImportSkippedEmptyFile">
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being empty.</value>
   </data>
-  
+
+  <data name="ProjectImportSkippedFaultedFile">
+    <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being faulted.</value>
+  </data>
+
   <data name="ProjectImported">
     <value>Importing project &quot;{0}&quot; into project &quot;{1}&quot; at ({2},{3}).</value>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1624,8 +1624,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being empty.</value>
   </data>
 
-  <data name="ProjectImportSkippedFaultedFile">
-    <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being faulted.</value>
+  <data name="ProjectImportSkippedInvalidFile">
+    <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being invalid.</value>
   </data>
 
   <data name="ProjectImported">


### PR DESCRIPTION
Add `ProjectLoadSettings.IgnoreFaultedImports` flag, behaving like `ProjectLoadSettings.IgnoreEmptyImports`, where an import that throws `InvalidProjectFileException`  will be logged and removed from that evaluation.

This change is to help improve CPS auto-reload of imports. Right now there is no common point for CPS to handle exceptions thrown from evaluation. With auto-reload of imports, it is not uncommon for an invalid project file to be saved, and attempted to reload. Our current design is to validate the file before reloading it, but this is expensive as it requires validating the XML as well as seeing if any project configuration would throw. Even then it is not a perfect system as we can only validate imports we know exist. For example, a conditioned import that goes from false to true and is invalid can still cause an error dialog or even crash VS. With this change we can tolerate any faulted import.

I would like to make 2 changes after this as well:
1. The event args for a skipped import should be an error or at least a warning.
2. Need to be able to identify what imports were skipped. This can either be a new property on the `Project` class, or the log messages can be uniquely identifiable (new type?) so CPS can track them via log messages.

/cc @lifengl @davkean 

Fixes #2179