### PR TITLE
Ensure *.CopyComplete file gets removed on Clean

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4308,7 +4308,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          input to projects that reference this one. -->
     <Touch Files="@(CopyUpToDateMarker)"
            AlwaysCreate="true"
-           Condition="'@(ReferencesCopiedInThisBuild)' != ''" />
+           Condition="'@(ReferencesCopiedInThisBuild)' != ''">
+        <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
 
   </Target>
 


### PR DESCRIPTION
The @(CopyUpToDateMarker) file is not added to @(FileWrites), so it gets
left behind after a Clean.

https://bugzilla.xamarin.com/show_bug.cgi?id=58174
- This is a Xamarin.Android bug, but the same issue is reproducible with
  regular .net projects too