### PR TITLE
Support backslashes in solution paths

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -699,6 +699,28 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
+        /// Test some characters that are valid in a file name but that also could be
+        /// considered a delimiter by a parser. Does quoting work for special characters?
+        /// </summary>
+        [Fact]
+        public void ParseFirstProjectLineWhereProjectPathHasBackslash()
+        {
+            SolutionFile p = new SolutionFile();
+            p.FullPath = NativeMethodsShared.IsWindows ? "c:\\foo.sln" : "/foo.sln";
+            ProjectInSolution proj = new ProjectInSolution(p);
+
+            p.ParseFirstProjectLine
+            (
+                "Project(\"{Project GUID}\")  = \"ProjectInSubdirectory\",  \"Relative\\path\\to\\project file\"    , \"Unique name-GUID\"",
+                 proj
+            );
+            Assert.Equal(SolutionProjectType.Unknown, proj.ProjectType);
+            Assert.Equal("ProjectInSubdirectory", proj.ProjectName);
+            Assert.Equal(Path.Combine("Relative", "path", "to", "project file"), proj.RelativePath);
+            Assert.Equal("Unique name-GUID", proj.ProjectGuid);
+        }
+
+        /// <summary>
         /// Helper method to create a SolutionFile object, and call it to parse the SLN file
         /// represented by the string contents passed in.
         /// </summary>

--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Security;
 using System.Text;
 using System.Xml;
+using Microsoft.Build.Shared;
 
 using XMakeAttributes = Microsoft.Build.Shared.XMakeAttributes;
 using ProjectFileErrorUtilities = Microsoft.Build.Shared.ProjectFileErrorUtilities;
@@ -155,7 +156,11 @@ namespace Microsoft.Build.Construction
         public string RelativePath
         {
             get { return _relativePath; }
-            internal set { _relativePath = value; }
+            internal set
+            {
+                _relativePath = FileUtilities.MaybeAdjustFilePath(value,
+                                                    baseDirectory:this.ParentSolution.SolutionFileDirectory ?? String.Empty);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Add a test that will fail on forward-slash OSes when reading a
backslash-containing relative path from a solution file.

Regression test for #2022.