### PR TITLE
fix signing issue with sha256 cert on 4.6.1

### DIFF
--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -640,13 +640,16 @@ namespace System.Deployment.Internal.CodeSigning
 
             // Setup up XMLDSIG engine.
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(licenseDom);
-            signedXml.SigningKey = GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256);
+            // only needs to change the provider type when RSACryptoServiceProvider is used
+            var rsaCsp = rsaPrivateKey is RSACryptoServiceProvider ?
+                            GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256) : rsaPrivateKey;
+            signedXml.SigningKey = rsaCsp;
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
             if (signer.UseSha256)
                 signedXml.SignedInfo.SignatureMethod = Sha256SignatureMethodUri;
 
             // Add the key information.
-            signedXml.KeyInfo.AddClause(new RSAKeyValue(GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256)));
+            signedXml.KeyInfo.AddClause(new RSAKeyValue(rsaCsp));
             signedXml.KeyInfo.AddClause(new KeyInfoX509Data(signer.Certificate, signer.IncludeOption));
 
             // Add the enveloped reference.

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -640,13 +640,13 @@ namespace System.Deployment.Internal.CodeSigning
 
             // Setup up XMLDSIG engine.
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(licenseDom);
-            signedXml.SigningKey = rsaPrivateKey;
+            signedXml.SigningKey = GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256);
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
             if (signer.UseSha256)
                 signedXml.SignedInfo.SignatureMethod = Sha256SignatureMethodUri;
 
             // Add the key information.
-            signedXml.KeyInfo.AddClause(new RSAKeyValue(rsaPrivateKey));
+            signedXml.KeyInfo.AddClause(new RSAKeyValue(GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256)));
             signedXml.KeyInfo.AddClause(new KeyInfoX509Data(signer.Certificate, signer.IncludeOption));
 
             // Add the enveloped reference.


### PR DESCRIPTION
This is to fix the regression caused by adding support of CNG cert signing. When VS(msbuild) running on .net 4.6.1 and SHA256 cert being used in signing manifest file, we need to update the RSA provider type to PROV_RSA_AES which is the only provider that supporst SHA2 operations.