### PR TITLE
Fix NuGet.MSBuildSdkResolver content files in localization package

### DIFF
--- a/build/NuGetPackages/Microsoft.Build.Localization.nuspec
+++ b/build/NuGetPackages/Microsoft.Build.Localization.nuspec
@@ -13,6 +13,9 @@
     <description>This package contains the localized satellite assemblies for MSBuild. Reference this package only if you want msbuild output to be localized in cs;de;en;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>MSBuild</tags>
+    <contentFiles>
+      <files include="**" buildAction="None" copyToOutput="true" flatten="false" />
+    </contentFiles>
   </metadata>
   <files>
 

--- a/src/MSBuild.sln
+++ b/src/MSBuild.sln
@@ -62,6 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGetPackages", "NuGetPacka
 		..\build\NuGetPackages\Microsoft.Build.Conversion.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Conversion.Core.nuspec
 		..\build\NuGetPackages\Microsoft.Build.Engine.nuspec = ..\build\NuGetPackages\Microsoft.Build.Engine.nuspec
 		..\build\NuGetPackages\Microsoft.Build.Framework.nuspec = ..\build\NuGetPackages\Microsoft.Build.Framework.nuspec
+		..\build\NuGetPackages\Microsoft.Build.Localization.nuspec = ..\build\NuGetPackages\Microsoft.Build.Localization.nuspec
 		..\build\NuGetPackages\Microsoft.Build.nuspec = ..\build\NuGetPackages\Microsoft.Build.nuspec
 		..\build\NuGetPackages\Microsoft.Build.Runtime.nuspec = ..\build\NuGetPackages\Microsoft.Build.Runtime.nuspec
 		..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec = ..\build\NuGetPackages\Microsoft.Build.Tasks.Core.nuspec


### PR DESCRIPTION
Default "buildAction" is "compile" and default "copyToOutput" is "false"

:cry: