### PR TITLE
Reduce test flakiness

### DIFF
--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -486,8 +486,6 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         /// of means of item creation. 
         /// </summary>
         [Fact]
-        // https://github.com/Microsoft/msbuild/issues/2884
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TestDefiningProjectMetadata()
         {
             string projectA = Path.Combine(ObjectModelHelpers.TempProjectDir, "a.proj");

--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -45,6 +45,9 @@
     <Compile Include="..\Shared\Traits.cs">
       <Link>SharedTraits.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\UnitTests\EngineTestEnvironment.cs">
+      <Link>EngineTestEnvironment.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/Build.UnitTests/EvaluationProfiler_Tests.cs
+++ b/src/Build.UnitTests/EvaluationProfiler_Tests.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Logging;
+using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Build.UnitTests.ObjectModelHelpers;

--- a/src/Build.UnitTests/ExpressionTree_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTree_Tests.cs
@@ -176,8 +176,6 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// </summary>
         [Fact]
-        // https://github.com/Microsoft/msbuild/issues/2884
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void ItemListTests()
         {
             Parser p = new Parser();

--- a/src/Build.UnitTests/FixPathOnUnix_Tests.cs
+++ b/src/Build.UnitTests/FixPathOnUnix_Tests.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Build.UnitTests
     public  class FixPathOnUnixTests
     {
         [Fact]
-        // failing only on CI https://github.com/Microsoft/msbuild/issues/2884
-        [Trait("Category", "netcore-osx-failing")]
         public void TestPathFixupInMetadata()
         {
             string buildProjectContents = @"

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -68,6 +68,9 @@
     <Compile Include="..\Shared\UnitTests\StreamHelpers.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\UnitTests\EngineTestEnvironment.cs">
+      <Link>EngineTestEnvironment.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
     <PlatformTarget>$(RuntimeOutputPlatformTarget)</PlatformTarget>
-
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyName>Microsoft.Build.Framework.UnitTests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.2.304-preview5" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
   </ItemGroup>
 
@@ -18,6 +19,26 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\UnitTests\TestEnvironment.cs" />
+    <Compile Include="..\Shared\FileUtilities.cs" />
+    <Compile Include="..\Shared\TempFileUtilities.cs" />
+    <Compile Include="..\Shared\ErrorUtilities.cs" />
+    <Compile Include="..\Shared\NativeMethodsShared.cs" />
+    <Compile Include="..\Shared\EscapingUtilities.cs" />
+    <Compile Include="..\Shared\BuildEnvironmentHelper.cs" />
+    <Compile Include="..\Shared\AssemblyUtilities.cs" />
+    <Compile Include="..\Shared\ResourceUtilities.cs" />
+    <Compile Include="..\Shared\InternalErrorException.cs" />
+    <Compile Include="..\Shared\ExceptionHandling.cs" />
+    <Compile Include="..\Shared\VisualStudioLocationHelper.cs" />
+    <Compile Include="..\Shared\StringBuilderCache.cs" />
+    <Compile Include="..\Shared\OpportunisticIntern.cs" />
+    <Compile Include="..\Shared\FileUtilitiesRegex.cs" />
+    <Compile Include="..\Shared\UnitTests\AssemblyResources.cs" />
+    <Compile Include="..\Shared\Traits.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\Shared\RegistryHelper.cs">
       <Link>RegistryHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\UnitTests\EngineTestEnvironment.cs" />
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -10,10 +10,10 @@ using System.Linq;
 using System.Threading;
 
 using Microsoft.Build.CommandLine;
-using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.Shared;
+using Microsoft.Build.UnitTests;
 using Xunit;
 using Shouldly;
 
@@ -1995,7 +1995,7 @@ namespace Microsoft.Build.UnitTests
 
         private string ExecuteMSBuildExeExpectSuccess(string projectContents, IDictionary<string, string> filesToCreate = null, params string[] arguments)
         {
-            using (TestEnvironment testEnvironment = Engine.UnitTests.TestEnvironment.Create())
+            using (TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create())
             {
                 TransientTestProjectWithFiles testProject = testEnvironment.CreateTestProjectWithFiles(projectContents, new string[0]);
 

--- a/src/Shared/UnitTests/AssemblyResources.cs
+++ b/src/Shared/UnitTests/AssemblyResources.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Shared
+{
+    /// <summary>
+    /// This class provides access to the assembly's resources.
+    /// </summary>
+    internal static class AssemblyResources
+    {
+        /// <summary>
+        /// Dummy
+        /// </summary>
+        internal static string GetString(string name)
+        {
+            return String.Empty;
+        }
+    }
+}

--- a/src/Shared/UnitTests/EngineTestEnvironment.cs
+++ b/src/Shared/UnitTests/EngineTestEnvironment.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Framework;
+using Shouldly;
+
+namespace Microsoft.Build.UnitTests
+{
+    public partial class TestEnvironment
+    {
+        /// <summary>
+        ///     Creates a test variant that corresponds to a project collection which will have its projects unloaded,
+        ///     loggers unregistered, toolsets removed and disposed when the test completes
+        /// </summary>
+        /// <returns></returns>
+        public TransientProjectCollection CreateProjectCollection()
+        {
+            return WithTransientTestState(new TransientProjectCollection());
+        }
+
+        /// <summary>
+        ///     Creates a test variant representing a test project with files relative to the project root. All files
+        ///     and the root will be cleaned up when the test completes.
+        /// </summary>
+        /// <param name="projectContents">Contents of the project file to be created.</param>
+        /// <param name="files">Files to be created.</param>
+        /// <param name="relativePathFromRootToProject">Path for the specified files to be created in relative to 
+        /// the root of the project directory.</param>
+        public TransientTestProjectWithFiles CreateTestProjectWithFiles(string projectContents, string[] files = null, string relativePathFromRootToProject = ".")
+        {
+            return WithTransientTestState(
+                new TransientTestProjectWithFiles(projectContents, files, relativePathFromRootToProject));
+        }
+
+        public TransientSdkResolution CustomSdkResolution(Dictionary<string, string> sdkToFolderMapping)
+        {
+            return WithTransientTestState(new TransientSdkResolution(sdkToFolderMapping));
+        }
+    }
+    
+    public class TransientTestProjectWithFiles : TransientTestState
+    {
+        private readonly TransientTestFolder _folder;
+
+        public string TestRoot => _folder.FolderPath;
+
+        public string[] CreatedFiles { get; }
+
+        public string ProjectFile { get; }
+
+        public TransientTestProjectWithFiles(string projectContents, string[] files,
+            string relativePathFromRootToProject = ".")
+        {
+            _folder = new TransientTestFolder();
+
+            var projectDir = Path.Combine(TestRoot, relativePathFromRootToProject);
+            Directory.CreateDirectory(projectDir);
+
+            ProjectFile = Path.Combine(projectDir, "build.proj");
+            File.WriteAllText(ProjectFile, ObjectModelHelpers.CleanupFileContents(projectContents));
+
+            CreatedFiles = Helpers.CreateFilesInDirectory(TestRoot, files);
+        }
+
+        internal MockLogger BuildProjectExpectFailure(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
+        {
+            MockLogger logger;
+
+            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeFalse();
+
+            return logger;
+        }
+
+        internal MockLogger BuildProjectExpectSuccess(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
+        {
+            MockLogger logger;
+
+            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeTrue();
+
+            return logger;
+        }
+
+        public override void Revert()
+        {
+            _folder.Revert();
+        }
+
+        private bool BuildProject(IDictionary<string, string> globalProperties, string toolsVersion, out MockLogger logger)
+        {
+            logger = new MockLogger();
+
+            using (ProjectCollection projectCollection = new ProjectCollection())
+            {
+                Project project = new Project(ProjectFile, globalProperties, toolsVersion, projectCollection);
+
+                return project.Build(logger);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents custom SDK resolution in the context of this test.
+    /// </summary>
+    public class TransientSdkResolution : TransientTestState
+    {
+        private readonly Dictionary<string, string> _mapping;
+
+        public TransientSdkResolution(Dictionary<string, string> mapping)
+        {
+            _mapping = mapping;
+
+            CallResetForTests(new List<SdkResolver> { new TestSdkResolver(_mapping) });
+        }
+
+        public override void Revert()
+        {
+            CallResetForTests(null);
+        }
+
+        /// <summary>
+        /// SdkResolution is internal (by design) and not all UnitTest projects are allowed to have
+        /// InternalsVisibleTo.
+        /// </summary>
+        /// <param name="resolvers"></param>
+        private static void CallResetForTests(IList<SdkResolver> resolvers)
+        {
+            Type sdkResolverServiceType = typeof(ProjectCollection).GetTypeInfo().Assembly.GetType("Microsoft.Build.BackEnd.SdkResolution.SdkResolverService");
+
+            PropertyInfo instancePropertyInfo = sdkResolverServiceType.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
+
+            object sdkResolverService = instancePropertyInfo.GetValue(null);
+
+            MethodInfo initializeForTestsMethodInfo = sdkResolverServiceType.GetMethod("InitializeForTests", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            initializeForTestsMethodInfo.Invoke(sdkResolverService, new object[] { null, resolvers });
+        }
+
+        private class TestSdkResolver : SdkResolver
+        {
+            private readonly Dictionary<string, string> _mapping;
+
+            public TestSdkResolver(Dictionary<string, string> mapping)
+            {
+                _mapping = mapping;
+            }
+            public override string Name => "TestSdkResolver";
+            public override int Priority => int.MinValue;
+
+            public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
+            {
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.ProjectFilePath)} = {resolverContext.ProjectFilePath}", MessageImportance.High);
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.SolutionFilePath)} = {resolverContext.SolutionFilePath}", MessageImportance.High);
+                resolverContext.Logger.LogMessage($"{nameof(resolverContext.MSBuildVersion)} = {resolverContext.MSBuildVersion}", MessageImportance.High);
+
+                return _mapping.ContainsKey(sdkReference.Name)
+                    ? factory.IndicateSuccess(_mapping[sdkReference.Name], null)
+                    : factory.IndicateFailure(new[] { $"Not in {nameof(_mapping)}" });
+            }
+        }
+    }
+
+    public class TransientProjectCollection : TransientTestState
+    {
+        public ProjectCollection Collection { get; }
+
+        public TransientProjectCollection()
+        {
+            Collection = new ProjectCollection();
+        }
+
+        public override void Revert()
+        {
+            Collection.UnloadAllProjects();
+            Collection.UnregisterAllLoggers();
+            Collection.RemoveAllToolsets();
+            Collection.Dispose();
+        }
+    }
+}

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -14,7 +14,7 @@ using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Shouldly;

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -20,8 +20,6 @@ using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
 
-using TempPaths = System.Collections.Generic.Dictionary<string, string>;
-
 // Microsoft.Build.Tasks has MSBuildConstants compiled into it under a different namespace otherwise
 // there are collisions with the one compiled into Microsoft.Build.Framework
 #if MICROSOFT_BUILD_TASKS_UNITTESTS
@@ -134,7 +132,7 @@ namespace Microsoft.Build.UnitTests
             normalizeSlashes);
         }
 
-        internal static void AssertItemEvaluationFromGenericItemEvaluator(Func<string, ProjectCollection, IList<TestItem>> itemEvaluator, string projectContents, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute = false, TempPaths[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
+        internal static void AssertItemEvaluationFromGenericItemEvaluator(Func<string, ProjectCollection, IList<TestItem>> itemEvaluator, string projectContents, string[] inputFiles, string[] expectedInclude, bool makeExpectedIncludeAbsolute = false, Dictionary<string, string>[] expectedMetadataPerItem = null, bool normalizeSlashes = false)
         {
             using (var env = TestEnvironment.Create())
             using (var collection = new ProjectCollection())
@@ -1633,113 +1631,6 @@ namespace Microsoft.Build.UnitTests
             Path.IsPathRooted(path)
                 ? path
                 : path.ToSlash();
-
-        /// <summary>
-        /// Creates a new temp path
-        /// Sets all OS temp environment variables to the new path
-        ///
-        /// Cleanup:
-        /// - restores OS temp environment variables
-        /// - deletes all files written to the new temp path
-        /// </summary>
-        internal class AlternativeTempPath : IDisposable
-        {
-            private const string TMP = "TMP";
-            private const string TMPDIR = "TMPDIR";
-            private const string TEMP = "TEMP";
-
-            private TempPaths _oldtempPaths;
-            private bool _disposed;
-
-            private string _path;
-            public string Path
-            {
-                get
-                {
-                    if (_disposed)
-                    {
-                        throw new ObjectDisposedException($"{nameof(AlternativeTempPath)}(\"{_path})\"");
-                    }
-
-                    return _path;
-                }
-
-                private set { _path = value; }
-            }
-
-            public AlternativeTempPath()
-            {
-                Path = System.IO.Path.GetFullPath($"TMP_{Guid.NewGuid()}");
-                Directory.CreateDirectory(_path);
-
-                // TODO: this could use TemporaryEnvironment
-                _oldtempPaths = SetTempPath(_path);
-            }
-
-            public void Dispose()
-            {
-                Cleanup();
-                GC.SuppressFinalize(this);
-            }
-
-            private void Cleanup()
-            {
-                if (_disposed)
-                {
-                    return;
-                }
-
-                SetTempPaths(_oldtempPaths);
-                FileUtilities.DeleteDirectoryNoThrow(Path, true);
-
-                _disposed = true;
-            }
-
-            ~AlternativeTempPath()
-            {
-                Cleanup();
-            }
-
-            private static TempPaths SetTempPaths(TempPaths tempPaths)
-            {
-                var oldTempPaths = GetTempPaths();
-
-                foreach (var key in oldTempPaths.Keys)
-                {
-                    Environment.SetEnvironmentVariable(key, tempPaths[key]);
-                }
-
-                return oldTempPaths;
-            }
-
-            private static TempPaths SetTempPath(string tempPath)
-            {
-                var oldTempPaths = GetTempPaths();
-
-                foreach (var key in oldTempPaths.Keys)
-                {
-                    Environment.SetEnvironmentVariable(key, tempPath);
-                }
-
-                return oldTempPaths;
-            }
-
-            private static TempPaths GetTempPaths()
-            {
-                var tempPaths = new TempPaths
-                {
-                    [TMP] = Environment.GetEnvironmentVariable(TMP),
-                    [TEMP] = Environment.GetEnvironmentVariable(TEMP)
-                };
-
-                if (NativeMethodsShared.IsUnixLike)
-                {
-                    tempPaths[TMPDIR] = Environment.GetEnvironmentVariable(TMPDIR);
-                }
-
-                return tempPaths;
-            }
-        }
 
         internal class ElementLocationComparerIgnoringType : IEqualityComparer<ElementLocation>
         {

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -777,7 +777,7 @@ namespace Microsoft.Build.UnitTests
         private static string s_tempProjectDir = null;
 
         /// <summary>
-        /// Returns the path %TEMP%\TempDirForMSBuildUnitTests
+        /// Creates and returns a unique path under temp
         /// </summary>
         internal static string TempProjectDir
         {
@@ -785,7 +785,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (s_tempProjectDir == null)
                 {
-                    s_tempProjectDir = Path.Combine(Path.GetTempPath(), "TempDirForMSBuildUnitTests");
+                    s_tempProjectDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 
                     Directory.CreateDirectory(s_tempProjectDir);
                 }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -11,12 +11,12 @@ using System.Text;
 using System.Xml;
 
 using Microsoft.Build.Construction;
-using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -42,7 +42,7 @@ public class MSBuildTestAssemblyFixture : IDisposable
         string newTempPath = Path.Combine(AppContext.BaseDirectory, "Temp");
         _testEnvironment.CreateFolder(newTempPath);
 
-        _testEnvironment.WithTempPath(newTempPath);
+        _testEnvironment.SetTempPath(newTempPath);
     }
 
     /// <summary>

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -39,7 +39,7 @@ public class MSBuildTestAssemblyFixture : IDisposable
 
         //  Use a project-specific temporary path
         //  This is so multiple test projects can be run in parallel without sharing the same temp directory
-        string newTempPath = Path.Combine(AppContext.BaseDirectory, "Temp");
+        string newTempPath = Path.Combine(AppContext.BaseDirectory, "TestTemp");
         _testEnvironment.CreateFolder(newTempPath);
 
         _testEnvironment.SetTempPath(newTempPath);

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -2,20 +2,16 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Execution;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using Microsoft.Build.UnitTests;
-using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.Build.Engine.UnitTests
+using TempPaths = System.Collections.Generic.Dictionary<string, string>;
+
+namespace Microsoft.Build.UnitTests
 {
-    public class TestEnvironment : IDisposable
+    public partial class TestEnvironment : IDisposable
     {
         /// <summary>
         ///     List of test invariants to assert value does not change.
@@ -131,6 +127,14 @@ namespace Microsoft.Build.Engine.UnitTests
             return WithInvariant(new StringInvariant(name, value));
         }
 
+        public TransientTempPath WithTempPath(string tempPath, bool deleteTempDirectory = false)
+        {
+            var transientTempPath = new TransientTempPath(tempPath, deleteTempDirectory);
+            _variants.Add(transientTempPath);
+
+            return transientTempPath;
+        }
+
         /// <summary>
         ///     Creates a test variant that corresponds to a temporary file which will be deleted when the test completes.
         /// </summary>
@@ -155,19 +159,9 @@ namespace Microsoft.Build.Engine.UnitTests
         ///     Creates a test variant used to add a unique temporary folder during a test. Will be deleted when the test
         ///     completes.
         /// </summary>
-        public TransientTestFolder CreateFolder()
+        public TransientTestFolder CreateFolder(string folderPath = null)
         {
-            return WithTransientTestState(new TransientTestFolder());
-        }
-
-        /// <summary>
-        ///     Creates a test variant that corresponds to a project collection which will have its projects unloaded,
-        ///     loggers unregistered, toolsets removed and disposed when the test completes
-        /// </summary>
-        /// <returns></returns>
-        public TransientProjectCollection CreateProjectCollection()
-        {
-            return WithTransientTestState(new TransientProjectCollection());
+            return WithTransientTestState(new TransientTestFolder(folderPath));
         }
 
         /// <summary>
@@ -182,26 +176,6 @@ namespace Microsoft.Build.Engine.UnitTests
         public TransientTestState SetCurrentDirectory(string newWorkingDirectory)
         {
             return WithTransientTestState(new TransientWorkingDirectory(newWorkingDirectory));
-        }
-
-        /// <summary>
-        ///     Creates a test variant representing a test project with files relative to the project root. All files
-        ///     and the root will be cleaned up when the test completes.
-        /// </summary>
-        /// <param name="projectContents">Contents of the project file to be created.</param>
-        /// <param name="files">Files to be created.</param>
-        /// <param name="relativePathFromRootToProject">Path for the specified files to be created in relative to 
-        /// the root of the project directory.</param>
-        public TransientTestProjectWithFiles CreateTestProjectWithFiles(string projectContents, string[] files = null,
-            string relativePathFromRootToProject = ".")
-        {
-            return WithTransientTestState(
-                new TransientTestProjectWithFiles(projectContents, files, relativePathFromRootToProject));
-        }
-
-        public TransientSdkResolution CustomSdkResolution(Dictionary<string, string> sdkToFolderMapping)
-        {
-            return WithTransientTestState(new TransientSdkResolution(sdkToFolderMapping));
         }
 
         #endregion
@@ -304,6 +278,77 @@ namespace Microsoft.Build.Engine.UnitTests
         }
     }
 
+    public class TransientTempPath : TransientTestState
+    {
+        private const string TMP = "TMP";
+        private const string TMPDIR = "TMPDIR";
+        private const string TEMP = "TEMP";
+
+        private readonly string _tempPath;
+        private readonly bool _deleteTempDirectory;
+
+        private readonly TempPaths _oldtempPaths;
+
+        public TransientTempPath(string tempPath, bool deleteTempDirectory)
+        {
+            _tempPath = tempPath;
+            _deleteTempDirectory = deleteTempDirectory;
+
+            _oldtempPaths = SetTempPath(tempPath);
+        }
+
+        private static TempPaths SetTempPath(string tempPath)
+        {
+            var oldTempPaths = GetTempPaths();
+
+            foreach (var key in oldTempPaths.Keys)
+            {
+                Environment.SetEnvironmentVariable(key, tempPath);
+            }
+
+            return oldTempPaths;
+        }
+
+        private static TempPaths SetTempPaths(TempPaths tempPaths)
+        {
+            var oldTempPaths = GetTempPaths();
+
+            foreach (var key in oldTempPaths.Keys)
+            {
+                Environment.SetEnvironmentVariable(key, tempPaths[key]);
+            }
+
+            return oldTempPaths;
+        }
+
+        private static TempPaths GetTempPaths()
+        {
+            var tempPaths = new TempPaths
+            {
+                [TMP] = Environment.GetEnvironmentVariable(TMP),
+                [TEMP] = Environment.GetEnvironmentVariable(TEMP)
+            };
+
+            if (NativeMethodsShared.IsUnixLike)
+            {
+                tempPaths[TMPDIR] = Environment.GetEnvironmentVariable(TMPDIR);
+            }
+
+            return tempPaths;
+        }
+
+        public override void Revert()
+        {
+            SetTempPaths(_oldtempPaths);
+
+            if (_deleteTempDirectory)
+            {
+                FileUtilities.DeleteDirectoryNoThrow(_tempPath, recursive: true);
+            }
+        }
+    }
+
+
     public class TransientTestFile : TransientTestState
     {
         public TransientTestFile(string extension)
@@ -326,9 +371,14 @@ namespace Microsoft.Build.Engine.UnitTests
 
     public class TransientTestFolder : TransientTestState
     {
-        public TransientTestFolder()
+        public TransientTestFolder(string folderPath = null)
         {
-            FolderPath = FileUtilities.GetTemporaryDirectory();
+            FolderPath = folderPath ?? FileUtilities.GetTemporaryDirectory();
+
+            if (!Directory.Exists(FolderPath))
+            {
+                Directory.CreateDirectory(FolderPath);
+            }
         }
 
         public string FolderPath { get; }
@@ -380,145 +430,6 @@ namespace Microsoft.Build.Engine.UnitTests
         public override void Revert()
         {
             Directory.SetCurrentDirectory(_originalValue);
-        }
-    }
-
-    public class TransientTestProjectWithFiles : TransientTestState
-    {
-        private readonly TransientTestFolder _folder;
-
-        public string TestRoot => _folder.FolderPath;
-
-        public string[] CreatedFiles { get; }
-
-        public string ProjectFile { get; }
-
-        public TransientTestProjectWithFiles(string projectContents, string[] files,
-            string relativePathFromRootToProject = ".")
-        {
-            _folder = new TransientTestFolder();
-
-            var projectDir = Path.Combine(TestRoot, relativePathFromRootToProject);
-            Directory.CreateDirectory(projectDir);
-
-            ProjectFile = Path.Combine(projectDir, "build.proj");
-            File.WriteAllText(ProjectFile, ObjectModelHelpers.CleanupFileContents(projectContents));
-
-            CreatedFiles = Helpers.CreateFilesInDirectory(TestRoot, files);
-        }
-
-        internal MockLogger BuildProjectExpectFailure(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
-        {
-            MockLogger logger;
-
-            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeFalse();
-
-            return logger;
-        }
-
-        internal MockLogger BuildProjectExpectSuccess(IDictionary<string, string> globalProperties = null, string toolsVersion = null)
-        {
-            MockLogger logger;
-
-            BuildProject(globalProperties, toolsVersion, out logger).ShouldBeTrue();
-
-            return logger;
-        }
-
-        public override void Revert()
-        {
-            _folder.Revert();
-        }
-
-        private bool BuildProject(IDictionary<string, string> globalProperties, string toolsVersion, out MockLogger logger)
-        {
-            logger = new MockLogger();
-
-            using (ProjectCollection projectCollection = new ProjectCollection())
-            {
-                Project project = new Project(ProjectFile, globalProperties, toolsVersion, projectCollection);
-
-                return project.Build(logger);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents custom SDK resolution in the context of this test.
-    /// </summary>
-    public class TransientSdkResolution : TransientTestState
-    {
-        private readonly Dictionary<string, string> _mapping;
-
-        public TransientSdkResolution(Dictionary<string, string> mapping)
-        {
-            _mapping = mapping;
-            
-            CallResetForTests(new List<SdkResolver> { new TestSdkResolver(_mapping) });
-        }
-
-        public override void Revert()
-        {
-            CallResetForTests(null);
-        }
-
-        /// <summary>
-        /// SdkResolution is internal (by design) and not all UnitTest projects are allowed to have
-        /// InternalsVisibleTo.
-        /// </summary>
-        /// <param name="resolvers"></param>
-        private static void CallResetForTests(IList<SdkResolver> resolvers)
-        {
-            Type sdkResolverServiceType = typeof(ProjectCollection).GetTypeInfo().Assembly.GetType("Microsoft.Build.BackEnd.SdkResolution.SdkResolverService");
-
-            PropertyInfo instancePropertyInfo = sdkResolverServiceType.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
-
-            object sdkResolverService = instancePropertyInfo.GetValue(null);
-
-            MethodInfo initializeForTestsMethodInfo = sdkResolverServiceType.GetMethod("InitializeForTests", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            initializeForTestsMethodInfo.Invoke(sdkResolverService, new object[] { null, resolvers });
-        }
-
-        private class TestSdkResolver : SdkResolver
-        {
-            private readonly Dictionary<string, string> _mapping;
-
-            public TestSdkResolver(Dictionary<string, string> mapping)
-            {
-                _mapping = mapping;
-            }
-            public override string Name => "TestSdkResolver";
-            public override int Priority => int.MinValue;
-
-            public override SdkResult Resolve(SdkReference sdkReference, SdkResolverContext resolverContext, SdkResultFactory factory)
-            {
-                resolverContext.Logger.LogMessage($"{nameof(resolverContext.ProjectFilePath)} = {resolverContext.ProjectFilePath}", MessageImportance.High);
-                resolverContext.Logger.LogMessage($"{nameof(resolverContext.SolutionFilePath)} = {resolverContext.SolutionFilePath}", MessageImportance.High);
-                resolverContext.Logger.LogMessage($"{nameof(resolverContext.MSBuildVersion)} = {resolverContext.MSBuildVersion}", MessageImportance.High);
-
-                return _mapping.ContainsKey(sdkReference.Name)
-                    ? factory.IndicateSuccess(_mapping[sdkReference.Name], null)
-                    : factory.IndicateFailure(new[] {$"Not in {nameof(_mapping)}"});
-            }
-        }
-    }
-
-    public class TransientProjectCollection : TransientTestState
-    {
-        public ProjectCollection Collection { get; }
-
-        public TransientProjectCollection()
-        {
-            Collection = new ProjectCollection();
-        }
-
-        public override void Revert()
-        {
-            Collection.UnloadAllProjects();
-            Collection.UnregisterAllLoggers();
-            Collection.RemoveAllToolsets();
-            Collection.Dispose();
         }
     }
 }

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Build.UnitTests
 
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
             Cleanup();
+            GC.SuppressFinalize(this);
         }
 
         ~TestEnvironment()

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -127,7 +127,23 @@ namespace Microsoft.Build.UnitTests
             return WithInvariant(new StringInvariant(name, value));
         }
 
-        public TransientTempPath WithTempPath(string tempPath, bool deleteTempDirectory = false)
+        /// <summary>
+        /// Creates a new temp path
+        /// </summary>
+        public TransientTempPath CreateNewTempPath()
+        {
+            var folder = CreateFolder();
+            return SetTempPath(folder.FolderPath, true);
+        }
+
+        /// <summary>
+        /// Creates a new temp path
+        /// Sets all OS temp environment variables to the new path
+        ///
+        /// Cleanup:
+        /// - restores OS temp environment variables
+        /// </summary>
+        public TransientTempPath SetTempPath(string tempPath, bool deleteTempDirectory = false)
         {
             var transientTempPath = new TransientTempPath(tempPath, deleteTempDirectory);
             _variants.Add(transientTempPath);
@@ -284,14 +300,15 @@ namespace Microsoft.Build.UnitTests
         private const string TMPDIR = "TMPDIR";
         private const string TEMP = "TEMP";
 
-        private readonly string _tempPath;
         private readonly bool _deleteTempDirectory;
 
         private readonly TempPaths _oldtempPaths;
 
+        public string TempPath { get; }
+
         public TransientTempPath(string tempPath, bool deleteTempDirectory)
         {
-            _tempPath = tempPath;
+            TempPath = tempPath;
             _deleteTempDirectory = deleteTempDirectory;
 
             _oldtempPaths = SetTempPath(tempPath);
@@ -343,7 +360,7 @@ namespace Microsoft.Build.UnitTests
 
             if (_deleteTempDirectory)
             {
-                FileUtilities.DeleteDirectoryNoThrow(_tempPath, recursive: true);
+                FileUtilities.DeleteDirectoryNoThrow(TempPath, recursive: true);
             }
         }
     }

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Build.UnitTests
         [Trait("Category", "mono-osx-failing")]
         public void NoTempFileLeaks()
         {
-            using (var alternativeTemp = new Helpers.AlternativeTempPath())
+            using (var testEnvironment = TestEnvironment.Create())
             {
                 // This test counts files in TEMP. If it uses the system TEMP, some
                 // other process may interfere. Use a private TEMP instead.
-                var newTempPath = alternativeTemp.Path;
+                var newTempPath = testEnvironment.CreateNewTempPath().TempPath;
 
                 string tempPath = Path.GetTempPath();
                 Assert.StartsWith(newTempPath, tempPath);

--- a/src/Tasks.UnitTests/FileStateTests.cs
+++ b/src/Tasks.UnitTests/FileStateTests.cs
@@ -348,8 +348,6 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [Trait("Category", "mono-osx-failing")]
-        // failing only on CI https://github.com/Microsoft/msbuild/issues/2884
-        [Trait("Category", "netcore-osx-failing")]
         public void ReadOnlyOnDirectory()
         {
             Assert.Equal(new FileInfo(Path.GetTempPath()).IsReadOnly, new FileState(Path.GetTempPath()).IsReadOnly);

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="..\Shared\UnitTests\ObjectModelHelpers.cs" />
     <Compile Include="..\Shared\UnitTests\ResourceUtilities_Tests.cs" />
     <Compile Include="..\Shared\QuotingUtilities.cs" />
+    <Compile Include="..\Shared\UnitTests\EngineTestEnvironment.cs" />
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/Tasks.UnitTests/PortableTasks_Tests.cs
+++ b/src/Tasks.UnitTests/PortableTasks_Tests.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 using System.Text.RegularExpressions;
-using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.UnitTests;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.Shared;
 using Shouldly;

--- a/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
+++ b/src/Tasks.UnitTests/ProjectExtensionsImportTestBase.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Build.UnitTests
         /// Ensures that even if the MSBuildProjectExtensionsPath exists, the extensions are not imported if the functionality is disabled via the <see cref="PropertyNameToEnableImport"/>.
         /// </summary>
         [Fact]
-        // https://github.com/Microsoft/msbuild/issues/2884
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void DoesNotImportProjectWhenDisabled()
         {
             // ---------------------
@@ -131,9 +129,6 @@ namespace Microsoft.Build.UnitTests
         /// Ensures that if the default MSBuildProjectExtensions directory is used, that the projects will be imported.
         /// </summary>
         [Fact]
-        // seems to be flaky on !windows
-        // https://github.com/Microsoft/msbuild/issues/2884
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void ImportsProjectIfExists()
         {
             ObjectModelHelpers.CreateFileInTempProjectDirectory(ImportProjectPath, BasicProjectImportContents);

--- a/src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
+++ b/src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
@@ -30,6 +30,7 @@
     <Compile Include="..\Shared\UnitTests\MockLogger.cs" />
     <Compile Include="..\Shared\UnitTests\ObjectModelHelpers.cs" />
     <Compile Include="..\Shared\UnitTests\ResourceUtilities_Tests.cs" />
+    <Compile Include="..\Shared\UnitTests\EngineTestEnvironment.cs" />
     <Compile Include="..\Shared\UnitTests\TestEnvironment.cs">
       <Link>TestEnvironment.cs</Link>
     </Compile>

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Collections;
-using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.UnitTests;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Xunit;

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -167,7 +167,7 @@
       <Link>VisualStudioLocationHelper.cs</Link>
     </Compile>
     <Compile Include="..\Shared\Traits.cs">
-      <Link>SharedTraits.cs</Link>
+      <Link>Traits.cs</Link>
     </Compile>
 
     <!-- Win32 RC Files -->


### PR DESCRIPTION
- Unique temp for each test assembly. With the new tooling, tests run in parallel across test assemblies, and sequential within one assembly. [TestAssemblyInfo](https://github.com/Microsoft/msbuild/blob/exp/update-toolset/src/Shared/UnitTests/TestAssemblyInfo.cs) ensures that each test assembly gets its own temp directory. On !windows it failed to do this right, so I made it use TestEnvironment to ensure proper setup / cleanup of the temp dir. This meant doing some surgery on the TestEnvironment:
  - Separate generic invariants / variants from build specific ones. This enables all test assemblies to reference TestEnvironment without having to also depend on Microsoft.Build.dll
  - Make Microsoft.Build.Framework.UnitTests depend on TestEnvironment
- Make some temp paths unique

I'll also try and re-enable some previously disabled tests here.
