### PR TITLE
Skip TF-compat checks for P2Ps that don't reference output

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1543,9 +1543,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       We give this treatment to .vcxproj by default since no .vcxproj can target more
       than one framework.
+
+      Likewise if the dependency is for build ordering instead of an assembly reference
+      (ReferenceOutputAssembly=false), skip the checks since we can't know what TF
+      the output would need to be compatible with.
    -->
    <ItemGroup>
-      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and '%(Extension)' == '.vcxproj'">
+      <_MSBuildProjectReferenceExistent
+        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and
+                   ('%(Extension)' == '.vcxproj' or '%(ReferenceOutputAssembly)' == 'false')">
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </_MSBuildProjectReferenceExistent>
    </ItemGroup>


### PR DESCRIPTION
Allows having a `ProjectReference` pointing to a project with an incompatible TF, as long as you don't reference the output of that project.

This is common, for example, if you have a netcoreapp1.0 code generator that you want to run in a later project's build.

When we introduced multitargeting support in 15.x, we started doing complicated dances to figure out the "most compatible" TF of the referenced project, given the referencing project's current TF. But that's only relevant if there's going to be a direct reference.

This was especially annoying because adding a solution-level build dependency secretly creates `ProjectReference` items with `ReferenceOutputAssembly=false`, _even though they're not in the project file_.

Fixes #2661 / dotnet/sdk#939.