### PR TITLE
Remove System.Diagnostics.Process from CoreXT pkg

### DIFF
--- a/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/setup/MsBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -30,7 +30,6 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/System.Diagnostics.Process.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.IO.Compression.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Runtime.InteropServices.RuntimeInformation.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Security.Cryptography.Algorithms.dll" target="v15.0/bin" />
@@ -74,7 +73,6 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/System.Diagnostics.Process.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.IO.Compression.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Runtime.InteropServices.RuntimeInformation.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Security.Cryptography.Algorithms.dll" target="v15.0/bin/amd64" />


### PR DESCRIPTION
This doesn't appear to be used and is not copied by the build. No idea
how this worked before, sync to the last successful build also does not
produce this file. This is failing our official build.

MSBuild only references System.Diagnostics.Process for netstandard, not
for net46 so appears to have been added by mistake.