### PR TITLE
[Mono] Optimize MSBuild environment initialization

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -75,9 +75,7 @@ namespace Microsoft.Build.Shared
             var possibleLocations = new Func<BuildEnvironment>[]
             {
                 TryFromEnvironmentVariable,
-#if !MONO                
                 TryFromVisualStudioProcess,
-#endif
                 TryFromMSBuildProcess,
                 TryFromMSBuildAssembly,
                 TryFromDevConsole,
@@ -128,6 +126,9 @@ namespace Microsoft.Build.Shared
 
         private static BuildEnvironment TryFromVisualStudioProcess()
         {
+            if (!NativeMethodsShared.IsWindows)
+                return null;
+
             var vsProcess = s_getProcessFromRunningProcess();
             if (!IsProcessInList(vsProcess, s_visualStudioProcess)) return null;
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Build.Shared
             var possibleLocations = new Func<BuildEnvironment>[]
             {
                 TryFromEnvironmentVariable,
+#if !MONO                
                 TryFromVisualStudioProcess,
+#endif
                 TryFromMSBuildProcess,
                 TryFromMSBuildAssembly,
                 TryFromDevConsole,


### PR DESCRIPTION
TryFromVisualStudioProcess only looks for Windows specific paths. It seems to incur a 1.77s penalty, mostly in Process.GetModules inside Mono.

Thus skip this probe path on Mono.