### PR TITLE
Fix preprocessed output when project path specified in import includes `--`

### DIFF
--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -731,6 +731,8 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 
                 project.SaveLogicalProject(writer);
 
+                string directoryXmlCommentFriendly = directory.Replace("--", "__");
+
                 string expected = ObjectModelHelpers.CleanupFileContents(
         @"<?xml version=""1.0"" encoding=""utf-16""?>
 <!--
@@ -741,9 +743,9 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
   <!--
 ============================================================================================================================================
-  <Import Project=""" + Path.Combine(directory, "*.targets") + @""">
+  <Import Project=""" + Path.Combine(directoryXmlCommentFriendly, "*.targets") + @""">
 
-" + Path.Combine(directory, "1.targets") + @"
+" + Path.Combine(directoryXmlCommentFriendly, "1.targets") + @"
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -756,9 +758,9 @@ namespace Microsoft.Build.UnitTests.Preprocessor
 -->
   <!--
 ============================================================================================================================================
-  <Import Project=""" + Path.Combine(directory, "*.targets") + @""">
+  <Import Project=""" + Path.Combine(directoryXmlCommentFriendly, "*.targets") + @""">
 
-" + Path.Combine(directory, "2.targets") + @"
+" + Path.Combine(directoryXmlCommentFriendly, "2.targets") + @"
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -890,7 +892,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
   <Import Project=""Sdk.props"" Sdk=""MSBuildUnitTestSdk"">
   This import was added implicitly because of the Project element's Sdk attribute specified ""MSBuildUnitTestSdk"".
 
-{sdkPropsPath}
+{sdkPropsPath.Replace("--", "__")}
 ============================================================================================================================================
 -->
   <PropertyGroup>
@@ -911,7 +913,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
   <Import Project=""Sdk.targets"" Sdk=""MSBuildUnitTestSdk"">
   This import was added implicitly because of the Project element's Sdk attribute specified ""MSBuildUnitTestSdk"".
 
-{sdkTargetsPath}
+{sdkTargetsPath.Replace("--", "__")}
 ============================================================================================================================================
 -->
   <PropertyGroup>

--- a/src/Build/Evaluation/Preprocessor.cs
+++ b/src/Build/Evaluation/Preprocessor.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Evaluation
                     // To display what the <Import> tag looked like
                     string importCondition = ((XmlElement)child).GetAttribute(XMakeAttributes.condition);
                     string condition = importCondition.Length > 0 ? $" Condition=\"{importCondition}\"" : String.Empty;
-                    string importProject = ((XmlElement)child).GetAttribute(XMakeAttributes.project);
+                    string importProject = ((XmlElement)child).GetAttribute(XMakeAttributes.project).Replace("--", "__");
                     string importSdk = ((XmlElement)child).GetAttribute(XMakeAttributes.sdk);
                     string sdk = importSdk.Length > 0 ? $" {XMakeAttributes.sdk}=\"{importSdk}\"" : String.Empty;
 


### PR DESCRIPTION
This issue was similar to https://github.com/Microsoft/msbuild/issues/491, but applied when the path specified in an `Import`'s `Project` attribute itself included `--`.

This was caught now because as part of the toolset update, the temp path is now under the repo root, which has `--` in it in Jenkins.