### PR TITLE
Open the .binlog file as read-only during playback.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Logging
         /// <param name="sourceFilePath">The full file path of the binary log file</param>
         public void Replay(string sourceFilePath)
         {
-            using (var stream = new FileStream(sourceFilePath, FileMode.Open))
+            using (var stream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read))
             {
                 var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
                 var binaryReader = new BinaryReader(gzipStream);

--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Logging
         /// <param name="sourceFilePath">The full file path of the binary log file</param>
         public void Replay(string sourceFilePath)
         {
-            using (var stream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read))
+            using (var stream = new FileStream(sourceFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
                 var binaryReader = new BinaryReader(gzipStream);


### PR DESCRIPTION
This avoids a possible File Access exception when reading the binlog from a network share where you don't have write access.