### PR TITLE
Undo Newtonsoft.Json bootstrapper change

### DIFF
--- a/targets/BootStrapMSBuild.proj
+++ b/targets/BootStrapMSBuild.proj
@@ -62,7 +62,7 @@
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.protocol\$(NuGetVersion)\lib\net46\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuget.versioning\$(NuGetVersion)\lib\net46\**\*.*" />
       <NuGetCommonExtensions Include="$(ProjectDir)packages\nuspec.referencegenerator\$(NuGetVersion)\lib\net46\**\*.*" />
-      <NuGetCommonExtensions Include="$(ProjectDir)packages\Newtonsoft.Json\9.0.1\lib\net46\**\*.*" />
+      <NuGetCommonExtensions Include="$(ProjectDir)packages\Newtonsoft.Json\9.0.1\lib\net45\**\*.*" />
 
       <FreshlyBuiltBinariesSdkResolvers Include="$(DeploymentDir)\NuGet.MSBuildSdkResolver.dll">
         <DestinationSubDirectory>NuGet.MSBuildSdkResolver</DestinationSubDirectory>


### PR DESCRIPTION
One too many Ctrl+D in VS Code :(

Our CI doesn't catch this and it only happens on a clean enlistment. Our official build did catch it because we package it up for the CoreXT package.