### PR TITLE
Add new MSBuildVersion property

### DIFF
--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -928,7 +928,7 @@ namespace Microsoft.Build.Evaluation
 
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.toolsPath, EscapingUtilities.Escape(ToolsPath), mayBeReserved: true));
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion, mayBeReserved: true));
-                    reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinor, mayBeReserved: true));
+                    reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinorBuild, mayBeReserved: true));
 
                     // Add one for the subtoolset version property -- it may or may not be set depending on whether it has already been set by the 
                     // environment or global properties, but it's better to create a dictionary that's one too big than one that's one too small.  

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -928,6 +928,7 @@ namespace Microsoft.Build.Evaluation
 
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.toolsPath, EscapingUtilities.Escape(ToolsPath), mayBeReserved: true));
                     reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion, mayBeReserved: true));
+                    reservedProperties.Add(ProjectPropertyInstance.Create(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinor, mayBeReserved: true));
 
                     // Add one for the subtoolset version property -- it may or may not be set depending on whether it has already been set by the 
                     // environment or global properties, but it's better to create a dictionary that's one too big than one that's one too small.  

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1486,7 +1486,7 @@ namespace Microsoft.Build.Evaluation
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.buildNodeCount, _maxNodeCount.ToString(CultureInfo.CurrentCulture)));
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.programFiles32, FrameworkLocationHelper.programFiles32));
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion));
-            builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinor));
+            builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinorBuild));
 
             // Fake OS env variables when not on Windows
             if (!NativeMethodsShared.IsWindows)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1477,7 +1477,7 @@ namespace Microsoft.Build.Evaluation
         {
             string startupDirectory = BuildParameters.StartupDirectory;
 
-            List<P> builtInProperties = new List<P>(12);
+            List<P> builtInProperties = new List<P>(19);
 
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.toolsVersion, _data.Toolset.ToolsVersion));
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.toolsPath, _data.Toolset.ToolsPath));
@@ -1486,6 +1486,8 @@ namespace Microsoft.Build.Evaluation
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.buildNodeCount, _maxNodeCount.ToString(CultureInfo.CurrentCulture)));
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.programFiles32, FrameworkLocationHelper.programFiles32));
             builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.assemblyVersion, Constants.AssemblyVersion));
+            builtInProperties.Add(SetBuiltInProperty(ReservedPropertyNames.version, MSBuildAssemblyFileVersion.Instance.MajorMinor));
+
             // Fake OS env variables when not on Windows
             if (!NativeMethodsShared.IsWindows)
             {

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -617,6 +617,7 @@
     <Compile Include="Resources\Constants.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Resources\MSBuildAssemblyFileVersion.cs" />
     <!-- ######################## -->
     <!-- ######################## -->
     <!-- ######################## -->

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Build.Internal
         internal const string programFiles32 = "MSBuildProgramFiles32";
         internal const string localAppData = "LocalAppData";
         internal const string assemblyVersion = "MSBuildAssemblyVersion";
+        internal const string version = "MSBuildVersion";
         internal const string osName = "OS";
         internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";
 
@@ -101,6 +102,7 @@ namespace Microsoft.Build.Internal
                         s_reservedProperties.Add(lastTaskResult);
                         s_reservedProperties.Add(programFiles32);
                         s_reservedProperties.Add(assemblyVersion);
+                        s_reservedProperties.Add(version);
                     }
                 }
 

--- a/src/Build/Resources/MSBuildAssemblyFileVersion.cs
+++ b/src/Build/Resources/MSBuildAssemblyFileVersion.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Build.Internal
     {
         private static readonly Lazy<MSBuildAssemblyFileVersion> MSBuildAssemblyFileVersionLazy = new Lazy<MSBuildAssemblyFileVersion>(GetMSBuildAssemblyFileVersion, isThreadSafe: true);
 
-        private MSBuildAssemblyFileVersion(string majorMinor)
+        private MSBuildAssemblyFileVersion(string majorMinorBuild)
         {
-            MajorMinor = majorMinor;
+            MajorMinorBuild = majorMinorBuild;
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Gets the assembly file version in the format major.minor.
         /// </summary>
-        public string MajorMinor { get; set; }
+        public string MajorMinorBuild { get; set; }
 
         private static MSBuildAssemblyFileVersion GetMSBuildAssemblyFileVersion()
         {
@@ -44,10 +44,10 @@ namespace Microsoft.Build.Internal
             if (String.IsNullOrEmpty(versionString) || !Version.TryParse(versionString, out version))
             {
                 // Fall back to the constant AssemblyVersion
-                return new MSBuildAssemblyFileVersion(Constants.AssemblyVersion);
+                version = Version.Parse(Constants.AssemblyVersion);
             }
 
-            return new MSBuildAssemblyFileVersion($"{version.Major}.{version.Minor}");
+            return new MSBuildAssemblyFileVersion($"{version.Major}.{version.Minor}.{version.Build}");
         }
     }
 }

--- a/src/Build/Resources/MSBuildAssemblyFileVersion.cs
+++ b/src/Build/Resources/MSBuildAssemblyFileVersion.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.Build.Internal
+{
+    /// <summary>
+    /// Gets the <see cref="AssemblyFileVersionAttribute"/> of Microsoft.Build.dll.
+    /// </summary>
+    internal sealed class MSBuildAssemblyFileVersion
+    {
+        private static readonly Lazy<MSBuildAssemblyFileVersion> MSBuildAssemblyFileVersionLazy = new Lazy<MSBuildAssemblyFileVersion>(GetMSBuildAssemblyFileVersion, isThreadSafe: true);
+
+        private MSBuildAssemblyFileVersion(string majorMinor)
+        {
+            MajorMinor = majorMinor;;
+        }
+
+        /// <summary>
+        /// Gets a singleton instance of <see cref="MSBuildAssemblyFileVersion"/>.
+        /// </summary>
+        public static MSBuildAssemblyFileVersion Instance
+        {
+            get { return MSBuildAssemblyFileVersionLazy.Value; }
+        }
+
+        /// <summary>
+        /// Gets the assembly file version in the format major.minor.
+        /// </summary>
+        public string MajorMinor { get; set; }
+
+        private static MSBuildAssemblyFileVersion GetMSBuildAssemblyFileVersion()
+        {
+            string versionString = typeof(MSBuildAssemblyFileVersion).GetTypeInfo()?.Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+
+            Version version;
+
+            if (String.IsNullOrEmpty(versionString) || !Version.TryParse(versionString, out version))
+            {
+                // Fall back to the constant AssemblyVersion
+                return new MSBuildAssemblyFileVersion(Constants.AssemblyVersion);
+            }
+
+            return new MSBuildAssemblyFileVersion($"{version.Major}.{version.Minor}");
+        }
+    }
+}

--- a/src/Build/Resources/MSBuildAssemblyFileVersion.cs
+++ b/src/Build/Resources/MSBuildAssemblyFileVersion.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Internal
 
         private MSBuildAssemblyFileVersion(string majorMinor)
         {
-            MajorMinor = majorMinor;;
+            MajorMinor = majorMinor;
         }
 
         /// <summary>
@@ -33,7 +33,11 @@ namespace Microsoft.Build.Internal
 
         private static MSBuildAssemblyFileVersion GetMSBuildAssemblyFileVersion()
         {
-            string versionString = typeof(MSBuildAssemblyFileVersion).GetTypeInfo()?.Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
+            string versionString = typeof(MSBuildAssemblyFileVersion)
+                .GetTypeInfo()
+                ?.Assembly
+                .GetCustomAttribute<AssemblyFileVersionAttribute>()
+                ?.Version;
 
             Version version;
 


### PR DESCRIPTION
`MSBuildVersion` will be major.minor.build version of MSBuild according to the `[assembly:AssemblyFileVersion]` attribute (currently `15.6.X`).  This allows build owners to implement errors if a user is using an older version of MSBuild that might not be able to build their source code.

I've implemented an `MSBuildAssemblyFileVersion` class which gets the assembly attribute with a Lazy singleton.  This should create very little overhead and not add any perf cost.

Closes #2350