### PR TITLE
👷 Ignore temporary ProjectImports zip file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ artifacts/
 *.tmp_proj
 *.log
 *.binlog
+*.ProjectImports.zip
 *.vspscc
 *.vssscc
 .builds


### PR DESCRIPTION
This file is created during cibuilds and may persist if MSBuild is
aborted abnormally. It's a build output like other logs and shouldn't be
checked in.