### PR TITLE
Support folder name "Sdk" or "sdk" in NuGet SDK resolver

### DIFF
--- a/src/NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGetSdkResolver/NuGetSdkResolver.cs
@@ -203,21 +203,13 @@ namespace NuGet.MSBuildSdkResolver
                     return false;
                 }
 
-                if (NativeMethodsShared.IsWindows)
-                {
-                    // Get the installed path and add the expected "Sdk" folder.  Windows file systems are not case sensitive
-                    installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
-                }
-                else
-                {
-                    // On non-Windows, default to proper case "Sdk" folder
-                    installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
+                // Get the installed path and add the expected "Sdk" folder.  Windows file systems are not case sensitive
+                installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
 
-                    if (!Directory.Exists(installedPath))
-                    {
-                        // Fall back to lower case "sdk" folder in case the file system is case sensitive
-                        installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "sdk");
-                    }
+                if (!NativeMethodsShared.IsWindows && !Directory.Exists(installedPath))
+                {
+                    // Fall back to lower case "sdk" folder in case the file system is case sensitive
+                    installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "sdk");
                 }
 
                 installedVersion = packageInfo.Version.ToString();

--- a/src/NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGetSdkResolver/NuGetSdkResolver.cs
@@ -203,8 +203,23 @@ namespace NuGet.MSBuildSdkResolver
                     return false;
                 }
 
-                // Get the installed path and add the expected "Sdk" folder
-                installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
+                if (NativeMethodsShared.IsWindows)
+                {
+                    // Get the installed path and add the expected "Sdk" folder.  Windows file systems are not case sensitive
+                    installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
+                }
+                else
+                {
+                    // On non-Windows, default to proper case "Sdk" folder
+                    installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "Sdk");
+
+                    if (!Directory.Exists(installedPath))
+                    {
+                        // Fall back to lower case "sdk" folder in case the file system is case sensitive
+                        installedPath = Path.Combine(packageInfo.PathResolver.GetInstallPath(packageInfo.Id, packageInfo.Version), "sdk");
+                    }
+                }
+
                 installedVersion = packageInfo.Version.ToString();
 
                 return true;


### PR DESCRIPTION
Since some non-Windows file systems are case sensitive, SDK authors will need to know that the "Sdk" folder is supposed to be capitalized.

This change makes it so that SDK package owners can use "Sdk" or "sdk".  See relevant discuss here: https://github.com/Microsoft/msbuild/issues/2803#issuecomment-360617172

There will be a little overhead to check directory existence.