### PR TITLE
Move NuGet SDK resolver to its own assembly

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Localization.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Localization.nuspec
@@ -79,5 +79,21 @@
     <file src="$outputPath$tr\Microsoft.Build.Utilities.Core.resources.dll" target="lib\netstandard1.3\tr\Microsoft.Build.Utilities.Core.resources.dll" />
     <file src="$outputPath$zh-Hans\Microsoft.Build.Utilities.Core.resources.dll" target="lib\netstandard1.3\zh-Hans\Microsoft.Build.Utilities.Core.resources.dll" />
     <file src="$outputPath$zh-Hant\Microsoft.Build.Utilities.Core.resources.dll" target="lib\netstandard1.3\zh-Hant\Microsoft.Build.Utilities.Core.resources.dll" />
+
+    <!-- NuGet.MSBuildSdkResolver.dll -->
+    <file src="$outputPath$cs\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\cs\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$de\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\de\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$en\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\en\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$es\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\es\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$fr\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\fr\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$it\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\it\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$ja\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\ja\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$ko\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\ko\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$pl\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\pl\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$pt-BR\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\pt-BR\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$ru\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\ru\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$tr\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\tr\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$zh-Hans\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\zh-Hans\NuGet.MSBuildSdkResolver.resources.dll"/>
+    <file src="$outputPath$zh-Hant\NuGet.MSBuildSdkResolver.resources.dll" target="contentFiles\any\netstandard1.3\SdkResolvers\NuGet.MSBuildSdkResolver\zh-Hant\NuGet.MSBuildSdkResolver.resources.dll"/>
   </files>
 </package>

--- a/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Runtime.nuspec
@@ -65,6 +65,7 @@
     <file src="$outputPath$Microsoft.Xaml.targets" target="contentFiles\any\net46\" buildAction="None" copyToOutput="true"/>
     <file src="$outputPath$Workflow.Targets" target="contentFiles\any\net46\" buildAction="None" copyToOutput="true"/>
     <file src="$outputPath$Workflow.VisualBasic.Targets" target="contentFiles\any\net46\" buildAction="None" copyToOutput="true"/>
+    <file src="$outputPath$NuGet.MSBuildSdkResolver.dll" target="contentFiles\any\net46\SdkResolvers\NuGet.MSBuildSdkResolver\" buildAction="None" copyToOutput="true"/>
 
     <!--
       contentFiles\any\netcoreapp1.0
@@ -90,5 +91,6 @@
     <file src="$outputPathNetCore$Microsoft.VisualStudioVersion.v11.Common.props" target="contentFiles\any\netcoreapp1.0\" buildAction="None" copyToOutput="true"/>
     <file src="$outputPathNetCore$Microsoft.VisualStudioVersion.v12.Common.props" target="contentFiles\any\netcoreapp1.0\" buildAction="None" copyToOutput="true"/>
     <file src="$outputPathNetCore$Microsoft.VisualStudioVersion.v14.Common.props" target="contentFiles\any\netcoreapp1.0\" buildAction="None" copyToOutput="true"/>
+    <file src="$outputPathNetCore$NuGet.MSBuildSdkResolver.dll" target="contentFiles\any\netcoreapp1.0\SdkResolvers\NuGet.MSBuildSdkResolver\" buildAction="None" copyToOutput="true"/>
   </files>
 </package>

--- a/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -16,6 +16,8 @@
     <file src="$X86BinPath$/Microsoft.Common.props" target="\Extensions\15.0" />
     <file src="$X86BinPath$/Microsoft.VisualStudioVersion.v15.Common.props" target="\Extensions\15.0" />
 
+    <file src="$X86BinPath$/NuGet.MSBuildSdkResolver.dll" target="v15.0/bin/SdkResolvers/NuGet.MSBuildSdkResolver" />
+
     <!-- x86 -->
 
     <file src="$X86BinPath$/MSBuild.exe" target="v15.0/bin" />

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -10,6 +10,8 @@ folder InstallDir:\MSBuild\15.0
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props
   file source=$(ThirdPartyNotice)
 
+
+
 folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
@@ -52,6 +54,38 @@ folder InstallDir:\MSBuild\15.0\Bin
 folder InstallDir:\MSBuild\15.0\Bin\MSBuild
   file source=$(X86BinPath)Microsoft.Build.Core.xsd
   file source=$(X86BinPath)Microsoft.Build.CommonTypes.xsd
+
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver
+  file source=$(X86BinPath)NuGet.MSBuildSdkResolver.dll
+
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\cs
+  file source=$(X86BinPath)cs\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\de
+  file source=$(X86BinPath)de\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\en
+  file source=$(X86BinPath)en\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\es
+  file source=$(X86BinPath)es\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\fr
+  file source=$(X86BinPath)fr\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\it
+  file source=$(X86BinPath)it\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\ja
+  file source=$(X86BinPath)ja\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\ko
+  file source=$(X86BinPath)ko\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\pl
+  file source=$(X86BinPath)pl\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\pt-BR
+  file source=$(X86BinPath)pt-BR\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\ru
+  file source=$(X86BinPath)ru\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\tr
+  file source=$(X86BinPath)tr\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\zh-Hans
+  file source=$(X86BinPath)zh-Hans\NuGet.MSBuildSdkResolver.resources.dll
+folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\NuGet.MSBuildSdkResolver\zh-Hant
+  file source=$(X86BinPath)zh-Hant\NuGet.MSBuildSdkResolver.resources.dll
 
 folder InstallDir:\MSBuild\15.0\Bin\cs
   file source=$(X86BinPath)cs\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all

--- a/setup/files.swr
+++ b/setup/files.swr
@@ -10,8 +10,6 @@ folder InstallDir:\MSBuild\15.0
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props
   file source=$(ThirdPartyNotice)
 
-
-
 folder InstallDir:\MSBuild\15.0\Bin
   file source=$(X86BinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all

--- a/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Build.BackEnd.SdkResolution;
-using Microsoft.Build.BackEnd.SdkResolution.NuGet;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
@@ -34,22 +33,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             var resolvers = loader.LoadResolvers(_loggingContext, new MockElementLocation("file"));
 
-            resolvers.Select(i => i.GetType()).ShouldBe(new [] { typeof(NuGetSdkResolver) , typeof(DefaultSdkResolver) });
-        }
-
-        [Fact]
-        public void AssertDefaultLoaderDoesNotReturnsNuGetSdkResolverWhenDisabled()
-        {
-            using (TestEnvironment env = TestEnvironment.Create())
-            {
-                env.SetEnvironmentVariable("MSBUILDDISABLENUGETSDKRESOLVER", "1");
-
-                var loader = new SdkResolverLoader();
-
-                var resolvers = loader.LoadResolvers(_loggingContext, new MockElementLocation("file"));
-
-                resolvers.Select(i => i.GetType()).ShouldBe(new[] { typeof(DefaultSdkResolver) });
-            }
+            resolvers.Select(i => i.GetType()).ShouldBe(new [] { typeof(DefaultSdkResolver) });
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             string result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
             Assert.Equal("resolverpath1", result);
-            Assert.Equal("MockSdkResolver1 running", _log.ToString().Trim());
+            Assert.Contains("MockSdkResolver1 running", _log.ToString().Trim());
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     key => GetSdkResult(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath));
             }
 
-            if (!SdkResolverService.IsReferenceSameVersion(sdk, result.Version))
+            if (result != null && !SdkResolverService.IsReferenceSameVersion(sdk, result.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.
                 loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, result.Version, result.ElementLocation, sdk.Version);
@@ -153,14 +153,17 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
             SdkResult sdkResult = SdkResolverService.Instance.GetSdkResult(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath);
 
-            if (!SdkResolverService.IsReferenceSameVersion(sdk, sdkResult.Version))
+            if (sdkResult != null)
             {
-                // MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.
-                loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "SdkResultVersionDifferentThanReference", sdk.Name, sdk.Version, sdkResult.Version);
-            }
+                if (!SdkResolverService.IsReferenceSameVersion(sdk, sdkResult.Version))
+                {
+                    // MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.
+                    loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "SdkResultVersionDifferentThanReference", sdk.Name, sdk.Version, sdkResult.Version);
+                }
 
-            // Associate the element location of the resolved SDK reference
-            sdkResult.ElementLocation = sdkReferenceLocation;
+                // Associate the element location of the resolved SDK reference
+                sdkResult.ElementLocation = sdkReferenceLocation;
+            }
 
             return sdkResult;
         }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 {
                     result = (SdkResult) sdkResolver.Resolve(sdk, context, resultFactory);
                 }
-                catch (FileNotFoundException e) when (sdkResolver.GetType().GetTypeInfo().Name.Equals("NuGetSdkResolver", StringComparison.Ordinal))
+                catch (Exception e) when (e is FileNotFoundException || e is FileLoadException && sdkResolver.GetType().GetTypeInfo().Name.Equals("NuGetSdkResolver", StringComparison.Ordinal))
                 {
                     // Since we explicitly add the NuGetSdkResolver, we special case this.  The NuGetSdkResolver has special logic
                     // to load NuGet assemblies at runtime which could fail if the user is not running installed MSBuild.  Rather

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // than give them a generic error, we want to give a more specific message.  This exception cannot be caught by
                     // the resolver itself because it is usually thrown before the class is loaded
                     // MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}
-                    loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunNuGetSdkResolver", e.Message);
+                    loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "CouldNotRunNuGetSdkResolver", MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName, e.Message);
                     continue;
                 }
                 catch (Exception e)

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -16,11 +16,6 @@
     <DefineConstants>$(DefineConstants);BUILD_ENGINE</DefineConstants>
     <GenerateReferenceAssemblySources>true</GenerateReferenceAssemblySources>
     <EnableDocumentationFile>true</EnableDocumentationFile>
-    <!--
-        Have to set this to false because NuSpecGenerator will include NuGet dependencies.
-        We can turn this back on when we've moved to the new SDK and can set PrivateAssets="All"
-    -->
-    <UpdateNuGetPackageDependencies>false</UpdateNuGetPackageDependencies>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -235,11 +230,6 @@
     <Compile Include="BackEnd\Components\Scheduler\SchedulingPlan.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\DefaultSdkResolver.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\ISdkResolverService.cs" />
-    <Compile Include="BackEnd\Components\SdkResolution\NuGet\GlobalJsonReader.cs" />
-    <Compile Include="BackEnd\Components\SdkResolution\NuGet\NuGetSdkLogger.cs" />
-    <Compile Include="BackEnd\Components\SdkResolution\NuGet\NuGetSdkResolver.cs" />
-    <Compile Include="BackEnd\Components\SdkResolution\NuGet\NuGetSdkResolverBase.cs" />
-    <Compile Include="BackEnd\Components\SdkResolution\NuGet\RestoreRunnerEx.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\OutOfProcNodeSdkResolverService.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\OutOfProcNodeSdkResolverServiceFactory.cs" />
     <Compile Include="BackEnd\Components\SdkResolution\SdkLogger.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1208,7 +1208,7 @@
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" UESanitized="false" Visibility="Public">
-    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "MSBUILD_NUGET_PATH" to the folder that contains the required NuGet assemblies. {1}</value>
+    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "MSBUILD_NUGET_PATH" to the folder that contains the required NuGet assemblies. {0}</value>
     <comment>{StrBegin="MSB4243: "}</comment>
   </data>
   <data name="InvalidSdkElementName" UESanitized="false" Visibility="Public">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1208,20 +1208,8 @@
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" UESanitized="false" Visibility="Public">
-    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
+    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "MSBUILD_NUGET_PATH" to the folder that contains the required NuGet assemblies. {1}</value>
     <comment>{StrBegin="MSB4243: "}</comment>
-  </data>
-  <data name="FailedToParseGlobalJson" UESanitized="false" Visibility="Public">
-    <value>Failed to parse "{0}". {1}</value>
-    <comment></comment>
-  </data>
-  <data name="NuGetSdkResolverCouldNotFindInstalledPackage" UESanitized="false" Visibility="Public">
-    <value>MSB4244: Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</value>
-    <comment>{StrBegin="MSB4244: "}</comment>
-  </data>
-  <data name="NuGetSdkResolverPackageWasNotInstalled" UESanitized="false" Visibility="Public">
-    <value>MSB4245: Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</value>
-    <comment>{StrBegin="MSB4245: "}</comment>
   </data>
   <data name="InvalidSdkElementName" UESanitized="false" Visibility="Public">
     <value>MSB4238: The name "{0}" is not a valid SDK name.</value>
@@ -1688,7 +1676,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4246.
+        Next message code should be MSB4244.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1208,7 +1208,7 @@
     <comment>{StrBegin="MSB4242: "}</comment>
   </data>
   <data name="CouldNotRunNuGetSdkResolver" UESanitized="false" Visibility="Public">
-    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "MSBUILD_NUGET_PATH" to the folder that contains the required NuGet assemblies. {0}</value>
+    <value>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</value>
     <comment>{StrBegin="MSB4243: "}</comment>
   </data>
   <data name="InvalidSdkElementName" UESanitized="false" Visibility="Public">

--- a/src/Build/project.json
+++ b/src/Build/project.json
@@ -1,8 +1,4 @@
 ﻿{
-  "dependencies": {
-    "NuGet.Commands": "4.5.0",
-    "NuGet.Protocol": "4.5.0"
-  },
   "frameworks": {
     "net46": {
       "dependencies": {

--- a/src/MSBuild.sln
+++ b/src/MSBuild.sln
@@ -70,6 +70,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGetPackages", "NuGetPacka
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlFileLogger", "..\Samples\XmlFileLogger\XmlFileLogger.csproj", "{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.MSBuildSdkResolver", "NuGetSdkResolver\NuGet.MSBuildSdkResolver.csproj", "{C7988833-3EF2-43F4-A170-34E8CCCB1320}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -810,6 +812,48 @@ Global
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Release-NetCore|x64.Build.0 = Release-NetCore|x64
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Release-NetCore|x86.ActiveCfg = Release-NetCore|x86
 		{7D8BA0AA-B715-4646-A2F8-844DB2F15C81}.Release-NetCore|x86.Build.0 = Release-NetCore|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|x64.ActiveCfg = Debug|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|x64.Build.0 = Debug|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|x86.ActiveCfg = Debug|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug|x86.Build.0 = Debug|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|Any CPU.ActiveCfg = Debug-MONO|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|Any CPU.Build.0 = Debug-MONO|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|x64.ActiveCfg = Debug-MONO|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|x64.Build.0 = Debug-MONO|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|x86.ActiveCfg = Debug-MONO|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-MONO|x86.Build.0 = Debug-MONO|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|Any CPU.ActiveCfg = Debug-NetCore|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|Any CPU.Build.0 = Debug-NetCore|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|x64.ActiveCfg = Debug-NetCore|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|x64.Build.0 = Debug-NetCore|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|x86.ActiveCfg = Debug-NetCore|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Debug-NetCore|x86.Build.0 = Debug-NetCore|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|Any CPU.ActiveCfg = Port-Progress|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|Any CPU.Build.0 = Port-Progress|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|x64.ActiveCfg = Port-Progress|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|x64.Build.0 = Port-Progress|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|x86.ActiveCfg = Port-Progress|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Port-Progress|x86.Build.0 = Port-Progress|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|x64.ActiveCfg = Release|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|x64.Build.0 = Release|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|x86.ActiveCfg = Release|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release|x86.Build.0 = Release|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|Any CPU.ActiveCfg = Release-MONO|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|Any CPU.Build.0 = Release-MONO|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|x64.ActiveCfg = Release-MONO|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|x64.Build.0 = Release-MONO|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|x86.ActiveCfg = Release-MONO|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-MONO|x86.Build.0 = Release-MONO|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|Any CPU.ActiveCfg = Release-NetCore|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|Any CPU.Build.0 = Release-NetCore|Any CPU
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|x64.ActiveCfg = Release-NetCore|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|x64.Build.0 = Release-NetCore|x64
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|x86.ActiveCfg = Release-NetCore|x86
+		{C7988833-3EF2-43F4-A170-34E8CCCB1320}.Release-NetCore|x86.Build.0 = Release-NetCore|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NuGetSdkResolver/GlobalJsonReader.cs
+++ b/src/NuGetSdkResolver/GlobalJsonReader.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
 
-namespace Microsoft.Build.BackEnd.SdkResolution.NuGet
+namespace NuGet.MSBuildSdkResolver
 {
     /// <summary>
     /// Reads MSBuild related sections from a global.json.

--- a/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
+++ b/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug-NetCore' or '$(Configuration)' == 'Release-NetCore'">
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v1.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="..\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{C7988833-3EF2-43F4-A170-34E8CCCB1320}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.MSBuildSdkResolver</RootNamespace>
+    <AssemblyName>NuGet.MSBuildSdkResolver</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug-MONO|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-MONO|AnyCPU'" />
+  <ItemGroup Condition="'$(NetCoreBuild)' != 'true'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj">
+      <Project>{571f09db-a81a-4444-945c-6f7b530054cd}</Project>
+      <Name>Microsoft.Build.Framework</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GlobalJsonReader.cs" />
+    <Compile Include="NuGetSdkLogger.cs" />
+    <Compile Include="NuGetSdkResolver.cs" />
+    <Compile Include="NuGetSdkResolverBase.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Resources\AssemblyResources.cs" />
+    <Compile Include="RestoreRunnerEx.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Shared\AssemblyUtilities.cs">
+      <Link>Shared\AssemblyUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs">
+      <Link>Shared\BuildEnvironmentHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\Constants.cs">
+      <Link>Shared\Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\ErrorUtilities.cs">
+      <Link>Shared\ErrorUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\EscapingUtilities.cs">
+      <Link>Shared\EscapingUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\ExceptionHandling.cs">
+      <Link>Shared\ExceptionHandling.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileUtilities.cs">
+      <Link>Shared\FileUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileUtilitiesRegex.cs">
+      <Link>Shared\FileUtilitiesRegex.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\InternalErrorException.cs">
+      <Link>Shared\InternalErrorException.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\NativeMethodsShared.cs">
+      <Link>Shared\NativeMethodsShared.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\OpportunisticIntern.cs">
+      <Link>Shared\OpportunisticIntern.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\ResourceUtilities.cs">
+      <Link>Shared\ResourceUtilities.cs</Link>
+    </Compile>
+    <Compile Condition="'$(NetCoreBuild)' == 'true'" Include="..\Shared\Compat\SafeHandleZeroOrMinusOneIsInvalid.cs">
+      <Link>Shared\Compat\SafeHandleZeroOrMinusOneIsInvalid.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\StringBuilderCache.cs">
+      <Link>Shared\StringBuilderCache.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\Traits.cs">
+      <Link>Shared\Traits.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs">
+      <Link>Shared\VisualStudioLocationHelper.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="Resources\Strings\Strings.cs.xlf" />
+    <None Include="Resources\Strings\Strings.de.xlf" />
+    <None Include="Resources\Strings\Strings.es.xlf" />
+    <None Include="Resources\Strings\Strings.fr.xlf" />
+    <None Include="Resources\Strings\Strings.it.xlf" />
+    <None Include="Resources\Strings\Strings.ja.xlf" />
+    <None Include="Resources\Strings\Strings.ko.xlf" />
+    <None Include="Resources\Strings\Strings.pl.xlf" />
+    <None Include="Resources\Strings\Strings.pt-BR.xlf" />
+    <None Include="Resources\Strings\Strings.ru.xlf" />
+    <None Include="Resources\Strings\Strings.tr.xlf" />
+    <None Include="Resources\Strings\Strings.xlf" />
+    <None Include="Resources\Strings\Strings.zh-Hans.xlf" />
+    <None Include="Resources\Strings\Strings.zh-Hant.xlf" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\Strings.resx">
+      <LogicalName>$(AssemblyName).Strings.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="..\dir.targets" />
+</Project>

--- a/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
+++ b/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
@@ -94,20 +94,20 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
-    <None Include="Resources\Strings\Strings.cs.xlf" />
-    <None Include="Resources\Strings\Strings.de.xlf" />
-    <None Include="Resources\Strings\Strings.es.xlf" />
-    <None Include="Resources\Strings\Strings.fr.xlf" />
-    <None Include="Resources\Strings\Strings.it.xlf" />
-    <None Include="Resources\Strings\Strings.ja.xlf" />
-    <None Include="Resources\Strings\Strings.ko.xlf" />
-    <None Include="Resources\Strings\Strings.pl.xlf" />
-    <None Include="Resources\Strings\Strings.pt-BR.xlf" />
-    <None Include="Resources\Strings\Strings.ru.xlf" />
-    <None Include="Resources\Strings\Strings.tr.xlf" />
-    <None Include="Resources\Strings\Strings.xlf" />
-    <None Include="Resources\Strings\Strings.zh-Hans.xlf" />
-    <None Include="Resources\Strings\Strings.zh-Hant.xlf" />
+    <None Include="Resources\xlf\Strings.cs.xlf" />
+    <None Include="Resources\xlf\Strings.de.xlf" />
+    <None Include="Resources\xlf\Strings.es.xlf" />
+    <None Include="Resources\xlf\Strings.fr.xlf" />
+    <None Include="Resources\xlf\Strings.it.xlf" />
+    <None Include="Resources\xlf\Strings.ja.xlf" />
+    <None Include="Resources\xlf\Strings.ko.xlf" />
+    <None Include="Resources\xlf\Strings.pl.xlf" />
+    <None Include="Resources\xlf\Strings.pt-BR.xlf" />
+    <None Include="Resources\xlf\Strings.ru.xlf" />
+    <None Include="Resources\xlf\Strings.tr.xlf" />
+    <None Include="Resources\xlf\Strings.xlf" />
+    <None Include="Resources\xlf\Strings.zh-Hans.xlf" />
+    <None Include="Resources\xlf\Strings.zh-Hant.xlf" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Strings.resx">

--- a/src/NuGetSdkResolver/NuGetSdkLogger.cs
+++ b/src/NuGetSdkResolver/NuGetSdkLogger.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using INuGetLogger = NuGet.Common.ILogger;
 using SdkLoggerBase = Microsoft.Build.Framework.SdkLogger;
 
-namespace Microsoft.Build.BackEnd.SdkResolution.NuGet
+namespace NuGet.MSBuildSdkResolver
 {
     /// <summary>
     /// An implementation of <see cref="T:NuGet.Common.ILogger" /> that logs messages to an <see cref="T:Microsoft.Build.Framework.SdkLogger" />.

--- a/src/NuGetSdkResolver/NuGetSdkResolverBase.cs
+++ b/src/NuGetSdkResolver/NuGetSdkResolverBase.cs
@@ -26,17 +26,12 @@ namespace NuGet.MSBuildSdkResolver
         public const string PathToNuGetUnderVisualStudioRoot = @"Common7\IDE\CommonExtensions\Microsoft\NuGet";
 
         /// <summary>
-        /// The name of an environment variable a user can use to specify a custom path containing NuGet assemblies.
-        /// </summary>
-        public const string NuGetAssemblyPathEnvironmentVariableName = "MSBUILD_NUGET_PATH";
-
-        /// <summary>
         /// Attempts to locate the NuGet assemblies based on the current <see cref="BuildEnvironmentMode"/>.
         /// </summary>
         private static readonly Lazy<string> NuGetAssemblyPathLazy = new Lazy<string>(() =>
         {
             // The environment variable overrides everything
-            string basePath = Environment.GetEnvironmentVariable(NuGetAssemblyPathEnvironmentVariableName);
+            string basePath = Environment.GetEnvironmentVariable(MSBuildConstants.NuGetAssemblyPathEnvironmentVariableName);
 
             if (!String.IsNullOrWhiteSpace(basePath) && Directory.Exists(basePath))
             {
@@ -54,7 +49,8 @@ namespace NuGet.MSBuildSdkResolver
         });
 
         /// <summary>
-        /// A list of NuGet assemblies that we have a dependency on but should load at runtime.
+        /// A list of NuGet assemblies that we have a dependency on but should load at runtime.  This list is from dependencies of the
+        /// NuGet.Commands and NuGet.Protocol packages in project.json.  This list should be updated if those dependencies change.
         /// </summary>
         private static readonly HashSet<string> NuGetAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {

--- a/src/NuGetSdkResolver/NuGetSdkResolverBase.cs
+++ b/src/NuGetSdkResolver/NuGetSdkResolverBase.cs
@@ -50,13 +50,13 @@ namespace NuGet.MSBuildSdkResolver
             }
 
             // Expect the NuGet assemblies to be next to MSBuild.exe, which is the case when running .NET CLI
-            return BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
+            return BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
         });
 
         /// <summary>
         /// A list of NuGet assemblies that we have a dependency on but should load at runtime.
         /// </summary>
-        private static readonly HashSet<string> NuGetAssemblies = new HashSet<string>
+        private static readonly HashSet<string> NuGetAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Newtonsoft.Json",
             "NuGet.Commands",
@@ -78,7 +78,7 @@ namespace NuGet.MSBuildSdkResolver
 #if FEATURE_APPDOMAIN
                 AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve;
 #else
-            AssemblyLoadContext.Default.Resolving += AssemblyResolve;
+                AssemblyLoadContext.Default.Resolving += AssemblyResolve;
 #endif
             }
         }

--- a/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
+++ b/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
@@ -7,47 +7,14 @@
 
 using System;
 using System.Reflection;
-using System.Resources;
-#if FEATURE_SECURITY_PERMISSIONS
-using System.Security.Permissions;
-#endif
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-
-#if FEATURE_SECURITY_PERMISSIONS
-// A combination of RequestMinimum and RequestOptional causes the permissions granted to 
-// the assembly to only be the permission requested (like a PermitOnly). More generally
-// the equation for the PermissionSet granted at load time is:
-//
-//        Granted = (MaxGrant intersect (ReqMin union ReqOpt)) - ReqRefuse
-//
-// Where,
-//        MaxGrant -- the permissions granted by policy.
-//        ReqMin -- the permissions that RequestMinimum is specified for.
-//        ReqOpt -- the permissions that RequestOptional is specified for.
-//        ReqRefuse -- the permissions that Request refuse is specified for.
-//
-// Note that if ReqOpt is the empty set, then it is consider to be "FullTrust" and this 
-// equation becomes:
-//
-//        Granted = MaxGrant - ReqRefuse
-//
-// Regardless of whether ReqMin is empty or not.
-#pragma warning disable 618
-[assembly: SecurityPermission(SecurityAction.RequestMinimum, Flags = SecurityPermissionFlag.Execution)]
-#pragma warning restore 618
-#endif
 
 #if STATIC_VERSION_NUMBER
 [assembly: AssemblyVersion(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion)]
 [assembly: AssemblyFileVersion(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyFileVersion)]
 #endif
 
-// This will enable passing the SafeDirectories flag to any P/Invoke calls/implementations within the assembly, 
-// so that we don't run into known security issues with loading libraries from unsafe locations 
-[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-
 #if (LOCALIZED_BUILD)
+using System.Resources;
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
 // We want "en" to require a satellite assembly for debug builds in order to flush out localization
 // issues, but we want release builds to work without it. Also, .net core does not have resource fallbacks

--- a/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
+++ b/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
@@ -7,6 +7,9 @@
 
 using System;
 using System.Reflection;
+#if (LOCALIZED_BUILD)
+using System.Resources;
+#endif
 
 #if STATIC_VERSION_NUMBER
 [assembly: AssemblyVersion(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion)]
@@ -14,7 +17,6 @@ using System.Reflection;
 #endif
 
 #if (LOCALIZED_BUILD)
-using System.Resources;
 // Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
 // We want "en" to require a satellite assembly for debug builds in order to flush out localization
 // issues, but we want release builds to work without it. Also, .net core does not have resource fallbacks

--- a/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
+++ b/src/NuGetSdkResolver/Properties/AssemblyInfo.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//-----------------------------------------------------------------------
+// </copyright>
+// <summary>Assembly info.</summary>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Reflection;
+using System.Resources;
+#if FEATURE_SECURITY_PERMISSIONS
+using System.Security.Permissions;
+#endif
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+#if FEATURE_SECURITY_PERMISSIONS
+// A combination of RequestMinimum and RequestOptional causes the permissions granted to 
+// the assembly to only be the permission requested (like a PermitOnly). More generally
+// the equation for the PermissionSet granted at load time is:
+//
+//        Granted = (MaxGrant intersect (ReqMin union ReqOpt)) - ReqRefuse
+//
+// Where,
+//        MaxGrant -- the permissions granted by policy.
+//        ReqMin -- the permissions that RequestMinimum is specified for.
+//        ReqOpt -- the permissions that RequestOptional is specified for.
+//        ReqRefuse -- the permissions that Request refuse is specified for.
+//
+// Note that if ReqOpt is the empty set, then it is consider to be "FullTrust" and this 
+// equation becomes:
+//
+//        Granted = MaxGrant - ReqRefuse
+//
+// Regardless of whether ReqMin is empty or not.
+#pragma warning disable 618
+[assembly: SecurityPermission(SecurityAction.RequestMinimum, Flags = SecurityPermissionFlag.Execution)]
+#pragma warning restore 618
+#endif
+
+#if STATIC_VERSION_NUMBER
+[assembly: AssemblyVersion(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyVersion)]
+[assembly: AssemblyFileVersion(Microsoft.Build.Shared.MSBuildConstants.CurrentAssemblyFileVersion)]
+#endif
+
+// This will enable passing the SafeDirectories flag to any P/Invoke calls/implementations within the assembly, 
+// so that we don't run into known security issues with loading libraries from unsafe locations 
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+
+#if (LOCALIZED_BUILD)
+// Needed for the "hub-and-spoke model to locate and retrieve localized resources": https://msdn.microsoft.com/en-us/library/21a15yht(v=vs.110).aspx
+// We want "en" to require a satellite assembly for debug builds in order to flush out localization
+// issues, but we want release builds to work without it. Also, .net core does not have resource fallbacks
+#if (DEBUG && !RUNTIME_TYPE_NETCORE)
+[assembly: NeutralResourcesLanguage("en", UltimateResourceFallbackLocation.Satellite)]
+#else
+[assembly: NeutralResourcesLanguage("en")]
+#endif
+#endif
+
+[assembly: CLSCompliant(true)]
+
+[assembly: AssemblyTitle("NuGet.MSBuildSdkResolver.dll")]
+[assembly: AssemblyDescription("NuGet.MSBuildSdkResolver.dll")]
+[assembly: AssemblyCompany("Microsoft Corporation")]
+[assembly: AssemblyProduct("Microsoft® Build Tools®")]
+[assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]

--- a/src/NuGetSdkResolver/Resources/AssemblyResources.cs
+++ b/src/NuGetSdkResolver/Resources/AssemblyResources.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Resources;
+using System.Reflection;
+using System.Globalization;
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// This class provides access to the assembly's resources.
+    /// </summary>
+    internal static class AssemblyResources
+    {
+        /// <summary>
+        /// A slot for msbuild.exe to add a resource manager over its own resources, that can also be consulted.
+        /// </summary>
+        private static ResourceManager s_msbuildExeResourceManager;
+
+        /// <summary>
+        /// The internals of the Engine are exposed to MSBuild.exe, so they must share the same AssemblyResources class and 
+        /// ResourceUtilities class that uses it. To make this possible, MSBuild.exe registers its resources here and they are
+        /// normally consulted last. This assumes that there are no duplicated resource ID's between the Engine and MSBuild.exe.
+        /// (Actually there are currently two: LoggerCreationError and LoggerNotFoundError.
+        /// We can't change the resource ID's this late in the cycle and we sometimes want to load the MSBuild.exe ones,
+        /// because they're a little different. So for that purpose we call GetStringLookingInMSBuildExeResourcesFirst() )
+        /// </summary>
+        internal static void RegisterMSBuildExeResources(ResourceManager manager)
+        {
+            ErrorUtilities.VerifyThrow(s_msbuildExeResourceManager == null, "Only one extra resource manager");
+
+            s_msbuildExeResourceManager = manager;
+        }
+
+        /// <summary>
+        /// Loads the specified resource string, either from the assembly's primary resources, or its shared resources.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="name"></param>
+        /// <returns>The resource string, or null if not found.</returns>
+        internal static string GetString(string name)
+        {
+            // NOTE: the ResourceManager.GetString() method is thread-safe
+            string resource = GetStringFromEngineResources(name);
+
+            if (resource == null)
+            {
+                resource = GetStringFromMSBuildExeResources(name);
+            }
+
+            return resource;
+        }
+
+        /// <summary>
+        /// Loads the specified resource string.
+        /// </summary>
+        /// <returns>The resource string, or null if not found.</returns>
+        internal static string GetStringLookingInMSBuildExeResourcesFirst(string name)
+        {
+            string resource = GetStringFromMSBuildExeResources(name);
+
+            if (resource == null)
+            {
+                resource = GetStringFromEngineResources(name);
+            }
+
+            return resource;
+        }
+
+        /// <summary>
+        /// Loads the specified resource string, from the Engine or else Shared resources.
+        /// </summary>
+        /// <returns>The resource string, or null if not found.</returns>
+        private static string GetStringFromEngineResources(string name)
+        {
+            string resource = s_resources.GetString(name, CultureInfo.CurrentUICulture);
+
+            if (resource == null)
+            {
+                resource = s_sharedResources.GetString(name, CultureInfo.CurrentUICulture);
+            }
+
+            ErrorUtilities.VerifyThrow(resource != null, "Missing resource '{0}'", name);
+
+            return resource;
+        }
+
+        /// <summary>
+        /// Loads the specified resource string, from the MSBuild.exe resources.
+        /// </summary>
+        /// <returns>The resource string, or null if not found.</returns>
+        private static string GetStringFromMSBuildExeResources(string name)
+        {
+            string resource = null;
+
+            if (s_msbuildExeResourceManager != null)
+            {
+                // Try MSBuild.exe's resources
+                resource = s_msbuildExeResourceManager.GetString(name, CultureInfo.CurrentUICulture);
+            }
+
+            return resource;
+        }
+
+        internal static ResourceManager PrimaryResources
+        {
+            get { return s_resources; }
+        }
+
+        internal static ResourceManager SharedResources
+        {
+            get { return s_sharedResources; }
+        }
+
+        // assembly resources
+        private static readonly ResourceManager s_resources = new ResourceManager("NuGet.MSBuildSdkResolver.Strings", typeof(AssemblyResources).GetTypeInfo().Assembly);
+        // shared resources
+        private static readonly ResourceManager s_sharedResources = new ResourceManager("NuGet.MSBuildSdkResolver.Strings.shared", typeof(AssemblyResources).GetTypeInfo().Assembly);
+    }
+}

--- a/src/NuGetSdkResolver/Resources/AssemblyResources.cs
+++ b/src/NuGetSdkResolver/Resources/AssemblyResources.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Resources;
-using System.Reflection;
 using System.Globalization;
+using System.Reflection;
+using System.Resources;
 
 namespace Microsoft.Build.Shared
 {
@@ -12,109 +12,22 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class AssemblyResources
     {
-        /// <summary>
-        /// A slot for msbuild.exe to add a resource manager over its own resources, that can also be consulted.
-        /// </summary>
-        private static ResourceManager s_msbuildExeResourceManager;
-
-        /// <summary>
-        /// The internals of the Engine are exposed to MSBuild.exe, so they must share the same AssemblyResources class and 
-        /// ResourceUtilities class that uses it. To make this possible, MSBuild.exe registers its resources here and they are
-        /// normally consulted last. This assumes that there are no duplicated resource ID's between the Engine and MSBuild.exe.
-        /// (Actually there are currently two: LoggerCreationError and LoggerNotFoundError.
-        /// We can't change the resource ID's this late in the cycle and we sometimes want to load the MSBuild.exe ones,
-        /// because they're a little different. So for that purpose we call GetStringLookingInMSBuildExeResourcesFirst() )
-        /// </summary>
-        internal static void RegisterMSBuildExeResources(ResourceManager manager)
-        {
-            ErrorUtilities.VerifyThrow(s_msbuildExeResourceManager == null, "Only one extra resource manager");
-
-            s_msbuildExeResourceManager = manager;
-        }
-
-        /// <summary>
-        /// Loads the specified resource string, either from the assembly's primary resources, or its shared resources.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="name"></param>
-        /// <returns>The resource string, or null if not found.</returns>
-        internal static string GetString(string name)
-        {
-            // NOTE: the ResourceManager.GetString() method is thread-safe
-            string resource = GetStringFromEngineResources(name);
-
-            if (resource == null)
-            {
-                resource = GetStringFromMSBuildExeResources(name);
-            }
-
-            return resource;
-        }
+        internal static ResourceManager PrimaryResources { get; } = new ResourceManager("NuGet.MSBuildSdkResolver.Strings", typeof(AssemblyResources).GetTypeInfo().Assembly);
 
         /// <summary>
         /// Loads the specified resource string.
         /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="name">The name of the resource.</param>
         /// <returns>The resource string, or null if not found.</returns>
-        internal static string GetStringLookingInMSBuildExeResourcesFirst(string name)
+        internal static string GetString(string name)
         {
-            string resource = GetStringFromMSBuildExeResources(name);
-
-            if (resource == null)
-            {
-                resource = GetStringFromEngineResources(name);
-            }
-
-            return resource;
-        }
-
-        /// <summary>
-        /// Loads the specified resource string, from the Engine or else Shared resources.
-        /// </summary>
-        /// <returns>The resource string, or null if not found.</returns>
-        private static string GetStringFromEngineResources(string name)
-        {
-            string resource = s_resources.GetString(name, CultureInfo.CurrentUICulture);
-
-            if (resource == null)
-            {
-                resource = s_sharedResources.GetString(name, CultureInfo.CurrentUICulture);
-            }
+            // NOTE: the ResourceManager.GetString() method is thread-safe
+            string resource = PrimaryResources.GetString(name, CultureInfo.CurrentUICulture);
 
             ErrorUtilities.VerifyThrow(resource != null, "Missing resource '{0}'", name);
 
             return resource;
         }
-
-        /// <summary>
-        /// Loads the specified resource string, from the MSBuild.exe resources.
-        /// </summary>
-        /// <returns>The resource string, or null if not found.</returns>
-        private static string GetStringFromMSBuildExeResources(string name)
-        {
-            string resource = null;
-
-            if (s_msbuildExeResourceManager != null)
-            {
-                // Try MSBuild.exe's resources
-                resource = s_msbuildExeResourceManager.GetString(name, CultureInfo.CurrentUICulture);
-            }
-
-            return resource;
-        }
-
-        internal static ResourceManager PrimaryResources
-        {
-            get { return s_resources; }
-        }
-
-        internal static ResourceManager SharedResources
-        {
-            get { return s_sharedResources; }
-        }
-
-        // assembly resources
-        private static readonly ResourceManager s_resources = new ResourceManager("NuGet.MSBuildSdkResolver.Strings", typeof(AssemblyResources).GetTypeInfo().Assembly);
-        // shared resources
-        private static readonly ResourceManager s_sharedResources = new ResourceManager("NuGet.MSBuildSdkResolver.Strings.shared", typeof(AssemblyResources).GetTypeInfo().Assembly);
     }
 }

--- a/src/NuGetSdkResolver/Resources/Strings.resx
+++ b/src/NuGetSdkResolver/Resources/Strings.resx
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="UESanitized" type="xsd:boolean" msdata:Ordinal="3" />
+              <xsd:attribute name="Visibility" type="Visibility_Type" msdata:Ordinal="4" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="5" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="6" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+    <xsd:simpleType name="Visibility_Type">
+      <xsd:restriction base="xsd:string">
+        <xsd:enumeration value="Public" />
+        <xsd:enumeration value="Obsolete" />
+        <xsd:enumeration value="Private_OM" />
+      </xsd:restriction>
+    </xsd:simpleType>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FailedToParseGlobalJson" UESanitized="false" Visibility="Public">
+    <value>Failed to parse "{0}". {1}</value>
+    <comment></comment>
+  </data>
+  <data name="CouldNotFindInstalledPackage" UESanitized="false" Visibility="Public">
+    <value>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</value>
+    <comment></comment>
+  </data>
+  <data name="PackageWasNotInstalled" UESanitized="false" Visibility="Public">
+    <value>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</value>
+    <comment></comment>
+  </data>
+</root>

--- a/src/NuGetSdkResolver/Resources/Strings.resx
+++ b/src/NuGetSdkResolver/Resources/Strings.resx
@@ -67,7 +67,7 @@
     <comment></comment>
   </data>
   <data name="PackageWasNotInstalled" UESanitized="false" Visibility="Public">
-    <value>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</value>
+    <value>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</value>
     <comment></comment>
   </data>
 </root>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
+    <body>
+      <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
+      <trans-unit id="FailedToParseGlobalJson">
+        <source>Failed to parse "{0}". {1}</source>
+        <target state="new">Failed to parse "{0}". {1}</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="CouldNotFindInstalledPackage">
+        <source>Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</source>
+        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the could not located.</target>
+        <note/>
+      </trans-unit>
+      <trans-unit id="PackageWasNotInstalled">
+        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <note/>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
@@ -14,8 +14,8 @@
         <note/>
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
-        <source>Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successfully but a package with the ID of "{1}" was not installed.</target>
+        <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
+        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
         <note/>
       </trans-unit>
     </body>

--- a/src/NuGetSdkResolver/RestoreRunnerEx.cs
+++ b/src/NuGetSdkResolver/RestoreRunnerEx.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -16,7 +15,7 @@ using System.Threading.Tasks;
 
 using ILogger = NuGet.Common.ILogger;
 
-namespace Microsoft.Build.BackEnd.SdkResolution.NuGet
+namespace NuGet.Commands
 {
     /// <summary>
     /// An extension of the NuGet.Commands.RestoreRunner class that contains APIs we do not yet have.

--- a/src/NuGetSdkResolver/project.json
+++ b/src/NuGetSdkResolver/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "dependencies": {
+    "NuGet.Commands": "4.5.0",
+    "NuGet.Protocol": "4.5.0"
+  },
+  "frameworks": {
+    "net46": {
+      "dependencies": {
+        "Microsoft.VisualStudio.Setup.Configuration.Interop": "1.14.114",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
+      }
+    },
+    "netstandard1.5": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+        "System.Runtime.Handles": "4.0.1",
+        "System.Runtime.Loader": "4.0.0"
+      }
+    }
+  }
+}

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -46,6 +46,10 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal const string WarningsAsMessages = "MSBuildWarningsAsMessages";
 
+        /// <summary>
+        /// The name of the environment variable that users can specify to override where NuGet assemblies are loaded from in the NuGetSdkResolver.
+        /// </summary>
+        internal const string NuGetAssemblyPathEnvironmentVariableName = "MSBUILD_NUGET_PATH";
 
         /// <summary>
         /// The name of the target to run when a user specifies the /restore command-line argument.

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -20,6 +20,7 @@
     <Project Include="Build.UnitTests\Microsoft.Build.Engine.UnitTests.csproj" />
     <Project Include="Build.OM.UnitTests\Microsoft.Build.Engine.OM.UnitTests.csproj" />
     <Project Include="UnitTests.Shared\Microsoft.Build.UnitTests.Shared.csproj" />
+    <Project Include="NuGetSdkResolver\NuGet.MSBuildSdkResolver.csproj" />
   </ItemGroup>
 
   <Import Project="dir.targets" />

--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -64,7 +64,11 @@
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuspec.referencegenerator\$(NuGetVersion)\lib\net45\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\Newtonsoft.Json\9.0.1\lib\net45\**\*.*" />
 
-      <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.dll" />
+      <FreshlyBuiltBinariesSdkResolvers Include="$(DeploymentDir)\NuGet.MSBuildSdkResolver.dll">
+        <DestinationSubDirectory>NuGet.MSBuildSdkResolver</DestinationSubDirectory>
+      </FreshlyBuiltBinariesSdkResolvers>
+
+      <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.dll" Exclude="@(FreshlyBuiltBinariesSdkResolvers)" />
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.exe" />
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.pdb" />
       <FreshlyBuiltBinaries Include="$(DeploymentDir)**\*.exe.config" />
@@ -102,11 +106,20 @@
     <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
     <Copy SourceFiles="@(FreshlyBuiltProjects)"
           DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- Copy our freshly-built SDK resolvers -->
+    <Copy SourceFiles="@(FreshlyBuiltBinariesSdkResolvers)"
+          DestinationFiles="@(FreshlyBuiltBinariesSdkResolvers -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\SdkResolvers\%(DestinationSubDirectory)\%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="BootstrapNetCore">
     <ItemGroup>
-      <DeployedItems Include="$(DeploymentDir)\**\*.*"/>
+      
+      <FreshlyBuiltBinariesSdkResolvers Include="$(DeploymentDir)\NuGet.MSBuildSdkResolver.dll">
+        <DestinationSubDirectory>NuGet.MSBuildSdkResolver</DestinationSubDirectory>
+      </FreshlyBuiltBinariesSdkResolvers>
+
+      <DeployedItems Include="$(DeploymentDir)\**\*.*" Exclude="@(FreshlyBuiltBinariesSdkResolvers)"/>
 
       <!-- TODO: Automate getting NuGet.Build.Tasks.dll + all dependencies. -->
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.build.tasks\$(NuGetVersion)\lib\netstandard1.3\**\*.*" />
@@ -143,5 +156,9 @@
     <!-- Microsoft.Portable.CSharp.targets imports this file with a capital T -->
     <Copy SourceFiles="$(DeploymentDir)\Microsoft.CSharp.targets"
           DestinationFiles="$(BootstrapDestination)\Microsoft.CSharp.Targets" />
+    
+    <!-- Copy our freshly-built SDK resolvers -->
+    <Copy SourceFiles="@(FreshlyBuiltBinariesSdkResolvers)"
+          DestinationFiles="@(FreshlyBuiltBinariesSdkResolvers -> '$(BootstrapDestination)\SdkResolvers\%(DestinationSubDirectory)\%(Filename)%(Extension)')" />
   </Target>
 </Project>


### PR DESCRIPTION
Having a reference to NuGet but not shipping NuGet breaks NGEN and is a no-go.  This change moves it to its own assembly while leaving in all of the optimizations where NuGet assemblies are only loaded if needed.

1. New assembly
2. Moved resources
3. Updated SWR file, confirmed VSIX package layout
4. Updated bootstrap for local dev builds