### PR TITLE
Feature/add tree information to profiler

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -17,12 +17,13 @@
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -20,7 +20,6 @@
         <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
-        <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
@@ -28,6 +27,7 @@
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />		
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -17,13 +17,13 @@
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -17,13 +17,13 @@
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
+		<dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -23,7 +23,7 @@
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
-		<dependency id="System.Resources.ResourceManager" version="4.0.1" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -17,17 +17,17 @@
       <group targetFramework=".NETStandard1.3">
         <dependency id="System.Threading.Tasks.Parallel" version="4.0.1" />
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Runtime" version="4.1.0" />
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
-        <dependency id="System.Diagnostics.Process" version="4.1.0" />		
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -19,7 +19,6 @@
         <dependency id="System.Runtime.Extensions" version="4.1.0" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
-        <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
@@ -28,6 +27,7 @@
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />		
       </group>
     </dependencies>
   </metadata>

--- a/build/NuGetPackages/Microsoft.Build.Framework.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Framework.nuspec
@@ -20,6 +20,7 @@
         <dependency id="System.Resources.ResourceManager" version="4.0.1" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Globalization" version="4.0.11" />
         <dependency id="System.Linq" version="4.1.0" />
         <dependency id="System.ObjectModel" version="4.0.12" />
@@ -27,7 +28,6 @@
         <dependency id="System.Runtime.InteropServices" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
-        <dependency id="System.Diagnostics.Process" version="4.1.0" />		
       </group>
     </dependencies>
   </metadata>

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -547,10 +547,6 @@ namespace Microsoft.Build.Framework
 }
 namespace Microsoft.Build.Framework.Profiler
 {
-    public static partial class EvaluationIdProvider
-    {
-        public static long GetNextId() { throw null; }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
@@ -581,13 +577,6 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<long> parentId) { throw null; }
-    }
-    public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
-    {
-        internal EvaluationLocationIdAgnosticComparer() { }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocationIdAgnosticComparer Singleton;
-        public bool Equals(Microsoft.Build.Framework.Profiler.EvaluationLocation x, Microsoft.Build.Framework.Profiler.EvaluationLocation y) { throw null; }
-        public int GetHashCode(Microsoft.Build.Framework.Profiler.EvaluationLocation obj) { throw null; }
     }
     public enum EvaluationLocationKind : byte
     {

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -549,29 +549,29 @@ namespace Microsoft.Build.Framework.Profiler
 {
     public static partial class EvaluationIdProvider
     {
-        public static int GetNextId() { throw null; }
+        public static long GetNextId() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
         public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public EvaluationLocation(int id, System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public EvaluationLocation(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(long id, System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
         public string ElementDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string EvaluationPassDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public long Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public bool IsEvaluationPass { get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Nullable<int> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Nullable<long> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -580,7 +580,7 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
-        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<int> parentId) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<long> parentId) { throw null; }
     }
     public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
     {

--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -547,22 +547,31 @@ namespace Microsoft.Build.Framework
 }
 namespace Microsoft.Build.Framework.Profiler
 {
+    public static partial class EvaluationIdProvider
+    {
+        public static int GetNextId() { throw null; }
+    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string description, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(int id, System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public string ElementDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string EvaluationDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string EvaluationPassDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public int Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsEvaluationPass { get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Nullable<int> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -571,12 +580,20 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<int> parentId) { throw null; }
+    }
+    public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
+    {
+        internal EvaluationLocationIdAgnosticComparer() { }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocationIdAgnosticComparer Singleton;
+        public bool Equals(Microsoft.Build.Framework.Profiler.EvaluationLocation x, Microsoft.Build.Framework.Profiler.EvaluationLocation y) { throw null; }
+        public int GetHashCode(Microsoft.Build.Framework.Profiler.EvaluationLocation obj) { throw null; }
     }
     public enum EvaluationLocationKind : byte
     {
         Condition = (byte)1,
+        Element = (byte)0,
         Glob = (byte)2,
-        Item = (byte)0,
     }
     public enum EvaluationPass : byte
     {

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -544,22 +544,31 @@ namespace Microsoft.Build.Framework
 }
 namespace Microsoft.Build.Framework.Profiler
 {
+    public static partial class EvaluationIdProvider
+    {
+        public static int GetNextId() { throw null; }
+    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
-        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string elementName, string description, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public string Description { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(int id, System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public string ElementDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public string EvaluationDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public string EvaluationPassDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public int Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsEvaluationPass { get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Nullable<int> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -568,12 +577,20 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<int> parentId) { throw null; }
+    }
+    public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
+    {
+        internal EvaluationLocationIdAgnosticComparer() { }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocationIdAgnosticComparer Singleton;
+        public bool Equals(Microsoft.Build.Framework.Profiler.EvaluationLocation x, Microsoft.Build.Framework.Profiler.EvaluationLocation y) { throw null; }
+        public int GetHashCode(Microsoft.Build.Framework.Profiler.EvaluationLocation obj) { throw null; }
     }
     public enum EvaluationLocationKind : byte
     {
         Condition = (byte)1,
+        Element = (byte)0,
         Glob = (byte)2,
-        Item = (byte)0,
     }
     public enum EvaluationPass : byte
     {

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -546,29 +546,29 @@ namespace Microsoft.Build.Framework.Profiler
 {
     public static partial class EvaluationIdProvider
     {
-        public static int GetNextId() { throw null; }
+        public static long GetNextId() { throw null; }
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
         public EvaluationLocation(Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public EvaluationLocation(int id, System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
-        public EvaluationLocation(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(long id, System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
+        public EvaluationLocation(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationPassDescription, string file, System.Nullable<int> line, string elementName, string elementDescription, Microsoft.Build.Framework.Profiler.EvaluationLocationKind kind) { throw null;}
         public string ElementDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string ElementName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation EmptyLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationPass EvaluationPass { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string EvaluationPassDescription { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public int Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public long Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public bool IsEvaluationPass { get { throw null; } }
         public Microsoft.Build.Framework.Profiler.EvaluationLocationKind Kind { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public System.Nullable<int> Line { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        public System.Nullable<int> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public System.Nullable<long> ParentId { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForAggregatedGlob() { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<int> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForCondition(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string condition) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForGlob(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, string globDescription) { throw null; }
+        public static Microsoft.Build.Framework.Profiler.EvaluationLocation CreateLocationForProject(System.Nullable<long> parentId, Microsoft.Build.Framework.Profiler.EvaluationPass evaluationPass, string evaluationDescription, string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public override bool Equals(object obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public override string ToString() { throw null; }
@@ -577,7 +577,7 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndCondition(string file, System.Nullable<int> line, string condition) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
-        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<int> parentId) { throw null; }
+        public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<long> parentId) { throw null; }
     }
     public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
     {

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -544,10 +544,6 @@ namespace Microsoft.Build.Framework
 }
 namespace Microsoft.Build.Framework.Profiler
 {
-    public static partial class EvaluationIdProvider
-    {
-        public static long GetNextId() { throw null; }
-    }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct EvaluationLocation
     {
@@ -578,13 +574,6 @@ namespace Microsoft.Build.Framework.Profiler
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithFileLineAndElement(string file, System.Nullable<int> line, Microsoft.Build.Framework.IProjectElement element) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithGlob(string globDescription) { throw null; }
         public Microsoft.Build.Framework.Profiler.EvaluationLocation WithParentId(System.Nullable<long> parentId) { throw null; }
-    }
-    public partial class EvaluationLocationIdAgnosticComparer : System.Collections.Generic.IEqualityComparer<Microsoft.Build.Framework.Profiler.EvaluationLocation>
-    {
-        internal EvaluationLocationIdAgnosticComparer() { }
-        public static Microsoft.Build.Framework.Profiler.EvaluationLocationIdAgnosticComparer Singleton;
-        public bool Equals(Microsoft.Build.Framework.Profiler.EvaluationLocation x, Microsoft.Build.Framework.Profiler.EvaluationLocation y) { throw null; }
-        public int GetHashCode(Microsoft.Build.Framework.Profiler.EvaluationLocation obj) { throw null; }
     }
     public enum EvaluationLocationKind : byte
     {

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -347,15 +347,15 @@ namespace Microsoft.Build.UnitTests
                 ProfilerResult = new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
                 {
                     {
-                        new EvaluationLocation(EvaluationPass.InitialProperties, "desc1", "file1", 7, "element1", "description", EvaluationLocationKind.Condition),
+                        new EvaluationLocation(1, 0, EvaluationPass.InitialProperties, "desc1", "file1", 7, "element1", "description", EvaluationLocationKind.Condition),
                         new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 1)
                     },
                     {
-                        new EvaluationLocation(EvaluationPass.LazyItems, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Glob),
+                        new EvaluationLocation(0, null, EvaluationPass.LazyItems, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Glob),
                         new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 2)
                     },
                     {
-                        new EvaluationLocation(EvaluationPass.Properties, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Item),
+                        new EvaluationLocation(2, 0, EvaluationPass.Properties, "desc2", "file1", null, "element2", "description2", EvaluationLocationKind.Element),
                         new ProfiledLocation(TimeSpan.FromSeconds(1), TimeSpan.FromHours(2), 2)
                     }
                 })

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Build.Logging
         //   - new TargetStartedEventArgs.BuildReason
         // version 5:
         //   - new EvaluationFinished.ProfilerResult
-        internal const int FileFormatVersion = 5;
+        // version 6:
+        //   -  Ids and parent ids for the evaluation locations
+        internal const int FileFormatVersion = 6;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -841,6 +841,10 @@ namespace Microsoft.Build.Logging
 
         private EvaluationLocation ReadEvaluationLocation()
         {
+            var id = ReadInt32();
+            int? parentId = null;
+            var hasParent = ReadBoolean();
+            if (hasParent) parentId = ReadInt32();
             var elementName = ReadOptionalString();
             var description = ReadOptionalString();
             var evaluationDescription = ReadOptionalString();
@@ -852,7 +856,7 @@ namespace Microsoft.Build.Logging
             var hasLine = ReadBoolean();
             if (hasLine) line = ReadInt32();
 
-            return new EvaluationLocation(evaluationPass, evaluationDescription, file, line, elementName, description, kind);
+            return new EvaluationLocation(id, parentId, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
         }
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -791,6 +791,11 @@ namespace Microsoft.Build.Logging
             return Read7BitEncodedInt(binaryReader);
         }
 
+        private long ReadInt64()
+        {
+            return binaryReader.ReadInt64();
+        }
+
         private bool ReadBoolean()
         {
             return binaryReader.ReadBoolean();
@@ -841,10 +846,10 @@ namespace Microsoft.Build.Logging
 
         private EvaluationLocation ReadEvaluationLocation()
         {
-            var id = ReadInt32();
-            int? parentId = null;
+            var id = ReadInt64();
+            long? parentId = null;
             var hasParent = ReadBoolean();
-            if (hasParent) parentId = ReadInt32();
+            if (hasParent) parentId = ReadInt64();
             var elementName = ReadOptionalString();
             var description = ReadOptionalString();
             var evaluationDescription = ReadOptionalString();

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -846,10 +846,6 @@ namespace Microsoft.Build.Logging
 
         private EvaluationLocation ReadEvaluationLocation()
         {
-            var id = ReadInt64();
-            long? parentId = null;
-            var hasParent = ReadBoolean();
-            if (hasParent) parentId = ReadInt64();
             var elementName = ReadOptionalString();
             var description = ReadOptionalString();
             var evaluationDescription = ReadOptionalString();
@@ -859,9 +855,26 @@ namespace Microsoft.Build.Logging
 
             int? line = null;
             var hasLine = ReadBoolean();
-            if (hasLine) line = ReadInt32();
+            if (hasLine)
+            {
+                line = ReadInt32(); 
+            }
 
-            return new EvaluationLocation(id, parentId, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
+            // Id and parent Id were introduced in version 6
+            if (fileFormatVersion > 5)
+            {
+                var id = ReadInt64();
+                long? parentId = null;
+                var hasParent = ReadBoolean();
+                if (hasParent)
+                {
+                    parentId = ReadInt64();
+
+                }
+                return new EvaluationLocation(id, parentId, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
+            }
+
+            return new EvaluationLocation(0, null, evaluationPass, evaluationDescription, file, line, elementName, description, kind);
         }
     }
 }

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -667,9 +667,17 @@ namespace Microsoft.Build.Logging
 
         private void Write(EvaluationLocation item)
         {
+            Write(item.Id);
+
+            Write(item.ParentId.HasValue);
+            if (item.ParentId.HasValue)
+            {
+                Write(item.ParentId.Value);
+            }
+
             WriteOptionalString(item.ElementName);
-            WriteOptionalString(item.Description);
-            WriteOptionalString(item.EvaluationDescription);
+            WriteOptionalString(item.ElementDescription);
+            WriteOptionalString(item.EvaluationPassDescription);
             WriteOptionalString(item.File);
             Write((int)item.Kind);
             Write((int)item.EvaluationPass);

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -672,14 +672,6 @@ namespace Microsoft.Build.Logging
 
         private void Write(EvaluationLocation item)
         {
-            Write(item.Id);
-
-            Write(item.ParentId.HasValue);
-            if (item.ParentId.HasValue)
-            {
-                Write(item.ParentId.Value);
-            }
-
             WriteOptionalString(item.ElementName);
             WriteOptionalString(item.ElementDescription);
             WriteOptionalString(item.EvaluationPassDescription);
@@ -691,6 +683,13 @@ namespace Microsoft.Build.Logging
             if (item.Line.HasValue)
             {
                 Write(item.Line.Value);
+            }
+
+            Write(item.Id);
+            Write(item.ParentId.HasValue);
+            if (item.ParentId.HasValue)
+            {
+                Write(item.ParentId.Value);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -606,6 +606,11 @@ namespace Microsoft.Build.Logging
             Write7BitEncodedInt(binaryWriter, value);
         }
 
+        private void Write(long value)
+        {
+            binaryWriter.Write(value);
+        }
+
         private void Write7BitEncodedInt(BinaryWriter writer, int value)
         {
             // Write out an int 7 bits at a time.  The high bit of the byte,

--- a/src/Build/Logging/EvaluationLocationIdAgnosticComparer.cs
+++ b/src/Build/Logging/EvaluationLocationIdAgnosticComparer.cs
@@ -6,14 +6,15 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Build.Framework.Profiler;
 
-namespace Microsoft.Build.Framework.Profiler
+namespace Microsoft.Build.Logging
 {
     /// <summary>
     /// Comparer for <see cref="EvaluationLocation"/> that ignores 
     /// both <see cref="EvaluationLocation.Id"/> and <see cref="EvaluationLocation.ParentId"/>
     /// </summary>
-    public class EvaluationLocationIdAgnosticComparer : IEqualityComparer<EvaluationLocation>
+    internal class EvaluationLocationIdAgnosticComparer : IEqualityComparer<EvaluationLocation>
     {
         /// <nodoc/>
         public static EvaluationLocationIdAgnosticComparer Singleton = new EvaluationLocationIdAgnosticComparer();

--- a/src/Build/Logging/ProfilerLogger.cs
+++ b/src/Build/Logging/ProfilerLogger.cs
@@ -96,59 +96,165 @@ namespace Microsoft.Build.Logging
 
             // The aggregation is delayed until the whole aggregated result is needed for generating the final content
             // There is a memory/speed trade off here, but we are prioritizing not interfeering with regular evaluation times
-            Debug.Assert(_aggregatedLocations == null, "GetAggregatedResult was called, but a new ProjectEvaluationFinishedEventArgs arrived after that.");
+            Debug.Assert(_aggregatedLocations == null,
+                "GetAggregatedResult was called, but a new ProjectEvaluationFinishedEventArgs arrived after that.");
             _profiledResults.Enqueue(projectFinishedEvent.ProfilerResult.Value);
         }
 
         /// <summary>
         /// Returns the result of aggregating all profiled projects across a build
         /// </summary>
+        /// <param name="pruneSmallItems">Whether small items should be pruned. This is called with false on some tests since the result may vary depending on the evaluator speed</param>
         /// <remarks>
         /// Not thread safe. After this method is called, the assumption is that no new ProjectEvaluationFinishedEventArgs will arrive.
         /// In the regular code path, this method is called only once per build. But some test cases may call it multiple times to validate 
         /// the aggregated data
         /// </remarks>
-        internal ProfilerResult GetAggregatedResult()
+        internal ProfilerResult GetAggregatedResult(bool pruneSmallItems = true)
         {
             if (_aggregatedLocations != null)
             {
                 return new ProfilerResult(_aggregatedLocations);
             }
 
-            _aggregatedLocations = new Dictionary<EvaluationLocation, ProfiledLocation>();
+            // We want to ignore ids so we can appropriately merge entries for the same item
+            _aggregatedLocations =
+                new Dictionary<EvaluationLocation, ProfiledLocation>(EvaluationLocationIdAgnosticComparer.Singleton);
+
+            // Map from evaluation locations that got merged into the evaluation locations they got merged into
+            // This is used to remap the parent id of an incoming item if that parent got merged
+            var mergeMap = new Dictionary<int, int>();
+            // Unfortunately there is no way to retrieve the original key of a dictionary given a key that is considered Equals
+            // So keeping that map here
+            var originalLocations = new Dictionary<EvaluationLocation, EvaluationLocation>(EvaluationLocationIdAgnosticComparer.Singleton);
 
             while (!_profiledResults.IsEmpty)
             {
                 ProfilerResult profiledResult;
                 var result = _profiledResults.TryDequeue(out profiledResult);
-                Debug.Assert(result, "Expected a non empty queue, this method is not supposed to be called in a multithreaded way");
+                Debug.Assert(result,
+                    "Expected a non empty queue, this method is not supposed to be called in a multithreaded way");
 
+                // Appropriately merge all items
                 foreach (var pair in profiledResult.ProfiledLocations)
                 {
-                    //  Add elapsed times to evaluation counter dictionaries
-                    ProfiledLocation previousTimeSpent;
-                    if (!_aggregatedLocations.TryGetValue(pair.Key, out previousTimeSpent))
-                    {
-                        previousTimeSpent = new ProfiledLocation(TimeSpan.Zero, TimeSpan.Zero, 0);
-                    }
-
-                    var updatedTimeSpent = AggregateProfiledLocation(previousTimeSpent, pair.Value);
-
-                    _aggregatedLocations[pair.Key] = updatedTimeSpent;
+                    MergeItem(originalLocations, mergeMap, _aggregatedLocations, pair);
                 }
             }
 
-            // Add one single item representing the total aggregated evaluation time for globs
+            if (pruneSmallItems)
+            {
+                // After aggregating all items, prune the ones that are too small to report
+                _aggregatedLocations = PruneSmallItems(_aggregatedLocations);
+            }
+
+            // Add one single top-level item representing the total aggregated evaluation time for globs.
             var aggregatedGlobs = _aggregatedLocations.Keys
                 .Where(key => key.Kind == EvaluationLocationKind.Glob)
-                .Aggregate(new ProfiledLocation(), (profiledLocation, evaluationLocation) => AggregateProfiledLocation(profiledLocation, _aggregatedLocations[evaluationLocation]));
+                .Aggregate(new ProfiledLocation(),
+                    (profiledLocation, evaluationLocation) =>
+                        AggregateProfiledLocation(profiledLocation, _aggregatedLocations[evaluationLocation]));
 
-            _aggregatedLocations[EvaluationLocation.CreateLocationForAggregatedGlob()] = aggregatedGlobs;
+            _aggregatedLocations[EvaluationLocation.CreateLocationForAggregatedGlob()] =
+                aggregatedGlobs;
 
             return new ProfilerResult(_aggregatedLocations);
         }
 
-        private static ProfiledLocation AggregateProfiledLocation(ProfiledLocation location, ProfiledLocation otherLocation)
+        private static void MergeItem(
+            IDictionary<EvaluationLocation, EvaluationLocation> originalLocations,
+            IDictionary<int, int> mergeMap,
+            IDictionary<EvaluationLocation, ProfiledLocation> aggregatedLocations,
+            KeyValuePair<EvaluationLocation, ProfiledLocation> pairToMerge)
+        {
+            ProfiledLocation existingProfiledLocation;
+            if (aggregatedLocations.TryGetValue(pairToMerge.Key, out existingProfiledLocation))
+            {
+                // A previous item, structurally equivalent, is already there
+                // So we aggregate the profiled location times
+                var profiledLocation = AggregateProfiledLocation(existingProfiledLocation, pairToMerge.Value);
+                // We update the *original* key with the aggregated times, so the location table is kept in a sound state regarding parents
+                var originalKey = originalLocations[pairToMerge.Key];
+                aggregatedLocations[originalKey] = profiledLocation;
+                // And we update the merge map to flag that the merge happened
+                mergeMap[pairToMerge.Key.Id] = originalKey.Id;
+            }
+            else
+            {
+                // The item is new, so the profiled times are legit, nothing to aggregate
+                // But we have to check if this item points to a parent that got merged
+                int mergedParent;
+                if (mergeMap.TryGetValue(pairToMerge.Key.Id, out mergedParent))
+                {
+                    // The parent Id got merged, so update it to the merged parent before storing
+                    aggregatedLocations[pairToMerge.Key.WithParentId(mergedParent)] = pairToMerge.Value;
+                }
+                else
+                {
+                    // Otherwise, it is safe to add directly
+                    aggregatedLocations[pairToMerge.Key] = pairToMerge.Value;
+                }
+                // Update the original location with the new key, so next time
+                // a structurally equivalent key arrives, we can retrieve the original one
+                originalLocations[pairToMerge.Key] = pairToMerge.Key;
+            }
+        }
+
+        private static Dictionary<EvaluationLocation, ProfiledLocation> PruneSmallItems(
+            IDictionary<EvaluationLocation, ProfiledLocation> aggregatedLocations)
+        {
+            var result = new Dictionary<EvaluationLocation, ProfiledLocation>();
+
+            // Let's build an index of profiled locations by id, to speed up subsequent queries
+            var idTable = aggregatedLocations.ToDictionary(pair => pair.Key.Id,
+                pair => new Pair<EvaluationLocation, ProfiledLocation>(pair.Key, pair.Value));
+
+            // We want to keep all evaluation pass entries plus the big enough regular entries
+            foreach (var prunedPair in aggregatedLocations.Where(pair =>
+                pair.Key.IsEvaluationPass || !IsTooSmall(pair.Value)))
+            {
+                var key = prunedPair.Key;
+                // We already know this pruned pair is something we want to keep. But the parent may be broken since we may remove it
+                var parentId = FindBigEnoughParentId(idTable, key.ParentId);
+                result[key.WithParentId(parentId)] = prunedPair.Value;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Finds the first ancestor of parentId (which could be itself) that is either an evaluation pass location or a big enough profiled data
+        /// </summary>
+        private static int? FindBigEnoughParentId(IDictionary<int, Pair<EvaluationLocation, ProfiledLocation>> idTable,
+            int? parentId)
+        {
+            // The parent id is null, which means the item was pointing to an evaluation pass item. So we keep it as is.
+            if (!parentId.HasValue)
+            {
+                return null;
+            }
+
+            var pair = idTable[parentId.Value];
+
+            // We go up the parent relationship until we find an item that is either an evaluation pass or a big enough regular item
+            while (!pair.Key.IsEvaluationPass || IsTooSmall(pair.Value))
+            {
+                Debug.Assert(pair.Key.ParentId.HasValue,
+                    "A location that is not an evaluation pass should always have a parent");
+                pair = idTable[pair.Key.ParentId.Value];
+            }
+
+            return pair.Key.Id;
+        }
+
+        private static bool IsTooSmall(ProfiledLocation profiledData)
+        {
+            return profiledData.InclusiveTime.TotalMilliseconds < 1 ||
+                   profiledData.ExclusiveTime.TotalMilliseconds < 1;
+        }
+
+        private static ProfiledLocation AggregateProfiledLocation(ProfiledLocation location,
+            ProfiledLocation otherLocation)
         {
             return new ProfiledLocation(
                 location.InclusiveTime + otherLocation.InclusiveTime,

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -265,6 +265,7 @@
     <Compile Include="Evaluation\LazyItemEvaluator.ItemFactoryWrapper.cs" />
     <Compile Include="Evaluation\LazyItemEvaluator.RemoveOperation.cs" />
     <Compile Include="Evaluation\MetadataReference.cs" />
+    <Compile Include="Logging\EvaluationLocationIdAgnosticComparer.cs" />
     <Compile Include="Logging\ProfilerLogger.cs" />
     <Compile Include="Evaluation\Profiler\ProfilerResultPrettyPrinter.cs" />
     <Compile Include="Evaluation\ProjectChangedEventArgs.cs" />

--- a/src/Framework.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
+++ b/src/Framework.UnitTests/ProjectEvaluationFinishedEventArgs_Tests.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Build.Framework.UnitTests
 
             yield return new object[] { new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
             {
-                {new EvaluationLocation(EvaluationPass.TotalEvaluation, "1", "myFile", 42, "elementName", "description", EvaluationLocationKind.Condition), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {new EvaluationLocation(EvaluationPass.Targets, "1", null, null, null, null, EvaluationLocationKind.Glob), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {new EvaluationLocation(EvaluationPass.LazyItems, "2", null, null, null, null, EvaluationLocationKind.Item), new ProfiledLocation(TimeSpan.Zero, TimeSpan.Zero, 0)}
+                {new EvaluationLocation(0, null, EvaluationPass.TotalEvaluation, "1", "myFile", 42, "elementName", "description", EvaluationLocationKind.Condition), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {new EvaluationLocation(1, 0, EvaluationPass.Targets, "1", null, null, null, null, EvaluationLocationKind.Glob), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {new EvaluationLocation(2, 0, EvaluationPass.LazyItems, "2", null, null, null, null, EvaluationLocationKind.Element), new ProfiledLocation(TimeSpan.Zero, TimeSpan.Zero, 0)}
             }) };
 
             var element = new ProjectRootElement(
@@ -66,10 +66,10 @@ namespace Microsoft.Build.Framework.UnitTests
 
             yield return new object[] { new ProfilerResult(new Dictionary<EvaluationLocation, ProfiledLocation>
             {
-                {EvaluationLocation.CreateLocationForCondition(EvaluationPass.UsingTasks, "1", "myFile", 42, "conditionCase"), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {EvaluationLocation.CreateLocationForProject(EvaluationPass.InitialProperties, "1", "myFile", 42, element),
+                {EvaluationLocation.CreateLocationForCondition(null, EvaluationPass.UsingTasks, "1", "myFile", 42, "conditionCase"), new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
+                {EvaluationLocation.CreateLocationForProject(null, EvaluationPass.InitialProperties, "1", "myFile", 42, element),
                     new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)},
-                {EvaluationLocation.CreateLocationForGlob(EvaluationPass.InitialProperties, "1", "myFile", 42, "glob description"),
+                {EvaluationLocation.CreateLocationForGlob(null, EvaluationPass.InitialProperties, "1", "myFile", 42, "glob description"),
                 new ProfiledLocation(TimeSpan.MaxValue, TimeSpan.MinValue, 2)}
             }) };
 

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -116,7 +116,9 @@
     <Compile Include="OutputAttribute.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Profiler\EvaluationIdProvider.cs" />
     <Compile Include="Profiler\EvaluationLocation.cs" />
+    <Compile Include="Profiler\EvaluationLocationIdAgnosticComparer.cs" />
     <Compile Include="Profiler\ProfilerResult.cs" />
     <Compile Include="ProjectEvaluationFinishedEventArgs.cs" />
     <Compile Include="ProjectEvaluationStartedEventArgs.cs" />

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -118,7 +118,6 @@
     </Compile>
     <Compile Include="Profiler\EvaluationIdProvider.cs" />
     <Compile Include="Profiler\EvaluationLocation.cs" />
-    <Compile Include="Profiler\EvaluationLocationIdAgnosticComparer.cs" />
     <Compile Include="Profiler\ProfilerResult.cs" />
     <Compile Include="ProjectEvaluationFinishedEventArgs.cs" />
     <Compile Include="ProjectEvaluationStartedEventArgs.cs" />

--- a/src/Framework/Profiler/EvaluationIdProvider.cs
+++ b/src/Framework/Profiler/EvaluationIdProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Build.Framework.Profiler
+{
+    /// <summary>
+    /// Assigns unique evaluation ids. Thread safe.
+    /// </summary>
+    public static class EvaluationIdProvider
+    {
+        private static int _sAssignedId = -1;
+        private static readonly int ProcessId = Process.GetCurrentProcess().Id;
+
+        /// <summary>
+        /// Returns a unique evaluation id
+        /// </summary>
+        /// <remarks>
+        /// The id is guaranteed to be unique across all running processes
+        /// </remarks>
+        public static int GetNextId()
+        {
+            var nextId = Interlocked.Increment(ref _sAssignedId);
+            // Returns a unique number based on nextId (a unique number for this process) and the current process Id
+            // Uses the Cantor pairing function (https://en.wikipedia.org/wiki/Pairing_function) to guarantee uniqueness
+            return (((nextId + ProcessId) * (nextId + ProcessId + 1)) / 2) + ProcessId;
+        }
+    }
+}

--- a/src/Framework/Profiler/EvaluationIdProvider.cs
+++ b/src/Framework/Profiler/EvaluationIdProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Framework.Profiler
     /// <summary>
     /// Assigns unique evaluation ids. Thread safe.
     /// </summary>
-    public static class EvaluationIdProvider
+    internal static class EvaluationIdProvider
     {
         private static long _sAssignedId = -1;
         private static readonly long ProcessId = Process.GetCurrentProcess().Id;

--- a/src/Framework/Profiler/EvaluationIdProvider.cs
+++ b/src/Framework/Profiler/EvaluationIdProvider.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Diagnostics;
 using System.Threading;
 
@@ -14,21 +15,25 @@ namespace Microsoft.Build.Framework.Profiler
     /// </summary>
     public static class EvaluationIdProvider
     {
-        private static int _sAssignedId = -1;
-        private static readonly int ProcessId = Process.GetCurrentProcess().Id;
+        private static long _sAssignedId = -1;
+        private static readonly long ProcessId = Process.GetCurrentProcess().Id;
 
         /// <summary>
         /// Returns a unique evaluation id
         /// </summary>
         /// <remarks>
-        /// The id is guaranteed to be unique across all running processes
+        /// The id is guaranteed to be unique across all running processes.
+        /// Additionally, it is monotonically increasing for callers on the same process id
         /// </remarks>
-        public static int GetNextId()
+        public static long GetNextId()
         {
-            var nextId = Interlocked.Increment(ref _sAssignedId);
-            // Returns a unique number based on nextId (a unique number for this process) and the current process Id
-            // Uses the Cantor pairing function (https://en.wikipedia.org/wiki/Pairing_function) to guarantee uniqueness
-            return (((nextId + ProcessId) * (nextId + ProcessId + 1)) / 2) + ProcessId;
+            checked
+            {
+                var nextId = Interlocked.Increment(ref _sAssignedId);
+                // Returns a unique number based on nextId (a unique number for this process) and the current process Id
+                // Uses the Cantor pairing function (https://en.wikipedia.org/wiki/Pairing_function) to guarantee uniqueness
+                return (((nextId + ProcessId) * (nextId + ProcessId + 1)) / 2) + ProcessId;
+            }
         }
     }
 }

--- a/src/Framework/Profiler/EvaluationLocation.cs
+++ b/src/Framework/Profiler/EvaluationLocation.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Build.Framework.Profiler
             };
 
         /// <nodoc/>
-        public int Id { get; }
+        public long Id { get; }
 
         /// <nodoc/>
-        public int? ParentId { get; }
+        public long? ParentId { get; }
 
         /// <nodoc/>
         public EvaluationPass EvaluationPass { get; }
@@ -108,14 +108,14 @@ namespace Microsoft.Build.Framework.Profiler
         public bool IsEvaluationPass => File == null;
 
         /// <nodoc/>
-        public static EvaluationLocation CreateLocationForCondition(int? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file,
+        public static EvaluationLocation CreateLocationForCondition(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file,
             int? line, string condition)
         {
             return new EvaluationLocation(parentId, evaluationPass, evaluationDescription, file, line, "Condition", condition, kind: EvaluationLocationKind.Condition);
         }
 
         /// <nodoc/>
-        public static EvaluationLocation CreateLocationForProject(int? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file,
+        public static EvaluationLocation CreateLocationForProject(long? parentId, EvaluationPass evaluationPass, string evaluationDescription, string file,
             int? line, IProjectElement element)
         {
             return new EvaluationLocation(parentId, evaluationPass, evaluationDescription, file, line, element?.ElementName,
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Framework.Profiler
         }
 
         /// <nodoc/>
-        public static EvaluationLocation CreateLocationForGlob(int? parentId, EvaluationPass evaluationPass,
+        public static EvaluationLocation CreateLocationForGlob(long? parentId, EvaluationPass evaluationPass,
             string evaluationDescription, string file, int? line, string globDescription)
         {
             return new EvaluationLocation(parentId, evaluationPass, evaluationDescription, file, line, "Glob", globDescription, kind: EvaluationLocationKind.Glob);
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Framework.Profiler
         /// <remarks>
         /// Used by serialization/deserialization purposes
         /// </remarks>
-        public EvaluationLocation(int id, int? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file,
+        public EvaluationLocation(long id, long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file,
             int? line, string elementName, string elementDescription, EvaluationLocationKind kind)
         {
             Id = id;
@@ -164,7 +164,7 @@ namespace Microsoft.Build.Framework.Profiler
         /// A unique Id gets assigned automatically
         /// Used by serialization/deserialization purposes
         /// </remarks>
-        public EvaluationLocation(int? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind)
+        public EvaluationLocation(long? parentId, EvaluationPass evaluationPass, string evaluationPassDescription, string file, int? line, string elementName, string elementDescription, EvaluationLocationKind kind)
             : this(EvaluationIdProvider.GetNextId(), parentId, evaluationPass, evaluationPassDescription, file, line, elementName, elementDescription, kind)
         {
         }
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Framework.Profiler
         }
 
         /// <nodoc/>
-        public EvaluationLocation WithParentId(int? parentId)
+        public EvaluationLocation WithParentId(long? parentId)
         {
             // Simple optimization. If the new parent id is the same as the current one, then we just return this
             if (parentId == this.ParentId)
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Framework.Profiler
             var hashCode = 1198539463;
             hashCode = hashCode * -1521134295 + base.GetHashCode();
             hashCode = hashCode * -1521134295 + Id.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(ParentId);
+            hashCode = hashCode * -1521134295 + EqualityComparer<long?>.Default.GetHashCode(ParentId);
             hashCode = hashCode * -1521134295 + EvaluationPass.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EvaluationPassDescription);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(File);

--- a/src/Framework/Profiler/EvaluationLocationIdAgnosticComparer.cs
+++ b/src/Framework/Profiler/EvaluationLocationIdAgnosticComparer.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Framework.Profiler
+{
+    /// <summary>
+    /// Comparer for <see cref="EvaluationLocation"/> that ignores 
+    /// both <see cref="EvaluationLocation.Id"/> and <see cref="EvaluationLocation.ParentId"/>
+    /// </summary>
+    public class EvaluationLocationIdAgnosticComparer : IEqualityComparer<EvaluationLocation>
+    {
+        /// <nodoc/>
+        public static EvaluationLocationIdAgnosticComparer Singleton = new EvaluationLocationIdAgnosticComparer();
+
+        private EvaluationLocationIdAgnosticComparer()
+        { }
+
+        /// <inheritdoc/>
+        public bool Equals(EvaluationLocation x, EvaluationLocation y)
+        {
+            return
+                x.EvaluationPass == y.EvaluationPass &&
+                x.EvaluationPassDescription == y.EvaluationPassDescription &&
+                string.Equals(x.File, y.File, StringComparison.OrdinalIgnoreCase) &&
+                x.Line == y.Line &&
+                x.ElementName == y.ElementName &&
+                x.ElementDescription == y.ElementDescription &&
+                x.Kind == y.Kind;
+        }
+
+        /// <inheritdoc/>
+        public int GetHashCode(EvaluationLocation obj)
+        {
+            var hashCode = 1198539463;
+            hashCode = hashCode * -1521134295 + obj.EvaluationPass.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.EvaluationPassDescription);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.File);
+            hashCode = hashCode * -1521134295 + EqualityComparer<int?>.Default.GetHashCode(obj.Line);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.ElementName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.ElementDescription);
+            hashCode = hashCode * -1521134295 + obj.Kind.GetHashCode();
+            return hashCode;
+        }
+    }
+}

--- a/src/Framework/project.json
+++ b/src/Framework/project.json
@@ -2,15 +2,16 @@
   "frameworks": {
     "net46": {},
     "netstandard1.3": {
-      "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "PdbGit": "3.0.41",
-        "SourceLink.Create.CommandLine": "2.1.2",
-        "System.Runtime.Serialization.Primitives": "4.1.1",
-        "System.Text.Encoding.CodePages" : "4.0.1",
-        "System.Threading.Tasks.Parallel": "4.0.1",
-        "System.Threading.Thread": "4.0.0"
-      }
+        "dependencies": {
+            "NETStandard.Library": "1.6.0",
+            "PdbGit": "3.0.41",
+            "SourceLink.Create.CommandLine": "2.1.2",
+            "System.Runtime.Serialization.Primitives": "4.1.1",
+            "System.Text.Encoding.CodePages": "4.0.1",
+            "System.Threading.Tasks.Parallel": "4.0.1",
+            "System.Threading.Thread": "4.0.0",
+            "System.Diagnostics.Process": "4.1.0"
+        }
     }
   }
 }

--- a/src/Shared/NodePacketTranslator.cs
+++ b/src/Shared/NodePacketTranslator.cs
@@ -1507,8 +1507,8 @@ namespace Microsoft.Build.BackEnd
             private static void TranslatorForEvaluationLocation(ref EvaluationLocation evaluationLocation,
                 INodePacketTranslator translator)
             {
-                int id = 0;
-                int? parentId = null;
+                long id = 0;
+                long? parentId = null;
                 EvaluationPass evaluationPass = default(EvaluationPass);
                 string evaluationPassDescription = null;
                 string file = null;
@@ -1533,7 +1533,7 @@ namespace Microsoft.Build.BackEnd
                 translator.Translate(ref id);
                 if (translator.TranslateNullable(parentId))
                 {
-                    var parentIdValue = 0;
+                    long parentIdValue = 0;
                     if (translator.Mode == TranslationDirection.WriteToStream)
                     {
                         parentIdValue = parentId.Value;


### PR DESCRIPTION
This PR adds id/parent id information for each entry in the profiler report. This allows for future visualizers to display the report in a tree-like structure, where inclusive/exclusive times can be seen more clearly.

Additionally, it fixes a bug where entries representing the same element were not merged properly.