### PR TITLE
Add globbing information to the profiler

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -550,18 +550,19 @@ namespace Microsoft.Build.Framework.Profiler
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null;}
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null;}
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string elementOrCondition, bool isElement) { throw null;}
+        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string description, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string ElementOrCondition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string EvaluationDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool IsCondition { get { throw null; } }
-        public bool IsElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -569,17 +570,25 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFile(string file) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
+    }
+    public enum EvaluationLocationKind : byte
+    {
+        Condition = (byte)1,
+        Glob = (byte)2,
+        Item = (byte)0,
     }
     public enum EvaluationPass : byte
     {
-        InitialProperties = (byte)1,
-        ItemDefinitionGroups = (byte)3,
-        Items = (byte)4,
-        LazyItems = (byte)5,
-        Properties = (byte)2,
-        Targets = (byte)7,
+        InitialProperties = (byte)2,
+        ItemDefinitionGroups = (byte)4,
+        Items = (byte)5,
+        LazyItems = (byte)6,
+        Properties = (byte)3,
+        Targets = (byte)8,
         TotalEvaluation = (byte)0,
-        UsingTasks = (byte)6,
+        TotalGlobbing = (byte)1,
+        UsingTasks = (byte)7,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProfiledLocation

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -547,18 +547,19 @@ namespace Microsoft.Build.Framework.Profiler
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null;}
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null;}
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string elementOrCondition, bool isElement) { throw null;}
+        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string description, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string ElementOrCondition { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string EvaluationDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public bool IsCondition { get { throw null; } }
-        public bool IsElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -566,17 +567,25 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFile(string file) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
+    }
+    public enum EvaluationLocationKind : byte
+    {
+        Condition = (byte)1,
+        Glob = (byte)2,
+        Item = (byte)0,
     }
     public enum EvaluationPass : byte
     {
-        InitialProperties = (byte)1,
-        ItemDefinitionGroups = (byte)3,
-        Items = (byte)4,
-        LazyItems = (byte)5,
-        Properties = (byte)2,
-        Targets = (byte)7,
+        InitialProperties = (byte)2,
+        ItemDefinitionGroups = (byte)4,
+        Items = (byte)5,
+        LazyItems = (byte)6,
+        Properties = (byte)3,
+        Targets = (byte)8,
         TotalEvaluation = (byte)0,
-        UsingTasks = (byte)6,
+        TotalGlobbing = (byte)1,
+        UsingTasks = (byte)7,
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProfiledLocation

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -347,14 +347,17 @@ namespace Microsoft.Build.UnitTests
                 ProfilerResult = new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
                 {
                     {
-                        new EvaluationLocation(EvaluationPass.InitialProperties, "desc1", "file1", 7, "element1", "elementorcondition1", true),
+                        new EvaluationLocation(EvaluationPass.InitialProperties, "desc1", "file1", 7, "element1", "description", EvaluationLocationKind.Condition),
                         new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 1)
                     },
                     {
-                        new EvaluationLocation(EvaluationPass.LazyItems, "desc2", "file1", null, "element2", "elementorcondition2", false),
+                        new EvaluationLocation(EvaluationPass.LazyItems, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Glob),
+                        new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 2)
+                    },
+                    {
+                        new EvaluationLocation(EvaluationPass.Properties, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Item),
                         new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 2)
                     }
-
                 })
             };
 

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -96,12 +96,17 @@ namespace Microsoft.Build.Evaluation
                             excludePatternsForGlobs = BuildExcludePatternsForGlobs(globsToIgnore, excludePatterns);
                         }
 
-                        string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
-                            _rootDirectory,
-                            glob,
-                            excludePatternsForGlobs,
-                            entriesCache: EntriesCache
+                        string[] includeSplitFilesEscaped;
+                        using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob,
+                            excludePatternsForGlobs))
+                        {
+                            includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
+                                _rootDirectory,
+                                glob,
+                                excludePatternsForGlobs,
+                                entriesCache: EntriesCache
                             );
+                        }
 
                         foreach (string includeSplitFileEscaped in includeSplitFilesEscaped)
                         {

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Build.Evaluation
         {
             private readonly string _itemType;
             private readonly ImmutableDictionary<string, LazyItemList> _referencedItemLists;
-            private readonly LazyItemEvaluator<P, I, M, D> _lazyEvaluator;
 
+            protected readonly LazyItemEvaluator<P, I, M, D> _lazyEvaluator;
             protected readonly ProjectItemElement _itemElement;
             protected readonly ItemSpec<P, I> _itemSpec;
             protected readonly EvaluatorData _evaluatorData;

--- a/src/Build/Evaluation/Profiler/EvaluationProfiler.cs
+++ b/src/Build/Evaluation/Profiler/EvaluationProfiler.cs
@@ -58,6 +58,17 @@ namespace Microsoft.Build.Evaluation
 
         /// <nodoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IDisposable TrackGlob(string rootDirectory, string glob, ISet<string> excludePatterns)
+        {
+            return _shouldTrackElements
+                ? new EvaluationFrame(this,
+                    CurrentLocation.WithGlob(
+                        $"root: '${rootDirectory}', pattern: '${glob}', excludes: '${string.Join(";", excludePatterns)}'"))
+                : null;
+        }
+
+        /// <nodoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IDisposable TrackElement(ProjectElement element)
         {
             return _shouldTrackElements ? new EvaluationFrame(this, CurrentLocation.WithFileLineAndElement(element.Location.File, element.Location.Line, element)) : null;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -842,17 +842,17 @@ namespace Microsoft.Build.Logging
         private EvaluationLocation ReadEvaluationLocation()
         {
             var elementName = ReadOptionalString();
-            var elementOrCondition = ReadOptionalString();
+            var description = ReadOptionalString();
             var evaluationDescription = ReadOptionalString();
             var file = ReadOptionalString();
-            var isElement = ReadBoolean();
+            var kind = (EvaluationLocationKind)ReadInt32();
             var evaluationPass = (EvaluationPass)ReadInt32();
 
             int? line = null;
             var hasLine = ReadBoolean();
             if (hasLine) line = ReadInt32();
 
-            return new EvaluationLocation(evaluationPass, evaluationDescription, file, line, elementName, elementOrCondition, isElement);
+            return new EvaluationLocation(evaluationPass, evaluationDescription, file, line, elementName, description, kind);
         }
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -668,10 +668,10 @@ namespace Microsoft.Build.Logging
         private void Write(EvaluationLocation item)
         {
             WriteOptionalString(item.ElementName);
-            WriteOptionalString(item.ElementOrCondition);
+            WriteOptionalString(item.Description);
             WriteOptionalString(item.EvaluationDescription);
             WriteOptionalString(item.File);
-            Write(item.IsElement);
+            Write((int)item.Kind);
             Write((int)item.EvaluationPass);
 
             Write(item.Line.HasValue);

--- a/src/Framework.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Build.Framework.UnitTests
 
             yield return new object[] { new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
             {
-                {new EvaluationLocation(EvaluationPass.TotalEvaluation, "1", "myFile", 42, "elementName", "elementOrCondition", true), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {new EvaluationLocation(EvaluationPass.Targets, "1", null, null, null, null, false), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {new EvaluationLocation(EvaluationPass.LazyItems, "2", null, null, null, null, false), new ProfiledLocation(TimeSpan.Zero, TimeSpan.Zero, 0)}
+                {new EvaluationLocation(EvaluationPass.TotalEvaluation, "1", "myFile", 42, "elementName", "description", EvaluationLocationKind.Condition), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {new EvaluationLocation(EvaluationPass.Targets, "1", null, null, null, null, EvaluationLocationKind.Glob), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {new EvaluationLocation(EvaluationPass.LazyItems, "2", null, null, null, null, EvaluationLocationKind.Item), new ProfiledLocation(TimeSpan.Zero, TimeSpan.Zero, 0)}
             }) };
 
             var element = new ProjectRootElement(
@@ -66,9 +66,11 @@ namespace Microsoft.Build.Framework.UnitTests
 
             yield return new object[] { new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
             {
-                {new EvaluationLocation(EvaluationPass.UsingTasks, "1", "myFile", 42, "conditionCase"), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {new EvaluationLocation(EvaluationPass.InitialProperties, "1", "myFile", 42, element),
-                    new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)}
+                {EvaluationLocation.CreateLocationForCondition(EvaluationPass.UsingTasks, "1", "myFile", 42, "conditionCase"), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {EvaluationLocation.CreateLocationForProject(EvaluationPass.InitialProperties, "1", "myFile", 42, element),
+                    new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {EvaluationLocation.CreateLocationForGlob(EvaluationPass.InitialProperties, "1", "myFile", 42, "glob description"),
+                new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)}
             }) };
 
         }

--- a/src/Framework/Profiler/EvaluationLocation.cs
+++ b/src/Framework/Profiler/EvaluationLocation.cs
@@ -195,9 +195,7 @@ namespace Microsoft.Build.Framework.Profiler
                     string.Equals(File, other.File, StringComparison.OrdinalIgnoreCase) &&
                     Line == other.Line &&
                     ElementName == other.ElementName &&
-                    ElementOrCondition == other.ElementOrCondition &&
-                    IsElement == other.IsElement;
-					Description == other.Description &&
+                    Description == other.Description &&
 					Kind == other.Kind;
             }
             return false;
@@ -206,13 +204,13 @@ namespace Microsoft.Build.Framework.Profiler
         /// <nodoc/>
         public override string ToString()
         {
-            return $"{EvaluationDescription ?? string.Empty}\t{File ?? string.Empty}\t{Line?.ToString() ?? string.Empty}\t{ElementName ?? string.Empty}\tIsElement?{IsElement}\tElementOrCondition:{ElementOrCondition}\t{this.EvaluationDescription}";
+            return $"{EvaluationDescription ?? string.Empty}\t{File ?? string.Empty}\t{Line?.ToString() ?? string.Empty}\t{ElementName ?? string.Empty}\tDescription:{Description}\t{this.EvaluationDescription}";
         }
 
         /// <nodoc/>
         public override int GetHashCode()
         {
-            var hashCode = -433772733;
+            var hashCode = 1198539463;
             hashCode = hashCode * -1521134295 + base.GetHashCode();
             hashCode = hashCode * -1521134295 + EvaluationPass.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EvaluationDescription);
@@ -220,9 +218,7 @@ namespace Microsoft.Build.Framework.Profiler
             hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(Line);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ElementName);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Description);
-            hashCode = hashCode * -1521134295 + EqualityComparer<EvaluationLocationKind>.Default.GetHashCode(Kind);
-            hashCode = hashCode * -1521134295 + IsElement.GetHashCode();
-            hashCode = hashCode * -1521134295 + IsCondition.GetHashCode();
+            hashCode = hashCode * -1521134295 + Kind.GetHashCode();
             return hashCode;
         }
     }

--- a/src/Framework/Profiler/EvaluationLocation.cs
+++ b/src/Framework/Profiler/EvaluationLocation.cs
@@ -20,23 +20,23 @@ namespace Microsoft.Build.Framework.Profiler
     public enum EvaluationPass : byte
     {
         /// <nodoc/>
-        TotalEvaluation,
+        TotalEvaluation = 0,
         /// <nodoc/>
-        TotalGlobbing,
+        TotalGlobbing = 1,
         /// <nodoc/>
-        InitialProperties,
+        InitialProperties = 2,
         /// <nodoc/>
-        Properties,
+        Properties = 3,
         /// <nodoc/>
-        ItemDefinitionGroups,
+        ItemDefinitionGroups = 4,
         /// <nodoc/>
-        Items,
+        Items = 5,
         /// <nodoc/>
-        LazyItems,
+        LazyItems = 6,
         /// <nodoc/>
-        UsingTasks,
+        UsingTasks = 7,
         /// <nodoc/>
-        Targets
+        Targets = 8
     }
 
     /// <summary>
@@ -45,11 +45,11 @@ namespace Microsoft.Build.Framework.Profiler
     public enum EvaluationLocationKind : byte
     {
         /// <nodoc/>
-        Item,
+        Item = 0,
         /// <nodoc/>
-        Condition,
+        Condition = 1,
         /// <nodoc/>
-        Glob
+        Glob = 2
     }
 
     /// <summary>

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -1512,8 +1512,8 @@ namespace Microsoft.Build.BackEnd
                 string file = null;
                 int? line = null;
                 string elementName = null;
-                string elementOrCondition = null;
-                bool isElement = false;
+                string description = null;
+                EvaluationLocationKind kind = default(EvaluationLocationKind);
 
                 if (translator.Mode == TranslationDirection.WriteToStream)
                 {
@@ -1522,8 +1522,8 @@ namespace Microsoft.Build.BackEnd
                     file = evaluationLocation.File;
                     line = evaluationLocation.Line;
                     elementName = evaluationLocation.ElementName;
-                    elementOrCondition = evaluationLocation.ElementOrCondition;
-                    isElement = evaluationLocation.IsElement;
+                    description = evaluationLocation.Description;
+                    kind = evaluationLocation.Kind;
                 }
 
                 translator.TranslateEnum(ref evaluationPass, (int)evaluationPass);
@@ -1545,12 +1545,12 @@ namespace Microsoft.Build.BackEnd
                 }
 
                 translator.Translate(ref elementName);
-                translator.Translate(ref elementOrCondition);
-                translator.Translate(ref isElement);
+                translator.Translate(ref description);
+                translator.TranslateEnum(ref kind, (byte)kind);
 
                 if (translator.Mode == TranslationDirection.ReadFromStream)
                 {
-                    evaluationLocation = new EvaluationLocation(evaluationPass, evaluationPassDescription, file, line, elementName, elementOrCondition, isElement);
+                    evaluationLocation = new EvaluationLocation(evaluationPass, evaluationPassDescription, file, line, elementName, description, kind);
                 }
             }
 


### PR DESCRIPTION
Adds glob-specific profiling under /prof. Every top-level glob call will have an entry in the profiler report, plus a single entry with an aggregated item representing the overall evaluation time spent in glob calls.