### PR TITLE
Use same pattern for test results as artifacts

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -111,7 +111,7 @@ def imageVersionMap = ['Windows_NT':'latest-dev15-5',
             Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
             // Add archiving of logs (even if the build failed)
             Utilities.addArchival(newJob,
-                                  'artifacts/**/log/*.binlog,artifacts/**/log/*.log,artifacts/**/Microsoft.*.UnitTests_*', /* filesToArchive */
+                                  'artifacts/**/log/*.binlog,artifacts/**/log/*.log,artifacts/**/TestResults/*', /* filesToArchive */
                                   '', /* filesToExclude */
                                   false, /* doNotFailIfNothingArchived */
                                   false, /* archiveOnlyIfSuccessful */)


### PR DESCRIPTION
Before, we were archiving a slightly different pattern from what the Jenkins plugin was scraping test results from, which could have led to confusion.