### PR TITLE
Enable cache for RAR

### DIFF
--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -311,11 +311,13 @@ namespace Microsoft.Build.Framework
     public partial class LoggerException : System.Exception
     {
         public LoggerException() { }
+        protected LoggerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public LoggerException(string message) { }
         public LoggerException(string message, System.Exception innerException) { }
         public LoggerException(string message, System.Exception innerException, string errorCode, string helpKeyword) { }
         public string ErrorCode { get { throw null; } }
         public string HelpKeyword { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     [System.Runtime.InteropServices.ComVisibleAttribute(true)]
     public enum LoggerVerbosity

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -861,9 +861,11 @@ namespace Microsoft.Build.Exceptions
     public partial class BuildAbortedException : System.Exception
     {
         public BuildAbortedException() { }
+        protected BuildAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public BuildAbortedException(string message) { }
         public BuildAbortedException(string message, System.Exception innerException) { }
         public string ErrorCode { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed partial class InternalLoggerException : System.Exception
     {
@@ -874,6 +876,7 @@ namespace Microsoft.Build.Exceptions
         public string ErrorCode { get { throw null; } }
         public string HelpKeyword { get { throw null; } }
         public bool InitializationException { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public sealed partial class InvalidProjectFileException : System.Exception
     {
@@ -892,15 +895,18 @@ namespace Microsoft.Build.Exceptions
         public int LineNumber { get { throw null; } }
         public override string Message { get { throw null; } }
         public string ProjectFile { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public partial class InvalidToolsetDefinitionException : System.Exception
     {
         public InvalidToolsetDefinitionException() { }
+        protected InvalidToolsetDefinitionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public InvalidToolsetDefinitionException(string message) { }
         public InvalidToolsetDefinitionException(string message, System.Exception innerException) { }
         public InvalidToolsetDefinitionException(string message, string errorCode) { }
         public InvalidToolsetDefinitionException(string message, string errorCode, System.Exception innerException) { }
         public string ErrorCode { get { throw null; } }
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
 }
 namespace Microsoft.Build.Execution

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -361,13 +361,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -376,11 +371,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 @"c:\my project\myproj.proj",
                 _continueOnErrorDefault,
                 "TaskName",
-#if FEATURE_ASSEMBLY_LOADFROM
                 @"c:\MyTasks\MyTask.dll",
-#else
-                new AssemblyName("MyTask"),
-#endif
                 parameters);
 
             ((INodePacketTranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());

--- a/src/Build/Logging/LoggerDescription.cs
+++ b/src/Build/Logging/LoggerDescription.cs
@@ -301,29 +301,9 @@ namespace Microsoft.Build.Logging
         #region CustomSerializationToStream
         internal void WriteToStream(BinaryWriter writer)
         {
-            #region LoggerClassName
-            if (_loggerClassName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(_loggerClassName);
-            }
-            #endregion
-            #region LoggerSwitchParameters
-            if (_loggerSwitchParameters == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(_loggerSwitchParameters);
-            }
-            #endregion
-            #region LoggerAssembly
+            writer.WriteOptionalString(_loggerClassName);
+            writer.WriteOptionalString(_loggerSwitchParameters);
+
             if (_loggerAssembly == null)
             {
                 writer.Write((byte)0);
@@ -331,76 +311,32 @@ namespace Microsoft.Build.Logging
             else
             {
                 writer.Write((byte)1);
-                if (_loggerAssembly.AssemblyFile == null)
-                {
-                    writer.Write((byte)0);
-                }
-                else
-                {
-                    writer.Write((byte)1);
-                    writer.Write(_loggerAssembly.AssemblyFile);
-                }
 
-                if (_loggerAssembly.AssemblyName == null)
-                {
-                    writer.Write((byte)0);
-                }
-                else
-                {
-                    writer.Write((byte)1);
-                    writer.Write(_loggerAssembly.AssemblyName);
-                }
+                writer.WriteOptionalString(_loggerAssembly.AssemblyFile);
+                writer.WriteOptionalString(_loggerAssembly.AssemblyName);
             }
-            #endregion
+
             writer.Write((Int32)_verbosity);
             writer.Write((Int32)_loggerId);
         }
 
         internal void CreateFromStream(BinaryReader reader)
         {
-            #region LoggerClassName
-            if (reader.ReadByte() == 0)
-            {
-                _loggerClassName = null;
-            }
-            else
-            {
-                _loggerClassName = reader.ReadString();
-            }
-            #endregion 
-            #region LoggerSwitchParameters
-            if (reader.ReadByte() == 0)
-            {
-                _loggerSwitchParameters = null;
-            }
-            else
-            {
-                _loggerSwitchParameters = reader.ReadString();
-            }
-            #endregion
-            #region LoggerAssembly
+            _loggerClassName = reader.ReadByte() == 0 ? null : reader.ReadString();
+            _loggerSwitchParameters = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             if (reader.ReadByte() == 0)
             {
                 _loggerAssembly = null;
             }
             else
             {
-                string assemblyName = null;
-                string assemblyFile = null;
-
-                if (reader.ReadByte() != 0)
-                {
-                    assemblyFile = reader.ReadString();
-                }
-
-                if (reader.ReadByte() != 0)
-                {
-                    assemblyName = reader.ReadString();
-                }
+                string assemblyFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+                string assemblyName = reader.ReadByte() == 0 ? null : reader.ReadString();
 
                 _loggerAssembly = AssemblyLoadInfo.Create(assemblyName, assemblyFile);
             }
-            #endregion
+
             _verbosity = (LoggerVerbosity)reader.ReadInt32();
             _loggerId = reader.ReadInt32();
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -78,6 +78,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\BinaryWriterExtensions.cs" Link="BinaryWriterExtensions.cs" />
     <Compile Include="..\Shared\EncodingUtilities.cs">
       <Link>SharedUtilities\EncodingUtilities.cs</Link>
     </Compile>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -65,6 +65,7 @@
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_REGISTRY_SDKS</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_REGISTRYHIVE_DYNDATA</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESGEN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RESGENCACHE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCE_EXPOSURE</DefineConstants>
     <!-- System.Resources.ResourceManager.GetResourceSet() method is currently only in full framework -->
     <DefineConstants>$(DefineConstants);FEATURE_RESOURCEMANAGER_GETRESOURCESET</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);STANDALONEBUILD</DefineConstants>
+    <DefineConstants>$(DefineConstants);STANDALONEBUILD;FEATURE_BINARY_SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
@@ -29,8 +29,8 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CULTUREINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CLONE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_BINARY_SERIALIZATION_EVENTARGS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_BINARY_SERIALIZATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILE_IN_TESTS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONSOLE_BUFFERWIDTH</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -14,13 +14,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);STANDALONEBUILD;FEATURE_BINARY_SERIALIZATION;FEATURE_MEMORYSTREAM_GETBUFFER</DefineConstants>
+    <DefineConstants>$(DefineConstants);STANDALONEBUILD;FEATURE_BINARY_SERIALIZATION;FEATURE_MEMORYSTREAM_GETBUFFER;FEATURE_APM;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
     <DefineConstants>$(DefineConstants);FEATURE_64BIT_ENVIRONMENT_QUERY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APARTMENT_STATE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_APM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
     <FeatureAppDomain>true</FeatureAppDomain>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);STANDALONEBUILD;FEATURE_BINARY_SERIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);STANDALONEBUILD;FEATURE_BINARY_SERIALIZATION;FEATURE_MEMORYSTREAM_GETBUFFER</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('net3'))">
@@ -54,7 +54,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_HTTP_LISTENER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_INSTALLED_MSBUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_LEGACY_GETFULLPATH</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_MEMORYSTREAM_GETBUFFER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>

--- a/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
+++ b/src/Framework.UnitTests/CustomEventArgSerialization_Tests.cs
@@ -35,18 +35,8 @@ namespace Microsoft.Build.UnitTests
         private BinaryWriter _writer;
         private BinaryReader _reader;
 
-#if FEATURE_DOTNETVERSION
         private int _eventArgVersion = (Environment.Version.Major * 10) + Environment.Version.Minor;
-#else
-        private static readonly int s_defaultPacketVersion = GetDefaultPacketVersion();
 
-        private static int GetDefaultPacketVersion()
-        {
-            Assembly coreAssembly = typeof(object).GetTypeInfo().Assembly;
-            Version coreAssemblyVersion = coreAssembly.GetName().Version;
-            return 1000 + coreAssemblyVersion.Major * 10 + coreAssemblyVersion.Minor;
-        }
-#endif
 
         public CustomEventArgSerialization_Tests()
         {

--- a/src/Framework/BuildErrorEventArgs.cs
+++ b/src/Framework/BuildErrorEventArgs.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -182,95 +183,46 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// The custom sub-type of the event.         
         /// </summary>
-        public string Subcategory
-        {
-            get
-            {
-                return subcategory;
-            }
-        }
+        public string Subcategory => subcategory;
 
         /// <summary>
         /// Code associated with event. 
         /// </summary>
-        public string Code
-        {
-            get
-            {
-                return code;
-            }
-        }
+        public string Code => code;
 
         /// <summary>
         /// File associated with event.   
         /// </summary>  
-        public string File
-        {
-            get
-            {
-                return file;
-            }
-        }
+        public string File => file;
 
         /// <summary>
         /// The project file which issued this event.
         /// </summary>
         public string ProjectFile
         {
-            get
-            {
-                return projectFile;
-            }
-
-            set
-            {
-                projectFile = value;
-            }
+            get => projectFile;
+            set => projectFile = value;
         }
 
         /// <summary>
         /// Line number of interest in associated file. 
         /// </summary>
-        public int LineNumber
-        {
-            get
-            {
-                return lineNumber;
-            }
-        }
+        public int LineNumber => lineNumber;
 
         /// <summary>
         /// Column number of interest in associated file. 
         /// </summary>
-        public int ColumnNumber
-        {
-            get
-            {
-                return columnNumber;
-            }
-        }
+        public int ColumnNumber => columnNumber;
 
         /// <summary>
         /// Ending line number of interest in associated file. 
         /// </summary>
-        public int EndLineNumber
-        {
-            get
-            {
-                return endLineNumber;
-            }
-        }
+        public int EndLineNumber => endLineNumber;
 
         /// <summary>
         /// Ending column number of interest in associated file. 
         /// </summary>
-        public int EndColumnNumber
-        {
-            get
-            {
-                return endColumnNumber;
-            }
-        }
+        public int EndColumnNumber => endColumnNumber;
 
 #if FEATURE_BINARY_SERIALIZATION
         #region CustomSerializationToStream
@@ -281,50 +233,12 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region SubCategory
-            if (subcategory == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(subcategory);
-            }
-            #endregion
-            #region Code
-            if (code == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(code);
-            }
-            #endregion
-            #region File
-            if (file == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(file);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
+
+            writer.WriteOptionalString(subcategory);
+            writer.WriteOptionalString(code);
+            writer.WriteOptionalString(file);
+            writer.WriteOptionalString(projectFile);
+
             writer.Write((Int32)lineNumber);
             writer.Write((Int32)columnNumber);
             writer.Write((Int32)endLineNumber);
@@ -339,53 +253,20 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region SubCategory
-            if (reader.ReadByte() == 0)
-            {
-                subcategory = null;
-            }
-            else
-            {
-                subcategory = reader.ReadString();
-            }
-            #endregion
-            #region Code
-            if (reader.ReadByte() == 0)
-            {
-                code = null;
-            }
-            else
-            {
-                code = reader.ReadString();
-            }
-            #endregion
-            #region File
-            if (reader.ReadByte() == 0)
-            {
-                file = null;
-            }
-            else
-            {
-                file = reader.ReadString();
-            }
-            #endregion
-            #region ProjectFile
+
+            subcategory = reader.ReadByte() == 0 ? null : reader.ReadString();
+            code = reader.ReadByte() == 0 ? null : reader.ReadString();
+            file = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             if (version > 20)
             {
-                if (reader.ReadByte() == 0)
-                {
-                    projectFile = null;
-                }
-                else
-                {
-                    projectFile = reader.ReadString();
-                }
+                projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
             }
             else
             {
                 projectFile = null;
             }
-            #endregion
+
             lineNumber = reader.ReadInt32();
             columnNumber = reader.ReadInt32();
             endLineNumber = reader.ReadInt32();

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -9,6 +9,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -160,38 +161,10 @@ namespace Microsoft.Build.Framework
         /// <param name="writer">Binary writer which is attached to the stream the event will be serialized into</param>
         internal virtual void WriteToStream(BinaryWriter writer)
         {
-            if (message == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(message);
-            }
-
-            if (helpKeyword == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(helpKeyword);
-            }
-
-            if (senderName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(senderName);
-            }
-
-            writer.Write((Int64)timestamp.Ticks);
-            writer.Write((Int32)timestamp.Kind);
+            writer.WriteOptionalString(message);
+            writer.WriteOptionalString(helpKeyword);
+            writer.WriteOptionalString(senderName);
+            writer.WriteTimestamp(timestamp);
 
             writer.Write((Int32)threadId);
 

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Build.Framework
         /// </summary>
         private DateTime timestamp;
 
+        [NonSerialized]
+        private DateTime? _localTimestamp;
+
         /// <summary>
         /// Thread id
         /// </summary>
@@ -105,78 +108,48 @@ namespace Microsoft.Build.Framework
                 // Rather than storing dates in Local time all the time, we store in UTC type, and only
                 // convert to Local when the user requests access to this field.  This lets us avoid the
                 // expensive conversion to Local time unless it's absolutely necessary.
-                if (timestamp.Kind == DateTimeKind.Utc)
+                if (!_localTimestamp.HasValue)
                 {
-                    timestamp = timestamp.ToLocalTime();
+                    _localTimestamp = timestamp.Kind == DateTimeKind.Utc || timestamp.Kind == DateTimeKind.Unspecified
+                        ? timestamp.ToLocalTime()
+                        : timestamp;
                 }
 
-                return timestamp;
+                return _localTimestamp.Value;
             }
         }
 
         /// <summary>
         /// The thread that raised event.  
         /// </summary>
-        public int ThreadId
-        {
-            get
-            {
-                return threadId;
-            }
-        }
+        public int ThreadId => threadId;
 
         /// <summary>
         /// Text of event. 
         /// </summary>
         public virtual string Message
         {
-            get
-            {
-                return message;
-            }
-
-            protected set
-            {
-                message = value;
-            }
+            get => message;
+            protected set => message = value;
         }
 
         /// <summary>
         /// Custom help keyword associated with event.
         /// </summary>
-        public string HelpKeyword
-        {
-            get
-            {
-                return helpKeyword;
-            }
-        }
+        public string HelpKeyword => helpKeyword;
 
         /// <summary>
         /// Name of the object sending this event.
         /// </summary>
-        public string SenderName
-        {
-            get
-            {
-                return senderName;
-            }
-        }
+        public string SenderName => senderName;
 
         /// <summary>
         /// Event contextual information for the build event argument
         /// </summary>
         public BuildEventContext BuildEventContext
         {
-            get
-            {
-                return buildEventContext;
-            }
-
-            set
-            {
-                buildEventContext = value;
-            }
+            get => buildEventContext;
+            set => buildEventContext = value;
         }
 
 #if FEATURE_BINARY_SERIALIZATION

--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -24,9 +24,7 @@ namespace Microsoft.Build.Framework
     /// without following certain special FX guidelines, can break both
     /// forward and backward compatibility
     /// </remarks>
-#if FEATURE_BINARY_SERIALIZATION
     [Serializable]
-#endif
     public abstract class BuildEventArgs : EventArgs
     {
         /// <summary>
@@ -182,14 +180,13 @@ namespace Microsoft.Build.Framework
         }
 
 #if FEATURE_BINARY_SERIALIZATION
-        #region CustomSerializationToStream
+#region CustomSerializationToStream
         /// <summary>
         /// Serializes to a stream through a binary writer
         /// </summary>
         /// <param name="writer">Binary writer which is attached to the stream the event will be serialized into</param>
         internal virtual void WriteToStream(BinaryWriter writer)
         {
-            #region Message
             if (message == null)
             {
                 writer.Write((byte)0);
@@ -199,8 +196,7 @@ namespace Microsoft.Build.Framework
                 writer.Write((byte)1);
                 writer.Write(message);
             }
-            #endregion
-            #region HelpKeyword
+
             if (helpKeyword == null)
             {
                 writer.Write((byte)0);
@@ -210,8 +206,7 @@ namespace Microsoft.Build.Framework
                 writer.Write((byte)1);
                 writer.Write(helpKeyword);
             }
-            #endregion
-            #region SenderName
+
             if (senderName == null)
             {
                 writer.Write((byte)0);
@@ -221,13 +216,12 @@ namespace Microsoft.Build.Framework
                 writer.Write((byte)1);
                 writer.Write(senderName);
             }
-            #endregion
-            #region TimeStamp
+
             writer.Write((Int64)timestamp.Ticks);
             writer.Write((Int32)timestamp.Kind);
-            #endregion
+
             writer.Write((Int32)threadId);
-            #region BuildEventContext
+
             if (buildEventContext == null)
             {
                 writer.Write((byte)0);
@@ -243,7 +237,6 @@ namespace Microsoft.Build.Framework
                 writer.Write((Int32)buildEventContext.ProjectInstanceId);
                 writer.Write((Int32)buildEventContext.EvaluationId);
             }
-            #endregion
         }
 
         /// <summary>
@@ -253,38 +246,12 @@ namespace Microsoft.Build.Framework
         /// <param name="version">The version of the runtime the message packet was created from</param>
         internal virtual void CreateFromStream(BinaryReader reader, int version)
         {
-            #region Message
-            if (reader.ReadByte() == 0)
-            {
-                message = null;
-            }
-            else
-            {
-                message = reader.ReadString();
-            }
-            #endregion
-            #region HelpKeyword
-            if (reader.ReadByte() == 0)
-            {
-                helpKeyword = null;
-            }
-            else
-            {
-                helpKeyword = reader.ReadString();
-            }
-            #endregion
-            #region SenderName
-            if (reader.ReadByte() == 0)
-            {
-                senderName = null;
-            }
-            else
-            {
-                senderName = reader.ReadString();
-            }
-            #endregion
-            #region TimeStamp
+            message = reader.ReadByte() == 0 ? null : reader.ReadString();
+            helpKeyword = reader.ReadByte() == 0 ? null : reader.ReadString();
+            senderName = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             long timestampTicks = reader.ReadInt64();
+
             if (version > 20)
             {
                 DateTimeKind kind = (DateTimeKind)reader.ReadInt32();
@@ -294,9 +261,9 @@ namespace Microsoft.Build.Framework
             {
                 timestamp = new DateTime(timestampTicks);
             }
-            #endregion
+
             threadId = reader.ReadInt32();
-            #region BuildEventContext
+
             if (reader.ReadByte() == 0)
             {
                 buildEventContext = null;
@@ -320,13 +287,12 @@ namespace Microsoft.Build.Framework
                     buildEventContext = new BuildEventContext(nodeId, targetId, projectContextId, taskId);
                 }
             }
-            #endregion
         }
-        #endregion
+#endregion
 #endif
 
 #if FEATURE_BINARY_SERIALIZATION
-        #region SetSerializationDefaults
+#region SetSerializationDefaults
         /// <summary>
         /// Run before the object has been deserialized
         /// UNDONE (Logging.)  Can this and the next function go away, and instead return a BuildEventContext.Invalid from
@@ -357,7 +323,10 @@ namespace Microsoft.Build.Framework
                                        );
             }
         }
-        #endregion
+#endregion
+
+        //private BuildErrorEventArgs()
+
 #endif
     }
 }

--- a/src/Framework/BuildMessageEventArgs.cs
+++ b/src/Framework/BuildMessageEventArgs.cs
@@ -8,6 +8,7 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -285,51 +286,14 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
+
             writer.Write((Int32)importance);
-            #region SubCategory
-            if (subcategory == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(subcategory);
-            }
-            #endregion
-            #region Code
-            if (code == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(code);
-            }
-            #endregion
-            #region File
-            if (file == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(file);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
+
+            writer.WriteOptionalString(subcategory);
+            writer.WriteOptionalString(code);
+            writer.WriteOptionalString(file);
+            writer.WriteOptionalString(projectFile);
+
             writer.Write((Int32)lineNumber);
             writer.Write((Int32)columnNumber);
             writer.Write((Int32)endLineNumber);
@@ -349,46 +313,11 @@ namespace Microsoft.Build.Framework
             //The data in the stream beyond this point are new to 4.0
             if (version > 20)
             {
-                #region SubCategory
-                if (reader.ReadByte() == 0)
-                {
-                    subcategory = null;
-                }
-                else
-                {
-                    subcategory = reader.ReadString();
-                }
-                #endregion
-                #region Code
-                if (reader.ReadByte() == 0)
-                {
-                    code = null;
-                }
-                else
-                {
-                    code = reader.ReadString();
-                }
-                #endregion
-                #region File
-                if (reader.ReadByte() == 0)
-                {
-                    file = null;
-                }
-                else
-                {
-                    file = reader.ReadString();
-                }
-                #endregion
-                #region ProjectFile
-                if (reader.ReadByte() == 0)
-                {
-                    projectFile = null;
-                }
-                else
-                {
-                    projectFile = reader.ReadString();
-                }
-                #endregion
+                subcategory = reader.ReadByte() == 0 ? null : reader.ReadString();
+                code = reader.ReadByte() == 0 ? null : reader.ReadString();
+                file = reader.ReadByte() == 0 ? null : reader.ReadString();
+                projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+
                 lineNumber = reader.ReadInt32();
                 columnNumber = reader.ReadInt32();
                 endLineNumber = reader.ReadInt32();
@@ -401,105 +330,50 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Importance of the message
         /// </summary>
-        public MessageImportance Importance
-        {
-            get
-            {
-                return importance;
-            }
-        }
+        public MessageImportance Importance => importance;
 
         /// <summary>
         /// The custom sub-type of the event.
         /// </summary>
-        public string Subcategory
-        {
-            get
-            {
-                return subcategory;
-            }
-        }
+        public string Subcategory => subcategory;
 
         /// <summary>
         /// Code associated with event. 
         /// </summary>
-        public string Code
-        {
-            get
-            {
-                return code;
-            }
-        }
+        public string Code => code;
 
         /// <summary>
         /// File associated with event.
         /// </summary>
-        public string File
-        {
-            get
-            {
-                return file;
-            }
-        }
+        public string File => file;
 
         /// <summary>
         /// Line number of interest in associated file. 
         /// </summary>
-        public int LineNumber
-        {
-            get
-            {
-                return lineNumber;
-            }
-        }
+        public int LineNumber => lineNumber;
 
         /// <summary>
         /// Column number of interest in associated file. 
         /// </summary>
-        public int ColumnNumber
-        {
-            get
-            {
-                return columnNumber;
-            }
-        }
+        public int ColumnNumber => columnNumber;
 
         /// <summary>
         /// Ending line number of interest in associated file. 
         /// </summary>
-        public int EndLineNumber
-        {
-            get
-            {
-                return endLineNumber;
-            }
-        }
+        public int EndLineNumber => endLineNumber;
 
         /// <summary>
         /// Ending column number of interest in associated file. 
         /// </summary>
-        public int EndColumnNumber
-        {
-            get
-            {
-                return endColumnNumber;
-            }
-        }
+        public int EndColumnNumber => endColumnNumber;
 
         /// <summary>
         /// The project which was building when the message was issued.
         /// </summary>
         public string ProjectFile
         {
-            get
-            {
-                return projectFile;
-            }
-
-            set
-            {
-                projectFile = value;
-            }
+            get => projectFile;
+            set => projectFile = value;
         }
     }
 }

--- a/src/Framework/BuildWarningEventArgs.cs
+++ b/src/Framework/BuildWarningEventArgs.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices;
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -153,50 +154,12 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region SubCategory
-            if (subcategory == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(subcategory);
-            }
-            #endregion
-            #region Code
-            if (code == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(code);
-            }
-            #endregion
-            #region File
-            if (file == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(file);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
+
+            writer.WriteOptionalString(subcategory);
+            writer.WriteOptionalString(code);
+            writer.WriteOptionalString(file);
+            writer.WriteOptionalString(projectFile);
+
             writer.Write((Int32)lineNumber);
             writer.Write((Int32)columnNumber);
             writer.Write((Int32)endLineNumber);
@@ -211,49 +174,16 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region SubCategory
-            if (reader.ReadByte() == 0)
-            {
-                subcategory = null;
-            }
-            else
-            {
-                subcategory = reader.ReadString();
-            }
-            #endregion
-            #region Code
-            if (reader.ReadByte() == 0)
-            {
-                code = null;
-            }
-            else
-            {
-                code = reader.ReadString();
-            }
-            #endregion
-            #region File
-            if (reader.ReadByte() == 0)
-            {
-                file = null;
-            }
-            else
-            {
-                file = reader.ReadString();
-            }
-            #endregion
-            #region ProjectFile
+
+            subcategory = reader.ReadByte() == 0 ? null : reader.ReadString();
+            code = reader.ReadByte() == 0 ? null : reader.ReadString();
+            file = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             if (version > 20)
             {
-                if (reader.ReadByte() == 0)
-                {
-                    projectFile = null;
-                }
-                else
-                {
-                    projectFile = reader.ReadString();
-                }
+                projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
             }
-            #endregion
+
             lineNumber = reader.ReadInt32();
             columnNumber = reader.ReadInt32();
             endLineNumber = reader.ReadInt32();
@@ -265,94 +195,45 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// The custom sub-type of the event.         
         /// </summary>
-        public string Subcategory
-        {
-            get
-            {
-                return subcategory;
-            }
-        }
+        public string Subcategory => subcategory;
 
         /// <summary>
         /// Code associated with event. 
         /// </summary>
-        public string Code
-        {
-            get
-            {
-                return code;
-            }
-        }
+        public string Code => code;
 
         /// <summary>
         /// File associated with event.   
         /// </summary>
-        public string File
-        {
-            get
-            {
-                return file;
-            }
-        }
+        public string File => file;
 
         /// <summary>
         /// Line number of interest in associated file. 
         /// </summary>
-        public int LineNumber
-        {
-            get
-            {
-                return lineNumber;
-            }
-        }
+        public int LineNumber => lineNumber;
 
         /// <summary>
         /// Column number of interest in associated file. 
         /// </summary>
-        public int ColumnNumber
-        {
-            get
-            {
-                return columnNumber;
-            }
-        }
+        public int ColumnNumber => columnNumber;
 
         /// <summary>
         /// Ending line number of interest in associated file. 
         /// </summary>
-        public int EndLineNumber
-        {
-            get
-            {
-                return endLineNumber;
-            }
-        }
+        public int EndLineNumber => endLineNumber;
 
         /// <summary>
         /// Ending column number of interest in associated file. 
         /// </summary>
-        public int EndColumnNumber
-        {
-            get
-            {
-                return endColumnNumber;
-            }
-        }
+        public int EndColumnNumber => endColumnNumber;
 
         /// <summary>
         /// The project which was building when the message was issued.
         /// </summary>
         public string ProjectFile
         {
-            get
-            {
-                return projectFile;
-            }
-
-            set
-            {
-                projectFile = value;
-            }
+            get => projectFile;
+            set => projectFile = value;
         }
     }
 }

--- a/src/Framework/LazyFormattedBuildEventArgs.cs
+++ b/src/Framework/LazyFormattedBuildEventArgs.cs
@@ -28,7 +28,13 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Stores the original culture for String.Format.
         /// </summary>
-        private CultureInfo originalCulture;
+        private string originalCultureName;
+
+        /// <summary>
+        /// Non-serializable CultureInfo object
+        /// </summary>
+        [NonSerialized]
+        private CultureInfo originalCultureInfo;
 
         /// <summary>
         /// Lock object.
@@ -73,7 +79,8 @@ namespace Microsoft.Build.Framework
             : base(message, helpKeyword, senderName, eventTimestamp)
         {
             arguments = messageArgs;
-            originalCulture = CultureInfo.CurrentCulture;
+            originalCultureName = CultureInfo.CurrentCulture.Name;
+            originalCultureInfo = CultureInfo.CurrentCulture;
             locker = new Object();
         }
 
@@ -97,7 +104,12 @@ namespace Microsoft.Build.Framework
                 {
                     if (arguments != null && arguments.Length > 0)
                     {
-                        base.Message = FormatString(originalCulture, base.Message, arguments);
+                        if (originalCultureInfo == null)
+                        {
+                            originalCultureInfo = new CultureInfo(originalCultureName);
+                        }
+
+                        base.Message = FormatString(originalCultureInfo, base.Message, arguments);
                         arguments = null;
                     }
                 }
@@ -139,10 +151,10 @@ namespace Microsoft.Build.Framework
                 }
                 else
                 {
-                    writer.Write((Int32)(-1));
+                    writer.Write(-1);
                 }
 
-                writer.Write(originalCulture != null ? originalCulture.LCID : 0);
+                writer.Write(originalCultureName);
             }
         }
 
@@ -172,18 +184,7 @@ namespace Microsoft.Build.Framework
 
                 arguments = messageArgs;
 
-                int originalCultureId = reader.ReadInt32();
-                if (originalCultureId != 0)
-                {
-                    if (originalCultureId == CultureInfo.CurrentCulture.LCID)
-                    {
-                        originalCulture = CultureInfo.CurrentCulture;
-                    }
-                    else
-                    {
-                        originalCulture = new CultureInfo(originalCultureId);
-                    }
-                }
+                originalCultureName = reader.ReadString();
             }
         }
 #endif

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -6,6 +6,9 @@
     <Description>This package contains the $(MSBuildProjectName) assembly which is a common assembly used by other MSBuild assemblies.</Description>
     <IncludeSatelliteOutputInPack>false</IncludeSatelliteOutputInPack>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="BinaryWriterExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
@@ -16,6 +19,9 @@
   <ItemGroup>
     <Compile Include="..\Shared\Constants.cs">
       <Link>Shared\Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\BinaryWriterExtensions.cs">
+      <Link>Shared\BinaryWriterExtensions.cs</Link>
     </Compile>
   </ItemGroup>
 

--- a/src/Framework/ProjectFinishedEventArgs.cs
+++ b/src/Framework/ProjectFinishedEventArgs.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices;
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -87,16 +88,7 @@ namespace Microsoft.Build.Framework
         {
             base.WriteToStream(writer);
 
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-
+            writer.WriteOptionalString(projectFile);
             writer.Write(succeeded);
         }
 
@@ -109,15 +101,7 @@ namespace Microsoft.Build.Framework
         {
             base.CreateFromStream(reader, version);
 
-            if (reader.ReadByte() == 0)
-            {
-                projectFile = null;
-            }
-            else
-            {
-                projectFile = reader.ReadString();
-            }
-
+            projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
             succeeded = reader.ReadBoolean();
         }
         #endregion
@@ -126,23 +110,11 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Project name
         /// </summary>
-        public string ProjectFile
-        {
-            get
-            {
-                return projectFile;
-            }
-        }
+        public string ProjectFile => projectFile;
 
         /// <summary>
         /// True if project built successfully, false otherwise
         /// </summary>
-        public bool Succeeded
-        {
-            get
-            {
-                return succeeded;
-            }
-        }
+        public bool Succeeded => succeeded;
     }
 }

--- a/src/Framework/TargetFinishedEventArgs.cs
+++ b/src/Framework/TargetFinishedEventArgs.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System;
 using System.IO;
 using System.Collections;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -128,39 +129,11 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
-            #region TargetFile
-            if (targetFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(targetFile);
-            }
-            #endregion TargetFile
-            #region TargetName
-            if (targetName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(targetName);
-            }
-            #endregion
+
+            writer.WriteOptionalString(projectFile);
+            writer.WriteOptionalString(targetFile);
+            writer.WriteOptionalString(targetName);
+
             writer.Write(succeeded);
         }
 
@@ -172,36 +145,11 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region ProjectFile
-            if (reader.ReadByte() == 0)
-            {
-                projectFile = null;
-            }
-            else
-            {
-                projectFile = reader.ReadString();
-            }
-            #endregion
-            #region TargetFile
-            if (reader.ReadByte() == 0)
-            {
-                targetFile = null;
-            }
-            else
-            {
-                targetFile = reader.ReadString();
-            }
-            #endregion
-            #region TargetName
-            if (reader.ReadByte() == 0)
-            {
-                targetName = null;
-            }
-            else
-            {
-                targetName = reader.ReadString();
-            }
-            #endregion
+
+            projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            targetFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            targetName = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             succeeded = reader.ReadBoolean();
         }
         #endregion
@@ -210,61 +158,30 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Target name
         /// </summary>
-        public string TargetName
-        {
-            get
-            {
-                return targetName;
-            }
-        }
+        public string TargetName => targetName;
 
         /// <summary>
         /// True if target built successfully, false otherwise
         /// </summary>
-        public bool Succeeded
-        {
-            get
-            {
-                return succeeded;
-            }
-        }
+        public bool Succeeded => succeeded;
 
         /// <summary>
         /// Project file associated with event.   
         /// </summary>
-        public string ProjectFile
-        {
-            get
-            {
-                return projectFile;
-            }
-        }
+        public string ProjectFile => projectFile;
 
         /// <summary>
         /// File where this target was declared.
         /// </summary>
-        public string TargetFile
-        {
-            get
-            {
-                return targetFile;
-            }
-        }
+        public string TargetFile => targetFile;
 
         /// <summary>
         /// Target outputs
         /// </summary>
         public IEnumerable TargetOutputs
         {
-            get
-            {
-                return targetOutputs;
-            }
-
-            set
-            {
-                targetOutputs = value;
-            }
+            get => targetOutputs;
+            set => targetOutputs = value;
         }
     }
 }

--- a/src/Framework/TargetStartedEventArgs.cs
+++ b/src/Framework/TargetStartedEventArgs.cs
@@ -4,6 +4,7 @@
 using System.Runtime.InteropServices;
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -127,53 +128,12 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region TargetName
-            if (targetName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(targetName);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
-            #region TargetFile
-            if (targetFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(targetFile);
-            }
-            #endregion
-            #region ParentTarget
-            if (parentTarget == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(parentTarget);
-            }
-            #endregion
-            #region BuildReason
+            writer.WriteOptionalString(targetName);
+            writer.WriteOptionalString(projectFile);
+            writer.WriteOptionalString(targetFile);
+            writer.WriteOptionalString(parentTarget);
+
             writer.Write((int)buildReason);
-            #endregion
         }
 
         /// <summary>
@@ -184,55 +144,16 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region TargetName
-            if (reader.ReadByte() == 0)
-            {
-                targetName = null;
-            }
-            else
-            {
-                targetName = reader.ReadString();
-            }
-            #endregion
-            #region ProjectFile
-            if (reader.ReadByte() == 0)
-            {
-                projectFile = null;
-            }
-            else
-            {
-                projectFile = reader.ReadString();
-            }
-            #endregion
-            #region TargetFile
-            if (reader.ReadByte() == 0)
-            {
-                targetFile = null;
-            }
-            else
-            {
-                targetFile = reader.ReadString();
-            }
-            #endregion
-            #region ParentTarget
+
+            targetName = reader.ReadByte() == 0 ? null : reader.ReadString();
+            projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            targetFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             if (version > 20)
             {
-                if (reader.ReadByte() == 0)
-                {
-                    parentTarget = null;
-                }
-                else
-                {
-                    parentTarget = reader.ReadString();
-                }
-            }
-            #endregion
-            #region BuildReason
-            if (version > 20)
-            {
+                parentTarget = reader.ReadByte() == 0 ? null : reader.ReadString();
                 buildReason = (TargetBuiltReason) reader.ReadInt32();
             }
-            #endregion 
         }
         #endregion
 #endif
@@ -240,56 +161,26 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// target name
         /// </summary>
-        public string TargetName
-        {
-            get
-            {
-                return targetName;
-            }
-        }
+        public string TargetName => targetName;
 
         /// <summary>
         /// Target which caused this target to build
         /// </summary>
-        public string ParentTarget
-        {
-            get
-            {
-                return parentTarget;
-            }
-        }
+        public string ParentTarget => parentTarget;
 
         /// <summary>
         /// Project file associated with event.   
         /// </summary>
-        public string ProjectFile
-        {
-            get
-            {
-                return projectFile;
-            }
-        }
+        public string ProjectFile => projectFile;
 
         /// <summary>
         /// File where this target was declared.
         /// </summary>
-        public string TargetFile
-        {
-            get
-            {
-                return targetFile;
-            }
-        }
+        public string TargetFile => targetFile;
 
         /// <summary>
         /// Why this target was built by its parent.
         /// </summary>
-        public TargetBuiltReason BuildReason
-        {
-            get
-            {
-                return buildReason;
-            }
-        }
+        public TargetBuiltReason BuildReason => buildReason;
     }
 }

--- a/src/Framework/TaskFinishedEventArgs.cs
+++ b/src/Framework/TaskFinishedEventArgs.cs
@@ -8,6 +8,7 @@
 using System.Runtime.InteropServices;
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -102,39 +103,11 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region TaskName
-            if (taskName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(taskName);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
-            #region TaskFile
-            if (taskFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(taskFile);
-            }
-            #endregion
+
+            writer.WriteOptionalString(taskName);
+            writer.WriteOptionalString(projectFile);
+            writer.WriteOptionalString(taskFile);
+
             writer.Write(succeeded);
         }
 
@@ -146,36 +119,11 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region TaskName
-            if (reader.ReadByte() == 0)
-            {
-                taskName = null;
-            }
-            else
-            {
-                taskName = reader.ReadString();
-            }
-            #endregion
-            #region ProjectFile
-            if (reader.ReadByte() == 0)
-            {
-                projectFile = null;
-            }
-            else
-            {
-                projectFile = reader.ReadString();
-            }
-            #endregion
-            #region TaskFile
-            if (reader.ReadByte() == 0)
-            {
-                taskFile = null;
-            }
-            else
-            {
-                taskFile = reader.ReadString();
-            }
-            #endregion
+
+            taskName = reader.ReadByte() == 0 ? null : reader.ReadString();
+            projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            taskFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+
             succeeded = reader.ReadBoolean();
         }
         #endregion
@@ -184,45 +132,21 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Task Name
         /// </summary>
-        public string TaskName
-        {
-            get
-            {
-                return taskName;
-            }
-        }
+        public string TaskName => taskName;
 
         /// <summary>
         /// True if target built successfully, false otherwise
         /// </summary>
-        public bool Succeeded
-        {
-            get
-            {
-                return succeeded;
-            }
-        }
+        public bool Succeeded => succeeded;
 
         /// <summary>
         /// Project file associated with event.   
         /// </summary>
-        public string ProjectFile
-        {
-            get
-            {
-                return projectFile;
-            }
-        }
+        public string ProjectFile => projectFile;
 
         /// <summary>
         /// MSBuild file where this task was defined.   
         /// </summary>
-        public string TaskFile
-        {
-            get
-            {
-                return taskFile;
-            }
-        }
+        public string TaskFile => taskFile;
     }
 }

--- a/src/Framework/TaskStartedEventArgs.cs
+++ b/src/Framework/TaskStartedEventArgs.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.IO;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Framework
 {
@@ -95,39 +96,10 @@ namespace Microsoft.Build.Framework
         internal override void WriteToStream(BinaryWriter writer)
         {
             base.WriteToStream(writer);
-            #region TaskName
-            if (taskName == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(taskName);
-            }
-            #endregion
-            #region ProjectFile
-            if (projectFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(projectFile);
-            }
-            #endregion
-            #region TaskFile
-            if (taskFile == null)
-            {
-                writer.Write((byte)0);
-            }
-            else
-            {
-                writer.Write((byte)1);
-                writer.Write(taskFile);
-            }
-            #endregion
+
+            writer.WriteOptionalString(taskName);
+            writer.WriteOptionalString(projectFile);
+            writer.WriteOptionalString(taskFile);
         }
 
         /// <summary>
@@ -138,36 +110,10 @@ namespace Microsoft.Build.Framework
         internal override void CreateFromStream(BinaryReader reader, int version)
         {
             base.CreateFromStream(reader, version);
-            #region TaskName
-            if (reader.ReadByte() == 0)
-            {
-                taskName = null;
-            }
-            else
-            {
-                taskName = reader.ReadString();
-            }
-            #endregion
-            #region ProjectFile
-            if (reader.ReadByte() == 0)
-            {
-                projectFile = null;
-            }
-            else
-            {
-                projectFile = reader.ReadString();
-            }
-            #endregion
-            #region TaskFile
-            if (reader.ReadByte() == 0)
-            {
-                taskFile = null;
-            }
-            else
-            {
-                taskFile = reader.ReadString();
-            }
-            #endregion
+
+            taskName = reader.ReadByte() == 0 ? null : reader.ReadString();
+            projectFile = reader.ReadByte() == 0 ? null : reader.ReadString();
+            taskFile = reader.ReadByte() == 0 ? null : reader.ReadString();
         }
         #endregion
 #endif
@@ -175,34 +121,16 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Task name.
         /// </summary>
-        public string TaskName
-        {
-            get
-            {
-                return taskName;
-            }
-        }
+        public string TaskName => taskName;
 
         /// <summary>
         /// Project file associated with event.   
         /// </summary>
-        public string ProjectFile
-        {
-            get
-            {
-                return projectFile;
-            }
-        }
+        public string ProjectFile => projectFile;
 
         /// <summary>
         /// MSBuild file where this task was defined.   
         /// </summary>
-        public string TaskFile
-        {
-            get
-            {
-                return taskFile;
-            }
-        }
+        public string TaskFile => taskFile;
     }
 }

--- a/src/Shared/BinaryWriterExtensions.cs
+++ b/src/Shared/BinaryWriterExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Shared
+{
+    internal static class BinaryWriterExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteOptionalString(this BinaryWriter writer, string value)
+        {
+            if (value == null)
+            {
+                writer.Write((byte)0);
+            }
+            else
+            {
+                writer.Write((byte)1);
+                writer.Write(value);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteTimestamp(this BinaryWriter writer, DateTime timestamp)
+        {
+            writer.Write((Int64)timestamp.Ticks);
+            writer.Write((Int32)timestamp.Kind);
+        }
+    }
+}

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private Dictionary<string, TaskParameter> _taskParameters;
 
-#if FEATURE_APPDOMAIN
         /// <summary>
         /// Constructor
         /// </summary>
@@ -116,47 +115,17 @@ namespace Microsoft.Build.BackEnd
                 IDictionary<string, string> buildProcessEnvironment,
                 CultureInfo culture,
                 CultureInfo uiCulture,
+#if FEATURE_APPDOMAIN
                 AppDomainSetup appDomainSetup,
-                int lineNumberOfTask,
-                int columnNumberOfTask,
-                string projectFileOfTask,
-                bool continueOnError,
-                string taskName,
-                string taskLocation,
-                IDictionary<string, object> taskParameters
-            )
-#else
-        /// <summary>
-        /// Constructor
-        /// </summary>
-        /// <param name="nodeId">The ID of the node being configured.</param>
-        /// <param name="startupDirectory">The startup directory for the task being executed.</param>
-        /// <param name="buildProcessEnvironment">The set of environment variables to apply to the task execution process.</param>
-        /// <param name="culture">The culture of the thread that will execute the task.</param>
-        /// <param name="uiCulture">The UI culture of the thread that will execute the task.</param>
-        /// <param name="lineNumberOfTask">The line number of the location from which this task was invoked.</param>
-        /// <param name="columnNumberOfTask">The column number of the location from which this task was invoked.</param>
-        /// <param name="projectFileOfTask">The project file from which this task was invoked.</param>
-        /// <param name="continueOnError">Flag to continue with the build after a the task failed</param>
-        /// <param name="taskName">Name of the task.</param>
-        /// <param name="taskLocation">Location of the assembly the task is to be loaded from.</param>
-        /// <param name="taskParameters">Parameters to apply to the task.</param>
-        public TaskHostConfiguration
-            (
-                int nodeId,
-                string startupDirectory,
-                IDictionary<string, string> buildProcessEnvironment,
-                CultureInfo culture,
-                CultureInfo uiCulture,
-                int lineNumberOfTask,
-                int columnNumberOfTask,
-                string projectFileOfTask,
-                bool continueOnError,
-                string taskName,
-                string taskLocation,
-                IDictionary<string, object> taskParameters
-            )
 #endif
+                int lineNumberOfTask,
+                int columnNumberOfTask,
+                string projectFileOfTask,
+                bool continueOnError,
+                string taskName,
+                string taskLocation,
+                IDictionary<string, object> taskParameters
+            )
         {
             ErrorUtilities.VerifyThrowInternalLength(taskName, "taskName");
             ErrorUtilities.VerifyThrowInternalLength(taskLocation, "taskLocation");

--- a/src/Shared/UnitTests/xunit.runner.json
+++ b/src/Shared/UnitTests/xunit.runner.json
@@ -1,6 +1,7 @@
 ﻿{
     "shadowCopy": false,
-    "appDomain":  "required",
+    "appDomain": "required",
     "maxParallelThreads": 1,
-    "parallelizeTestCollections": false
+    "parallelizeTestCollections": false,
+    "diagnosticMessages":  true
 }

--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -155,7 +155,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -319,7 +319,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
                 GenerateResource t2 = Utilities.CreateTask(_output);
@@ -382,7 +382,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -563,7 +563,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t.OutputResources[1].ItemSpec, resourcesFile2);
                 Assert.Equal(t.FilesWritten[1].ItemSpec, resourcesFile2);
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -584,7 +584,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t2.OutputResources[1].ItemSpec, resourcesFile2);
                 Assert.Equal(t2.FilesWritten[1].ItemSpec, resourcesFile2);
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t2);
 #endif
 
@@ -1417,7 +1417,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 // Task should have failed
                 Assert.False(success);
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
                 // Should not have created an output for the invalid resx
@@ -1471,7 +1471,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 // Task should have failed
                 Assert.False(success);
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -1836,7 +1836,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.True(File.Exists(t.FilesWritten[i].ItemSpec));
             }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -1899,7 +1899,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t.FilesWritten[1].ItemSpec, Path.ChangeExtension(t.Sources[1].ItemSpec, ".resources"));
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
 
@@ -2129,7 +2129,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  Read-only StateFile yields message
         /// </summary>
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         [Fact]
 #else
         [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/297")]

--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -20,12 +20,14 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 {
     [Trait("Category", "mono-osx-failing")]
     [Trait("Category", "mono-windows-failing")]
-    sealed public class RequiredTransformations
+    public sealed class RequiredTransformations
     {
+        private readonly TestEnvironment _env;
         private readonly ITestOutputHelper _output;
 
         public RequiredTransformations(ITestOutputHelper output)
         {
+            _env = TestEnvironment.Create(output);
             _output = output;
         }
 
@@ -303,56 +305,41 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         [Trait("Category", "netcore-linux-failing")]
         public void ForceOutOfDate()
         {
-            string resxFile = Utilities.WriteTestResX(false, null, null);
+            var folder = _env.CreateFolder();
+            string resxFile = Utilities.WriteTestResX(false, null, null, _env.CreateFile(folder, ".resx").Path);
 
             GenerateResource t = Utilities.CreateTask(_output);
-            t.StateFile = new TaskItem(Utilities.GetTempFileName(".cache"));
+            t.StateFile = new TaskItem(_env.GetTempFile(".cache").Path);
+            t.Sources = new ITaskItem[] {new TaskItem(resxFile)};
 
-            try
-            {
-                t.Sources = new ITaskItem[] { new TaskItem(resxFile) };
+            Utilities.ExecuteTask(t);
 
-                Utilities.ExecuteTask(t);
-
-                string resourcesFile = t.OutputResources[0].ItemSpec;
-                Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
-                resourcesFile = t.FilesWritten[0].ItemSpec;
-                Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
+            string resourcesFile = t.OutputResources[0].ItemSpec;
+            Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
+            resourcesFile = t.FilesWritten[0].ItemSpec;
+            Assert.Equal(Path.GetExtension(resourcesFile), ".resources");
 
 #if FEATURE_RESGENCACHE
                 Utilities.AssertStateFileWasWritten(t);
 #endif
-                GenerateResource t2 = Utilities.CreateTask(_output);
-                t2.StateFile = new TaskItem(t.StateFile);
-                t2.Sources = new ITaskItem[] { new TaskItem(resxFile) };
+            GenerateResource t2 = Utilities.CreateTask(_output);
+            t2.StateFile = new TaskItem(t.StateFile);
+            t2.Sources = new ITaskItem[] {new TaskItem(resxFile)};
 
-                DateTime time = File.GetLastWriteTime(t.OutputResources[0].ItemSpec);
+            DateTime time = File.GetLastWriteTime(t.OutputResources[0].ItemSpec);
 
-                System.Threading.Thread.Sleep(200);
-                if (NativeMethodsShared.IsOSX)
-                {
-                    // Must be > 1 sec for HFS+ timestamp granularity
-                    System.Threading.Thread.Sleep(1100);
-                }
-
-                File.SetLastWriteTime(resxFile, DateTime.Now);
-
-                Utilities.ExecuteTask(t2);
-
-                Assert.True(DateTime.Compare(File.GetLastWriteTime(t2.OutputResources[0].ItemSpec), time) > 0);
-            }
-            finally
+            System.Threading.Thread.Sleep(200);
+            if (NativeMethodsShared.IsOSX)
             {
-                // Done, so clean up.
-                File.Delete(t.Sources[0].ItemSpec);
-                foreach (ITaskItem item in t.FilesWritten)
-                {
-                    if (File.Exists(item.ItemSpec))
-                    {
-                        File.Delete(item.ItemSpec);
-                    }
-                }
+                // Must be > 1 sec for HFS+ timestamp granularity
+                System.Threading.Thread.Sleep(1100);
             }
+
+            File.SetLastWriteTime(resxFile, DateTime.Now);
+
+            Utilities.ExecuteTask(t2);
+
+            Assert.True(DateTime.Compare(File.GetLastWriteTime(t2.OutputResources[0].ItemSpec), time) > 0);
         }
 
         /// <summary>
@@ -419,63 +406,50 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         [Fact]
         public void ForceSomeOutOfDate()
         {
-            string firstResx = null;
-            string secondResx = null;
-            string cache = null;
+            var folder = _env.CreateFolder();
 
-            try
+            var firstResx = Utilities.WriteTestResX(false, null, null, _env.CreateFile(folder, ".resx").Path);
+            var secondResx = Utilities.WriteTestResX(false, null, null, _env.CreateFile(folder, ".resx").Path);
+            var cache = _env.GetTempFile(folder, ".cache").Path;
+
+            GenerateResource createResources = Utilities.CreateTask(_output);
+            createResources.StateFile = new TaskItem(cache);
+            createResources.Sources = new ITaskItem[] {new TaskItem(firstResx), new TaskItem(secondResx)};
+
+            _output.WriteLine("Transform both");
+            Utilities.ExecuteTask(createResources);
+
+            _output.WriteLine("Get current write times of outputs");
+            DateTime firstOutputCreationTime = File.GetLastWriteTime(createResources.OutputResources[0].ItemSpec);
+            DateTime secondOutputCreationTime = File.GetLastWriteTime(createResources.OutputResources[1].ItemSpec);
+
+            _output.WriteLine("Create a new task to transform them again");
+            GenerateResource t2 = Utilities.CreateTask(_output);
+            t2.StateFile = new TaskItem(createResources.StateFile.ItemSpec);
+            t2.Sources = new ITaskItem[] {new TaskItem(firstResx), new TaskItem(secondResx)};
+
+            System.Threading.Thread.Sleep(200);
+            if (!NativeMethodsShared.IsWindows)
             {
-                firstResx = Utilities.WriteTestResX(false, null, null);
-                secondResx = Utilities.WriteTestResX(false, null, null);
-                cache = Utilities.GetTempFileName(".cache");
-
-                GenerateResource createResources = Utilities.CreateTask(_output);
-                createResources.StateFile = new TaskItem(cache);
-                createResources.Sources = new ITaskItem[] { new TaskItem(firstResx), new TaskItem(secondResx) };
-
-                _output.WriteLine("Transform both");
-                Utilities.ExecuteTask(createResources);
-
-                _output.WriteLine("Get current write times of outputs");
-                DateTime firstOutputCreationTime = File.GetLastWriteTime(createResources.OutputResources[0].ItemSpec);
-                DateTime secondOutputCreationTime = File.GetLastWriteTime(createResources.OutputResources[1].ItemSpec);
-
-                _output.WriteLine("Create a new task to transform them again");
-                GenerateResource t2 = Utilities.CreateTask(_output);
-                t2.StateFile = new TaskItem(createResources.StateFile.ItemSpec);
-                t2.Sources = new ITaskItem[] { new TaskItem(firstResx), new TaskItem(secondResx) };
-
-                System.Threading.Thread.Sleep(200);
-                if (!NativeMethodsShared.IsWindows)
-                {
-                    // Must be > 1 sec on some file systems for proper timestamp granularity
-                    // TODO: Implement an interface for fetching deterministic timestamps rather than relying on the file
-                    System.Threading.Thread.Sleep(1000);
-                }
-
-                _output.WriteLine("Touch one input");
-                File.SetLastWriteTime(firstResx, DateTime.Now);
-
-                Utilities.ExecuteTask(t2);
-
-                _output.WriteLine("Check only one output was updated");
-                File.GetLastWriteTime(t2.OutputResources[0].ItemSpec).ShouldBeGreaterThan(firstOutputCreationTime);
-                File.GetLastWriteTime(t2.OutputResources[1].ItemSpec).ShouldBe(secondOutputCreationTime);
-
-                // Although only one file was updated, both should be in OutputResources and FilesWritten
-                t2.OutputResources[0].ItemSpec.ShouldBe(createResources.OutputResources[0].ItemSpec);
-                t2.OutputResources[1].ItemSpec.ShouldBe(createResources.OutputResources[1].ItemSpec);
-                t2.FilesWritten[0].ItemSpec.ShouldBe(createResources.FilesWritten[0].ItemSpec);
-                t2.FilesWritten[1].ItemSpec.ShouldBe(createResources.FilesWritten[1].ItemSpec);
+                // Must be > 1 sec on some file systems for proper timestamp granularity
+                // TODO: Implement an interface for fetching deterministic timestamps rather than relying on the file
+                System.Threading.Thread.Sleep(1000);
             }
-            finally
-            {
-                if (null != firstResx) File.Delete(firstResx);
-                if (null != secondResx) File.Delete(secondResx);
-                if (null != cache) File.Delete(cache);
-                if (null != firstResx) File.Delete(Path.ChangeExtension(firstResx, ".resources"));
-                if (null != secondResx) File.Delete(Path.ChangeExtension(secondResx, ".resources"));
-            }
+
+            _output.WriteLine("Touch one input");
+            File.SetLastWriteTime(firstResx, DateTime.Now);
+
+            Utilities.ExecuteTask(t2);
+
+            _output.WriteLine("Check only one output was updated");
+            File.GetLastWriteTime(t2.OutputResources[0].ItemSpec).ShouldBeGreaterThan(firstOutputCreationTime);
+            File.GetLastWriteTime(t2.OutputResources[1].ItemSpec).ShouldBe(secondOutputCreationTime);
+
+            // Although only one file was updated, both should be in OutputResources and FilesWritten
+            t2.OutputResources[0].ItemSpec.ShouldBe(createResources.OutputResources[0].ItemSpec);
+            t2.OutputResources[1].ItemSpec.ShouldBe(createResources.OutputResources[1].ItemSpec);
+            t2.FilesWritten[0].ItemSpec.ShouldBe(createResources.FilesWritten[0].ItemSpec);
+            t2.FilesWritten[1].ItemSpec.ShouldBe(createResources.FilesWritten[1].ItemSpec);
         }
 
         /// <summary>
@@ -3472,12 +3446,9 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
         /// <param name="useType">Indicates whether to include an enum to test type-specific resource encoding with assembly references</param>
         /// <param name="linkedBitmap">The name of a linked-in bitmap.  use 'null' for no bitmap.</param>
         /// <returns>The name of the resx file</returns>
-        public static string WriteTestResX(bool useType, string linkedBitmap, string extraToken)
+        public static string WriteTestResX(bool useType, string linkedBitmap, string extraToken, string resxFileToWrite = null)
         {
-            string resgenFile = Utilities.GetTempFileName(".resx");
-            File.Delete(resgenFile);
-            File.WriteAllText(resgenFile, GetTestResXContent(useType, linkedBitmap, extraToken, false));
-            return resgenFile;
+            return WriteTestResX(useType, linkedBitmap, extraToken, useInvalidType: false, resxFileToWrite:resxFileToWrite);
         }
 
         /// <summary>
@@ -3486,10 +3457,15 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests
         /// <param name="useType">Indicates whether to include an enum to test type-specific resource encoding with assembly references</param>
         /// <param name="linkedBitmap">The name of a linked-in bitmap.  use 'null' for no bitmap.</param>
         /// <returns>The name of the resx file</returns>
-        public static string WriteTestResX(bool useType, string linkedBitmap, string extraToken, bool useInvalidType)
+        public static string WriteTestResX(bool useType, string linkedBitmap, string extraToken, bool useInvalidType, string resxFileToWrite = null)
         {
-            string resgenFile = Utilities.GetTempFileName(".resx");
-            File.Delete(resgenFile);
+            string resgenFile = resxFileToWrite;
+            if (string.IsNullOrEmpty(resgenFile))
+            {
+                resgenFile = GetTempFileName(".resx");
+                File.Delete(resgenFile);
+            }
+
             File.WriteAllText(resgenFile, GetTestResXContent(useType, linkedBitmap, extraToken, useInvalidType));
             return resgenFile;
         }

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 #endif
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Tasks
 
         #region Fields
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         // This cache helps us track the linked resource files listed inside of a resx resource file
         private ResGenDependencies _cache;
 #endif
@@ -809,7 +809,7 @@ namespace Microsoft.Build.Tasks
                                     OutputResources = outputResources;
                                 }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                                 // Get portable library cache info (and if needed, marshal it to this AD).
                                 List<ResGenDependencies.PortableLibraryFile> portableLibraryCacheInfo = process.PortableLibraryCacheInfo;
                                 for (int i = 0; i < portableLibraryCacheInfo.Count; i++)
@@ -853,7 +853,7 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                 // And now we serialize the cache to save our resgen linked file resolution for later use.
                 WriteStateFile();
 #endif
@@ -1219,7 +1219,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         private void GetResourcesToProcess(out List<ITaskItem> inputsToProcess, out List<ITaskItem> outputsToProcess, out List<ITaskItem> cachedOutputFiles)
         {
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             // First we look to see if we have a resgen linked files cache.  If so, then we can use that
             // cache to speed up processing.
             ReadStateFile();
@@ -1235,7 +1235,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (ExtractResWFiles)
                 {
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                     // We can't cheaply predict the output files, since that would require
                     // loading each assembly.  So don't even try guessing what they will be.
                     // However, our cache will sometimes record all the info we need (for incremental builds).
@@ -1249,7 +1249,7 @@ namespace Microsoft.Build.Tasks
                     {
 #endif
                         inputsToProcess.Add(Sources[i]);
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                     }
 #endif
 
@@ -1292,7 +1292,7 @@ namespace Microsoft.Build.Tasks
             }
         }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         /// <summary>
         /// Given a cached portable library that is up to date, create ITaskItems to represent the output of the task, as if we did real work.
         /// </summary>
@@ -1383,7 +1383,7 @@ namespace Microsoft.Build.Tasks
                 return NeedToRebuildSourceFile(sourceTime, outputTime);
             }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             // OK, we have a .resx file
 
             // PERF: Regardless of whether the outputFile exists, if the source file is a .resx 
@@ -1790,7 +1790,7 @@ namespace Microsoft.Build.Tasks
 
                         return true;
                     }
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                     catch (SerializationException e)
                     {
                         Log.LogMessageFromResources
@@ -1856,7 +1856,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool NeedSeparateAppDomainBasedOnSerializedType(XmlReader reader)
         {
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             while (reader.Read())
             {
                 if (reader.NodeType == XmlNodeType.Element)
@@ -1885,7 +1885,7 @@ namespace Microsoft.Build.Tasks
         }
 #endif
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         /// <summary>
         /// Deserializes a base64 block from a resx in order to figure out if its type is in the GAC.
         /// Because we're not providing any assembly resolution callback, deserialization
@@ -2085,7 +2085,7 @@ namespace Microsoft.Build.Tasks
         }
 #endif
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         /// <summary>
         /// Read the state file if able.
         /// </summary>
@@ -2245,7 +2245,7 @@ namespace Microsoft.Build.Tasks
         }
         private List<ITaskItem> _extractedResWFiles;
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
         /// <summary>
         /// Record all the information about outputs here to avoid future incremental builds.
         /// </summary>
@@ -2315,7 +2315,7 @@ namespace Microsoft.Build.Tasks
             _readers = new List<ReaderInfo>();
             _extractResWFiles = extractingResWFiles;
             _resWOutputDirectory = resWOutputDirectory;
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             _portableLibraryCacheInfo = new List<ResGenDependencies.PortableLibraryFile>();
 #endif
 
@@ -2514,7 +2514,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
             catch (Exception e) when (
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                                       e is SerializationException ||
 #endif
                                       e is TargetInvocationException)
@@ -2547,7 +2547,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (GetFormat(inFile) == Format.Assembly)
                 {
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                     // Prepare cache data
                     ResGenDependencies.PortableLibraryFile library = new ResGenDependencies.PortableLibraryFile(inFile);
 #endif
@@ -2591,20 +2591,20 @@ namespace Microsoft.Build.Tasks
                         ITaskItem newOutputFile = new TaskItem(escapedOutputFile);
                         resWFilesForThisAssembly.Add(escapedOutputFile);
                         newOutputFile.SetMetadata("ResourceIndexName", reader.assemblySimpleName);
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                         library.AssemblySimpleName = reader.assemblySimpleName;
 #endif
                         if (reader.fromNeutralResources)
                         {
                             newOutputFile.SetMetadata("NeutralResourceLanguage", reader.cultureName);
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                             library.NeutralResourceLanguage = reader.cultureName;
 #endif
                         }
                         ExtractedResWFiles.Add(newOutputFile);
                     }
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                     library.OutputFiles = resWFilesForThisAssembly.ToArray();
                     _portableLibraryCacheInfo.Add(library);
 #endif
@@ -2685,7 +2685,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
             catch (Exception e) when (
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
                                       e is SerializationException ||
 #endif
                                       e is TargetInvocationException)
@@ -3743,7 +3743,7 @@ namespace Microsoft.Build.Tasks
             private int lineNumber;
             private int column;
 
-#if FEATURE_BINARY_SERIALIZATION
+#if FEATURE_RESGENCACHE
             /// <summary>
             /// Fxcop want to have the correct basic exception constructors implemented
             /// </summary>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -497,6 +497,10 @@
     <Compile Include="XmlPoke.cs" />
     <Compile Include="CodeTaskFactory.cs" />
     <Compile Include="XamlTaskFactory\XamlTaskFactory.cs" />
+    <Compile Include="StateFileBase.cs" />
+    <Compile Include="Dependencies.cs" />
+    <Compile Include="SystemState.cs" />
+    <Compile Include="DependencyFile.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">
@@ -549,12 +553,6 @@
     <Compile Include="ComReferenceWrapperInfo.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="Dependencies.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="DependencyFile.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="FindInvalidProjectReferences.cs" />
     <Compile Include="FormatUrl.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -596,12 +594,8 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResGen.cs" />
-    <Compile Include="ResGenDependencies.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="ResolveComReference.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
+    <Compile Include="ResGenDependencies.cs" />
+    <Compile Include="ResolveComReference.cs" />
     <Compile Include="ResolveComReferenceCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -625,9 +619,6 @@
     <Compile Include="SignFile.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="StateFileBase.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="system.design\stronglytypedresourcebuilder.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -638,9 +629,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="System.Design.cs" />
-    <Compile Include="SystemState.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="TlbImp.cs" />
     <Compile Include="TlbReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2014,7 +2014,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         expensive to write the newly created cache file.
         -->
     <PropertyGroup>
-      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)ResolveAssemblyReference.cache</ResolveAssemblyReferencesStateFile>
+      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)AssemblyReference.cache</ResolveAssemblyReferencesStateFile>
     </PropertyGroup>
 
     <!-- Make an App.Config item that exists when AutoUnify is false. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2014,7 +2014,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         expensive to write the newly created cache file.
         -->
     <PropertyGroup>
-      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true'">$(IntermediateOutputPath)$(MSBuildProjectFile)ResolveAssemblyReference.cache</ResolveAssemblyReferencesStateFile>
+      <ResolveAssemblyReferencesStateFile Condition="'$(DisableRarCache)'!='true' and '$(ResolveAssemblyReferencesStateFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectFile)ResolveAssemblyReference.cache</ResolveAssemblyReferencesStateFile>
     </PropertyGroup>
 
     <!-- Make an App.Config item that exists when AutoUnify is false. -->

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Build.Tasks
         // Current version for serialization. This should be changed when breaking changes
         // are made to this class.
         // Note: Consider that changes can break VS2015 RTM which did not have a version check.
-        private const byte CurrentSerializationVersion = 3;
+        // Version 4 - VS2017.7:
+        //   Unify .NET Core + Full Framework. Custom serialization on some types that are no
+        //   longer [Serializable].
+        private const byte CurrentSerializationVersion = 4;
 
         // Version this instance is serialized with.
         private byte _serializedVersion = CurrentSerializationVersion;

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -154,12 +154,18 @@ namespace Microsoft.Build.Tasks
             {
                 ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-                lastModified = info.GetDateTime("lastModified");
-                assemblyName = (AssemblyNameExtension)info.GetValue("assemblyName", typeof(AssemblyNameExtension));
-                dependencies = (AssemblyNameExtension[])info.GetValue("dependencies", typeof(AssemblyNameExtension[]));
-                scatterFiles = (string[])info.GetValue("scatterFiles", typeof(string[]));
-                runtimeVersion = (string)info.GetValue("runtimeVersion", typeof(string));
-                frameworkName = (FrameworkName)info.GetValue("frameworkName", typeof(FrameworkName));
+                lastModified = new DateTime(info.GetInt64("mod"), (DateTimeKind)info.GetInt32("modk"));
+                assemblyName = (AssemblyNameExtension)info.GetValue("an", typeof(AssemblyNameExtension));
+                dependencies = (AssemblyNameExtension[])info.GetValue("deps", typeof(AssemblyNameExtension[]));
+                scatterFiles = (string[])info.GetValue("sfiles", typeof(string[]));
+                runtimeVersion = (string)info.GetValue("rtver", typeof(string));
+                if (info.GetBoolean("fn"))
+                {
+                    var frameworkNameVersion = (Version) info.GetValue("fnVer", typeof(Version));
+                    var frameworkIdentifier = info.GetString("fnId");
+                    var frameworkProfile = info.GetString("fmProf");
+                    frameworkName = new FrameworkName(frameworkIdentifier, frameworkNameVersion, frameworkProfile);
+                }
             }
 
             /// <summary>
@@ -170,12 +176,19 @@ namespace Microsoft.Build.Tasks
             {
                 ErrorUtilities.VerifyThrowArgumentNull(info, "info");
 
-                info.AddValue("lastModified", lastModified);
-                info.AddValue("assemblyName", assemblyName);
-                info.AddValue("dependencies", dependencies);
-                info.AddValue("scatterFiles", scatterFiles);
-                info.AddValue("runtimeVersion", runtimeVersion);
-                info.AddValue("frameworkName", frameworkName);
+                info.AddValue("mod", lastModified.Ticks);
+                info.AddValue("modk", (int)lastModified.Kind);
+                info.AddValue("an", assemblyName);
+                info.AddValue("deps", dependencies);
+                info.AddValue("sfiles", scatterFiles);
+                info.AddValue("rtver", runtimeVersion);
+                info.AddValue("fn", frameworkName != null);
+                if (frameworkName != null)
+                {
+                    info.AddValue("fnVer", frameworkName.Version);
+                    info.AddValue("fnId", frameworkName.Identifier);
+                    info.AddValue("fmProf", frameworkName.Profile);
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
Preliminary numbers on a basic netcoreapp2.0 -> netstandard2.0 library sln:

Tip of `exp/update-toolset` branch rebuild:
```
      439 ms  ResolveAssemblyReferences                  2 calls
      437 ms  ResolveAssemblyReference                   2 calls
```

This branch with RAR *.Core.cache file:
```
      238 ms  ResolveAssemblyReferences                  2 calls
      237 ms  ResolveAssemblyReference                   2 calls
```
This branch after deleting *.Core.cache:
```
      312 ms  ResolveAssemblyReferences                  2 calls
      311 ms  ResolveAssemblyReference                   2 calls
```

So even without the cache file it's still after with binary serialization turned on. Not sure why (there's a lot of code that differs). Also haven't done anything other than manual testing.