### PR TITLE
Add ability to replay .binlogs of older versions.

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Build.UnitTests
                 memoryStream.Position = 0;
 
                 var binaryReader = new BinaryReader(memoryStream);
-                var buildEventArgsReader = new BuildEventArgsReader(binaryReader);
+                var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
 
                 Assert.Throws<EndOfStreamException>(() => buildEventArgsReader.Read());
             }
@@ -425,7 +425,7 @@ namespace Microsoft.Build.UnitTests
             memoryStream.Position = 0;
 
             var binaryReader = new BinaryReader(memoryStream);
-            var buildEventArgsReader = new BuildEventArgsReader(binaryReader);
+            var buildEventArgsReader = new BuildEventArgsReader(binaryReader, BinaryLogger.FileFormatVersion);
             var deserializedArgs = (T)buildEventArgsReader.Read();
 
             Assert.Equal(length, memoryStream.Position);

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Logging
                     throw new NotSupportedException(text);
                 }
 
-                var reader = new BuildEventArgsReader(binaryReader);
+                var reader = new BuildEventArgsReader(binaryReader, fileFormatVersion);
                 while (true)
                 {
                     BuildEventArgs instance = null;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -582,9 +582,10 @@ namespace Microsoft.Build.Logging
             int projectInstanceId = ReadInt32();
 
             // evaluationId was introduced in format version 2
+            int evaluationId = BuildEventContext.InvalidEvaluationId;
             if (fileFormatVersion > 1)
             {
-                int evaluationId = ReadInt32();
+                evaluationId = ReadInt32();
             }
 
             var result = new BuildEventContext(

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Build.Logging
         /// Initializes a new instance of BuildEventArgsReader using a BinaryReader instance
         /// </summary>
         /// <param name="binaryReader">The BinaryReader to read BuildEventArgs from</param>
+        /// <param name="fileFormatVersion">The file format version of the log file being read.</param>
         public BuildEventArgsReader(BinaryReader binaryReader, int fileFormatVersion)
         {
             this.binaryReader = binaryReader;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Build.Logging
     internal class BuildEventArgsReader
     {
         private readonly BinaryReader binaryReader;
+        private readonly int fileFormatVersion;
 
         // reflection is needed to set these three fields because public constructors don't provide
         // a way to set these from the outside
@@ -27,9 +28,10 @@ namespace Microsoft.Build.Logging
         /// Initializes a new instance of BuildEventArgsReader using a BinaryReader instance
         /// </summary>
         /// <param name="binaryReader">The BinaryReader to read BuildEventArgs from</param>
-        public BuildEventArgsReader(BinaryReader binaryReader)
+        public BuildEventArgsReader(BinaryReader binaryReader, int fileFormatVersion)
         {
             this.binaryReader = binaryReader;
+            this.fileFormatVersion = fileFormatVersion;
         }
 
         /// <summary>
@@ -578,7 +580,12 @@ namespace Microsoft.Build.Logging
             int taskId = ReadInt32();
             int submissionId = ReadInt32();
             int projectInstanceId = ReadInt32();
-            int evaluationId = ReadInt32();
+
+            // evaluationId was introduced in format version 2
+            if (fileFormatVersion > 1)
+            {
+                int evaluationId = ReadInt32();
+            }
 
             var result = new BuildEventContext(
                 submissionId,


### PR DESCRIPTION
This allows for backwards compatibility, when a newer version of MSBuild is still able to replay .binlog files created with an older version of MSBuild.