### PR TITLE
Allow SDK resolvers to preserve state

### DIFF
--- a/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/net46/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -446,6 +446,7 @@ namespace Microsoft.Build.Framework
         public virtual System.Version MSBuildVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string ProjectFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string SolutionFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual object State { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public abstract partial class SdkResult
     {

--- a/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
+++ b/ref/netstandard1.3/Microsoft.Build.Framework/Microsoft.Build.Framework.cs
@@ -443,6 +443,7 @@ namespace Microsoft.Build.Framework
         public virtual System.Version MSBuildVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string ProjectFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string SolutionFilePath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual object State { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
     }
     public abstract partial class SdkResult
     {

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1664,9 +1664,6 @@ namespace Microsoft.Build.Execution
 
                     // Clear all cached SDKs for the submission
                     SdkResolverService.ClearCache(submission.SubmissionId);
-
-                    // Clear SDK resolver cache for the submission
-                    BackEnd.SdkResolution.SdkResolverService.Instance.ClearCache(submission.SubmissionId);
                 }
 
                 if (_buildSubmissions.Count == 0)

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1664,6 +1664,9 @@ namespace Microsoft.Build.Execution
 
                     // Clear all cached SDKs for the submission
                     SdkResolverService.ClearCache(submission.SubmissionId);
+
+                    // Clear SDK resolver cache for the submission
+                    BackEnd.SdkResolution.SdkResolverService.Instance.ClearCache(submission.SubmissionId);
                 }
 
                 if (_buildSubmissions.Count == 0)

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -66,7 +66,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
             ConcurrentDictionary<string, SdkResult> entry;
 
+            // Clear our cache of resolved SDKs
             _cache.TryRemove(submissionId, out entry);
+
+            // Also clear any cache for the SdkResolverService singleton which is the central place where resolution happens
+            SdkResolverService.Instance.ClearCache(submissionId);
         }
 
         /// <inheritdoc cref="INodePacketHandler.PacketReceived"/>

--- a/src/Framework/Sdk/SdkResolverContext.cs
+++ b/src/Framework/Sdk/SdkResolverContext.cs
@@ -33,5 +33,11 @@ namespace Microsoft.Build.Framework
         /// </remarks>
         /// </summary>
         public virtual Version MSBuildVersion { get; protected set; }
+
+        /// <summary>
+        ///     Gets or sets any custom state for current build.  This allows resolvers to maintain state between resolutions.
+        ///     This property is not thread-safe.
+        /// </summary>
+        public virtual object State { get; set; }
     }
 }


### PR DESCRIPTION
SDK resolvers can get and set the `State` property on the `SdkResolverContext` they receive.  This state is preserved for the same resolver during the same build submission.  When there is no build submission, the state is not preserved.  Resolvers will need to take account for these considerations.

This will allow the NuGet-based SDK resolver to only look for and parse `global.json` once per build.

Address item 2 in #2803