### PR TITLE
Project.LastEvaluationId should be valid during logging

### DIFF
--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -422,12 +422,16 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
         }
 
-        /// <summary>
-        /// Logs a project evaluation started event
-        /// </summary>
-        public BuildEventContext LogProjectEvaluationStarted(int nodeId, int submissionId, string projectFile)
+
+        /// <inheritdoc />
+        public BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId)
         {
             return new BuildEventContext(0, 0, 0, 0, 0, 0, 0);
+        }
+
+        /// <inheritdoc />
+        public void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile)
+        {
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/EvaluationLoggingContext.cs
@@ -19,10 +19,15 @@ namespace Microsoft.Build.BackEnd.Components.Logging
         public EvaluationLoggingContext(ILoggingService loggingService, BuildEventContext buildEventContext, string projectFile) :
             base(
                 loggingService,
-                loggingService.LogProjectEvaluationStarted(buildEventContext.NodeId, buildEventContext.SubmissionId, projectFile))
+                loggingService.CreateEvaluationBuildEventContext(buildEventContext.NodeId, buildEventContext.SubmissionId))
         {
             _projectFile = projectFile;
             IsValid = true;
+        }
+
+        public void LogProjectEvaluationStarted()
+        {
+            LoggingService.LogProjectEvaluationStarted(BuildEventContext, _projectFile);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Microsoft.Build.BackEnd.Components.Logging;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -368,13 +369,20 @@ namespace Microsoft.Build.BackEnd.Logging
         void LogBuildFinished(bool success);
 
         /// <summary>
+        /// Create an evaluation context, by generating a new evaluation id.
+        /// </summary>
+        /// <param name="nodeId">The node id</param>
+        /// <param name="submissionId">The submission id</param>
+        /// <returns></returns>
+        BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId);
+
+        /// <summary>
         /// Logs that a project evaluation has started
         /// </summary>
-        /// <param name="nodeId">The id of the node which is evaluating this project.</param>
-        /// <param name="submissionId">The id of the submission.</param>
-        /// <param name="projectFile">Project file to build</param>
+        /// <param name="eventContext">The event context to use for logging</param>
+        /// <param name="projectFile">Project file being built</param>
         /// <returns>The evaluation event context for the project.</returns>
-        BuildEventContext LogProjectEvaluationStarted(int nodeId, int submissionId, string projectFile);
+        void LogProjectEvaluationStarted(BuildEventContext eventContext, string projectFile);
 
         /// <summary>
         /// Logs that a project evaluation has finished

--- a/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingServiceLogMethods.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.BackEnd.Components.Logging;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -494,19 +495,17 @@ namespace Microsoft.Build.BackEnd.Logging
             }
         }
 
-        /// <summary>
-        /// Logs that a project evaluation has started
-        /// </summary>
-        /// <param name="nodeId">The id of the node which is evaluating this project.</param>
-        /// <param name="submissionId">The id of the submission.</param>
-        /// <param name="projectFile">Project file to build</param>
-        /// <returns>The evaluation event context for the project.</returns>
-        public BuildEventContext LogProjectEvaluationStarted(int nodeId, int submissionId, string projectFile)
+        /// <inheritdoc />
+        public BuildEventContext CreateEvaluationBuildEventContext(int nodeId, int submissionId)
+        {
+            return new BuildEventContext(submissionId, nodeId, NextEvaluationId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+        }
+
+        /// <inheritdoc />
+        public void LogProjectEvaluationStarted(BuildEventContext projectEvaluationEventContext, string projectFile)
         {
             lock (_lockObject)
             {
-                BuildEventContext projectEvaluationEventContext = new BuildEventContext(submissionId, nodeId, NextEvaluationId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-
                 ProjectEvaluationStartedEventArgs evaluationEvent =
                     new ProjectEvaluationStartedEventArgs(ResourceUtilities.GetResourceString("EvaluationStarted"),
                         projectFile)
@@ -516,8 +515,6 @@ namespace Microsoft.Build.BackEnd.Logging
                     };
 
                 ProcessLoggingEvent(evaluationEvent);
-
-                return projectEvaluationEventContext;
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -803,6 +803,9 @@ namespace Microsoft.Build.Evaluation
 
                 _evaluationLoggingContext = new EvaluationLoggingContext(loggingService, buildEventContext, projectFile);
                 _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
+
+                _evaluationLoggingContext.LogProjectEvaluationStarted();
+
                 ErrorUtilities.VerifyThrow(_data.EvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
 
 #if MSBUILDENABLEVSPROFILING

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -185,8 +185,7 @@ namespace Microsoft.Build.UnitTests
          */
         public void Initialize(IEventSource eventSource)
         {
-            eventSource.AnyEventRaised +=
-                    new AnyEventHandler(LoggerEventHandler);
+            eventSource.AnyEventRaised += LoggerEventHandler;
         }
 
         /// <summary>
@@ -219,6 +218,8 @@ namespace Microsoft.Build.UnitTests
             _testOutputHelper = testOutputHelper;
         }
 
+        public List<Action<object, BuildEventArgs>> AdditionalHandlers { get; set; } = new List<Action<object, BuildEventArgs>>();
+
         /*
          * Method:  LoggerEventHandler
          *
@@ -228,6 +229,11 @@ namespace Microsoft.Build.UnitTests
         internal void LoggerEventHandler(object sender, BuildEventArgs eventArgs)
         {
             AllBuildEvents.Add(eventArgs);
+
+            foreach (var handler in AdditionalHandlers)
+            {
+                handler(sender, eventArgs);
+            }
 
             if (eventArgs is BuildWarningEventArgs)
             {


### PR DESCRIPTION
CPS expects Project.LastEvaluationId to reflect the id of the ongoing, not yet finished evaluation.
This invariant regressed in #2748

LoggingService now creates an evaluation build event context separate from sending project started events. This allows the Evaluator to set the evaluation Id on Project before the first evaluation event gets fired.