### PR TITLE
In Expander.cs add a shortcut for some common string methods to bypass binding

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3565,6 +3565,15 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionStringGetCharsError()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                TestPropertyFunction("$(prop[5])", "prop", "461", "4");
+            });
+        }
+
+        [Fact]
         public void PropertyFunctionStringPadLeft1()
         {
             TestPropertyFunction("$(prop.PadLeft(2))", "prop", "x", " x");

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3539,5 +3539,44 @@ $(
 
             result.ShouldBe("6C854");
         }
+
+        [Fact]
+        public void PropertyFunctionStringArrayIndexerGetter()
+        {
+            TestPropertyFunction("$(prop.Split('-')[0])", "prop", "x-y-z", "x");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringGetChars()
+        {
+            TestPropertyFunction("$(prop[0])", "prop", "461", "4");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringPadLeft1()
+        {
+            TestPropertyFunction("$(prop.PadLeft(2, '0'))", "prop", "x", "0x");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringPadLeft2()
+        {
+            TestPropertyFunction("$(prop.PadLeft(2))", "prop", "x", " x");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringTrimEndCharArray()
+        {
+            TestPropertyFunction("$(prop.TrimEnd('.0123456789'))", "prop", "net461", "net");
+        }
+
+        private void TestPropertyFunction(string expression, string propertyName, string propertyValue, string expected)
+        {
+            var properties = new PropertyDictionary<ProjectPropertyInstance>();
+            properties.Set(ProjectPropertyInstance.Create(propertyName, propertyValue));
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(properties);
+            string result = expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
+            result.ShouldBe(expected);
+        }
     }
 }

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3547,6 +3547,18 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionSubstring1()
+        {
+            TestPropertyFunction("$(prop.Substring(2))", "prop", "abcdef", "cdef");
+        }
+
+        [Fact]
+        public void PropertyFunctionSubstring2()
+        {
+            TestPropertyFunction("$(prop.Substring(2, 3))", "prop", "abcdef", "cde");
+        }
+
+        [Fact]
         public void PropertyFunctionStringGetChars()
         {
             TestPropertyFunction("$(prop[0])", "prop", "461", "4");
@@ -3555,19 +3567,34 @@ $(
         [Fact]
         public void PropertyFunctionStringPadLeft1()
         {
-            TestPropertyFunction("$(prop.PadLeft(2, '0'))", "prop", "x", "0x");
+            TestPropertyFunction("$(prop.PadLeft(2))", "prop", "x", " x");
         }
 
         [Fact]
         public void PropertyFunctionStringPadLeft2()
         {
-            TestPropertyFunction("$(prop.PadLeft(2))", "prop", "x", " x");
+            TestPropertyFunction("$(prop.PadLeft(2, '0'))", "prop", "x", "0x");
         }
 
         [Fact]
         public void PropertyFunctionStringTrimEndCharArray()
         {
             TestPropertyFunction("$(prop.TrimEnd('.0123456789'))", "prop", "net461", "net");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringTrimEnd1()
+        {
+            TestPropertyFunction("$(prop.TrimEnd('a'))", "prop", "netaa", "net");
+        }
+
+        [Fact]
+        public void PropertyFunctionStringTrimEnd2()
+        {
+            Assert.Throws<InvalidProjectFileException>(() =>
+            {
+                TestPropertyFunction("$(prop.TrimEnd('a', 'b'))", "prop", "stringab", "string");
+            });
         }
 
         private void TestPropertyFunction(string expression, string propertyName, string propertyValue, string expected)

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3288,107 +3288,115 @@ namespace Microsoft.Build.Evaluation
             /// <returns>The value returned from the function call</returns>
             private object ExecuteWellKnownFunction(object objectInstance, object[] args)
             {
-                if (objectInstance is string text)
+                if (objectInstance is string)
                 {
+                    string text = (string)objectInstance;
                     if (string.Equals(_methodMethodName, "Substring", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1)
+                        int startIndex;
+                        int length;
+                        if (TryGetArg(args, out startIndex))
                         {
-                            if (args[0] is string arg0 &&
-                                int.TryParse(arg0, out int startIndex) &&
-                                startIndex >= 0 &&
-                                startIndex < text.Length)
-                            {
-                                return text.Substring(startIndex);
-                            }
+                            return text.Substring(startIndex);
                         }
-                        else if (args.Length == 2)
+                        else if (TryGetArgs(args, out startIndex, out length))
                         {
-                            if (args[0] is string arg0 &&
-                                args[1] is string arg1 &&
-                                int.TryParse(arg0, out int startIndex) &&
-                                int.TryParse(arg1, out int length) &&
-                                startIndex >= 0 &&
-                                startIndex <= text.Length &&
-                                length >= 0 &&
-                                startIndex + length <= text.Length)
-                            {
-                                return text.Substring(startIndex, length);
-                            }
+                            return text.Substring(startIndex, length);
                         }
                     }
                     else if (string.Equals(_methodMethodName, "Split", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1)
+                        string separator;
+                        if (TryGetArg(args, out separator) && separator.Length == 1)
                         {
-                            if (args[0] is string arg0 &&
-                                arg0.Length == 1)
-                            {
-                                return text.Split(arg0[0]);
-                            }
+                            return text.Split(separator[0]);
                         }
                     }
                     else if (string.Equals(_methodMethodName, "PadLeft", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1)
+                        int totalWidth;
+                        string paddingChar;
+                        if (TryGetArg(args, out totalWidth))
                         {
-                            if (args[0] is string arg0 &&
-                                int.TryParse(arg0, out int totalWidth))
-                            {
-                                return text.PadLeft(totalWidth);
-                            }
+                            return text.PadLeft(totalWidth);
                         }
-                        else if (args.Length == 2)
+                        else if (TryGetArgs(args, out totalWidth, out paddingChar) && paddingChar.Length == 1)
                         {
-                            if (args[0] is string arg0 &&
-                                args[1] is string arg1 &&
-                                int.TryParse(arg0, out int totalWidth) &&
-                                arg1.Length == 1)
-                            {
-                                return text.PadLeft(totalWidth, arg1[0]);
-                            }
+                            return text.PadLeft(totalWidth, paddingChar[0]);
                         }
                     }
                     else if (string.Equals(_methodMethodName, "TrimEnd", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1)
+                        string trimChars;
+                        if (TryGetArg(args, out trimChars) && trimChars.Length > 0)
                         {
-                            if (args[0] is string arg0 && arg0.Length > 0)
-                            {
-                                return text.TrimEnd(arg0.ToCharArray());
-                            }
+                            return text.TrimEnd(trimChars.ToCharArray());
                         }
                     }
                     else if (string.Equals(_methodMethodName, "get_Chars", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1 &&
-                            args[0] is string arg0 &&
-                            int.TryParse(arg0, out int index) &&
-                            index >= 0 &&
-                            index < text.Length)
+                        int index;
+                        if (TryGetArg(args, out index))
                         {
                             return text[index];
                         }
                     }
                 }
-                else if (objectInstance is string[] stringArray)
+                else if (objectInstance is string[])
                 {
+                    string[] stringArray = (string[])objectInstance;
                     if (string.Equals(_methodMethodName, "GetValue", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (args.Length == 1)
+                        int index;
+                        if (TryGetArg(args, out index))
                         {
-                            if (args[0] is string arg0 &&
-                                int.TryParse(arg0, out int index) &&
-                                index >= 0 &&
-                                index < stringArray.Length)
-                            {
-                                return stringArray[index];
-                            }
+                            return stringArray[index];
                         }
                     }
                 }
 
                 return null;
+            }
+
+            private static bool TryGetArg<A0>(object[] args, out A0 arg0)
+            {
+                if (args.Length != 1)
+                {
+                    arg0 = default(A0);
+                    return false;
+                }
+
+                var value = args[0];
+                if (value is A0)
+                {
+                    arg0 = (A0)value;
+                    return true;
+                }
+
+                arg0 = default(A0);
+                return false;
+            }
+
+            private static bool TryGetArgs<A0, A1>(object[] args, out A0 arg0, out A1 arg1)
+            {
+                arg0 = default(A0);
+                arg1 = default(A1);
+
+                if (args.Length != 2)
+                {
+                    return false;
+                }
+
+                var value0 = args[0];
+                var value1 = args[1];
+                if (value0 is A0 && value1 is A1)
+                {
+                    arg0 = (A0)value0;
+                    arg1 = (A1)value1;
+                    return true;
+                }
+
+                return false;
             }
 
             /// <summary>

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3358,41 +3358,75 @@ namespace Microsoft.Build.Evaluation
                 return null;
             }
 
-            private static bool TryGetArg<A0>(object[] args, out A0 arg0)
+            private static bool TryGetArg(object[] args, out int arg0)
             {
                 if (args.Length != 1)
                 {
-                    arg0 = default(A0);
+                    arg0 = 0;
                     return false;
                 }
 
                 var value = args[0];
-                if (value is A0)
+                if (value is string && int.TryParse((string)value, out arg0))
                 {
-                    arg0 = (A0)value;
                     return true;
                 }
 
-                arg0 = default(A0);
+                arg0 = 0;
                 return false;
             }
 
-            private static bool TryGetArgs<A0, A1>(object[] args, out A0 arg0, out A1 arg1)
+            private static bool TryGetArg(object[] args, out string arg0)
             {
-                arg0 = default(A0);
-                arg1 = default(A1);
+                if (args.Length != 1)
+                {
+                    arg0 = null;
+                    return false;
+                }
+
+                arg0 = args[0] as string;
+                return arg0 != null;
+            }
+
+            private static bool TryGetArgs(object[] args, out int arg0, out int arg1)
+            {
+                arg0 = 0;
+                arg1 = 0;
 
                 if (args.Length != 2)
                 {
                     return false;
                 }
 
-                var value0 = args[0];
-                var value1 = args[1];
-                if (value0 is A0 && value1 is A1)
+                var value0 = args[0] as string;
+                var value1 = args[1] as string;
+                if (value0 != null &&
+                    value1 != null &&
+                    int.TryParse(value0, out arg0) &&
+                    int.TryParse(value1, out arg1))
                 {
-                    arg0 = (A0)value0;
-                    arg1 = (A1)value1;
+                    return true;
+                }
+
+                return false;
+            }
+
+            private static bool TryGetArgs(object[] args, out int arg0, out string arg1)
+            {
+                arg0 = 0;
+                arg1 = null;
+
+                if (args.Length != 2)
+                {
+                    return false;
+                }
+
+                var value0 = args[0] as string;
+                arg1 = args[1] as string;
+                if (value0 != null &&
+                    arg1 != null &&
+                    int.TryParse(value0, out arg0))
+                {
                     return true;
                 }
 


### PR DESCRIPTION
This avoids first-chance MissingMethodExceptions when evaluating most solutions, such as Roslyn, MonoDevelop and a few other ones I tested.

This is a tactical fix to get the exception out of the way for now. We can think of a proper fix to the binder later. This should also slightly improve evaluation performance - each binder call that throws costs ~1.5 ms on my machine, whereas this method brings it down to ~0.05 ms, so about 30x improvement.

I'm just including the functions I ran into during testing that are in the wild. This list is not exhaustive, because for rare cases we can still fallback to the old behavior, it's just going to be way less common now. I've verified that using this MSBuild in a certain test environment is able to load large solutions without seeing any of the first-chance exceptions.