### PR TITLE
Make it easier to opt into "Core" satellite assembly gen

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3550,7 +3550,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="GenerateSatelliteAssemblies"
           Inputs="$(MSBuildAllProjects);@(_SatelliteAssemblyResourceInputs);$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
           Outputs="$(IntermediateOutputPath)%(Culture)\$(TargetName).resources.dll"
-          Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(MSBuildRuntimeType)' != 'Core'">
+          Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 
     <MakeDir
         Directories="@(EmbeddedResource->'$(IntermediateOutputPath)%(Culture)')" />


### PR DESCRIPTION
Currently the `GenerateSatelliteAssemblies` target handles generating satellite assemblies, _unless_ we're using the .NET Core version of MSBuild. In this case we skip `GenerateSatelliteAssemblies` and this is instead handled by the `CoreGenerateSatelliteAssemblies` target in the .NET SDK. This is because `GenerateSatelliteAssemblies` utilizes alink (al.exe) which has no counterpart for .NET Core. Instead, `CoreGenerateSatelliteAssemblies` uses csc.exe to create the assembly.

There are times where it would be helpful to use the .NET Core approach, even when we aren't using the .NET Core MSBuild. For example, al.exe has some key limitations. For example, it has [no support for public-signing](https://github.com/dotnet/roslyn/issues/23191) and [poor handling of AssemblyInformationalVersionAttribute](https://github.com/dotnet/roslyn/issues/23190). These issues are currently blocking the build of the dotnet/roslyn repo from generating its own satellite assemblies.

Opting _into_ `CoreGenerateSatelliteAssemblies` is easily done by setting the `GenerateSatelliteAssembliesForCore` property to `true`. However, there is currently no good way to opt _out_ of `GenerateSatelliteAssemblies`. This commit replaces the broad check that we're not using the "Core" runtime type with a specific check that `GenerateSatelliteAssembliesForCore` is not set to `true`.