### PR TITLE
Fix node task crash in SDK resolution which hangs MSBuild.exe

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -239,7 +239,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     catch (Exception e)
                     {
                         ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-                        loggingService.LogFatalError(new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath).BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation), "CouldNotRunSdkResolver", "foo", e.Message);
+
+                        EvaluationLoggingContext loggingContext = new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath);
+
+                        loggingService.LogFatalBuildError(loggingContext.BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation));
                     }
                     finally
                     {

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -238,16 +238,15 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     }
                     catch (Exception e)
                     {
-                        // Errors cannot be logged in this background thread so it must be sent to the awaiting
-                        // node to be logged.
-                        response = new SdkResolverResponse(e);
+                        ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+                        loggingService.LogFatalError(new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath).BuildEventContext, e, new BuildEventFileInfo(request.ElementLocation), "CouldNotRunSdkResolver", "foo", e.Message);
                     }
                     finally
                     {
                         // Get the node manager and send the response back to the node that requested the SDK
                         INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
-                        nodeManager.SendData(request.NodeId, response);
+                        nodeManager.SendData(request.NodeId, response ?? new SdkResolverResponse());
                     }
                 }));
             }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -222,21 +222,33 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 // Start a thread to resolve an SDK and add it to the list of threads
                 tasks.Add(Task.Run(() =>
                 {
-                    // Create an SdkReference from the request
-                    SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
+                    SdkResolverResponse response = null;
+                    try
+                    {
+                        // Create an SdkReference from the request
+                        SdkReference sdkReference = new SdkReference(request.Name, request.Version, request.MinimumVersion);
 
-                    ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
+                        ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
-                    // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                    SdkResult result = GetSdkResultAndCache(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath);
+                        // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
+                        SdkResult result = GetSdkResultAndCache(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath);
 
-                    // Create a response
-                    SdkResolverResponse response = new SdkResolverResponse(result.Path, result.Version);
+                        // Create a response
+                        response = new SdkResolverResponse(result?.Path, result?.Version);
+                    }
+                    catch (Exception e)
+                    {
+                        // Errors cannot be logged in this background thread so it must be sent to the awaiting
+                        // node to be logged.
+                        response = new SdkResolverResponse(e);
+                    }
+                    finally
+                    {
+                        // Get the node manager and send the response back to the node that requested the SDK
+                        INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
-                    // Get the node manager and send the response back to the node that requested the SDK
-                    INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
-
-                    nodeManager.SendData(request.NodeId, response);
+                        nodeManager.SendData(request.NodeId, response);
+                    }
                 }));
             }
 

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -68,15 +68,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 sdk.Name,
                 key => RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath));
 
-            if (!String.IsNullOrWhiteSpace(response.Error))
-            {
-                // Log an error that occured on the main node request handler thread which cannot log errors
-                loggingContext.LogErrorFromText(null, null, null, new BuildEventFileInfo(sdkReferenceLocation), response.Error);
-
-                return null;
-            }
-
-            if (response.Version != null && !SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
+            if (!SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version already specified at "{1}" will be used and the version will be "{2}" ignored.
                 loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.ElementLocation, sdk.Version);

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -68,10 +68,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 sdk.Name,
                 key => RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath));
 
-            if (!SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
+            if (response.Version != null && !SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
             {
-                // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version already specified at "{1}" will be used and the version will be "{2}" ignored.
-                loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.ElementLocation, sdk.Version);
+                // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.
+                loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.Version, response.ElementLocation, sdk.Version);
             }
 
             return response.FullPath;

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -68,7 +68,15 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 sdk.Name,
                 key => RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath));
 
-            if (!SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
+            if (!String.IsNullOrWhiteSpace(response.Error))
+            {
+                // Log an error that occured on the main node request handler thread which cannot log errors
+                loggingContext.LogErrorFromText(null, null, null, new BuildEventFileInfo(sdkReferenceLocation), response.Error);
+
+                return null;
+            }
+
+            if (response.Version != null && !SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version already specified at "{1}" will be used and the version will be "{2}" ignored.
                 loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.ElementLocation, sdk.Version);

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Build.BackEnd.SdkResolution
 {
     /// <summary>
@@ -9,6 +11,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     /// </summary>
     internal sealed class SdkResolverResponse : INodePacket
     {
+        private string _error;
         private string _fullPath;
         private string _version;
 
@@ -23,10 +26,21 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             Translate(translator);
         }
 
+        public SdkResolverResponse(Exception exception)
+        {
+            // Only translate the exception message so we don't have to serialize the whole object
+            _error = exception.Message;
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="ElementLocation"/> of the reference that created this response.
         /// </summary>
         public Construction.ElementLocation ElementLocation { get; set; }
+
+        /// <summary>
+        /// Gets an optional error associated with the response.
+        /// </summary>
+        public string Error => _error;
 
         /// <summary>
         /// Gets the full path to the resolved SDK.
@@ -49,6 +63,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
             translator.Translate(ref _fullPath);
             translator.Translate(ref _version);
+            translator.Translate(ref _error);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
@@ -11,9 +11,12 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     /// </summary>
     internal sealed class SdkResolverResponse : INodePacket
     {
-        private string _error;
         private string _fullPath;
         private string _version;
+
+        public SdkResolverResponse()
+        {
+        }
 
         public SdkResolverResponse(string fullPath, string version)
         {
@@ -26,21 +29,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             Translate(translator);
         }
 
-        public SdkResolverResponse(Exception exception)
-        {
-            // Only translate the exception message so we don't have to serialize the whole object
-            _error = exception.Message;
-        }
-
         /// <summary>
         /// Gets or sets the <see cref="ElementLocation"/> of the reference that created this response.
         /// </summary>
         public Construction.ElementLocation ElementLocation { get; set; }
-
-        /// <summary>
-        /// Gets an optional error associated with the response.
-        /// </summary>
-        public string Error => _error;
 
         /// <summary>
         /// Gets the full path to the resolved SDK.
@@ -63,7 +55,6 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
             translator.Translate(ref _fullPath);
             translator.Translate(ref _version);
-            translator.Translate(ref _error);
         }
     }
 }


### PR DESCRIPTION
In a multi-proc build when an SDK could not be found, a NullReferenceException would occur which would crash the thread on the main node responsible for responding to SDK resolution requests.  The out-of-proc node would then hang waiting for a response and MSBuild's main thread would be waiting for the out-of-proc node to finish.

The code is more resilient now by catching all exceptions and sending the response in a finally.  Any errors that occur in the request handler thread are sent back to the out-of-proc node to be logged.