### PR TITLE
Minor improvements to SDK resolver end-user experience

### DIFF
--- a/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
@@ -1,12 +1,21 @@
-﻿using Shouldly;
+﻿using System;
+using System.Collections.Generic;
+using Shouldly;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.BackEnd.SdkResolution;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Xunit;
+using Exception = System.Exception;
+using SdkResolverBase = Microsoft.Build.Framework.SdkResolver;
+using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
+using SdkResultBase = Microsoft.Build.Framework.SdkResult;
+using SdkResultFactoryBase = Microsoft.Build.Framework.SdkResultFactory;
 
 namespace Microsoft.Build.Engine.UnitTests.BackEnd
 {
@@ -71,6 +80,160 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             finally
             {
                 FileUtilities.DeleteDirectoryNoThrow(root, true);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that if an SDK resolver throws while creating an instance that a warning is logged.
+        /// </summary>
+        [Fact]
+        public void VerifyWarningLoggedWhenResolverFailsToLoad()
+        {
+            SdkResolverLoader sdkResolverLoader = new MockSdkResolverLoader
+            {
+                LoadResolverAssemblyFunc = (resolverPath, loggingContext, location) => typeof(SdkResolverLoader_Tests).GetTypeInfo().Assembly,
+                FindPotentialSdkResolversFunc = rootFolder => new List<string>
+                {
+                    "myresolver.dll"
+                },
+                GetResolverTypesFunc = assembly => new[] { typeof(MockSdkResolverThatDoesNotLoad) }
+            };
+
+            sdkResolverLoader.LoadResolvers(_loggingContext, ElementLocation.EmptyLocation);
+
+            _logger.Warnings.Select(i => i.Message).ShouldBe(new []
+            {
+                $"The SDK resolver type \"{nameof(MockSdkResolverThatDoesNotLoad)}\" failed to load. A8BB8B3131D3475D881ACD3AF8D75BD6"
+            });
+            _logger.ErrorCount.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// Verifies that when we attempt to create an instance of a resolver with no public constructor that a warning
+        /// is logged with the appropriate message.
+        /// </summary>
+        [Fact]
+        public void VerifyWarningLoggedResolverHasNoPublicConstructor()
+        {
+            SdkResolverLoader sdkResolverLoader = new MockSdkResolverLoader
+            {
+                LoadResolverAssemblyFunc = (resolverPath, loggingContext, location) => typeof(SdkResolverLoader_Tests).GetTypeInfo().Assembly,
+                FindPotentialSdkResolversFunc = rootFolder => new List<string>
+                {
+                    "myresolver.dll"
+                },
+                GetResolverTypesFunc = assembly => new[] { typeof(MockSdkResolverNoPublicConstructor) }
+            };
+
+            sdkResolverLoader.LoadResolvers(_loggingContext, ElementLocation.EmptyLocation);
+
+            _logger.Warnings.Select(i => i.Message).ShouldBe(new[]
+            {
+                $"The SDK resolver type \"{nameof(MockSdkResolverNoPublicConstructor)}\" failed to load. No parameterless constructor defined for this object."
+            });
+            _logger.ErrorCount.ShouldBe(0);
+        }
+
+        /// <summary>
+        /// Verifies that when a resolver assembly cannot be loaded, that a warning is logged and other resolvers are still loaded.
+        /// </summary>
+        [Fact]
+        public void VerifyWarningLoggedWhenResolverAssemblyCannotBeLoaded()
+        {
+            const string assemblyPath = @"C:\foo\bar\myresolver.dll";
+            const string expectedMessage = "91BF077D4E9646819DE7AB2CBA2637B6";
+
+            SdkResolverLoader sdkResolverLoader = new MockSdkResolverLoader
+            {
+                LoadResolverAssemblyFunc = (resolverPath, loggingContext, location) => throw new Exception(expectedMessage),
+                FindPotentialSdkResolversFunc = rootFolder => new List<string>
+                {
+                    assemblyPath,
+                }
+            };
+
+            IList<SdkResolverBase> resolvers = sdkResolverLoader.LoadResolvers(_loggingContext, ElementLocation.EmptyLocation);
+
+            resolvers.Count.ShouldBe(1);
+
+            _logger.Warnings.Select(i => i.Message).ShouldBe(new[]
+            {
+                $"The SDK resolver assembly \"{assemblyPath}\" could not be loaded. {expectedMessage}"
+            });
+            _logger.ErrorCount.ShouldBe(0);
+        }
+
+        private class MockSdkResolverThatDoesNotLoad : SdkResolverBase
+        {
+            public const string ExpectedMessage = "A8BB8B3131D3475D881ACD3AF8D75BD6";
+
+            public MockSdkResolverThatDoesNotLoad()
+            {
+                throw new Exception(ExpectedMessage);
+            }
+
+            public override string Name => nameof(MockSdkResolverThatDoesNotLoad);
+
+            public override int Priority => 0;
+
+            public override SdkResultBase Resolve(SdkReference sdkReference, SdkResolverContextBase resolverContext, SdkResultFactoryBase factory)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class MockSdkResolverNoPublicConstructor : SdkResolverBase
+        {
+            private MockSdkResolverNoPublicConstructor()
+            {
+            }
+
+            public override string Name => nameof(MockSdkResolverNoPublicConstructor);
+
+            public override int Priority => 0;
+
+            public override SdkResultBase Resolve(SdkReference sdkReference, SdkResolverContextBase resolverContext, SdkResultFactoryBase factory)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class MockSdkResolverLoader : SdkResolverLoader
+        {
+            public Func<string, LoggingContext, ElementLocation, Assembly> LoadResolverAssemblyFunc { get; set; }
+
+            public Func<string, IList<string>> FindPotentialSdkResolversFunc { get; set; }
+
+            public Func<Assembly, IEnumerable<Type>> GetResolverTypesFunc { get; set; }
+
+            protected override Assembly LoadResolverAssembly(string resolverPath, LoggingContext loggingContext, ElementLocation location)
+            {
+                if (LoadResolverAssemblyFunc != null)
+                {
+                    return LoadResolverAssemblyFunc(resolverPath, loggingContext, location);
+                }
+
+                return base.LoadResolverAssembly(resolverPath, loggingContext, location);
+            }
+
+            protected override IEnumerable<Type> GetResolverTypes(Assembly assembly)
+            {
+                if (GetResolverTypesFunc != null)
+                {
+                    return GetResolverTypesFunc(assembly);
+                }
+
+                return base.GetResolverTypes(assembly);
+            }
+
+            internal override IList<string> FindPotentialSdkResolvers(string rootFolder)
+            {
+                if (FindPotentialSdkResolversFunc != null)
+                {
+                    return FindPotentialSdkResolversFunc(rootFolder);
+                }
+
+                return base.FindPotentialSdkResolvers(rootFolder);
             }
         }
     }

--- a/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
@@ -145,7 +145,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverLoader sdkResolverLoader = new MockSdkResolverLoader
             {
-                LoadResolverAssemblyFunc = (resolverPath, loggingContext, location) => throw new Exception(expectedMessage),
+                LoadResolverAssemblyFunc = (resolverPath, loggingContext, location) =>
+                {
+                    throw new Exception(expectedMessage);
+                },
                 FindPotentialSdkResolversFunc = rootFolder => new List<string>
                 {
                     assemblyPath,

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             }
             catch (Exception e)
             {
-                loggingContext.LogWarning(null, new BuildEventFileInfo(location), "CouldNotLoadSdkResolverAssembly", resolverPath, e.Message);
+                ProjectFileErrorUtilities.ThrowInvalidProjectFile(new BuildEventFileInfo(location), e, "CouldNotLoadSdkResolverAssembly", resolverPath, e.Message);
 
                 return;
             }
@@ -102,11 +102,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     // Attempt to get the inner exception in this case, but fall back to the top exception message
                     string message = e.InnerException?.Message ?? e.Message;
 
-                    loggingContext.LogWarning(null, new BuildEventFileInfo(location), "CouldNotLoadSdkResolver", type.Name, message);
+                    ProjectFileErrorUtilities.ThrowInvalidProjectFile(new BuildEventFileInfo(location), e.InnerException ?? e, "CouldNotLoadSdkResolver", type.Name, message);
                 }
                 catch (Exception e)
                 {
-                    loggingContext.LogWarning(null, new BuildEventFileInfo(location), "CouldNotLoadSdkResolver", type.Name, e.Message);
+                    ProjectFileErrorUtilities.ThrowInvalidProjectFile(new BuildEventFileInfo(location), e, "CouldNotLoadSdkResolver", type.Name, e.Message);
                 }
             }
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1200,8 +1200,12 @@
     <comment>{StrBegin="MSB4236: "}</comment>
   </data>
   <data name="CouldNotLoadSdkResolver" UESanitized="false" Visibility="Public">
-    <value>MSB4237: An SDK resolver was found but could not be loaded. {0}</value>
+    <value>MSB4237: The SDK resolver type "{0}" failed to load. {1}</value>
     <comment>{StrBegin="MSB4237: "}</comment>
+  </data>
+  <data name="CouldNotLoadSdkResolverAssembly" UESanitized="false" Visibility="Public">
+    <value>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</value>
+    <comment>{StrBegin="MSB4244: "}</comment>
   </data>
   <data name="CouldNotRunSdkResolver" UESanitized="false" Visibility="Public">
     <value>MSB4242: The SDK resolver "{0}" failed to run. {1}</value>
@@ -1676,7 +1680,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4244.
+        Next message code should be MSB4245.
               
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>


### PR DESCRIPTION
A few minor improvements:

1. Make SdkResolverLoader easier to mock by splitting functionality into more virtual methods
2. Add a different error message if the SDK resolver assembly itself cannot be loaded
3. Fix issue where if one resolver failed to load, the remaining ones would not be loaded
4. More unit tests