### PR TITLE
Stop using static constructor to wire up AssemblyResolve event handler in NuGetSdkResolver

### DIFF
--- a/src/NuGetSdkResolver.UnitTests/NuGetSdkResolver_Tests.cs
+++ b/src/NuGetSdkResolver.UnitTests/NuGetSdkResolver_Tests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Build.Engine.UnitTests;
 using NuGet.Versioning;
 using Shouldly;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
@@ -101,6 +104,38 @@ namespace NuGet.MSBuildSdkResolver.UnitTests
                 context: context);
         }
 
+#if FEATURE_APPDOMAIN
+        /// <summary>
+        /// Verifies that when an SDK version is null that no NuGet assemblies are loaded.  This helps ensure that we're not loading
+        /// extra assemblies unless they are needed.  A lot of private classes exist in the NuGetSdkResolver in order to make sure
+        /// that types are loaded until they are needed.
+        /// </summary>
+        [Fact]
+        private void TryGetNuGetVersionNullVersionShouldNotLoadNuGetAssemblies()
+        {
+            // Keep a list of assemblies loaded before attempting to parse
+            Assembly[] assembliesLoadedBeforeParsingVersion = AppDomain.CurrentDomain.GetAssemblies();
+
+            MockSdkResolverContext context = new MockSdkResolverContext("foo.proj");
+
+            object parsedVersion;
+
+            // Since we pass a null version, we expect no NuGet assemblies to be loaded
+            NuGetSdkResolver.TryGetNuGetVersionForSdk(
+                id: "foo",
+                version: null,
+                context: context,
+                parsedVersion: out parsedVersion);
+
+            foreach (string newlyLoadedAssembly in AppDomain.CurrentDomain.GetAssemblies()
+                .Except(assembliesLoadedBeforeParsingVersion)
+                .Select(i => i.ManifestModule.Name))
+            {
+                NuGetSdkResolverBase.NuGetAssemblies.ShouldNotContain(newlyLoadedAssembly);
+            }
+        }
+
+#endif
         private void VerifyTryGetNuGetVersionForSdk(string version, NuGetVersion expectedVersion, SdkResolverContextBase context = null)
         {
             object parsedVersion;

--- a/src/NuGetSdkResolver/NuGetSdkResolver.cs
+++ b/src/NuGetSdkResolver/NuGetSdkResolver.cs
@@ -12,7 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Utilities;
+
 using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
 using SdkResultBase = Microsoft.Build.Framework.SdkResult;
 using SdkResultFactoryBase = Microsoft.Build.Framework.SdkResultFactory;
@@ -31,14 +31,8 @@ namespace NuGet.MSBuildSdkResolver
 
         public override int Priority => 2500;
 
-        public override SdkResultBase Resolve(SdkReference sdk, SdkResolverContextBase context, SdkResultFactoryBase factory)
+        protected override SdkResultBase ResolveSdk(SdkReference sdk, SdkResolverContextBase context, SdkResultFactoryBase factory)
         {
-            // Escape hatch to disable this resolver
-            if (Traits.Instance.EscapeHatches.DisableNuGetSdkResolver)
-            {
-                return null;
-            }
-
             object parsedSdkVersion;
 
             // This resolver only works if the user specifies a version in a project or a global.json.


### PR DESCRIPTION
My original intent was to wire up the AssemblyResolve event as soon as possible.  Later I moved all NuGet type references to private classes instead which means that NuGet assemblies are not loaded until these private classes are accessed.  The private classes are not accessed unless the user specified a version.

So wiring up AssemblyResolve in a static constructor means that in Visual Studio all AssemblyResolve events are sent through the NuGet SDK resolver which is not ideal.  Instead, it can be wired up prior to resolving an SDK and then removed.

I also added a unit test to ensure that NuGet assemblies are not loaded when no version is specified.