### PR TITLE
Close handles returned from CreateProcess

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -555,8 +555,13 @@ namespace Microsoft.Build.BackEnd
                 throw new NodeFailedToLaunchException(e.NativeErrorCode.ToString(CultureInfo.InvariantCulture), e.Message);
             }
 
-            CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", processInfo.dwProcessId);
-            return processInfo.dwProcessId;
+            int childProcessId = processInfo.dwProcessId;
+
+            NativeMethodsShared.CloseHandle(processInfo.hProcess);
+            NativeMethodsShared.CloseHandle(processInfo.hThread);
+
+            CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", childProcessId);
+            return childProcessId;
 #endif
         }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -557,8 +557,15 @@ namespace Microsoft.Build.BackEnd
 
             int childProcessId = processInfo.dwProcessId;
 
-            NativeMethodsShared.CloseHandle(processInfo.hProcess);
-            NativeMethodsShared.CloseHandle(processInfo.hThread);
+            if (processInfo.hProcess != IntPtr.Zero && processInfo.hProcess != NativeMethods.InvalidHandle)
+            {
+                NativeMethodsShared.CloseHandle(processInfo.hProcess);
+            }
+
+            if (processInfo.hThread != IntPtr.Zero && processInfo.hThread != NativeMethods.InvalidHandle)
+            {
+                NativeMethodsShared.CloseHandle(processInfo.hThread);
+            }
 
             CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", childProcessId);
             return childProcessId;

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -210,10 +210,6 @@ namespace Microsoft.Build.Shared
             {
                 return CloseHandle(handle);
             }
-
-            [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
-            [DllImport("KERNEL32.DLL")]
-            private static extern bool CloseHandle(IntPtr hObject);
         }
 
         /// <summary>
@@ -1373,6 +1369,11 @@ namespace Microsoft.Build.Shared
             out FILETIME lpLastAccessTime,
             out FILETIME lpLastWriteTime
             );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+
+        internal static extern bool CloseHandle(IntPtr hObject);
 
 #endregion
 


### PR DESCRIPTION
Avoids a handle leak when spawning worker nodes.

Fixes #2974.