### PR TITLE
Do not avoid best-match TF checks for ReferenceOutputAssembly=false

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1545,15 +1545,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       We give this treatment to .vcxproj by default since no .vcxproj can target more
       than one framework.
-
-      Likewise if the dependency is for build ordering instead of an assembly reference
-      (ReferenceOutputAssembly=false), skip the checks since we can't know what TF
-      the output would need to be compatible with.
    -->
    <ItemGroup>
-      <_MSBuildProjectReferenceExistent
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and
-                   ('%(Extension)' == '.vcxproj' or '%(ReferenceOutputAssembly)' == 'false')">
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and '%(Extension)' == '.vcxproj'">
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </_MSBuildProjectReferenceExistent>
    </ItemGroup>


### PR DESCRIPTION
This reverts commit 91c86a746b312fce1aba31f8fb8540e949c11a01.

Fixes #2922 but undoes the fix for #2661.

Details as to why in https://github.com/Microsoft/msbuild/pull/2923#issuecomment-361999701 and https://github.com/Microsoft/msbuild/pull/2867#issuecomment-361998280.