### PR TITLE
Allow SDK Version in explicit project imports

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -6,11 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
+using Microsoft.Build.Framework;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.OM.Construction
@@ -25,9 +28,20 @@ namespace Microsoft.Build.UnitTests.OM.Construction
   {1}
 </Project>";
 
+        private const string ProjectTemplateSdkAsAttributeWithVersion = @"
+<Project Sdk=""{0}/{2}"">
+  {1}
+</Project>";
+
         private const string ProjectTemplateSdkAsElement = @"
 <Project>
   <Sdk Name=""{0}"" />
+  {1}
+</Project>";
+
+        private const string ProjectTemplateSdkAsElementWithVersion = @"
+<Project>
+  <Sdk Name=""{0}"" Version=""{2}"" MinimumVersion=""{3}""/>
   {1}
 </Project>";
 
@@ -36,6 +50,13 @@ namespace Microsoft.Build.UnitTests.OM.Construction
   <Import Project=""Sdk.props"" Sdk=""{0}"" />
   {1}
   <Import Project=""Sdk.targets"" Sdk=""{0}"" />
+</Project>";
+
+        private const string ProjectTemplateSdkAsExplicitImportWithVersion = @"
+<Project>
+  <Import Project=""Sdk.props"" Sdk=""{0}"" Version=""{2}"" MinimumVersion=""{3}"" />
+  {1}
+  <Import Project=""Sdk.targets"" Sdk=""{0}"" Version=""{2}"" MinimumVersion=""{3}"" />
 </Project>";
 
         private const string SdkName = "MSBuildUnitTestSdk";
@@ -381,6 +402,39 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.Equal("MSB4229", exception.ErrorCode);
         }
 
+        [Theory]
+        // MinimumVersion & Version not supported in SDK attribute at the same time
+        [InlineData(ProjectTemplateSdkAsAttributeWithVersion, "1.0.0", null)]
+        [InlineData(ProjectTemplateSdkAsAttributeWithVersion, "min=1.0.0", "1.0.0")]
+
+        [InlineData(ProjectTemplateSdkAsElementWithVersion, "1.0.0", "1.0.0")]
+        [InlineData(ProjectTemplateSdkAsExplicitImportWithVersion, "1.0.0", "1.0.0")]
+        public void SdkImportsSupportVersion(string projectFormatString, string sdkVersion, string minimumSdkVersion)
+        {
+            _env.SetEnvironmentVariable("MSBuildSDKsPath", _testSdkRoot);
+            string projectInnerContents = @"<PropertyGroup><UsedToTestIfImplicitImportsAreInTheCorrectLocation>null</UsedToTestIfImplicitImportsAreInTheCorrectLocation></PropertyGroup>";
+            File.WriteAllText(_sdkPropsPath, "<Project><PropertyGroup><InitialImportProperty>Hello</InitialImportProperty></PropertyGroup></Project>");
+            File.WriteAllText(_sdkTargetsPath, "<Project><PropertyGroup><FinalImportProperty>World</FinalImportProperty></PropertyGroup></Project>");
+
+            string content = string.Format(projectFormatString, SdkName, projectInnerContents, sdkVersion, minimumSdkVersion);
+
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
+            var project = new Project(projectRootElement);
+            project.Imports.Count.ShouldBe(2);
+            var importElement = project.Imports[0].ImportingElement;
+            var sdk = GetParsedSdk(importElement);
+
+            if (sdkVersion.StartsWith("min="))
+            {
+                // Ignore version when min= string is specified
+                sdkVersion = null;
+            }
+
+            sdk.Name.ShouldBe(SdkName);
+            sdk.Version.ShouldBe(sdkVersion);
+            sdk.MinimumVersion.ShouldBe(minimumSdkVersion);
+        }
+
         public void Dispose()
         {
             _env.Dispose();
@@ -397,6 +451,12 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             Assert.True(property.IsImported);
 
             Assert.Equal(expectedValue, property.EvaluatedValue);
+        }
+
+        private SdkReference GetParsedSdk(ProjectImportElement element)
+        {
+            PropertyInfo parsedSdkInfo = typeof(ProjectImportElement).GetProperty("ParsedSdkReference", BindingFlags.Instance | BindingFlags.NonPublic);
+            return (SdkReference)parsedSdkInfo.GetValue(element);
         }
     }
 }

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Valid attributes on import element
         /// </summary>
-        private readonly static string[] s_validAttributesOnImport = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.project, XMakeAttributes.sdk };
+        private readonly static string[] s_validAttributesOnImport = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.project, XMakeAttributes.sdk, XMakeAttributes.sdkVersion, XMakeAttributes.sdkMinimumVersion };
 
         /// <summary>
         /// Valid attributes on usingtask element


### PR DESCRIPTION
All the code was here but the attribute was not allowed on the Import
element at project parse time for Version or MinimumVersion. This change
allows those attributes and rest of the code worked as expected. Added
tests for the scenario and a few others.