### PR TITLE
Fix some spaces problem

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -88,7 +88,7 @@ function InstallDotNetCli {
 
   if (!(Test-Path $SdkInstallDir)) {
     # Use Invoke-Expression so that $DotNetInstallVerbosity is not positionally bound when empty
-    Invoke-Expression -Command "$DotNetInstallScript -Version $DotNetCliVersion $DotNetInstallVerbosity"
+    Invoke-Expression -Command "& '$DotNetInstallScript' -Version $DotNetCliVersion $DotNetInstallVerbosity"
 
     if($LASTEXITCODE -ne 0) {
       throw "Failed to install stage0"

--- a/build/cibuild.cmd
+++ b/build/cibuild.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass "%~dp0build.ps1" -build -pack -sign -ci -prepareMachine %*
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass "& '%~dp0build.ps1'" -build -pack -sign -ci -prepareMachine %*
 exit /b %ErrorLevel%

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -110,8 +110,8 @@
         * VsInstallRoot is discovered by MSBuild, but in our bootstrapped build it's wrong (VS isn't installed
           to our 'bin' folder). When building from MicroBuild (or any installed VS), this value is correct.
       -->
-      <EditBinCommand Condition="'$(VSINSTALLDIR)' != ''">call &quot;$(VSINSTALLDIR)\Common7\Tools\VsDevCmd.bat&quot; /no_logo&amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
-      <EditBinCommand Condition="'$(VsInstallRoot)' != '' and '$(EditBinCommand)' == ''">call &quot;$(VsInstallRoot)\Common7\Tools\VsDevCmd.bat&quot; /no_logo&amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) @(IntermediateAssembly)</EditBinCommand>
+      <EditBinCommand Condition="'$(VSINSTALLDIR)' != ''">call &quot;$(VSINSTALLDIR)\Common7\Tools\VsDevCmd.bat&quot; /no_logo&amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) &quot;@(IntermediateAssembly)&quot;</EditBinCommand>
+      <EditBinCommand Condition="'$(VsInstallRoot)' != '' and '$(EditBinCommand)' == ''">call &quot;$(VsInstallRoot)\Common7\Tools\VsDevCmd.bat&quot; /no_logo&amp;&amp; editbin.exe /NOLOGO $(EditBinFlags) &quot;@(IntermediateAssembly)&quot;</EditBinCommand>
     </PropertyGroup>
 
     <Exec Command="$(EditBinCommand)"


### PR DESCRIPTION
I fix some problem with paths include spaces.
I now one more problem but can't fix it:
```
  Packaging ...
MSBUILD : error MSB1008: Only one project can be specified. [C:\Users\mikha\.nuget\packages\roslyntools.repotoolset\1.0.0-beta-62512-02\tools\Build.proj]
  Switch: folder\msbuild\

  For switch syntax, type "MSBuild /help"
C:\Users\mikha\.nuget\packages\roslyntools.repotoolset\1.0.0-beta-62512-02\tools\Build.proj(191,5): error MSB3073: The command ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\MSBuild.exe" /nodeReuse:fal
se "D:\Work\space folder\msbuild\MSBuild.sln" /nologo /m /v:minimal /t:Pack /p:NoBuild=true /bl:"D:\Work\space folder\msbuild\artifacts\Debug\log\Pack.binlog" /p:Configuration=Debug /p:CIBuild=True /p:RepoRoot=D:\Work\space folder\msbui
ld\ /p:VersionsPropsPath=D:\Work\space folder\msbuild\build\Versions.props /p:DotNetPackageVersionPropsPath= /p:__BuildPhase=SolutionBuild" exited with code 1.

Build FAILED.

MSBUILD : error MSB1008: Only one project can be specified. [C:\Users\mikha\.nuget\packages\roslyntools.repotoolset\1.0.0-beta-62512-02\tools\Build.proj]
C:\Users\mikha\.nuget\packages\roslyntools.repotoolset\1.0.0-beta-62512-02\tools\Build.proj(191,5): error MSB3073: The command ""C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\MSBuild.exe" /nodeReuse:fal
se "D:\Work\space folder\msbuild\MSBuild.sln" /nologo /m /v:minimal /t:Pack /p:NoBuild=true /bl:"D:\Work\space folder\msbuild\artifacts\Debug\log\Pack.binlog" /p:Configuration=Debug /p:CIBuild=True /p:RepoRoot=D:\Work\space folder\msbui
ld\ /p:VersionsPropsPath=D:\Work\space folder\msbuild\build\Versions.props /p:DotNetPackageVersionPropsPath= /p:__BuildPhase=SolutionBuild" exited with code 1.
    0 Warning(s)
    2 Error(s)
```