### PR TITLE
Fix for issue 1593 where msbuild spends a long time checking if a str…

### DIFF
--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -90,6 +90,14 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// The number here is arbitrary. For a StringBuilder we have a chunk length of 8000 characters which corresponds to
+        /// 5 StringBuilder chunks which need to be walked before the next character can be fetched (see MaxChunkSize of StringBuilder).
+        /// That should be a good compromise to not allocate to much but still make use of the intern cache. The actual cutoff where it is cheaper
+        /// to allocate a temp string might be well below that limit but that depends on many other factors such as GC Heap size and other allocating threads. 
+        /// </summary>
+        const int MaxByCharCompareLength = 40 * 1000;
+
+        /// <summary>
         /// Compare target to string. 
         /// </summary>
         bool OpportunisticIntern.IInternable.IsOrdinalEqualToStringOfSameLength(string other)
@@ -97,7 +105,7 @@ namespace Microsoft.Build.Shared
 #if DEBUG
             ErrorUtilities.VerifyThrow(other.Length == _borrowedBuilder.Length, "should be same length");
 #endif
-            if (other.Length > 40_000)
+            if (other.Length > MaxByCharCompareLength)
             {
                 return String.Equals( ((OpportunisticIntern.IInternable) this).ExpensiveConvertToString(), other, StringComparison.Ordinal);
             }

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Build.Shared
         private StringBuilder _borrowedBuilder;
 
         /// <summary>
+        /// Profiling showed that the hot code path for large string builder calls first IsOrdinalEqualToStringOfSameLength followed by ExpensiveConvertToString
+        /// when IsOrdinalEqualToStringOfSameLength did return true. We can therefore reduce the costs for large strings by over a factor two. 
+        /// </summary>
+        private string _cachedString;
+
+        /// <summary>
         /// Capacity to initialize the builder with.
         /// </summary>
         private int _capacity;
@@ -75,9 +81,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         string OpportunisticIntern.IInternable.ExpensiveConvertToString()
         {
+            if( _cachedString == null)
             {
-                return ((ReuseableStringBuilder)this).ToString();
+                _cachedString = ((ReuseableStringBuilder)this).ToString();
             }
+            return _cachedString;
+
         }
 
         /// <summary>
@@ -88,6 +97,10 @@ namespace Microsoft.Build.Shared
 #if DEBUG
             ErrorUtilities.VerifyThrow(other.Length == _borrowedBuilder.Length, "should be same length");
 #endif
+            if (other.Length > 40_000)
+            {
+                return String.Equals( ((OpportunisticIntern.IInternable) this).ExpensiveConvertToString(), other, StringComparison.Ordinal);
+            }
             // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
             // For example, C:\project1, C:\project2
             for (int i = _borrowedBuilder.Length - 1; i >= 0; --i)
@@ -130,6 +143,7 @@ namespace Microsoft.Build.Shared
             if (_borrowedBuilder != null)
             {
                 ReuseableStringBuilderFactory.Release(_borrowedBuilder);
+                _cachedString = null;
                 _borrowedBuilder = null;
                 _capacity = -1;
             }
@@ -141,6 +155,7 @@ namespace Microsoft.Build.Shared
         internal ReuseableStringBuilder Append(char value)
         {
             LazyPrepare();
+            _cachedString = null;
             _borrowedBuilder.Append(value);
             return this;
         }
@@ -151,6 +166,7 @@ namespace Microsoft.Build.Shared
         internal ReuseableStringBuilder Append(string value)
         {
             LazyPrepare();
+            _cachedString = null;
             _borrowedBuilder.Append(value);
             return this;
         }
@@ -161,6 +177,7 @@ namespace Microsoft.Build.Shared
         internal ReuseableStringBuilder Append(string value, int startIndex, int count)
         {
             LazyPrepare();
+            _cachedString = null;
             _borrowedBuilder.Append(value, startIndex, count);
             return this;
         }
@@ -171,6 +188,7 @@ namespace Microsoft.Build.Shared
         internal ReuseableStringBuilder Remove(int startIndex, int length)
         {
             LazyPrepare();
+            _cachedString = null;
             _borrowedBuilder.Remove(startIndex, length);
             return this;
         }


### PR DESCRIPTION
Profiling showed that StringBuilder[xx] character access performance is much slower compared to create the string and compare the two string directly.
A second optimization is to cache the created string until the StringBuilder is modified again which gives another 15%.
This issue pops up when large directories with many files are stored in msbuild lists which are then compared for equality which will internally cause msbuild to stringify the large lists.

To test the change you can use this msbuild target file
``` XML
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 <!--
  The intention of this file is to force msbuild to create large lists of concatenated file names to check the performance of ReuseableStringBuilder.
  We create directory hardlinks from C:\temp to the Windows\System32 directory to have different paths to the same file sets which msbuild will not
  treat as identical files and not squash the redundant list to the same identical flile list while we try to create a larger list with
     n
  2n
  3n
  4n
  5n
  files of all dlls from C:\windows\system32\*.dll
  To run it call
     msbuild Slow.target /clp:PerformanceSummary=true

 -->
    <ItemGroup>
  <ManyFiles1 Include="C:\Temp\Win1\System32\*.dll" />
  <ManyFiles2 Include="C:\Temp\Win1\System32\*.dll;C:\Temp\Win2\System32\*.dll"/>
  <ManyFiles3 Include="C:\Temp\Win1\System32\*.dll;C:\Temp\Win2\System32\*.dll;C:\Temp\Win3\System32\*.dll"/>
  <ManyFiles4 Include="C:\Temp\Win1\System32\*.dll;C:\Temp\Win2\System32\*.dll;C:\Temp\Win3\System32\*.dll;C:\Temp\Win4\System32\*.dll"/>
  <ManyFiles5 Include="C:\Temp\Win1\System32\*.dll;C:\Temp\Win2\System32\*.dll;C:\Temp\Win3\System32\*.dll;C:\Temp\Win4\System32\*.dll;C:\Temp\Win5\System32\*.dll"/>
  <OtherFiles Include="C:\Temp\Win1\System32\*.dll" />
    </ItemGroup>
    <Target Name="RunMyTask0" DependsOnTargets="DeleteWinLinks;CreateWinLinks;RunMyTask1;RunMyTask2;RunMyTask3;RunMyTask4;RunMyTask5;DeleteWinLinks"  >
  <Message Text="Task 0 is executed"/>
    </Target>
    <Target Name="RunMyTask1">
  <Message Text="Task1"/>
  <Message Condition="'@(OtherFiles)' == '%(ManyFiles1.Identity)'" Text="Values are equal"/>
    </Target>
    <Target Name="RunMyTask2">
  <Message Text="Task2"/>
  <Message Condition="'@(OtherFiles)' == '%(ManyFiles2.Identity)'" Text="Values are equal"/>
    </Target>
    <Target Name="RunMyTask3">
  <Message Text="Task3"/>
  <Message Condition="'@(OtherFiles)' == '%(ManyFiles3.Identity)'" Text="Values are equal"/>
    </Target>
    <Target Name="RunMyTask4">
  <Message Text="Task4"/>
  <Message Condition="'@(OtherFiles)' == '%(ManyFiles4.Identity)'" Text="Values are equal"/>
    </Target>
    <Target Name="RunMyTask5">
  <Message Text="Task5"/>
  <Message Condition="'@(OtherFiles)' == '%(ManyFiles5.Identity)'" Text="Values are equal"/>
    </Target>
  <Target Name="CreateWinLinks">
        <Exec Command="mklink /D C:\temp\Win1 c:\Windows"/>
  <Exec Command="mklink /D C:\temp\Win2 c:\Windows"/>
  <Exec Command="mklink /D C:\temp\Win3 c:\Windows"/>
  <Exec Command="mklink /D C:\temp\Win4 c:\Windows"/>
  <Exec Command="mklink /D C:\temp\Win5 c:\Windows"/>
  <Exec Command="mklink /D C:\temp\Win6 c:\Windows"/>
    </Target>
 <Target Name="DeleteWinLinks">
        <Exec Command="rd C:\temp\Win1"/>
     <Exec Command="rd C:\temp\Win2"/>
  <Exec Command="rd C:\temp\Win3"/>
  <Exec Command="rd C:\temp\Win4"/>
  <Exec Command="rd C:\temp\Win5"/>
  <Exec Command="rd C:\temp\Win6"/>
    </Target>
</Project>
```