### PR TITLE
Enable source linking

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,6 +52,10 @@
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
+    <PackageReference Include="PdbGit" Version="3.0.41" PrivateAssets="All"
+                      Condition="'$(DebugType)' == 'full' And '$(IsUnitTestProject)' != 'true'" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.6" PrivateAssets="All"
+                      Condition="'$(DebugType)' != 'full' And '$(IsUnitTestProject)' != 'true'" />    
   </ItemGroup>
   
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
Add back source link packages we had before the toolset upgrade.

I'm not sure how to verify this is working, we may need to get a build after merging into the repo to do so.

@tmat Do you have a better way of doing this?