### PR TITLE
Check exact match for "running msbuild.exe"

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -327,11 +327,15 @@ namespace Microsoft.Build.Shared
         /// <returns></returns>
         private static bool IsProcessInList(string processName, string[] processList)
         {
-            return
-                processList.Any(
-                    s =>
-                        Path.GetFileNameWithoutExtension(processName)?
-                            .IndexOf(s, StringComparison.OrdinalIgnoreCase) >= 0);
+            var processFileName = Path.GetFileNameWithoutExtension(processName);
+
+            if (string.IsNullOrEmpty(processFileName))
+            {
+                return false;
+            }
+
+            return processList.Any(s =>
+                processFileName.Equals(s, StringComparison.OrdinalIgnoreCase));
         }
 
         private static string GetProcessFromRunningProcess()


### PR DESCRIPTION
Fixes the problem where a program using the MSBuild API and
containing the string "MSBuild" in its name was incorrectly detected as
running in MSBuild.exe in standalone mode.

Fixes #2194.

Note that the concerns in https://github.com/Microsoft/msbuild/issues/2194#issuecomment-307151488 about test detection no longer applies after b8d01363.