### PR TITLE
Implement a /restoreProperty command-line argument for specifying global properties

### DIFF
--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1112,6 +1112,7 @@ namespace Microsoft.Build.UnitTests
                                         null,
                                         "ScoobyDoo",
                                         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                                        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
                                         new ILogger[] { },
                                         LoggerVerbosity.Normal,
                                         new DistributedLoggerRecord[] { },

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Build.CommandLine
             BinaryLogger,
             Restore,
             ProfileEvaluation,
+            RestoreProperty,
             NumberOfParameterizedSwitches,
         }
 
@@ -285,6 +286,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "binarylogger", "bl" },                ParameterizedSwitch.BinaryLogger,               null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "restore", "r" },                      ParameterizedSwitch.Restore,                    null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "profileevaluation", "prof" },         ParameterizedSwitch.ProfileEvaluation,          null,                           false,          "MissingProfileParameterError",        true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "restoreproperty", "rp" },             ParameterizedSwitch.RestoreProperty,            null,                           true,           "MissingRestorePropertyError",         true,   false  ),
         };
 
         /// <summary>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -687,6 +687,23 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
+  <data name="HelpMessage_32_RestorePropertySwitch" UESanitized="false" Visibility="Public">
+    <value>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </value>
+    <comment>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
+  </data>
   <data name="InvalidConfigurationFile" Visibility="Public">
     <value>MSBUILD : Configuration error MSB1043: The application could not start. {0}</value>
     <comment>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -687,7 +687,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
-  <data name="HelpMessage_32_RestorePropertySwitch" UESanitized="false" Visibility="Public">
+  <data name="HelpMessage_32_ProfilerSwitch" xml:space="preserve">
+    <value>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file.
+    </value>
+  </data>
+  <data name="HelpMessage_33_RestorePropertySwitch" UESanitized="false" Visibility="Public">
     <value>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
                      Set or override these project-level properties only
                      during restore and do not use properties specified
@@ -1097,12 +1103,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       UE: This happens if the user does something like "msbuild.exe /warnasmessage:" without any codes.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
-  </data>
-  <data name="HelpMessage_32_ProfilerSwitch" xml:space="preserve">
-    <value>  /profileevaluation:&lt;file&gt;    
-                     Profiles MSBuild evaluation and writes the result 
-                     to the specified file.
-    </value>
   </data>
   <data name="InvalidProfilerValue" xml:space="preserve">
     <value>MSBUILD : error MSB1053: Provided filename is not valid. {0}</value>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2034,7 +2034,7 @@ namespace Microsoft.Build.CommandLine
                     // figure out which properties have been set on the command line
                     globalProperties = ProcessPropertySwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Property]);
 
-                    // figure out restore properties have been set on the command line
+                    // figure out which restore-only properties have been set on the command line
                     restoreProperties = ProcessPropertySwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.RestoreProperty]);
 
                     // figure out if there was a max cpu count provided

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3529,7 +3529,7 @@ namespace Microsoft.Build.CommandLine
             }
 #endif
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_31_RestoreSwitch"));
-            Console.WriteLine(AssemblyResources.GetString("HelpMessage_32_RestorePropertySwitch"));
+            Console.WriteLine(AssemblyResources.GetString("HelpMessage_33_RestorePropertySwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_32_ProfilerSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_7_ResponseFile"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_8_NoAutoResponseSwitch"));


### PR DESCRIPTION
If a user does not specify any /restoreProperty arguments, the global properties specified by /property arguments will be used

If a user specifies any /restoreProperty arguments, only those properties will be set during restore

Usage looks like this:

```
  /restoreProperty:<n>=<v>
                     Set or override these project-level properties only
                     during restore and do not use properties specified
                     with the /property argument. <n> is the property
                     name, and <v> is the property value. Use a
                     semicolon or a comma to separate multiple properties,
                     or specify each property separately.
                     (Short form: /rp)
                     Example:
                       /restoreProperty:IsRestore=true;MyProperty=value
```