### PR TITLE
Allow XmlPeek into XML containing DTD

### DIFF
--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1217,8 +1217,8 @@ namespace Microsoft.Build.Tasks
     public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
     {
         public XmlPeek() { }
-        public bool DisallowDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Namespaces { get { throw null; } set { } }
+        public bool ProhibitDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Query { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Result { get { throw null; } }

--- a/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/net46/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -1217,6 +1217,7 @@ namespace Microsoft.Build.Tasks
     public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
     {
         public XmlPeek() { }
+        public bool DisallowDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Namespaces { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -671,8 +671,8 @@ namespace Microsoft.Build.Tasks
     public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
     {
         public XmlPeek() { }
-        public bool DisallowDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Namespaces { get { throw null; } set { } }
+        public bool ProhibitDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Query { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Result { get { throw null; } }

--- a/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Tasks.Core/Microsoft.Build.Tasks.Core.cs
@@ -671,6 +671,7 @@ namespace Microsoft.Build.Tasks
     public partial class XmlPeek : Microsoft.Build.Tasks.TaskExtension
     {
         public XmlPeek() { }
+        public bool DisallowDtd { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Namespaces { get { throw null; } set { } }
         public string Query { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]

--- a/src/Tasks.UnitTests/XmlPeek_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPeek_Tests.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Build.UnitTests
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
 
-            p.DisallowDtd = true;
+            p.ProhibitDtd = true;
             p.XmlInputPath = new TaskItem(xmlInputPath);
             p.Query = "//s:variable/@Name";
 

--- a/src/Tasks.UnitTests/XmlPeek_Tests.cs
+++ b/src/Tasks.UnitTests/XmlPeek_Tests.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Build.UnitTests
     sealed public class XmlPeek_Tests
     {
         private string _xmlFileWithNs = @"<?xml version='1.0' encoding='utf-8'?>
-        
+
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
 <class AccessModifier='public' Name='test' xmlns:s='http://nsurl'>
   <s:variable Type='String' Name='a'></s:variable>
   <s:variable Type='String' Name='b'></s:variable>
@@ -37,7 +38,8 @@ namespace Microsoft.Build.UnitTests
 ";
 
         private string _xmlFileWithNsWithText = @"<?xml version='1.0' encoding='utf-8'?>
-        
+
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
 <class AccessModifier='public' Name='test' xmlns:s='http://nsurl'>
   <s:variable Type='String' Name='a'>This</s:variable>
   <s:variable Type='String' Name='b'>is</s:variable>
@@ -46,7 +48,7 @@ namespace Microsoft.Build.UnitTests
 </class>
 ";
 
-        private string _xmlFileNoNs = @"<?xml version='1.0' encoding='utf-8'?>
+        private string _xmlFileNoNsNoDtd = @"<?xml version='1.0' encoding='utf-8'?>
         
 <class AccessModifier='public' Name='test'>
   <variable Type='String' Name='a'></variable>
@@ -142,7 +144,7 @@ namespace Microsoft.Build.UnitTests
         {
             MockEngine engine = new MockEngine(true);
             string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            Prepare(_xmlFileNoNsNoDtd, out xmlInputPath);
 
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
@@ -167,7 +169,7 @@ namespace Microsoft.Build.UnitTests
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
 
-            p.XmlContent = _xmlFileNoNs;
+            p.XmlContent = _xmlFileNoNsNoDtd;
             p.Query = "//variable/@Name";
 
             Assert.True(p.Execute()); // "Test should've passed"
@@ -185,15 +187,15 @@ namespace Microsoft.Build.UnitTests
             MockEngine engine = new MockEngine(true);
 
             string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            Prepare(_xmlFileNoNsNoDtd, out xmlInputPath);
 
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
 
             p.XmlInputPath = new TaskItem(xmlInputPath);
-            p.XmlContent = _xmlFileNoNs;
+            p.XmlContent = _xmlFileNoNsNoDtd;
             Assert.True(p.XmlInputPath.ItemSpec.Equals(xmlInputPath));
-            Assert.True(p.XmlContent.Equals(_xmlFileNoNs));
+            Assert.True(p.XmlContent.Equals(_xmlFileNoNsNoDtd));
 
             p.Query = "//variable/@Name";
             Assert.True(p.Query.Equals("//variable/@Name"));
@@ -208,7 +210,7 @@ namespace Microsoft.Build.UnitTests
             MockEngine engine = new MockEngine(true);
 
             string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            Prepare(_xmlFileNoNsNoDtd, out xmlInputPath);
 
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
@@ -224,7 +226,7 @@ namespace Microsoft.Build.UnitTests
         {
             MockEngine engine = new MockEngine(true);
             string xmlInputPath;
-            Prepare(_xmlFileNoNs, out xmlInputPath);
+            Prepare(_xmlFileNoNsNoDtd, out xmlInputPath);
 
             XmlPeek p = new XmlPeek();
             p.BuildEngine = engine;
@@ -234,6 +236,24 @@ namespace Microsoft.Build.UnitTests
 
             Assert.False(p.Execute()); // "Test should've failed"
             Assert.True(engine.Log.Contains("MSB3743")); // "Engine log should contain error code MSB3743"
+        }
+
+        [Fact]
+        public void PeekDtdWhenDtdProhibitedError()
+        {
+            MockEngine engine = new MockEngine(true);
+            string xmlInputPath;
+            Prepare(_xmlFileWithNs, out xmlInputPath);
+
+            XmlPeek p = new XmlPeek();
+            p.BuildEngine = engine;
+
+            p.DisallowDtd = true;
+            p.XmlInputPath = new TaskItem(xmlInputPath);
+            p.Query = "//s:variable/@Name";
+
+            Assert.False(p.Execute()); // "Test should've failed"
+            Assert.True(engine.Log.Contains("MSB3733")); // "Engine log should contain error code MSB3733"
         }
 
         [Fact]
@@ -305,7 +325,7 @@ namespace Microsoft.Build.UnitTests
             // The task won't complete properly, but ContinueOnError converts the errors to warnings, so the build should succeed
             MockLogger logger = ObjectModelHelpers.BuildProjectExpectSuccess(projectContents);
 
-            // Verify that the task was indeed found. 
+            // Verify that the task was indeed found.
             logger.AssertLogDoesntContain("MSB4036");
         }
 

--- a/src/Tasks/XmlPeek.cs
+++ b/src/Tasks/XmlPeek.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //-----------------------------------------------------------------------
 // </copyright>
@@ -127,6 +127,16 @@ namespace Microsoft.Build.Tasks
                 _namespaces = value;
             }
         }
+
+        /// <summary>
+        /// Set to true to disallow loading XML with embedded DTD.
+        /// Use if XML comes from an untrusted source.
+        /// </summary>
+        public bool DisallowDtd
+        {
+            get;
+            set;
+        }
         #endregion
 
         /// <summary>
@@ -157,7 +167,7 @@ namespace Microsoft.Build.Tasks
             try
             {
                 // Load the XPath Document
-                using (XmlReader xr = xmlinput.CreateReader())
+                using (XmlReader xr = xmlinput.CreateReader(DisallowDtd))
                 {
                     xpathdoc = new XPathDocument(xr);
                     xr.Dispose();
@@ -381,16 +391,18 @@ namespace Microsoft.Build.Tasks
             /// Creates correct reader based on the input type.
             /// </summary>
             /// <returns>The XmlReader object</returns>
-            public XmlReader CreateReader()
+            public XmlReader CreateReader(bool disallowDtd)
             {
+                var settings = new XmlReaderSettings() {
+                    DtdProcessing = disallowDtd ? DtdProcessing.Prohibit : DtdProcessing.Ignore };
                 if (_xmlMode == XmlModes.XmlFile)
                 {
                     _fs = new FileStream(_data, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    return XmlReader.Create(_fs);
+                    return XmlReader.Create(_fs, settings: settings);
                 }
-                else // xmlModes.Xml 
+                else // xmlModes.Xml
                 {
-                    return XmlReader.Create(new StringReader(_data));
+                    return XmlReader.Create(new StringReader(_data), settings: settings);
                 }
             }
 

--- a/src/Tasks/XmlPeek.cs
+++ b/src/Tasks/XmlPeek.cs
@@ -129,10 +129,10 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
-        /// Set to true to disallow loading XML with embedded DTD.
-        /// Use if XML comes from an untrusted source.
+        /// Set to true to prohibit loading XML with embedded DTD and produce error MSB3733
+        /// if DTD is present. This was a pre-v15 behavior. By default, a DTD clause if any is ignored.
         /// </summary>
-        public bool DisallowDtd
+        public bool ProhibitDtd
         {
             get;
             set;
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Tasks
             try
             {
                 // Load the XPath Document
-                using (XmlReader xr = xmlinput.CreateReader(DisallowDtd))
+                using (XmlReader xr = xmlinput.CreateReader(ProhibitDtd))
                 {
                     xpathdoc = new XPathDocument(xr);
                     xr.Dispose();
@@ -391,10 +391,11 @@ namespace Microsoft.Build.Tasks
             /// Creates correct reader based on the input type.
             /// </summary>
             /// <returns>The XmlReader object</returns>
-            public XmlReader CreateReader(bool disallowDtd)
+            public XmlReader CreateReader(bool prohibitDtd)
             {
                 var settings = new XmlReaderSettings() {
-                    DtdProcessing = disallowDtd ? DtdProcessing.Prohibit : DtdProcessing.Ignore };
+                    DtdProcessing = prohibitDtd ? DtdProcessing.Prohibit : DtdProcessing.Ignore
+                };
                 if (_xmlMode == XmlModes.XmlFile)
                 {
                     _fs = new FileStream(_data, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);


### PR DESCRIPTION
Added property DisallowDtd in case the user wants to prohibit loading XML
with a DTD clause for additional security reasons. DTD is ignored by
default, but does not prevent loading the XML.

Closes #2141