### PR TITLE
Breaking Change in FileMatcher: ab*ba pattern matches aba by mistake

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.Build.Shared
                             // and hope that there is no * wildcard in order to return earlier
                             int inputTailIndex = inputLength;
                             int patternTailIndex = patternLength;
-                            while (patternIndex < patternTailIndex && inputTailIndex > 0)
+                            while (patternIndex < patternTailIndex && inputTailIndex > inputIndex)
                             {
                                 patternTailIndex--;
                                 inputTailIndex--;

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Build.UnitTests
                 "file1.txt",
                 "file1.txtother",
                 "fie1.txt",
-                "fire1.txt"
+                "fire1.txt",
+                "file.bak.txt"
             };
 
             try
@@ -49,16 +50,16 @@ namespace Microsoft.Build.UnitTests
 
                 var patterns = new Dictionary<string, int>
                 {
-                    {"*.txt", 4},
-                    { "???.cs", 1},
-                    { "????.cs", 1},
+                    {"*.txt", 5},
+                    {"???.cs", 1},
+                    {"????.cs", 1},
                     {"file?.txt", 1},
                     {"fi?e?.txt", 2},
-                    { "???.*", 1},
-                    { "????.*", 3},
-                    { "*.???", 4},
-                    { "f??e1.txt", 2},
-                    { "file.*.txt", 0 }
+                    {"???.*", 1},
+                    {"????.*", 4},
+                    {"*.???", 5},
+                    {"f??e1.txt", 2},
+                    {"file.*.txt", 1}
                 };
                 foreach (var pattern in patterns)
                 {

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Build.UnitTests
                     { "???.*", 1},
                     { "????.*", 3},
                     { "*.???", 4},
-                    { "f??e1.txt", 2}
+                    { "f??e1.txt", 2},
+                    { "file.*.txt", 0 }
                 };
                 foreach (var pattern in patterns)
                 {
@@ -82,6 +83,22 @@ namespace Microsoft.Build.UnitTests
         [InlineData(
             @"src\**\inner\**\*.cs", // Include
             new string[] { }, // Excludes
+            new[] // Expected matchings
+            {
+                @"src\foo\inner\foo.cs",
+                @"src\foo\inner\foo\foo.cs",
+                @"src\foo\inner\bar\bar.cs",
+                @"src\bar\inner\baz.cs",
+                @"src\bar\inner\baz\baz.cs",
+                @"src\bar\inner\foo\foo.cs"
+            }
+        )]
+        [InlineData(
+            @"src\**\inner\**\*.cs", // Include
+            new[] // Excludes
+            {
+                @"src\foo\inner\foo.*.cs"
+            },
             new[] // Expected matchings
             {
                 @"src\foo\inner\foo.cs",
@@ -343,6 +360,7 @@ namespace Microsoft.Build.UnitTests
                 new Tuple<string, string, bool>("ab", "*ab", true),
                 new Tuple<string, string, bool>("ab", "a*b", true),
                 new Tuple<string, string, bool>("ab", "ab*", true),
+                new Tuple<string, string, bool>("aba", "ab*ba", false),
                 new Tuple<string, string, bool>("", "*", true),
 
                 // ? wildcard


### PR DESCRIPTION
Pull request is created based on issue #2815
Performance optimization #2392 led to a breaking change in FileMatcher logic. Let's examine the following example with a single web.config file in working directory:
```
<MyFiles Include="**\*" Exclude="web.*.config">
</MyFiles>
```

Before the change @(MyFiles) included web.config because exclude pattern didn't match it. However after the change web.config was excluded from the item group. This is because implementation of FileMatcher.IsMatch() doesn't consider a situation when tail after wildcard (*) is longer than the remaining part of the input during "tail check". This is a pretty common scenario when several file extensions are used.

To be more specific FileMatcher.IsMatch("aba", "ab*ba") should return false instead of true.


I suggest a simple fix to cancel tail check when pattern tail length exceeds input tail length.