### PR TITLE
Fix potential issue in CoreClrAssemblyLoader

### DIFF
--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Shared
 
             assemblyName.Version = _currentAssemblyVersion;
 
-            return AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
+            return context.LoadFromAssemblyName(assemblyName);
         }
 
         private Assembly TryResolveAssembly(AssemblyLoadContext context, AssemblyName assemblyName)


### PR DESCRIPTION
While debugging something else, I noticed that CoreClrAssemblyLoader.TryGetWellKnownAssembly is being passed an AssemblyLoadContext but is not using it.

The AssemblyResolve event receives an AssemblyLoadContext but we won't end up respecting it and instead will load it into the default context.