### PR TITLE
Reset current directory on Core

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1147,10 +1147,9 @@ namespace Microsoft.Build.BackEnd
                 }
                 catch (DirectoryNotFoundException)
                 {
-#if FEATURE_ENVIRONMENT_SYSTEMDIRECTORY
                     // Somehow the startup directory vanished. This can happen if build was started from a USB Key and it was removed.
-                    NativeMethodsShared.SetCurrentDirectory(Environment.SystemDirectory);
-#endif
+                    NativeMethodsShared.SetCurrentDirectory(
+                        BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
                 }
             }
 

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -503,10 +503,9 @@ namespace Microsoft.Build.Execution
             // Shutdown any Out Of Proc Nodes Created
             _taskHostNodeManager.ShutdownConnectedNodes(_shutdownReason == NodeEngineShutdownReason.BuildCompleteReuse);
 
-#if FEATURE_ENVIRONMENT_SYSTEMDIRECTORY
-            // Restore the original current directory.
-            NativeMethodsShared.SetCurrentDirectory(Environment.SystemDirectory);
-#endif
+            // On Windows, a process holds a handle to the current directory,
+            // so reset it away from a user-requested folder that may get deleted.
+            NativeMethodsShared.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
 
             // Restore the original environment.
             // If the node was never configured, this will be null.
@@ -710,10 +709,8 @@ namespace Microsoft.Build.Execution
             }
             catch (DirectoryNotFoundException)
             {
-#if FEATURE_ENVIRONMENT_SYSTEMDIRECTORY
                 // Somehow the startup directory vanished. This can happen if build was started from a USB Key and it was removed.
                 NativeMethodsShared.SetCurrentDirectory(Environment.SystemDirectory);
-#endif
             }
 
             // Replicate the environment.  First, unset any environment variables set by the previous configuration.

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Build.Execution
             catch (DirectoryNotFoundException)
             {
                 // Somehow the startup directory vanished. This can happen if build was started from a USB Key and it was removed.
-                NativeMethodsShared.SetCurrentDirectory(Environment.SystemDirectory);
+                NativeMethodsShared.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
             }
 
             // Replicate the environment.  First, unset any environment variables set by the previous configuration.

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -735,10 +735,9 @@ namespace Microsoft.Build.CommandLine
             _registeredTaskObjectCache = null;
 #endif
 
-#if FEATURE_ENVIRONMENT_SYSTEMDIRECTORY
-            // Restore the original current directory.
-            NativeMethodsShared.SetCurrentDirectory(Environment.SystemDirectory);
-#endif
+            // On Windows, a process holds a handle to the current directory,
+            // so reset it away from a user-requested folder that may get deleted.
+            NativeMethodsShared.SetCurrentDirectory(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory);
 
             // Restore the original environment.
             CommunicationsUtilities.SetEnvironment(_savedEnvironment);


### PR DESCRIPTION
Full-framework MSBuild was resetting the current directory at the end of build requests and at node idle, which helps avoid holding handles to project directories that the user may wish to delete while a worker node is still alive in the background. That wasn't done on .NET Core because at the time of the original port, there wasn't an `Environment.SystemDirectory` to use.

That property is now available, but returns the empty string on Linux, which fails `Directory.SetCurrentDirectory()`. So I'm avoiding it by using the current MSBuild tools directory, which should exist as long as the MSBuild process keeps running.

Fixes #2977.