### PR TITLE
Update third party notice to include Samples for xUnit.net notice

### DIFF
--- a/THIRDPARTYNOTICES.txt
+++ b/THIRDPARTYNOTICES.txt
@@ -24,3 +24,23 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------
+
+Notice for Samples for xUnit.net 
+-------------------------------
+
+Copyright (c) .NET Foundation and Contributors 
+
+All Rights Reserved 
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. 
+
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+-------------------------------


### PR DESCRIPTION
This is for the [Assembly Fixture support](https://github.com/Microsoft/msbuild/tree/master/src/Xunit.NetCore.Extensions/AssemblyFixtureSupport), which was originally copied from https://github.com/xunit/samples.xunit/tree/master/AssemblyFixtureExample

XUnit doesn't have built-in capability to have assembly-level test startup / shutdown code (without annotating each test as being part of a collection).  If you want to do that, you need to take the sample code and adapt it as necessary.