### PR TITLE
Set the timestamp and BuildEventContext on unrecognized event args.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -89,7 +89,9 @@ namespace Microsoft.Build.Logging
                     e.Message,
                     e.HelpKeyword,
                     e.SenderName,
-                    MessageImportance.Normal);
+                    MessageImportance.Normal,
+                    e.Timestamp);
+                buildMessageEventArgs.BuildEventContext = e.BuildEventContext ?? BuildEventContext.Invalid;
                 Write(buildMessageEventArgs);
             }
         }


### PR DESCRIPTION
Just a little something I've noticed a while back and never had a chance to correct.