### PR TITLE
Need to check assembly version when doing IsFrameworkAssembly check

### DIFF
--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -450,15 +450,7 @@ namespace Microsoft.Build.Tasks
 
         private AssemblyNameExtension GetAssemblyNameExtension(string assemblyName)
         {
-            AssemblyNameExtension assemblyNameExtension = null;
-
-            if(!_assemblyNameToAssemblyNameExtension.TryGetValue(assemblyName, out assemblyNameExtension))
-            {
-                assemblyNameExtension = new AssemblyNameExtension(assemblyName);
-                _assemblyNameToAssemblyNameExtension.TryAdd(assemblyName, assemblyNameExtension);
-            }
-
-            return assemblyNameExtension;
+            return _assemblyNameToAssemblyNameExtension.GetOrAdd(assemblyName, (key) => new AssemblyNameExtension(key));
         }
 
         /// <summary>

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -159,7 +159,10 @@ namespace Microsoft.Build.Tasks
         public bool IsFrameworkAssembly(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null && !String.IsNullOrEmpty(entry.RedistName))
+            AssemblyNameExtension assembly = new AssemblyNameExtension(assemblyName);
+            if (entry != null && !String.IsNullOrEmpty(entry.RedistName) &&
+                // The version of the checking assembly should be lower than the one of the unified assembly
+                assembly.Version <= entry.AssemblyNameExtension.Version)
                 return entry.RedistName.StartsWith("Microsoft-Windows-CLRCoreComp", StringComparison.OrdinalIgnoreCase);
             else
                 return false;


### PR DESCRIPTION
Clickonce tooling relies on IsFrameworkAssembly method in Microsoft.Build.Tasks.Core.dll to determine if the assembly is part of .net framework redist. If so, Clickonce tooling won't publish that assembly. However, IsFraemworkAssembly method doesn't check the assembly version which causes assembly loading failure at runtime.

**Example**
If a project references System.Runtime nupkg 4.3, ClickOnce publish doesn’t include System.Runtime.dll into the publish file list.