### PR TITLE
Include obsolete assemblies in ExternalAPIs

### DIFF
--- a/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
+++ b/setup/DevDivPackage/VS.ExternalAPIs.MSBuild.nuspec
@@ -12,5 +12,9 @@
     <file src="Microsoft.Build.Framework.dll" target="lib\net46" />
     <file src="Microsoft.Build.Tasks.Core.dll" target="lib\net46" />
     <file src="Microsoft.Build.Utilities.Core.dll" target="lib\net46" />
+
+    <!-- Obsolete but still referenced in the VS repo -->
+    <file src="Microsoft.Build.Engine.dll" target="lib\net46" />
+    <file src="Microsoft.Build.Conversion.Core.dll" target="lib\net46" />
   </files>
 </package>


### PR DESCRIPTION
This is required to switch internal VS build processes off of the (obsolete) fork of MSBuild that's still checked into the VS repo. These projects are referenced but weren't available in the ExternalAPIs package.