### PR TITLE
Add SkippedTargetEventArgs and BuildReason

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -478,6 +478,7 @@ namespace Microsoft.Build.Framework
         public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
         public Microsoft.Build.Framework.TargetBuiltReason BuildReason { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string ParentTarget { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -451,6 +451,13 @@ namespace Microsoft.Build.Framework
         public abstract Microsoft.Build.Framework.SdkResult IndicateFailure(System.Collections.Generic.IEnumerable<string> errors, System.Collections.Generic.IEnumerable<string> warnings=null);
         public abstract Microsoft.Build.Framework.SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IEnumerable<string> warnings=null);
     }
+    public enum TargetBuiltReason
+    {
+        AfterTargets = 3,
+        BeforeTargets = 1,
+        DependsOn = 2,
+        None = 0,
+    }
     public partial class TargetFinishedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         protected TargetFinishedEventArgs() { }
@@ -468,6 +475,7 @@ namespace Microsoft.Build.Framework
     {
         public TargetSkippedEventArgs() { }
         public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
+        public Microsoft.Build.Framework.TargetBuiltReason BuildReason { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string ParentTarget { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
@@ -475,7 +483,9 @@ namespace Microsoft.Build.Framework
     {
         protected TargetStartedEventArgs() { }
         public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile) { }
+        public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, Microsoft.Build.Framework.TargetBuiltReason buildReason, System.DateTime eventTimestamp) { }
         public TargetStartedEventArgs(string message, string helpKeyword, string targetName, string projectFile, string targetFile, string parentTarget, System.DateTime eventTimestamp) { }
+        public Microsoft.Build.Framework.TargetBuiltReason BuildReason { get { throw null; } }
         public string ParentTarget { get { throw null; } }
         public string ProjectFile { get { throw null; } }
         public string TargetFile { get { throw null; } }

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -464,6 +464,13 @@ namespace Microsoft.Build.Framework
         public System.Collections.IEnumerable TargetOutputs { get { throw null; } set { } }
     }
     public delegate void TargetFinishedEventHandler(object sender, Microsoft.Build.Framework.TargetFinishedEventArgs e);
+    public partial class TargetSkippedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public TargetSkippedEventArgs() { }
+        public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
+        public string ParentTarget { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+    }
     public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         protected TargetStartedEventArgs() { }

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -475,6 +475,7 @@ namespace Microsoft.Build.Framework
         public TargetSkippedEventArgs(string message, params object[] messageArgs) { }
         public Microsoft.Build.Framework.TargetBuiltReason BuildReason { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string ParentTarget { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public partial class TargetStartedEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -3534,7 +3534,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             entry.RequestConfiguration.Project = projectInstance;
             IntrinsicTask task = IntrinsicTask.InstantiateTask(
                 targetChild,
-                nodeContext.LogProjectStarted(entry).LogTargetBatchStarted(projectInstance.FullPath, projectInstance.Targets["t"], null),
+                nodeContext.LogProjectStarted(entry).LogTargetBatchStarted(projectInstance.FullPath, projectInstance.Targets["t"], null, TargetBuiltReason.None),
                 projectInstance,
                 false);
 

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -3592,7 +3592,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     entry.RequestConfiguration.Project = projectInstance;
                     var task = IntrinsicTask.InstantiateTask(
                         targetChild,
-                        nodeContext.LogProjectStarted(entry).LogTargetBatchStarted(projectInstance.FullPath, projectInstance.Targets["t"], null),
+                        nodeContext.LogProjectStarted(entry).LogTargetBatchStarted(projectInstance.FullPath, projectInstance.Targets["t"], null, TargetBuiltReason.None),
                         projectInstance,
                         false);
 

--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -1042,7 +1042,7 @@ namespace Microsoft.Build.UnitTests.Logging
             Assert.Throws<InternalErrorException>(() =>
             {
                 ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
-                service.LogTargetStarted(null, "MyTarget", "ProjectFile", "ProjectFileOfTarget", null);
+                service.LogTargetStarted(null, "MyTarget", "ProjectFile", "ProjectFileOfTarget", null, TargetBuiltReason.None);
             }
            );
         }
@@ -1398,13 +1398,13 @@ namespace Microsoft.Build.UnitTests.Logging
             }
 
             ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
-            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, String.Empty);
+            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, String.Empty, TargetBuiltReason.None);
             VerifyTargetStartedEvent(targetName, projectFile, projectFileOfTarget, message, service);
 
             // Do not expect to have any event logged when OnlyLogCriticalEvents is true
             service.ResetProcessedBuildEvent();
             service.OnlyLogCriticalEvents = true;
-            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, null);
+            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, null, TargetBuiltReason.None);
             Assert.Null(service.ProcessedBuildEvent);
         }
 
@@ -1425,13 +1425,13 @@ namespace Microsoft.Build.UnitTests.Logging
             }
 
             ProcessBuildEventHelper service = (ProcessBuildEventHelper)ProcessBuildEventHelper.CreateLoggingService(LoggerMode.Synchronous, 1);
-            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, parentTargetName);
+            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, parentTargetName, TargetBuiltReason.AfterTargets);
             VerifyTargetStartedEvent(targetName, projectFile, projectFileOfTarget, message, service);
 
             // Do not expect to have any event logged when OnlyLogCriticalEvents is true
             service.ResetProcessedBuildEvent();
             service.OnlyLogCriticalEvents = true;
-            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, parentTargetName);
+            service.LogTargetStarted(s_targetBuildEventContext, targetName, projectFile, projectFileOfTarget, parentTargetName, TargetBuiltReason.BeforeTargets);
             Assert.Null(service.ProcessedBuildEvent);
         }
 
@@ -1509,6 +1509,7 @@ namespace Microsoft.Build.UnitTests.Logging
                            projectFile,
                            projectFileOfTarget,
                            String.Empty,
+                           TargetBuiltReason.None,
                            service.ProcessedBuildEvent.Timestamp
                        );
             buildEvent.BuildEventContext = s_targetBuildEventContext;

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -448,7 +448,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <param name="projectFile">The project file</param>
         /// <param name="projectFileOfTargetElement">The project file containing the target element</param>
         /// <returns>The build event context for the target</returns>
-        public BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName)
+        public BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName, TargetBuiltReason buildReason)
         {
             return new BuildEventContext(0, 0, 0, 0);
         }

--- a/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetEntry_Tests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildRequestConfiguration config = new BuildRequestConfiguration(1, new BuildRequestData("foo", new Dictionary<string, string>(), "foo", new string[0], null), "2.0");
                 BuildRequestEntry requestEntry = new BuildRequestEntry(CreateNewBuildRequest(1, new string[] { "foo" }), config);
                 Lookup lookup = new Lookup(new ItemDictionary<ProjectItemInstance>(project.Items), new PropertyDictionary<ProjectPropertyInstance>(project.Properties), null);
-                TargetEntry entry = new TargetEntry(requestEntry, this, null, lookup, null, _host, false);
+                TargetEntry entry = new TargetEntry(requestEntry, this, null, lookup, null, TargetBuiltReason.None, _host, false);
             }
            );
         }
@@ -94,7 +94,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 ProjectInstance project = CreateTestProject(true /* Returns enabled */);
                 BuildRequestConfiguration config = new BuildRequestConfiguration(1, new BuildRequestData("foo", new Dictionary<string, string>(), "foo", new string[0], null), "2.0");
                 BuildRequestEntry requestEntry = new BuildRequestEntry(CreateNewBuildRequest(1, new string[] { "foo" }), config);
-                TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification("Empty", null), null, null, _host, false);
+                TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification("Empty", null), null, null, TargetBuiltReason.None, _host, false);
             }
            );
         }
@@ -111,7 +111,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildRequestEntry requestEntry = new BuildRequestEntry(CreateNewBuildRequest(1, new string[] { "foo" }), config);
 
                 Lookup lookup = new Lookup(new ItemDictionary<ProjectItemInstance>(project.Items), new PropertyDictionary<ProjectPropertyInstance>(project.Properties), null);
-                TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification("Empty", null), lookup, null, null, false);
+                TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification("Empty", null), lookup, null, TargetBuiltReason.None, null, false);
             }
            );
         }
@@ -1017,7 +1017,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildRequestEntry requestEntry = new BuildRequestEntry(CreateNewBuildRequest(1, new string[] { "foo" }), config);
 
             Lookup lookup = new Lookup(new ItemDictionary<ProjectItemInstance>(project.Items), new PropertyDictionary<ProjectPropertyInstance>(project.Properties), null);
-            TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification(targetName, project.Targets[targetName].Location), lookup, null, _host, false);
+            TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification(targetName, project.Targets[targetName].Location), lookup, null, TargetBuiltReason.None, _host, false);
             return entry;
         }
 
@@ -1033,7 +1033,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildRequestConfiguration config = new BuildRequestConfiguration(1, new BuildRequestData("foo", new Dictionary<string, string>(), "foo", new string[0], null), "2.0");
             config.Project = project;
             BuildRequestEntry requestEntry = new BuildRequestEntry(CreateNewBuildRequest(1, new string[1] { "foo" }), config);
-            TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification(target, project.Targets[target].Location), baseEntry.Lookup, baseEntry, _host, false);
+            TargetEntry entry = new TargetEntry(requestEntry, this, new TargetSpecification(target, project.Targets[target].Location), baseEntry.Lookup, baseEntry, TargetBuiltReason.None, _host, false);
             return entry;
         }
 

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -359,6 +359,27 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void RoundtripTargetSkippedEventArgs()
+        {
+            var args = new TargetSkippedEventArgs(
+                "Message")
+            {
+                BuildEventContext = BuildEventContext.Invalid,
+                ProjectFile = "foo.csproj",
+                ParentTarget = "bar"
+            };
+
+            Roundtrip(args,
+                e => e.ParentTarget,
+                e => e.Importance.ToString(),
+                e => e.LineNumber.ToString(),
+                e => e.ColumnNumber.ToString(),
+                e => e.LineNumber.ToString(),
+                e => e.Message,
+                e => e.ProjectFile);
+        }
+
+        [Fact]
         public void ReadingCorruptedStreamThrows()
         {
             var memoryStream = new MemoryStream();

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Build.UnitTests
                 "C:\\projectfile.proj",
                 "C:\\Common.targets",
                 "ParentTarget",
+                TargetBuiltReason.AfterTargets,
                 DateTime.Parse("12/12/2015 06:11:56 PM"));
 
             Roundtrip(args,
@@ -115,6 +116,7 @@ namespace Microsoft.Build.UnitTests
                 e => e.ProjectFile,
                 e => e.TargetFile,
                 e => e.TargetName,
+                e => e.BuildReason.ToString(),
                 e => e.Timestamp.ToString());
         }
 
@@ -366,7 +368,8 @@ namespace Microsoft.Build.UnitTests
             {
                 BuildEventContext = BuildEventContext.Invalid,
                 ProjectFile = "foo.csproj",
-                ParentTarget = "bar"
+                ParentTarget = "bar",
+                BuildReason = TargetBuiltReason.DependsOn
             };
 
             Roundtrip(args,
@@ -376,7 +379,8 @@ namespace Microsoft.Build.UnitTests
                 e => e.ColumnNumber.ToString(),
                 e => e.LineNumber.ToString(),
                 e => e.Message,
-                e => e.ProjectFile);
+                e => e.ProjectFile,
+                e => e.BuildReason.ToString());
         }
 
         [Fact]

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -380,6 +380,7 @@ namespace Microsoft.Build.UnitTests
                 e => e.LineNumber.ToString(),
                 e => e.Message,
                 e => e.ProjectFile,
+                e => e.TargetFile,
                 e => e.BuildReason.ToString());
         }
 

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -397,8 +397,9 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="projectFile">The project file which is being built</param>
         /// <param name="projectFileOfTargetElement">The file in which the target is defined - typically a .targets file</param>
         /// <param name="parentTargetName">The name of the parent target.</param>
+        /// <param name="buildReason">The reason the parent target built the target.</param>
         /// <returns>The target build event context</returns>
-        BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName);
+        BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName, TargetBuiltReason buildReason);
 
         /// <summary>
         /// Log that a target has finished

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -606,6 +606,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="projectFile">Project file being built</param>
         /// <param name="projectFileOfTargetElement">Project file which contains the target</param>
         /// <param name="parentTargetName">The name of the parent target.</param>
+        /// <param name="buildReason">The reason the parent target built the target.</param>
         /// <returns>The build event context for the target.</returns>
         /// <exception cref="InternalErrorException">BuildEventContext is null</exception>
         public BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName, TargetBuiltReason buildReason)

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -608,7 +608,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="parentTargetName">The name of the parent target.</param>
         /// <returns>The build event context for the target.</returns>
         /// <exception cref="InternalErrorException">BuildEventContext is null</exception>
-        public BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName)
+        public BuildEventContext LogTargetStarted(BuildEventContext projectBuildEventContext, string targetName, string projectFile, string projectFileOfTargetElement, string parentTargetName, TargetBuiltReason buildReason)
         {
             lock (_lockObject)
             {
@@ -657,6 +657,7 @@ namespace Microsoft.Build.BackEnd.Logging
                             projectFile,
                             projectFileOfTargetElement,
                             parentTargetName,
+                            buildReason,
                             DateTime.UtcNow
                         );
                     buildEvent.BuildEventContext = targetBuildEventContext;

--- a/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/ProjectLoggingContext.cs
@@ -163,10 +163,10 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log that a target has started
         /// </summary>
-        internal TargetLoggingContext LogTargetBatchStarted(string projectFullPath, ProjectTargetInstance target, string parentTargetName)
+        internal TargetLoggingContext LogTargetBatchStarted(string projectFullPath, ProjectTargetInstance target, string parentTargetName, TargetBuiltReason buildReason)
         {
             ErrorUtilities.VerifyThrow(this.IsValid, "invalid");
-            return new TargetLoggingContext(this, projectFullPath, target, parentTargetName);
+            return new TargetLoggingContext(this, projectFullPath, target, parentTargetName, buildReason);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/TargetLoggingContext.cs
@@ -42,13 +42,13 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Creates a new target logging context from an existing project context and target.
         /// </summary>
-        internal TargetLoggingContext(ProjectLoggingContext projectLoggingContext, string projectFullPath, ProjectTargetInstance target, string parentTargetName)
+        internal TargetLoggingContext(ProjectLoggingContext projectLoggingContext, string projectFullPath, ProjectTargetInstance target, string parentTargetName, TargetBuiltReason buildReason)
             : base(projectLoggingContext)
         {
             _projectLoggingContext = projectLoggingContext;
             _target = target;
 
-            this.BuildEventContext = LoggingService.LogTargetStarted(projectLoggingContext.BuildEventContext, target.Name, projectFullPath, target.Location.File, parentTargetName);
+            this.BuildEventContext = LoggingService.LogTargetStarted(projectLoggingContext.BuildEventContext, target.Name, projectFullPath, target.Location.File, parentTargetName, buildReason);
             this.IsValid = true;
         }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -94,27 +94,6 @@ namespace Microsoft.Build.BackEnd
         private bool _legacyCallTargetContinueOnError;
 
         /// <summary>
-        /// Enum describing the type of targets we are pushing on the stack.
-        /// </summary>
-        private enum TargetPushType
-        {
-            /// <summary>
-            /// We are pushing BeforeTargets.  When pushed, if these are already executing, we ignore them.
-            /// </summary>
-            BeforeTargets,
-
-            /// <summary>
-            /// We are pushing AfterTargets.  When pushed, if they have already executed, we ignore them.
-            /// </summary>
-            AfterTargets,
-
-            /// <summary>
-            /// We are pushing normal targets.  We never ignore them.
-            /// </summary>
-            Normal
-        }
-
-        /// <summary>
         /// Builds the specified targets.
         /// </summary>
         /// <param name="loggingContext">The logging context for the project.</param>
@@ -184,7 +163,7 @@ namespace Microsoft.Build.BackEnd
 
             // Push targets onto the stack.  This method will reverse their push order so that they
             // get built in the same order specified in the array.
-            await PushTargets(targets, null, baseLookup, false, false, TargetPushType.Normal);
+            await PushTargets(targets, null, baseLookup, false, false, TargetBuiltReason.None);
 
             // Now process the targets
             ITaskBuilder taskBuilder = _componentHost.GetComponent(BuildComponentType.TaskBuilder) as ITaskBuilder;
@@ -294,7 +273,7 @@ namespace Microsoft.Build.BackEnd
                         targetToPush.Add(new TargetSpecification(targets[i], taskLocation));
 
                         // We push the targets one at a time to emulate the original CallTarget behavior.
-                        bool pushed = await PushTargets(targetToPush, currentTargetEntry, callTargetLookup, false, true, TargetPushType.Normal);
+                        bool pushed = await PushTargets(targetToPush, currentTargetEntry, callTargetLookup, false, true, TargetBuiltReason.None);
                         ErrorUtilities.VerifyThrow(pushed, "Failed to push any targets onto the stack.  Target: {0} Current Target: {1}", targets[i], currentTargetEntry.Target.Name);
                         await ProcessTargetStack(taskBuilder);
 
@@ -432,7 +411,7 @@ namespace Microsoft.Build.BackEnd
 
                             // Push our after targets, if any.  Our parent is the parent of the target after which we are running.
                             IList<TargetSpecification> afterTargets = _requestEntry.RequestConfiguration.Project.GetTargetsWhichRunAfter(currentTargetEntry.Name);
-                            bool didPushTargets = await PushTargets(afterTargets, currentTargetEntry.ParentEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, currentTargetEntry.StopProcessingOnCompletion, TargetPushType.AfterTargets);
+                            bool didPushTargets = await PushTargets(afterTargets, currentTargetEntry.ParentEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, currentTargetEntry.StopProcessingOnCompletion, TargetBuiltReason.AfterTargets);
 
                             // If we have after targets, the last one to run will inherit the stopProcessing flag and we will reset ours.  If we didn't push any targets, then we shouldn't clear the
                             // flag because it means we are still on the bottom of this CallTarget stack.
@@ -453,7 +432,7 @@ namespace Microsoft.Build.BackEnd
                             // inherit the stop processing flag and we will reset it.
                             // Our parent is the target before which we run, just like a depends-on target.
                             IList<TargetSpecification> beforeTargets = _requestEntry.RequestConfiguration.Project.GetTargetsWhichRunBefore(currentTargetEntry.Name);
-                            bool pushedTargets = await PushTargets(beforeTargets, currentTargetEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, stopProcessingStack, TargetPushType.BeforeTargets);
+                            bool pushedTargets = await PushTargets(beforeTargets, currentTargetEntry, currentTargetEntry.Lookup, currentTargetEntry.ErrorTarget, stopProcessingStack, TargetBuiltReason.BeforeTargets);
                             if (beforeTargets.Count != 0 && pushedTargets)
                             {
                                 stopProcessingStack = false;
@@ -462,7 +441,7 @@ namespace Microsoft.Build.BackEnd
                             // And if we have dependencies to run, push them now.
                             if (null != dependencies)
                             {
-                                await PushTargets(dependencies, currentTargetEntry, currentTargetEntry.Lookup, false, false, TargetPushType.Normal);
+                                await PushTargets(dependencies, currentTargetEntry, currentTargetEntry.Lookup, false, false, TargetBuiltReason.DependsOn);
                             }
                         }
 
@@ -492,7 +471,7 @@ namespace Microsoft.Build.BackEnd
                             try
                             {
                                 await PushTargets(errorTargets, currentTargetEntry, currentTargetEntry.Lookup, true,
-                                    false, TargetPushType.Normal);
+                                    false, TargetBuiltReason.None);
                             }
                             catch
                             {
@@ -561,7 +540,8 @@ namespace Microsoft.Build.BackEnd
                     {
                         BuildEventContext = _projectLoggingContext.BuildEventContext,
                         TargetName = currentTargetEntry.Name,
-                        ParentTarget = currentTargetEntry.ParentEntry?.Target.Name
+                        ParentTarget = currentTargetEntry.ParentEntry?.Target.Name,
+                        BuildReason = currentTargetEntry.BuildReason 
                     };
                     _projectLoggingContext.LogBuildEvent(skippedTargetEventArgs);
 
@@ -645,9 +625,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="baseLookup">The lookup to be used to build these targets.</param>
         /// <param name="addAsErrorTarget">True if this should be considered an error target.</param>
         /// <param name="stopProcessingOnCompletion">True if target stack processing should terminate when the last target in the list is processed.</param>
-        /// <param name="pushType">The <see cref="TargetPushType"/> targets being pushed onto the stack.</param>
+        /// <param name="buildReason">The reason the target is being built by the parent.</param>
         /// <returns>True if we actually pushed any targets, false otherwise.</returns>
-        private async Task<bool> PushTargets(IList<TargetSpecification> targets, TargetEntry parentTargetEntry, Lookup baseLookup, bool addAsErrorTarget, bool stopProcessingOnCompletion, TargetPushType pushType)
+        private async Task<bool> PushTargets(IList<TargetSpecification> targets, TargetEntry parentTargetEntry, Lookup baseLookup, bool addAsErrorTarget, bool stopProcessingOnCompletion, TargetBuiltReason buildReason)
         {
             List<TargetEntry> targetsToPush = new List<TargetEntry>(targets.Count);
 
@@ -656,7 +636,7 @@ namespace Microsoft.Build.BackEnd
             {
                 TargetSpecification targetSpecification = targets[i];
 
-                if (pushType != TargetPushType.Normal)
+                if (buildReason == TargetBuiltReason.BeforeTargets || buildReason == TargetBuiltReason.AfterTargets)
                 {
                     // Don't build any Before or After targets for which we already have results.  Unlike other targets, 
                     // we don't explicitly log a skipped-with-results message because it is not interesting.
@@ -689,7 +669,7 @@ namespace Microsoft.Build.BackEnd
                     }
                     else
                     {
-                        if (pushType == TargetPushType.AfterTargets)
+                        if (buildReason == TargetBuiltReason.AfterTargets)
                         {
                             // If the target we are pushing is supposed to run after the current target and it is already set to run after us then skip adding it now.
                             continue;
@@ -702,7 +682,7 @@ namespace Microsoft.Build.BackEnd
                 else
                 {
                     // Does this target exist in our direct parent chain, if it is a before target (since these can cause circular dependency issues)
-                    if (pushType == TargetPushType.BeforeTargets || pushType == TargetPushType.Normal)
+                    if (buildReason == TargetBuiltReason.BeforeTargets || buildReason == TargetBuiltReason.DependsOn || buildReason == TargetBuiltReason.None)
                     {
                         TargetEntry currentParent = parentTargetEntry;
                         while (currentParent != null)
@@ -739,7 +719,7 @@ namespace Microsoft.Build.BackEnd
 
                 // Add to the list of targets to push.  We don't actually put it on the stack here because we could run into a circular dependency
                 // during this loop, in which case the target stack would be out of whack.
-                TargetEntry newEntry = new TargetEntry(_requestEntry, this as ITargetBuilderCallback, targetSpecification, baseLookup, parentTargetEntry, _componentHost, stopProcessingOnCompletion);
+                TargetEntry newEntry = new TargetEntry(_requestEntry, this as ITargetBuilderCallback, targetSpecification, baseLookup, parentTargetEntry, buildReason, _componentHost, stopProcessingOnCompletion);
                 newEntry.ErrorTarget = addAsErrorTarget;
                 targetsToPush.Add(newEntry);
                 stopProcessingOnCompletion = false; // The first target on the stack (the last one to be run) always inherits the stopProcessing flag.

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs
@@ -540,6 +540,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         BuildEventContext = _projectLoggingContext.BuildEventContext,
                         TargetName = currentTargetEntry.Name,
+                        TargetFile = currentTargetEntry.Target.Location.File,
                         ParentTarget = currentTargetEntry.ParentEntry?.Target.Name,
                         BuildReason = currentTargetEntry.BuildReason 
                     };

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Debugging;
 #endif
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using ElementLocation = Microsoft.Build.Construction.ElementLocation;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -363,7 +364,17 @@ namespace Microsoft.Build.BackEnd
                     // target.  In the Task builder (and original Task Engine), a Task Skipped message would be logged in
                     // the context of the target, not the task.  This should be the same, especially given that we
                     // wish to allow batching on the condition of a target.
-                    projectLoggingContext.LogComment(MessageImportance.Low, "TargetSkippedFalseCondition", _target.Name, _target.Condition, expanded);
+                    var skippedTargetEventArgs = new TargetSkippedEventArgs(
+                        "TargetSkippedFalseCondition",
+                        _target.Name,
+                        _target.Condition,
+                        expanded)
+                    {
+                        BuildEventContext = projectLoggingContext.BuildEventContext,
+                        TargetName = _target.Name,
+                        ParentTarget = ParentEntry?.Target?.Name
+                    };
+                    projectLoggingContext.LogBuildEvent(skippedTargetEventArgs);
                 }
 
                 return new List<TargetSpecification>();

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -390,6 +390,7 @@ namespace Microsoft.Build.BackEnd
                     {
                         BuildEventContext = projectLoggingContext.BuildEventContext,
                         TargetName = _target.Name,
+                        TargetFile = _target.Location.File,
                         ParentTarget = ParentEntry?.Target?.Name,
                         BuildReason = BuildReason
                     };

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -19,6 +19,7 @@
         ProjectEvaluationStarted,
         ProjectEvaluationFinished,
         ProjectImported,
-        ProjectImportArchive
+        ProjectImportArchive,
+        TargetSkipped
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -21,7 +21,10 @@ namespace Microsoft.Build.Logging
         //   - new record kinds: ProjectEvaluationStarted, ProjectEvaluationFinished
         // version 3:
         //   - new ProjectImportedEventArgs.ImportIgnored
-        internal const int FileFormatVersion = 3;
+        // version 4:
+        //   - new TargetSkippedEventArgs
+        //   - new TargetStartedEventArgs.BuildReason
+        internal const int FileFormatVersion = 4;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -105,6 +105,9 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.ProjectImported:
                     result = ReadProjectImportedEventArgs();
                     break;
+                case BinaryLogRecordKind.TargetSkipped:
+                    result = ReadTargetSkippedEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -146,6 +149,24 @@ namespace Microsoft.Build.Logging
 
             e.ImportedProjectFile = importedProjectFile;
             e.UnexpandedProject = unexpandedProject;
+            return e;
+        }
+
+        private BuildEventArgs ReadTargetSkippedEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            // Read unused Importance, it defaults to Low
+            ReadInt32();
+            var parentTarget = ReadOptionalString();
+
+            var e = new TargetSkippedEventArgs(
+                fields.Message);
+
+            SetCommonFields(e, fields);
+
+            e.ProjectFile = fields.ProjectFile;
+
+            e.ParentTarget = parentTarget;
             return e;
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Build.Logging
             // Read unused Importance, it defaults to Low
             ReadInt32();
             var parentTarget = ReadOptionalString();
+            var buildReason = (TargetBuiltReason)ReadInt32();
 
             var e = new TargetSkippedEventArgs(
                 fields.Message);
@@ -167,6 +168,7 @@ namespace Microsoft.Build.Logging
             e.ProjectFile = fields.ProjectFile;
 
             e.ParentTarget = parentTarget;
+            e.BuildReason = buildReason;
             return e;
         }
 
@@ -277,6 +279,7 @@ namespace Microsoft.Build.Logging
             var projectFile = ReadOptionalString();
             var targetFile = ReadOptionalString();
             var parentTarget = ReadOptionalString();
+            var buildReason = (TargetBuiltReason) ReadInt32();
 
             var e = new TargetStartedEventArgs(
                 fields.Message,
@@ -285,6 +288,7 @@ namespace Microsoft.Build.Logging
                 projectFile,
                 targetFile,
                 parentTarget,
+                buildReason,
                 fields.Timestamp);
             SetCommonFields(e, fields);
             return e;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Build.Logging
             var fields = ReadBuildEventArgsFields();
             // Read unused Importance, it defaults to Low
             ReadInt32();
+            var targetFile = ReadOptionalString();
             var parentTarget = ReadOptionalString();
             var buildReason = (TargetBuiltReason)ReadInt32();
 
@@ -179,7 +180,7 @@ namespace Microsoft.Build.Logging
             SetCommonFields(e, fields);
 
             e.ProjectFile = fields.ProjectFile;
-
+            e.TargetFile = targetFile;
             e.ParentTarget = parentTarget;
             e.BuildReason = buildReason;
             return e;
@@ -292,7 +293,8 @@ namespace Microsoft.Build.Logging
             var projectFile = ReadOptionalString();
             var targetFile = ReadOptionalString();
             var parentTarget = ReadOptionalString();
-            var buildReason = (TargetBuiltReason) ReadInt32();
+            // BuildReason was introduced in version 4
+            var buildReason = fileFormatVersion > 3 ? (TargetBuiltReason) ReadInt32() : TargetBuiltReason.None;
 
             var e = new TargetStartedEventArgs(
                 fields.Message,

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Build.Logging
             if (e is TargetSkippedEventArgs)
             {
                 Write((TargetSkippedEventArgs)e);
+                return;
             }
 
             Write(BinaryLogRecordKind.Message);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -277,6 +277,7 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.TargetSkipped);
             WriteMessageFields(e);
+            WriteOptionalString(e.TargetFile);
             WriteOptionalString(e.ParentTarget);
             Write((int)e.BuildReason);
         }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -171,6 +171,7 @@ namespace Microsoft.Build.Logging
             WriteOptionalString(e.ProjectFile);
             WriteOptionalString(e.TargetFile);
             WriteOptionalString(e.ParentTarget);
+            Write((int) e.BuildReason);
         }
 
         private void Write(TargetFinishedEventArgs e)
@@ -273,6 +274,7 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.TargetSkipped);
             WriteMessageFields(e);
             WriteOptionalString(e.ParentTarget);
+            Write((int)e.BuildReason);
         }
 
         private void Write(CriticalBuildMessageEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -251,6 +251,11 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
+            if (e is TargetSkippedEventArgs)
+            {
+                Write((TargetSkippedEventArgs)e);
+            }
+
             Write(BinaryLogRecordKind.Message);
             WriteMessageFields(e);
         }
@@ -261,6 +266,13 @@ namespace Microsoft.Build.Logging
             WriteMessageFields(e);
             WriteOptionalString(e.ImportedProjectFile);
             WriteOptionalString(e.UnexpandedProject);
+        }
+
+        private void Write(TargetSkippedEventArgs e)
+        {
+            Write(BinaryLogRecordKind.TargetSkipped);
+            WriteMessageFields(e);
+            WriteOptionalString(e.ParentTarget);
         }
 
         private void Write(CriticalBuildMessageEventArgs e)

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -692,7 +692,7 @@ namespace Microsoft.Build.UnitTests
         public void TestTargetStartedEventArgs()
         {
             // Test using reasonable values
-            TargetStartedEventArgs genericEvent = new TargetStartedEventArgs("Message", "HelpKeyword", "TargetName", "ProjectFile", "TargetFile", "ParentTargetStartedEvent", DateTime.UtcNow);
+            TargetStartedEventArgs genericEvent = new TargetStartedEventArgs("Message", "HelpKeyword", "TargetName", "ProjectFile", "TargetFile", "ParentTargetStartedEvent", TargetBuiltReason.AfterTargets, DateTime.UtcNow);
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
             // Serialize
@@ -710,7 +710,7 @@ namespace Microsoft.Build.UnitTests
             //Test using Empty strings
             _stream.Position = 0;
             // Make sure empty strings are passed correctly
-            genericEvent = new TargetStartedEventArgs(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, DateTime.Now);
+            genericEvent = new TargetStartedEventArgs(string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, TargetBuiltReason.AfterTargets, DateTime.Now);
             genericEvent.BuildEventContext = new BuildEventContext(5, 4, 3, 2);
 
             // Serialize
@@ -728,14 +728,14 @@ namespace Microsoft.Build.UnitTests
             // Test using null strings
             _stream.Position = 0;
             // Make sure null string are passed correctly
-            genericEvent = new TargetStartedEventArgs(null, null, null, null, null, null, DateTime.Now);
+            genericEvent = new TargetStartedEventArgs(null, null, null, null, null, null, TargetBuiltReason.AfterTargets, DateTime.Now);
             genericEvent.BuildEventContext = null;
             //Serialize
             genericEvent.WriteToStream(_writer);
             streamWriteEndPosition = _stream.Position;
             //Deserialize and Verify
             _stream.Position = 0;
-            newGenericEvent = new TargetStartedEventArgs("Something", "Something", "Something", "Something", "Something", "Something", DateTime.Now);
+            newGenericEvent = new TargetStartedEventArgs("Something", "Something", "Something", "Something", "Something", "Something", TargetBuiltReason.AfterTargets, DateTime.Now);
             newGenericEvent.CreateFromStream(_reader, _eventArgVersion);
             _stream.Position.ShouldBe(streamWriteEndPosition); // "Stream End Positions Should Match"
             VerifyGenericEventArg(genericEvent, newGenericEvent);
@@ -751,6 +751,7 @@ namespace Microsoft.Build.UnitTests
             newGenericEvent.ProjectFile.ShouldBe(genericEvent.ProjectFile, StringCompareShould.IgnoreCase); // "Expected ProjectFile to Match"
             newGenericEvent.TargetName.ShouldBe(genericEvent.TargetName, StringCompareShould.IgnoreCase); // "Expected TargetName to Match"
             newGenericEvent.ParentTarget.ShouldBe(genericEvent.ParentTarget, StringCompareShould.IgnoreCase); // "Expected ParentTarget to Match"
+            newGenericEvent.BuildReason.ShouldBe(genericEvent.BuildReason); // "Exepected BuildReason to Match"
         }
 
         [Fact]

--- a/src/Framework.UnitTests/TargetStartedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/TargetStartedEventArgs_Tests.cs
@@ -31,8 +31,10 @@ namespace Microsoft.Build.UnitTests
             TargetStartedEventArgs targetStartedEvent = new TargetStartedEventArgs2();
             targetStartedEvent = new TargetStartedEventArgs("Message", "HelpKeyword", "TargetName", "ProjectFile", "TargetFile");
             targetStartedEvent = new TargetStartedEventArgs("Message", "HelpKeyword", "TargetName", "ProjectFile", "TargetFile", "ParentTarget", DateTime.Now);
+            targetStartedEvent = new TargetStartedEventArgs("Message", "HelpKeyword", "TargetName", "ProjectFile", "TargetFile", "ParentTarget", TargetBuiltReason.AfterTargets, DateTime.Now);
             targetStartedEvent = new TargetStartedEventArgs(null, null, null, null, null);
             targetStartedEvent = new TargetStartedEventArgs(null, null, null, null, null, null, DateTime.Now);
+            targetStartedEvent = new TargetStartedEventArgs(null, null, null, null, null, null, TargetBuiltReason.AfterTargets, DateTime.Now);
         }
 
         /// <summary>

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Sdk\SdkResolverContext.cs" />
     <Compile Include="Sdk\SdkResult.cs" />
     <Compile Include="Sdk\SdkResultFactory.cs" />
+    <Compile Include="TargetBuiltReason.cs" />
     <Compile Include="TargetFinishedEventArgs.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -141,6 +141,7 @@
     <Compile Include="TargetFinishedEventArgs.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="TargetSkippedEventArgs.cs" />
     <Compile Include="TargetStartedEventArgs.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Framework/TargetBuiltReason.cs
+++ b/src/Framework/TargetBuiltReason.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The reason that a target was built by its parent target.
+    /// </summary>
+    public enum TargetBuiltReason
+    {
+        /// <summary>
+        /// This wasn't built on because of a parent.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The target was part of the parent's BeforeTargets list.
+        /// </summary>
+        BeforeTargets,
+
+        /// <summary>
+        /// The target was part of the parent's DependsOn list.
+        /// </summary>
+        DependsOn,
+
+        /// <summary>
+        /// The target was part of the parent's AfterTargets list.
+        /// </summary>
+        AfterTargets
+    }
+}

--- a/src/Framework/TargetSkippedEventArgs.cs
+++ b/src/Framework/TargetSkippedEventArgs.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for the target skipped event.
+    /// </summary>
+#if FEATURE_BINARY_SERIALIZATION
+    [Serializable]
+#endif
+    public class TargetSkippedEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the TargetSkippedEventArgs class.
+        /// </summary>
+        public TargetSkippedEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the TargetSkippedEventArgs class.
+        /// </summary>
+        public TargetSkippedEventArgs
+        (
+            string message,
+            params object[] messageArgs
+        )
+            : base(null, null, null, 0, 0, 0, 0, message, null, null, MessageImportance.Low, DateTime.UtcNow, messageArgs)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the target being skipped.
+        /// </summary>
+        public string TargetName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parent target of the target being skipped.
+        /// </summary>
+        public string ParentTarget { get; set; }
+    }
+}

--- a/src/Framework/TargetSkippedEventArgs.cs
+++ b/src/Framework/TargetSkippedEventArgs.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Build.Framework
         public string ParentTarget { get; set; }
 
         /// <summary>
+        /// File where this target was declared.
+        /// </summary>
+        public string TargetFile { get; set; }
+
+        /// <summary>
         /// Why the parent target built this target.
         /// </summary>
         public TargetBuiltReason BuildReason { get; set; }

--- a/src/Framework/TargetSkippedEventArgs.cs
+++ b/src/Framework/TargetSkippedEventArgs.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Build.Framework
         /// Gets or sets the parent target of the target being skipped.
         /// </summary>
         public string ParentTarget { get; set; }
+
+        /// <summary>
+        /// Why the parent target built this target.
+        /// </summary>
+        public TargetBuiltReason BuildReason { get; set; }
     }
 }

--- a/src/Framework/TargetStartedEventArgs.cs
+++ b/src/Framework/TargetStartedEventArgs.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Framework
             string projectFile,
             string targetFile
         )
-            : this(message, helpKeyword, targetName, projectFile, targetFile, String.Empty, DateTime.UtcNow)
+            : this(message, helpKeyword, targetName, projectFile, targetFile, String.Empty, TargetBuiltReason.None, DateTime.UtcNow)
         {
         }
 
@@ -81,10 +81,42 @@ namespace Microsoft.Build.Framework
             this.parentTarget = parentTarget;
         }
 
+        /// <summary>
+        /// This constructor allows event data to be initialized.
+        /// </summary>
+        /// <param name="message">text message</param>
+        /// <param name="helpKeyword">help keyword </param>
+        /// <param name="targetName">target name</param>
+        /// <param name="projectFile">project file</param>
+        /// <param name="targetFile">file in which the target is defined</param>
+        /// <param name="parentTarget">The part of the target.</param>
+        /// <param name="buildReason">The reason the parent built this target.</param>
+        /// <param name="eventTimestamp">Timestamp when the event was created</param>
+        public TargetStartedEventArgs
+        (
+            string message,
+            string helpKeyword,
+            string targetName,
+            string projectFile,
+            string targetFile,
+            string parentTarget,
+            TargetBuiltReason buildReason,
+            DateTime eventTimestamp
+        )
+            : base(message, helpKeyword, "MSBuild", eventTimestamp)
+        {
+            this.targetName = targetName;
+            this.projectFile = projectFile;
+            this.targetFile = targetFile;
+            this.parentTarget = parentTarget;
+            this.buildReason = buildReason;
+        }
+
         private string targetName;
         private string projectFile;
         private string targetFile;
         private string parentTarget;
+        private TargetBuiltReason buildReason;
 
 #if FEATURE_BINARY_SERIALIZATION
         #region CustomSerializationToStream
@@ -139,6 +171,9 @@ namespace Microsoft.Build.Framework
                 writer.Write(parentTarget);
             }
             #endregion
+            #region BuildReason
+            writer.Write((int)buildReason);
+            #endregion
         }
 
         /// <summary>
@@ -192,6 +227,12 @@ namespace Microsoft.Build.Framework
                 }
             }
             #endregion
+            #region BuildReason
+            if (version > 20)
+            {
+                buildReason = (TargetBuiltReason) reader.ReadInt32();
+            }
+            #endregion 
         }
         #endregion
 #endif
@@ -237,6 +278,17 @@ namespace Microsoft.Build.Framework
             get
             {
                 return targetFile;
+            }
+        }
+
+        /// <summary>
+        /// Why this target was built by its parent.
+        /// </summary>
+        public TargetBuiltReason BuildReason
+        {
+            get
+            {
+                return buildReason;
             }
         }
     }

--- a/src/Shared/ResourceUtilities.cs
+++ b/src/Shared/ResourceUtilities.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Build.Shared
 
         [Obsolete("Use GetResourceString instead.", true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static string FormatResourceString()
+        internal static string FormatResourceString(string resourceName)
         {   // Avoids an accidental dependency on FormatResourceString(string, params object[])
             return null;
         }


### PR DESCRIPTION
This adds:

* SkippedTargetEventArgs which provides additional logging information about targets skipped during build.
* BuildReason for both SkippedTargetEventArgs and TargetStartedEventArgs that indicates whether the target was built because of its parent's BeforeTarget, DependsOn, or AfterTarget.

This fixes #2751. It also bumps the version of binlog.

cc: @AndyGerlicher @KirillOsenkov 