### PR TITLE
Skipped import logging

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -361,6 +361,7 @@ namespace Microsoft.Build.Framework
         public ProjectImportedEventArgs() { }
         public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Exception ImportException { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Build.Framework
         public ProjectImportedEventArgs() { }
         public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public System.Exception ImportException { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ImportIgnored { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -358,6 +358,7 @@ namespace Microsoft.Build.Framework
         public ProjectImportedEventArgs() { }
         public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public System.Exception ImportException { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Build.Framework
         public ProjectImportedEventArgs() { }
         public ProjectImportedEventArgs(int lineNumber, int columnNumber, string message, params object[] messageArgs) { }
         public string ImportedProjectFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public System.Exception ImportException { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ImportIgnored { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string UnexpandedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class ProjectStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4105,7 +4105,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     MockLogger logger = new MockLogger();
                     collection.RegisterLogger(logger);
 
-                    Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreInvalidImports);
+                    Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreMissingImports);
 
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4020,7 +4020,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
-                    Assert.NotNull(eventArgs.ImportException);
+                    Assert.True(eventArgs.ImportIgnored);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
@@ -4067,7 +4067,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
-                    Assert.NotNull(eventArgs.ImportException);
+                    Assert.True(eventArgs.ImportIgnored);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
@@ -4110,7 +4110,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
-                    Assert.NotNull(eventArgs.ImportException);
+                    Assert.True(eventArgs.ImportIgnored);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
@@ -4165,6 +4165,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                     Assert.Equal(pre2.FullPath, eventArgs.ProjectFile);
 
+                    Assert.False(eventArgs.ImportIgnored);
                     Assert.Equal(6, eventArgs.LineNumber);
                     Assert.Equal(3, eventArgs.ColumnNumber);
 

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4127,6 +4127,49 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         }
 
         [Fact]
+        public void ProjectImportedEventMissingFileNoGlobMatch()
+        {
+            using (var env = TestEnvironment.Create(_output))
+            {
+                env.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
+
+                ProjectRootElement pre = ProjectRootElement.Create(env.CreateFile(".proj").Path);
+
+                pre.AddPropertyGroup().AddProperty("NotUsed", "");
+
+                string importGlob = Path.Combine(pre.DirectoryPath, @"__NoMatch__\**");
+                var import = pre.AddImport(importGlob);
+
+                pre.Save();
+                pre.Reload();
+
+                using (ProjectCollection collection = new ProjectCollection())
+                {
+                    MockLogger logger = new MockLogger();
+                    collection.RegisterLogger(logger);
+
+                    Project unused = new Project(pre, null, null, collection);
+
+                    ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
+
+                    Assert.NotNull(eventArgs);
+                    Assert.True(eventArgs.ImportIgnored);
+
+                    Assert.Equal(import.Project, eventArgs.UnexpandedProject);
+
+                    Assert.Null(eventArgs.ImportedProjectFile);
+
+                    Assert.Equal(pre.FullPath, eventArgs.ProjectFile);
+
+                    Assert.Equal(6, eventArgs.LineNumber);
+                    Assert.Equal(3, eventArgs.ColumnNumber);
+
+                    logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to no matching files.");
+                }
+            }
+        }
+
+        [Fact]
         [Trait("Category", "netcore-osx-failing")] // https://github.com/Microsoft/msbuild/issues/2226
         [Trait("Category", "netcore-linux-failing")] // https://github.com/Microsoft/msbuild/issues/2226
         [Trait("Category", "mono-osx-failing")] // https://github.com/Microsoft/msbuild/issues/2226

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4020,10 +4020,11 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
+                    Assert.NotNull(eventArgs.ImportException);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
-                    Assert.Null(eventArgs.ImportedProjectFile);
+                    Assert.Equal(importFile.Path, eventArgs.ImportedProjectFile);
 
                     Assert.Equal(pre.FullPath, eventArgs.ProjectFile);
 
@@ -4066,10 +4067,11 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
+                    Assert.NotNull(eventArgs.ImportException);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 
-                    Assert.Null(eventArgs.ImportedProjectFile);
+                    Assert.Equal(importFile.Path, eventArgs.ImportedProjectFile);
 
                     Assert.Equal(pre.FullPath, eventArgs.ProjectFile);
 
@@ -4077,6 +4079,49 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     Assert.Equal(3, eventArgs.ColumnNumber);
 
                     logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to the file being invalid.");
+                }
+            }
+        }
+
+        [Fact]
+        public void ProjectImportedEventMissingFile()
+        {
+            using (var env = TestEnvironment.Create(_output))
+            {
+                env.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
+
+                ProjectRootElement pre = ProjectRootElement.Create(env.CreateFile(".proj").Path);
+
+                pre.AddPropertyGroup().AddProperty("NotUsed", "");
+
+                string importPath = Path.Combine(pre.DirectoryPath, Guid.NewGuid().ToString());
+                var import = pre.AddImport(importPath);
+
+                pre.Save();
+                pre.Reload();
+
+                using (ProjectCollection collection = new ProjectCollection())
+                {
+                    MockLogger logger = new MockLogger();
+                    collection.RegisterLogger(logger);
+
+                    Project unused = new Project(pre, null, null, collection, ProjectLoadSettings.IgnoreInvalidImports);
+
+                    ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
+
+                    Assert.NotNull(eventArgs);
+                    Assert.NotNull(eventArgs.ImportException);
+
+                    Assert.Equal(import.Project, eventArgs.UnexpandedProject);
+
+                    Assert.Equal(importPath, eventArgs.ImportedProjectFile);
+
+                    Assert.Equal(pre.FullPath, eventArgs.ProjectFile);
+
+                    Assert.Equal(6, eventArgs.LineNumber);
+                    Assert.Equal(3, eventArgs.ColumnNumber);
+
+                    logger.AssertLogContains($"Project \"{import.Project}\" was not imported by \"{pre.FullPath}\" at ({eventArgs.LineNumber},{eventArgs.ColumnNumber}), due to the file not existing.");
                 }
             }
         }

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -4153,7 +4153,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     ProjectImportedEventArgs eventArgs = logger.AllBuildEvents.SingleOrDefault(i => i is ProjectImportedEventArgs) as ProjectImportedEventArgs;
 
                     Assert.NotNull(eventArgs);
-                    Assert.True(eventArgs.ImportIgnored);
+                    Assert.False(eventArgs.ImportIgnored);
 
                     Assert.Equal(import.Project, eventArgs.UnexpandedProject);
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2643,34 +2643,25 @@ namespace Microsoft.Build.Evaluation
                         }
                         else
                         {
-                            // If IgnoreEmptyImports is enabled, check if the file is considered empty
-                            //
+                            bool ignoreImport = false;
+                            string ignoreImportResource = null;
+
                             if (((_loadSettings & ProjectLoadSettings.IgnoreEmptyImports) != 0 || Traits.Instance.EscapeHatches.IgnoreEmptyImports) && ProjectRootElement.IsEmptyXmlFile(importFileUnescaped))
                             {
-                                atleastOneImportIgnored = true;
-
-                                ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
-                                    importElement.Location.Line,
-                                    importElement.Location.Column,
-                                    ResourceUtilities.GetResourceString("ProjectImportSkippedEmptyFile"),
-                                    importFileUnescaped,
-                                    importElement.ContainingProject.FullPath,
-                                    importElement.Location.Line,
-                                    importElement.Location.Column)
-                                {
-                                    BuildEventContext = _evaluationLoggingContext.BuildEventContext,
-                                    UnexpandedProject = importElement.Project,
-                                    ProjectFile = importElement.ContainingProject.FullPath
-                                };
-
-                                _evaluationLoggingContext.LogBuildEvent(eventArgs);
-
-                                continue;
+                                // If IgnoreEmptyImports is enabled, check if the file is considered empty
+                                //
+                                ignoreImport = true;
+                                ignoreImportResource = "ProjectImportSkippedEmptyFile";
+                            }
+                            else if ((_loadSettings & ProjectLoadSettings.IgnoreInvalidImports) != 0)
+                            {
+                                // If IgnoreInvalidImports is enabled, log all other non-handled exceptions and continue
+                                //
+                                ignoreImport = true;
+                                ignoreImportResource = "ProjectImportSkippedInvalidFile";
                             }
 
-                            // If IgnoreInvalidImports is enabled, log all other non-handled exceptions and continue
-                            //
-                            if (((_loadSettings & ProjectLoadSettings.IgnoreInvalidImports) != 0))
+                            if (ignoreImport)
                             {
                                 atleastOneImportIgnored = true;
 
@@ -2678,7 +2669,7 @@ namespace Microsoft.Build.Evaluation
                                 ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
                                     importElement.Location.Line,
                                     importElement.Location.Column,
-                                    ResourceUtilities.GetResourceString("ProjectImportSkippedInvalidFile"),
+                                    ResourceUtilities.GetResourceString(ignoreImportResource),
                                     importFileUnescaped,
                                     importElement.ContainingProject.FullPath,
                                     importElement.Location.Line,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2481,7 +2481,8 @@ namespace Microsoft.Build.Evaluation
                         {
                             BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                             UnexpandedProject = importElement.Project,
-                            ProjectFile = importElement.ContainingProject.FullPath
+                            ProjectFile = importElement.ContainingProject.FullPath,
+                            ImportIgnored = true,
                         };
 
                         _evaluationLoggingContext.LogBuildEvent(eventArgs);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2482,7 +2482,6 @@ namespace Microsoft.Build.Evaluation
                             BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                             UnexpandedProject = importElement.Project,
                             ProjectFile = importElement.ContainingProject.FullPath,
-                            ImportIgnored = true,
                         };
 
                         _evaluationLoggingContext.LogBuildEvent(eventArgs);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2651,7 +2651,7 @@ namespace Microsoft.Build.Evaluation
                                         UnexpandedProject = importElement.Project,
                                         ProjectFile = importElement.ContainingProject.FullPath,
                                         ImportedProjectFile = importFileUnescaped,
-                                        ImportException = ex,
+                                        ImportIgnored = true,
                                     };
 
                                     _evaluationLoggingContext.LogBuildEvent(eventArgs);
@@ -2702,7 +2702,7 @@ namespace Microsoft.Build.Evaluation
                                     UnexpandedProject = importElement.Project,
                                     ProjectFile = importElement.ContainingProject.FullPath,
                                     ImportedProjectFile = importFileUnescaped,
-                                    ImportException = ex,
+                                    ImportIgnored = true,
                                 };
 
                                 _evaluationLoggingContext.LogBuildEvent(eventArgs);

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Build.Logging
         // version 2: 
         //   - new BuildEventContext.EvaluationId
         //   - new record kinds: ProjectEvaluationStarted, ProjectEvaluationFinished
-        internal const int FileFormatVersion = 2;
+        // version 3:
+        //   - new ProjectImportedEventArgs.ImportIgnored
+        internal const int FileFormatVersion = 3;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Build.Logging
             var fields = ReadBuildEventArgsFields();
             // Read unused Importance, it defaults to Low
             ReadInt32();
+            bool ignored = ReadBoolean();
             var importedProjectFile = ReadOptionalString();
             var unexpandedProject = ReadOptionalString();
 
@@ -146,6 +147,7 @@ namespace Microsoft.Build.Logging
 
             e.ImportedProjectFile = importedProjectFile;
             e.UnexpandedProject = unexpandedProject;
+            e.ImportIgnored = ignored;
             return e;
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -259,6 +259,7 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.ProjectImported);
             WriteMessageFields(e);
+            Write(e.ImportIgnored);
             WriteOptionalString(e.ImportedProjectFile);
             WriteOptionalString(e.UnexpandedProject);
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1628,6 +1628,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file being invalid.</value>
   </data>
 
+  <data name="ProjectImportSkippedMissingFile">
+    <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to the file not existing.</value>
+  </data>
+
   <data name="ProjectImported">
     <value>Importing project &quot;{0}&quot; into project &quot;{1}&quot; at ({2},{3}).</value>
   </data>

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -48,7 +48,9 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         /// Gets or sets if this import was ignored. Ignoring imports is controlled by
-        /// <code>ProjectLoadSettings</code>.
+        /// <code>ProjectLoadSettings</code>. This is only set when an import would have been included
+        /// but was ignored to due being invalid. This does not include when a globbed import returned
+        /// no matches, or a conditioned import that evaluated to false.
         /// </summary>
         public bool ImportIgnored { get; set; }
     }

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -43,5 +43,11 @@ namespace Microsoft.Build.Framework
         /// Gets or sets the full path to the project file that was imported.  If a project was not imported, the value is <code>null</code>.
         /// </summary>
         public string ImportedProjectFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exception encountered when evaluating this import, if any. Will only be set when a ProjectLoadSettings
+        /// to ignore imports is set.
+        /// </summary>
+        public Exception ImportException { get; set; }
     }
 }

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -40,13 +40,14 @@ namespace Microsoft.Build.Framework
         public string UnexpandedProject { get; set; }
 
         /// <summary>
-        /// Gets or sets the full path to the project file that was imported.  If a project was not imported, the value is <code>null</code>.
+        /// Gets or sets the full path to the project file that was imported.
+        /// Will be <code>null</code> if the import statement was a glob, and no files matched.
         /// </summary>
         public string ImportedProjectFile { get; set; }
 
         /// <summary>
-        /// Gets or sets the exception encountered when evaluating this import, if any. Will only be set when a ProjectLoadSettings
-        /// to ignore imports is set.
+        /// Gets or sets the exception encountered when evaluating this import, if any.
+        /// Will only be set when a ProjectLoadSettings to ignore imports is set.
         /// </summary>
         public Exception ImportException { get; set; }
     }

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         /// Gets or sets the full path to the project file that was imported. Will be <code>null</code>
-        /// if the import statement was a glob, and no files matched.
+        /// if the import statement was a glob and no files matched, or the condition (if any) evaluated
+        /// to false.
         /// </summary>
         public string ImportedProjectFile { get; set; }
 

--- a/src/Framework/ProjectImportedEventArgs.cs
+++ b/src/Framework/ProjectImportedEventArgs.cs
@@ -40,15 +40,15 @@ namespace Microsoft.Build.Framework
         public string UnexpandedProject { get; set; }
 
         /// <summary>
-        /// Gets or sets the full path to the project file that was imported.
-        /// Will be <code>null</code> if the import statement was a glob, and no files matched.
+        /// Gets or sets the full path to the project file that was imported. Will be <code>null</code>
+        /// if the import statement was a glob, and no files matched.
         /// </summary>
         public string ImportedProjectFile { get; set; }
 
         /// <summary>
-        /// Gets or sets the exception encountered when evaluating this import, if any.
-        /// Will only be set when a ProjectLoadSettings to ignore imports is set.
+        /// Gets or sets if this import was ignored. Ignoring imports is controlled by
+        /// <code>ProjectLoadSettings</code>.
         /// </summary>
-        public Exception ImportException { get; set; }
+        public bool ImportIgnored { get; set; }
     }
 }


### PR DESCRIPTION
Improves logging when an import is ignored.

1. Sets the `ImportedProjectFile` property
2. ~Adds `ProjectImportedEventArgs.ImportException` when an import is ignored. Had to be type `Exception` because `Microsoft.Build.Framework` does not reference `Microsoft.Build`, where that exception lives.~ Exception fails to serialize for .netcore, using `bool ImportIgnored` instead.
3. Logs for `IgnoreMissingImports`