### PR TITLE
Merge 15.6 to 15.7

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -555,8 +555,20 @@ namespace Microsoft.Build.BackEnd
                 throw new NodeFailedToLaunchException(e.NativeErrorCode.ToString(CultureInfo.InvariantCulture), e.Message);
             }
 
-            CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", processInfo.dwProcessId);
-            return processInfo.dwProcessId;
+            int childProcessId = processInfo.dwProcessId;
+
+            if (processInfo.hProcess != IntPtr.Zero && processInfo.hProcess != NativeMethods.InvalidHandle)
+            {
+                NativeMethodsShared.CloseHandle(processInfo.hProcess);
+            }
+
+            if (processInfo.hThread != IntPtr.Zero && processInfo.hThread != NativeMethods.InvalidHandle)
+            {
+                NativeMethodsShared.CloseHandle(processInfo.hThread);
+            }
+
+            CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", childProcessId);
+            return childProcessId;
 #endif
         }
 

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -68,10 +68,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 sdk.Name,
                 key => RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath));
 
-            if (!SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
+            if (response.Version != null && !SdkResolverService.IsReferenceSameVersion(sdk, response.Version))
             {
-                // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version already specified at "{1}" will be used and the version will be "{2}" ignored.
-                loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.ElementLocation, sdk.Version);
+                // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.
+                loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "ReferencingMultipleVersionsOfTheSameSdk", sdk.Name, response.Version, response.ElementLocation, sdk.Version);
             }
 
             return response.FullPath;

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverResponse.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.Build.BackEnd.SdkResolution
 {
     /// <summary>
@@ -11,6 +13,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     {
         private string _fullPath;
         private string _version;
+
+        public SdkResolverResponse()
+        {
+        }
 
         public SdkResolverResponse(string fullPath, string version)
         {

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -2003,8 +2003,8 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Překladač SDK byl nalezen, ale nejde zavést. Chyba: {0}</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: Typ překladače sady SDK {0} se nepodařilo načíst. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">Zadané rozhraní API {0} není k dispozici, protože při načítání tohoto projektu bylo nastaveno ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: Sestavení překladače sady SDK {0} nebylo možné načíst. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: Překladač sady SDK {0} se nepodařilo spustit. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: Překladač sady SDK založený na NuGet se nepodařilo spustit, protože sestavení NuGet se nenašla. Zkontrolujte instalaci nástroje MSBuild nebo nastavte proměnnou prostředí {0} na složku, která obsahuje požadovaná sestavení NuGet. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">{1} neimportoval projekt {0} v ({2},{3}), protože soubor je neplatný.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">{1} neimportoval projekt {0} v ({2},{3}), protože soubor neexistuje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD: chyba MSB4239: Při zápisu sestavy profilace došlo k chybě. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Sestava profileru se zapisuje do {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Zápis sestavy je hotový.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: Několik verzí stejné sady SDK {0} nelze zadat. Bude použita verze {1} sady SDK, kterou už určuje {2}, verze {3} bude ignorována.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: Odkaz na sadu SDK {0} verze {1} byl místo toho přeložen na verzi {2}. Pokud neaktualizujete odkazovanou verzi tak, aby se shodovala, může se používat jiná verze, než kterou očekáváte.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Překládá se sada SDK {0}...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -2003,8 +2003,8 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Ein SDK-Resolver wurde gefunden, konnte aber nicht geladen werden. Fehler: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: Der SDK-Resolvertyp "{0}" konnte nicht geladen werden. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2024,17 +2024,17 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedFalseCondition">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</source>
-        <target state="translated">Das Projekt "{0}" wurde von "{1}" bei ({2},{3}) aufgrund einer falschen Bedingung nicht importiert; ({4}) wurde als ({5}) ausgewertet.</target>
+        <target state="translated">Das Projekt "{0}" wurde aufgrund einer falschen Bedingung nicht von "{1}" in ({2},{3}) importiert; ({4}) wurde als ({5}) ausgewertet.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedNoMatches">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to no matching files.</source>
-        <target state="translated">Das Projekt "{0}" wurde von "{1}" bei ({2},{3}) aufgrund nicht übereinstimmender Dateien nicht importiert.</target>
+        <target state="translated">Das Projekt "{0}" wurde aufgrund nicht übereinstimmender Dateien nicht von "{1}" in ({2},{3}) importiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedEmptyFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being empty.</source>
-        <target state="translated">Das Projekt "{0}" wurde von "{1}" bei ({2},{3}) nicht importiert, da die Datei leer war.</target>
+        <target state="translated">Das Projekt "{0}" wurde von "{1}" nicht in ({2},{3}) importiert, da die Datei leer war.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImported">
@@ -2056,6 +2056,67 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">Die angegebene API "{0}" ist nicht verfügbar, weil beim Laden dieses Projekts "ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition" festgelegt wurde.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: Die SDK-Resolverassembly "{0}" konnte nicht geladen werden. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: Der SDK-Resolver "{0}" konnte nicht ausgeführt werden. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: Fehler beim NuGet-basierten SDK-Resolver, weil die NuGet-Assemblys nicht gefunden wurden. Überprüfen Sie Ihre Installation von MSBuild, oder legen Sie die Umgebungsvariable "{0}" auf den Ordner fest, der die erforderlichen NuGet-Assemblys enthält. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">Das Projekt "{0}" wurde von "{1}" nicht in ({2},{3}) importiert, weil die Datei ungültig ist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">Das Projekt "{0}" wurde von "{1}" nicht in ({2},{3}) importiert, weil die Datei nicht vorhanden ist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD: Fehler MSB4239: Fehler beim Schreiben des Profilerstellungsberichts. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Profilerbericht wird in "{0}" geschrieben...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Bericht wurde geschrieben.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: Es können nicht mehrere Versionen für dasselbe SDK "{0}" angegeben werden. Die bereits von "{2}" angegebene SDK-Version "{1}" wird verwendet, die Version "{3}" wird ignoriert.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: Der SDK-Verweis "{0}" auf Version "{1}" wurde stattdessen in Version "{2}" aufgelöst. Sie könnten eine andere Version als die erwartete verwenden, wenn Sie die referenzierte Version nicht entsprechend aktualisieren.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">SDK "{0}" wird aufgelöst...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -2003,8 +2003,8 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Se encontró una resolución de SDK pero no se pudo cargar. Error {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: El tipo de resolución del SDK "{0}" no se pudo cargar. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">La API especificada "{0}" no está disponible porque se configuró ProjectLoadSettings.DoNotEvaluat eElementsWithFalseCondition al cargar este proyecto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: El ensamblado de la resolución del SDK "{0}" no se pudo cargar. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: La resolución del SDK "{0}" no se pudo ejecutar. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: La resolución del SDK basado en NuGet no se pudo ejecutar porque no se encontraron los ensamblados de NuGet. Compruebe su instalación de MSBuild o configure la variable del entorno "{0}" en la carpeta que contiene los ensamblados de NuGet requeridos. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">"{1}" no importó el proyecto "{0}" en ({2},{3}) porque el archivo no era válido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">"{1}" no importó el proyecto "{0}" en ({2},{3}) porque el archivo no existía.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : error MSB4239: Error al escribir el informe de generación de perfiles. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Escribiendo informe del generador de perfiles en "{0}"...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Escritura de informe finalizada.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: No se pueden especificar varias versiones del mismo SDK "{0}". Se usará la versión del SDK "{1}" ya especificada por "{2}" y la versión "{3}" se ignorará.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: La referencia del SKD "{0}", versión "{1}", se resolvió en la versión "{2}". Podría estar utilizando una versión diferente de la esperada si no actualiza la versión de referencia para que coincida.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Resolviendo SDK "{0}"...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -2003,8 +2003,8 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Un programme de résolution du SDK a été détecté mais il n'a pas pu être chargé. Erreur : {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: Impossible de charger le type de résolution de SDK "{0}". {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">L'API spécifiée "{0}" n'est pas disponible parce que ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition a été défini lors du chargement de ce projet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: Impossible de charger l'assembly de résolution de SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: Impossible d'exécuter la résolution de SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: Impossible d'exécuter la résolution de SDK NuGet parce que les assemblys NuGet n'ont pas pu être localisés. Vérifiez votre installation de MSBuild ou définissez la variable d'environnement "{0}" dans le dossier qui contient les assemblys NuGet obligatoires. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">Le projet "{0}" n’a pas été importé par "{1}" sur ({2},{3}), car le fichier n’est pas valide.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">Le projet "{0}" n’a pas été importé par "{1}" sur ({2},{3}), car le fichier n’existe pas.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : erreur MSB4239 : Erreur lors de l'écriture du rapport de profilage. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Écriture du rapport du profileur dans '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Écriture du rapport terminée.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: Impossible de spécifier plusieurs versions du même SDK "{0}". La version du SDK "{1}" déjà spécifiée par "{2}" est utilisée, tandis que la version "{3}" est ignorée.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: La référence du SDK "{0}" version "{1}" a été résolue avec la version "{2}" à la place. Vous risquez d'utiliser une version différente de celle attendue si vous ne mettez pas à jour la version référencée correspondante.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Résolution du SDK '{0}'...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -2003,8 +2003,8 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: è stato trovato un resolver di SDK che però non è stato caricato. Errore: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: non è stato possibile caricare il tipo di resolver SDK "{0}". {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">L'API specificata "{0}" non è disponibile perché ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition è stato impostato durante il caricamento di questo progetto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: non è stato possibile caricare l'assembly "{0}" del resolver SDK. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: non è stato possibile eseguire il resolver SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: non è stato possibile eseguire il resolver SDK basato su NuGet perché non sono stati trovati assembly NuGet. Controllare l'installazione di MSBuild oppure impostare la variabile di ambiente "{0}" sulla cartella che contiene gli assembly NuGet richiesti. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">Il progetto "{0}" non è stato importato da "{1}" a ({2},{3}) perché il file non è valido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">Il progetto "{0}" non è stato importato da "{1}" a ({2},{3}) perché il file non esiste.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : error MSB4239: si è verificato un errore durante la scrittura del report di profilatura. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Scrittura del report del profiler in '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">La scrittura del report è stata completata.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: non è possibile specificare più versioni dello stesso SDK "{0}". Verrà usata La versione "{1}" dell'SDK già specificata da "{2}", mentre la versione "{3}" verrà ignorata.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: la versione "{1}" del riferimento "{0}" all'SDK è stata risolta nella versione "{2}". Se non si aggiorna la versione di riferimento in modo che corrisponda, è possibile che la versione in uso sia diversa da quella prevista.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Risoluzione dell'SDK '{0}'...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -2003,8 +2003,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: SDK リゾルバーが見つかりましたが、読み込めませんでした。エラー: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: SDK 競合回避モジュールの型 "{0}" を読み込めませんでした。{1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">このプロジェクトを読み込んだときに ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition が設定されていたため、指定された API "{0}" を使用できません。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: SDK 競合回避モジュールのアセンブリ "{0}" を読み込めませんでした。{1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: SDK 競合回避モジュール "{0}" を実行できませんでした。{1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: NuGet アセンブリを見つけることができなかったため、NuGet ベースの SDK 競合回避モジュールを実行できませんでした。MSBuild のインストールを確認するか、環境変数 "{0}" を、必要な NuGet アセンブリが含まれているフォルダーに設定してください。{1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">ファイルが無効であるため、プロジェクト "{0}" は "{1}" によって ({2},{3}) でインポートされませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">ファイルが存在しないため、プロジェクト "{0}" は "{1}" によって ({2},{3}) でインポートされませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : エラー MSB4239: プロファイル レポートの書き込みでエラーが発生しました。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">プロファイル レポートを '{0}' に書き込んでいます...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">レポートの書き込みが完了しました。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: 同じ SDK "{0}" の複数のバージョンを指定することはできません。既に "{2}" によって指定されている SDK バージョン "{1}" が使用され、バージョン "{3}" は無視されます。</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: SDK 参照 "{0}" のバージョン "{1}" は、代わりにバージョン "{2}" に解決されました。  参照されたバージョンを一致するように更新しない場合、必要なバージョンとは別のバージョンを使用する可能性があります。</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">SDK '{0}' を解決しています...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -1984,7 +1984,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: 잘못된 이진 로거 매개 변수: “{0}”. 예상 값: ProjectImports={{None,Embed,ZipFile}} 및/또는 [LogFile=]filePath.binlog(로그 파일 이름 또는 경로, 확장명이 “.binlog”여야 함).</target>
+        <target state="translated">MSB4234: 잘못된 이진 로거 매개 변수: "{0}". 예상 값: ProjectImports={{None,Embed,ZipFile}} 및/또는 [LogFile=]filePath.binlog(로그 파일 이름 또는 경로, 확장명이 ".binlog"여야 함).</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2003,8 +2003,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: SDK 확인자를 찾았지만 로드할 수 없습니다. 오류: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: SDK 확인자 형식 "{0}"을(를) 로드하지 못했습니다. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2024,22 +2024,22 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedFalseCondition">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</source>
-        <target state="translated">false 조건으로 인해 ({2},{3})의 “{1}”이(가) “{0}” 프로젝트를 가져오지 않았습니다. ({4})은(는) ({5})(으)로 확인되었습니다.</target>
+        <target state="translated">false 조건으로 인해 ({2},{3})의 "{1}”이(가) "{0}" 프로젝트를 가져오지 않았습니다. ({4})은(는) ({5})(으)로 확인되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedNoMatches">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to no matching files.</source>
-        <target state="translated">일치하는 파일이 없어 ({2},{3})의 “{1}”이(가) “{0}” 프로젝트를 가져오지 않았습니다.</target>
+        <target state="translated">일치하는 파일이 없어 ({2},{3})의 "{1}"이(가) "{0}" 프로젝트를 가져오지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImportSkippedEmptyFile">
         <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being empty.</source>
-        <target state="translated">파일이 비어 있어 ({2},{3})의 “{1}”이(가) “{0}” 프로젝트를 가져오지 않았습니다.</target>
+        <target state="translated">파일이 비어 있어 ({2},{3})의 "{1}"이(가) "{0}" 프로젝트를 가져오지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProjectImported">
         <source>Importing project "{0}" into project "{1}" at ({2},{3}).</source>
-        <target state="translated">“{0}” 프로젝트를 ({2},{3})의 “{1}” 프로젝트로 가져오는 중입니다.</target>
+        <target state="translated">"{0}" 프로젝트를 ({2},{3})의 "{1}" 프로젝트로 가져오는 중입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
@@ -2056,6 +2056,67 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">이 프로젝트를 로드할 때 ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition이 설정되었기 때문에 지정된 API "{0}"은(는) 사용할 수 없습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: SDK 확인자 어셈블리 "{0}"을(를) 로드할 수 없습니다. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: SDK 확인자 "{0}"을(를) 실행하지 못했습니다. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: NuGet 어셈블리를 찾을 수 없어 NuGet 기반 SDK 확인자를 실행하지 못했습니다. MSBuild 설치를 확인하거나 환경 변수 "{0}"을(를) 필요한 NuGet 어셈블리가 포함된 폴더로 설정하세요. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">파일이 잘못되어 ({2},{3})의 "{1}"이(가) "{0}" 프로젝트를 가져오지 않았습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">파일이 없어 ({2},{3})의 "{1}"이(가) "{0}" 프로젝트를 가져오지 않았습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : 오류 MSB4239: 프로파일링 보고서를 쓰는 동안 오류가 발생했습니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">프로파일러 보고서를 '{0}'에 쓰는 중...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">보고서 쓰기를 완료했습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: 동일한 SDK "{0}"의 여러 버전을 지정할 수 없습니다. "{2}"에서 이미 지정한 SDK 버전 "{1}"이(가) 사용되며 "{3}" 버전은 무시됩니다.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: SDK 참조 "{0}" 버전 "{1}"이(가) 대신 "{2}" 버전으로 확인되었습니다. 참조된 버전을 일치하도록 업데이트하지 않는 경우 예상과 다른 버전을 사용할 수 있습니다.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">SDK '{0}'을(를) 확인하는 중...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -2003,8 +2003,8 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Znaleziono program rozpoznawania zestawu SDK, ale nie można go załadować. Błąd: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: Nie można załadować typu programu rozpoznawania zestawu SDK „{0}”. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">Określony interfejs API „{0}” jest niedostępny, ponieważ podczas ładowania tego projektu został ustawiony element ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: Nie można załadować zestawu programu rozpoznawania zestawu SDK „{0}”. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: Nie można uruchomić programu rozpoznawania zestawu SDK „{0}”. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: Nie można uruchomić programu rozpoznawania zestawu SDK opartego na narzędziu NuGet, ponieważ nie można zlokalizować zestawów NuGet. Sprawdź instalację programu MSBuild lub ustaw zmienną środowiskową „{0}” na folder zawierający wymagane zestawy NuGet. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">Projekt „{0}” nie został zaimportowany przez projekt „{1}” w lokalizacji ({2},{3}), ponieważ plik był nieprawidłowy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">Projekt „{0}” nie został zaimportowany przez projekt „{1}” w lokalizacji ({2},{3}), ponieważ plik nie istniał.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : błąd MSB4239: Błąd zapisywania raportu profilowania. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Trwa zapisywanie raportu profilera w: „{0}”...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Zakończono zapisywanie raportu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: Nie można określić wielu wersji tego samego zestawu SDK „{0}”. Zostanie użyta wersja zestawu SDK „{1}” określona już przez lokalizację „{2}”, a wersja „{3}” zostanie zignorowana.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: Odwołanie do zestawu SDK „{0}” w wersji „{1}” zostało rozpoznane jako wersja „{2}”. Może zostać użyta inna wersja niż oczekiwana, jeśli nie zaktualizujesz wersji określonej w odwołaniu, tak aby była zgodna.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Trwa rozpoznawanie zestawu SDK „{0}”...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -2003,8 +2003,8 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: um resolvedor de SDK foi encontrado, mas não pôde ser carregado. Erro: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: falha ao carregar o tipo de resolvedor "{0}" do SDK. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">A API "{0}" especificada não está disponível porque ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition foi definido durante o carregamento do projeto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: não foi possível carregar o assembly do resolvedor "{0}" do SDK. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: falha ao executar o resolvedor "{0}" do SDK. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: falha ao executar o resolvedor do SDK baseado em NuGet porque não foi possível localizar os assemblies do NuGet. Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" para a pasta que contém os assemblies necessários do NuGet. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}) porque o arquivo era inválido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">O projeto "{0}" não foi importado por "{1}" em ({2},{3}) porque o arquivo não existia.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD: erro MSB4239: erro ao gravar relatório de criação de perfil. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Gravando relatório do criador de perfil em '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Gravação do relatório concluída.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: não é possível especificar várias versões do mesmo SDK "{0}". A versão "{1}" do SDK já especificada por "{2}" será usada e a versão "{3}" será ignorada.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: a referência do SDK "{0}" versão "{1}" foi resolvida para a versão "{2}". Talvez você estava usando uma versão diferente que a esperada caso não tenha atualizado a versão referenciada de maneira correspondente.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Resolvendo o SDK '{0}'...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -2003,8 +2003,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: не удалось загрузить найденный сопоставитель SDK. Ошибка: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: не удалось загрузить сопоставитель SDK типа "{0}". {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">Указанный API-интерфейс "{0}" недоступен, так как при загрузке проекта был задан элемент ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: не удалось загрузить сборку сопоставителя SDK типа "{0}". {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: не удалось запустить сопоставитель SDK "{0}". {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: не удалось запустить сопоставитель SDK на базе NuGet, так как не удалось найти сборки NuGet. Проверьте свою установку MSBuild или укажите папку, содержащую требуемые сборки NuGet, в качестве значения переменной среды "{0}". {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">Проект "{0}" не был импортирован "{1}" в ({2},{3}), так как файл недопустим.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">Проект "{0}" не был импортирован "{1}" в ({2},{3}), так как файл не существует.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD — ошибка MSB4239: ошибка при записи отчета профилирования. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Запись отчета профилирования в "{0}"…</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Отчет записан.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: невозможно указать множество версий одного пакета SDK "{0}". Будет использована версия SDK "{1}", уже указанная "{2}", а версия "{3}" будет пропущена.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: ссылка на пакет SDK "{0}" версии "{1}" была сопоставлена версии "{2}". Возможно, вы используете версию, отличную от ожидаемой, если вы не обновили версию по ссылке.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">Сопоставление SDK "{0}"…</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -2003,8 +2003,8 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: Bir SDK çözümleyicisi bulundu ancak yüklenemedi. Hata: {0}.</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: SDK çözümleyici türü "{0}" yüklenemedi. {1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">Bu proje yüklenirken ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition ayarlandığından, belirtilen "{0}" API ‘si kullanılamıyor.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: "{0}" SDK çözümleyicisi bütünleştirilmiş kodu yüklenemedi. {1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: "{0}" SDK çözümleyicisi çalıştırılamadı. {1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: NuGet bütünleştirilmiş kodları bulunamadığından NuGet tabanlı SDK çözümleyicisi çalıştırılamadı. MSBuild yüklemenizi denetleyin veya "{0}" ortam değişkenini gerekli NuGet bütünleştirilmiş kodlarını içeren klasör olarak ayarlayın. {1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">"{0}" adlı proje, dosyanın geçersiz olması nedeniyle ({2},{3}) konumundaki "{1}" tarafından içeri aktarılmadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">"{0}" adlı proje, dosyanın mevcut olmaması nedeniyle ({2},{3}) konumundaki "{1}" tarafından içeri aktarılmadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD: MSB4239 hatası: Profil oluşturma raporu yazılırken hata oluştu. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">Profil oluşturucu raporu '{0}' konumuna yazılıyor...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">Rapor yazma işlemi tamamlandı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: "{0}" SDK’sının birden çok sürümü belirtilemez. "{2}" tarafından zaten belirtilen SDK sürümü "{1}" kullanılacak ve "{3}" sürümü yoksayılacak.</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: "{0}" SDK başvurusunun "{1}" sürümü, bunun yerine sürüm "{2}" olarak çözümlendi. Başvurulan sürümü eşleşecek şekilde güncelleştirmezseniz beklenen sürümden farklı bir sürüm kullanıyor olabilirsiniz.</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">'{0}' SDK’sı çözümleniyor...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.xlf
+++ b/src/Build/Resources/xlf/Strings.xlf
@@ -1622,7 +1622,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -1663,7 +1663,57 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse">
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
+        <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
         <note></note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -2003,8 +2003,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: 找到了 SDK 解析程序，但其未加载。错误: {0}。</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: SDK 解析程序类型“{0}”加载失败。{1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">指定的 API“{0}”不可用，因为加载此项目时设置了 ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: 无法加载 SDK 解析程序程序集“{0}”。{1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: SDK 解析程序“{0}”运行失败。{1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: 基于 NuGet 的 SDK 解析程序运行失败，因为无法找到 NuGet 程序集。请检查你安装的 MSBuild 或将环境变量“{0}”设置为包含所需 NuGet 程序集的文件夹。{1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">由于文件无效，项目“{0}”不由 ({2},{3}) 处的“{1}”导入。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">由于文件不存在，项目“{0}”不由 ({2},{3}) 处的“{1}”导入。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : 错误 MSB4239: 写入分析报告时出错。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">正在将探查器报告写入“{0}”...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">已完成写入报告。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: 无法指定同一 SDK“{0}”的多个版本。将使用已由“{2}”指定的 SDK 版本“{1}”，并忽略版本“{3}”。</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: SDK 引用“{0}”版本“{1}”已改为解析到版本“{2}”。如果不更新要匹配的已引用版本，你可能会使用与预期不同的版本。</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">正在解析 SDK“{0}”...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -2003,8 +2003,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <note>{StrBegin="MSB4236: "}</note>
       </trans-unit>
       <trans-unit id="CouldNotLoadSdkResolver">
-        <source>MSB4237: An SDK resolver was found but could not be loaded. Error: {0}.</source>
-        <target state="translated">MSB4237: 找到了 SDK 解析程式，但無法載入。錯誤: {0}。</target>
+        <source>MSB4237: The SDK resolver type "{0}" failed to load. {1}</source>
+        <target state="translated">MSB4237: 無法載入 SDK 解析程式類型 "{0}"。{1}</target>
         <note>{StrBegin="MSB4237: "}</note>
       </trans-unit>
       <trans-unit id="InvalidSdkElementName">
@@ -2056,6 +2056,67 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
         <source>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</source>
         <target state="translated">因為 ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition 已在載入此專案時設定，所以指定的 API "{0}" 無法使用。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CouldNotLoadSdkResolverAssembly">
+        <source>MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</source>
+        <target state="translated">MSB4244: 無法載入 SDK 解析程式組件 "{0}"。{1}</target>
+        <note>{StrBegin="MSB4244: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunSdkResolver">
+        <source>MSB4242: The SDK resolver "{0}" failed to run. {1}</source>
+        <target state="translated">MSB4242: SDK 解析程式 "{0}" 無法執行。{1}</target>
+        <note>{StrBegin="MSB4242: "}</note>
+      </trans-unit>
+      <trans-unit id="CouldNotRunNuGetSdkResolver">
+        <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
+        <target state="translated">MSB4243: 因為找不到 NuGet 組件，所以 NuGet 型 SDK 解析程式無法執行。請檢查您的 MSBuild 安裝，或將環境變數 "{0}" 設定為包含必要 NuGet 組件的資料夾。{1}</target>
+        <note>{StrBegin="MSB4243: "}</note>
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedInvalidFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file being invalid.</source>
+        <target state="translated">專案 "{0}" 未在 ({2},{3}) 由 "{1}" 匯入，原因為檔案無效。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProjectImportSkippedMissingFile">
+        <source>Project "{0}" was not imported by "{1}" at ({2},{3}), due to the file not existing.</source>
+        <target state="translated">專案 "{0}" 未在 ({2},{3}) 由 "{1}" 匯入，原因為檔案不存在。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorWritingProfilerReport">
+        <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
+        <target state="translated">MSBUILD : 錯誤 MSB4239: 寫入分析報告時發生錯誤。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReport">
+        <source>Writing profiler report to '{0}'...</source>
+        <target state="translated">正在將分析工具報告寫入 '{0}'...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WritingProfilerReportDone">
+        <source>Done writing report.</source>
+        <target state="translated">寫入報告完成。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
+        <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The SDK version "{1}" already specified by "{2}" will be used and the version "{3}" will be ignored.</source>
+        <target state="translated">MSB4240: 無法指定相同 SDK "{0}" 的多個版本。會使用 "{2}" 已指定的 SDK 版本 "{1}"，而版本 "{3}" 則會略過。</target>
+        <note>{StrBegin="MSB4240: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResultVersionDifferentThanReference">
+        <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
+        <target state="translated">MSB4241: SDK 參考 "{0}" 版本 "{1}" 已改為解析成版本 {2}"。若您未將參考的版本更新為符合的版本，您可能使用了與預期不同的版本。</target>
+        <note>{StrBegin="MSB4241: "}
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
+      </trans-unit>
+      <trans-unit id="SdkResolving">
+        <source>Resolving SDK '{0}'...</source>
+        <target state="translated">正在解析 SDK '{0}'...</target>
+        <note>
+      LOCALIZATION:  Do not localize the word SDK.
+    </note>
       </trans-unit>
     </body>
   </file>

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -1406,6 +1406,59 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;soubor&gt;    
+                     Profiluje vyhodnocení nástroje MSBuild a zapíše výsledek 
+                     do určeného souboru. Pokud je přípona zadaného
+                     souboru .md, vygeneruje se výsledek ve formátu
+                     markdown, jinak vznikne soubor s hodnotami oddělenými tabulátorem.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Tyto vlastnosti na úrovni projektu nastavte nebo přepište
+                     jen během obnovení a nepoužívejte vlastnosti určené
+                     argumentem /property. &lt;n&gt; je název vlastnosti
+                     a &lt;v&gt; je hodnota vlastnosti. K oddělení více 
+                     vlastností použijte středník nebo čárku, případně zadejte
+                     každou vlastnost samostatně.
+                     (Krátký tvar: /rp)
+                     Příklad:
+                       /restoreProperty:IsRestore=true;Vlastnost=hodnota
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD: chyba MSB1053: Zadaný název souboru není platný. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD: chyba MSB1054: Kvůli vygenerování výsledku profileru musí být zadaný název souboru.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -1401,6 +1401,59 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;Datei&gt;    
+                     Erstellt ein Profil der MSBuild-Auswertung und speichert das Ergebnis 
+                     in der angegebenen Datei. Wenn die Erweiterung der angegebenen
+                     Datei ".md" lautet, wird das Ergebnis im Markdown-
+                     Format generiert. Andernfalls wird eine durch Tabstopp getrennte Datei erstellt.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;N&gt;=&lt;W&gt;
+                     Diese Eigenschaften auf Projektebene sollten nur
+                     während der Wiederherstellung festgelegt oder überschrieben werden, und Sie dürfen keine Eigenschaften verwenden,
+                     die mit dem Argument "/property" angegeben werden. "&lt;N&gt;" ist der Eigenschaftenname,
+                     "&lt;W&gt;" ist der Eigenschaftenwert. Verwenden Sie ein
+                     Semikolon oder Komma, um mehrere Eigenschaften voneinander zu trennen,
+                     oder geben Sie jede Eigenschaft separat an.
+                     (Kurzform: /rp)
+                     Beispiel:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD: Fehler MSB1053: Der angegebene Dateiname ist ungültig. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD: Fehler MSB1054: Ein Dateiname muss angegeben werden, um das Profilerergebnis zu generieren.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -1407,6 +1407,59 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;archivo&gt;    
+                     Genera un perfil de la evaluación de MSBuild y escribe el resultado
+                     en el archivo especificado. Si la extensión del archivo especificado
+                     es ".md", el resultado se genera en formato Markdown.
+                     Si no es así, se genera un archivo independiente.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Definir o invalidar estas propiedades de nivel de proyecto solo
+                     durante la restauración y no utilizar las propiedades especificadas
+                     con el argumento /property. &lt;n&gt; es el nombre
+                     de la propiedad, y &lt;v&gt; es el valor de la propiedad. Use un
+                     punto y coma o una coma para separar varias propiedades,
+                     o especifique cada propiedad de manera independiente.
+                     (Forma breve: /rp)
+                     Ejemplo:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : error MSB1053: El nombre de archivo proporcionado no es válido. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD :error MSB1054: Es necesario especificar un nombre de archivo para generar el resultado del generador de perfiles.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -1402,6 +1402,59 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;file&gt;    
+                     Profile l'évaluation de MSBuild et écrit le résultat 
+                     dans le fichier spécifié. Si l'extension du fichier
+                     spécifié est '.md', le résultat est généré au format
+                     markdown. Sinon, un fichier séparé par une tabulation est créé.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Définir ou remplacer ces propriétés de niveau projet seulement
+                     pendant la restauration et ne pas utiliser les propriétés spécifiées
+                     avec l'argument /property. &lt;n&gt; est le nom de la
+                     propriété, tandis que &lt;v&gt; est sa valeur. Utilisez un point-virgule
+                     ou une virgule pour séparer plusieurs propriétés
+                     ou spécifiez chaque propriété séparément.
+                     (Forme courte : /rp)
+                     Exemple :
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : erreur MSB1053 : Le nom de fichier fourni n'est pas valide. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD : erreur MSB1054 : Un nom de fichier doit être spécifié pour générer le résultat du profileur.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -1423,6 +1423,61 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;file&gt;    
+                     Esegue la profilatura della valutazione di MSBuild e scrive 
+                     il risultato nel file specificato. Se l'estensione del file
+                     specificato è '.md', il risultato viene generato in formato
+                     markdown. In caso contrario, viene prodotto un file 
+                     delimitato da tabulazioni.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Imposta le proprietà specificate a livello di progetto o ne
+                     esegue l'override solo durante il ripristino e non usa le 
+                     proprietà specificate con l'argomento /property. &lt;n&gt; è 
+                     il nome della proprietà, mentre &lt;v&gt; è il valore della
+                     proprietà. Usare un punto e virgola o una virgola per
+                     separare più proprietà oppure specificare ogni proprietà
+                     separatamente.
+                     Forma breve: /rp
+                     Esempio:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : error MSB1053: il nome file specificato non è valido. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD :error MSB1054: per generare il risultato del profiler, è necessario specificare un nome file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -1401,6 +1401,59 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;ファイル&gt;    
+                     MSBuild の評価のプロファイリングを行い、結果を
+                     指定されたファイルに書き込みます。指定されたファイルの拡張子が 
+                     '.md' の場合、結果は 
+                     Markdown 形式 で生成されます。'.md' 以外の場合は、タブ区切りファイルが生成されます。
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     復元時にのみ、これらのプロジェクト レベルのプロパティを
+                     設定またはオーバーライドします。/property 引数で
+                     指定したプロパティは使用しません。&lt;n&gt; はプロパティ
+                     名、&lt;v&gt; はプロパティ値です。
+                     複数のプロパティを区切るには、セミコロンまたはコンマを使用するか、
+                     各プロパティを個別に指定します。
+                     (短い形式: /rp)
+                     例:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : エラー MSB1053: 指定したファイル名が無効です。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD : エラー MSB1054: プロファイラーの結果を生成するには、ファイル名を指定する必要があります。</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -1337,7 +1337,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      수집하지 않습니다.
 
                      .binlog 파일을 프로젝트/솔루션 대신 인수로 msbuild.exe에
-                     전달하여 “재생”할 수 있습니다.다른 로거는 원본 빌드가
+                     전달하여 "재생"할 수 있습니다.다른 로거는 원본 빌드가
 		     발생하고 있는 것처럼 로그 파일에 포함된 정보를 받게 됩니다.
                      이진 로그 및 해당 사용법에 대한 자세한 내용은
                      다음 위치에서 확인할 수 있습니다.
@@ -1400,6 +1400,59 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;file&gt;    
+                     MSBuild 실행을 프로파일링하고 결과를 
+                     지정된 파일에 씁니다. 지정된 파일의 확장명이
+                     '.md'이면 결과가 markdown 형식으로
+                     생성됩니다. 그렇지 않으면 탭으로 구분된 파일이 생성됩니다.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     복원 중에만 이러한 프로젝트 수준 속성을
+                     설정하거나 재정의하고 /property 인수로 지정된 속성을
+                     사용하지 않습니다. 여기서, &lt;n&gt;은 속성 이름이고
+                     &lt;v&gt;는 속성 값입니다. 세미콜론
+                     또는 쉼표를 사용하여 여러 속성을 구분하거나
+                     각 속성을 따로 지정하세요.
+                     (약식: /rp)
+                     예:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : 오류 MSB1053: 지정한 파일 이름이 유효하지 않습니다. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD :오류 MSB1054: 프로파일러 결과를 생성하려면 파일 이름을 지정해야 합니다.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -1401,6 +1401,59 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;plik&gt;    
+                     Profiluje oszacowanie programu MSBuild i zapisuje wynik
+                     w określonym pliku. Jeśli rozszerzenie określonego
+                     pliku to „md”, wynik jest generowany w formacie
+                     znaczników markdown. W przeciwnym razie jest tworzony plik rozdzielany tabulatorami.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Ustawia lub zastępuje te właściwości na poziomie projektu tylko
+                     podczas przywracania i nie używa określonych właściwości
+                     z argumentem /property. &lt;n&gt; to nazwa
+                     właściwości, a &lt;v&gt; to wartość właściwości. Użyj
+                     średnika lub przecinka do rozdzielenia wielu właściwości
+                     albo określ każdą właściwość osobno.
+                     (Krótka forma: /rp)
+                     Przykład:
+                       /restoreProperty:IsRestore=true;MyProperty=wartość
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : błąd MSB1053: Podana nazwa pliku jest nieprawidłowa. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD : błąd MSB1054: Należy określić nazwę pliku, aby wygenerować wynik profilera.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -1401,6 +1401,59 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;file&gt;    
+                     Cria o perfil da avaliação do MSBuild e grava o resultado 
+                     no arquivo especificado. Se a extensão do arquivo especificado
+                     for '.md', o resultado será gerado no formato
+                     markdown. Caso contrário, um arquivo separado por tabulações será produzido.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Defina ou substitua essas propriedades em nível de projeto somente
+                     durante a restauração e não use as propriedades especificadas
+                     com o argumento /property. &lt;n&gt; é o nome da
+                     propriedade e &lt;v&gt; é o valor da propriedade. Use um
+                     ponto e vírgula ou uma vírgula para separar várias propriedades
+                     ou especifique cada propriedade separadamente.
+                     (Forma abreviada: /rp)
+                     Exemplo:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD: erro MSB1053: o nome de arquivo fornecido é inválido. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD: erro MSB1054: um nome de arquivo deve ser especificado para gerar o resultado do criador de perfil.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -1402,6 +1402,59 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;файл&gt;    
+                     Профилирует вычисление MSBuild и записывает результат 
+                     в указанный файл. Если файл имеет расширение
+                     ".md", результат создается в формате Markdown.
+                     В противном случае создается файл с разделением табуляцией.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Задавайте или переопределяйте эти свойства уровня проекта только
+                     при восстановлении и не используйте указанные свойства
+                     с аргументом "/property". &lt;n&gt; — это имя свойства,
+                     а &lt;v&gt; — его значение. Используйте для разделения
+                     свойств запятую или точку с запятой либо укажите
+                     каждое свойство по-отдельности.
+                     (Краткая форма: /rp)
+                     Пример:
+                       /restoreProperty:IsRestore=true;&lt;Свойство&gt;=&lt;значение&gt;
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD: ошибка MSB1053 — указанное имя файла недопустимо. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD: ошибка MSB1054 — укажите имя файла, чтобы создать результат профилировщика.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -1402,6 +1402,59 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;dosya&gt;    
+                     MSBuild değerlendirmesinin profilini oluşturur ve sonucu 
+                     belirtilen dosyaya yazar. Belirtilen dosyanın uzantısı 
+                     '.md' olursa, sonuç markdown biçiminde oluşturulur.
+                     Aksi takdirde, sekmeyle ayrılmış bir dosya oluşturulur.
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;a&gt;=&lt;d&gt;
+                     Proje düzeyindeki bu özellikleri yalnızca geri yükleme
+                     sırasında kullanın ve /property bağımsız değişkeniyle
+                     belirtilen özellikleri kullanmayın. &lt;a&gt; özellik
+                     adı, &lt;d&gt; ise özelliğin değeridir. Birden
+                     çok özelliği ayırmak için noktalı virgül veya virgül kullanın
+                     veya her özelliği ayrı ayrı belirtin.
+                     (Kısa biçim: /rp)
+                     Örnek:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD: MSB1053 hatası: Sağlanan dosya adı geçerli değil. {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD: MSB1054 hatası: Profil oluşturucu sonucunun oluşturulması için bir dosya adı belirtilmelidir.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.xlf
@@ -1022,6 +1022,40 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -1402,6 +1402,59 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;file&gt;    
+                     解析 MSBuild 评估并将结果写入
+                     指定文件。如果指定文件的扩展名
+                     为“.md”，则结果将以 markdown 格式
+                     生成。否则，将生成制表符分隔文件。
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     在还原期间仅设置或重写这些项目级
+                     属性并且不使用通过
+                     /property 参数指定的属性。&lt;n&gt; 是属性
+                     名，&lt;v&gt; 是属性值。请使用
+                     分号或逗号分隔多个属性，
+                     或分别指定每个属性。
+                     (缩写: /rp)
+                     示例:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : 错误 MSB1053: 提供的文件名无效。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD :错误 MSB1054: 必须指定文件名才可生成探查器结果。</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -1401,6 +1401,59 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_32_ProfilerSwitch">
+        <source>  /profileevaluation:&lt;file&gt;    
+                     Profiles MSBuild evaluation and writes the result 
+                     to the specified file. If the extension of the specified
+                     file is '.md', the result is generated in markdown
+                     format. Otherwise, a tab separated file is produced.
+    </source>
+        <target state="translated">  /profileevaluation:&lt;檔案&gt;    
+                     分析 MSBuild 評估並將結果寫入
+                     指定的檔案。若所指定檔案的副檔名為 
+                     '.md'，結果會以 Markdown 格式
+                     產生。否則會產生定位字元分隔檔案。
+    </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpMessage_33_RestorePropertySwitch">
+        <source>  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     Set or override these project-level properties only
+                     during restore and do not use properties specified
+                     with the /property argument. &lt;n&gt; is the property
+                     name, and &lt;v&gt; is the property value. Use a
+                     semicolon or a comma to separate multiple properties,
+                     or specify each property separately.
+                     (Short form: /rp)
+                     Example:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </source>
+        <target state="translated">  /restoreProperty:&lt;n&gt;=&lt;v&gt;
+                     請僅在還原期間設定或覆寫這些專案層級
+                     的屬性，並請勿使用以 /property 引數
+                     指定的屬性。&lt;n&gt; 為屬性名稱，
+                     &lt;v&gt; 則為屬性值。請使用分號或點 (.) 
+                     分隔多個屬性，
+                     或個別指定各屬性。
+                     (簡短形式: /rp)
+                     範例:
+                       /restoreProperty:IsRestore=true;MyProperty=value
+    </target>
+        <note>
+      LOCALIZATION: "/restoreProperty" and "/rp" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidProfilerValue">
+        <source>MSBUILD : error MSB1053: Provided filename is not valid. {0}</source>
+        <target state="translated">MSBUILD : 錯誤 MSB1053: 提供的檔案名稱無效。{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingProfileParameterError">
+        <source>MSBUILD :error MSB1054: A filename must be specified to generate the profiler result.</source>
+        <target state="translated">MSBUILD :錯誤 MSB1054: 必須指定檔案名稱才能產生分析工具結果。</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/NuGetSdkResolver.UnitTests/NuGetSdkResolver_Tests.cs
+++ b/src/NuGetSdkResolver.UnitTests/NuGetSdkResolver_Tests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Build.Engine.UnitTests;
 using NuGet.Versioning;
 using Shouldly;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 using SdkResolverContextBase = Microsoft.Build.Framework.SdkResolverContext;
@@ -101,6 +104,38 @@ namespace NuGet.MSBuildSdkResolver.UnitTests
                 context: context);
         }
 
+#if FEATURE_APPDOMAIN
+        /// <summary>
+        /// Verifies that when an SDK version is null that no NuGet assemblies are loaded.  This helps ensure that we're not loading
+        /// extra assemblies unless they are needed.  A lot of private classes exist in the NuGetSdkResolver in order to make sure
+        /// that types are loaded until they are needed.
+        /// </summary>
+        [Fact]
+        private void TryGetNuGetVersionNullVersionShouldNotLoadNuGetAssemblies()
+        {
+            // Keep a list of assemblies loaded before attempting to parse
+            Assembly[] assembliesLoadedBeforeParsingVersion = AppDomain.CurrentDomain.GetAssemblies();
+
+            MockSdkResolverContext context = new MockSdkResolverContext("foo.proj");
+
+            object parsedVersion;
+
+            // Since we pass a null version, we expect no NuGet assemblies to be loaded
+            NuGetSdkResolver.TryGetNuGetVersionForSdk(
+                id: "foo",
+                version: null,
+                context: context,
+                parsedVersion: out parsedVersion);
+
+            foreach (string newlyLoadedAssembly in AppDomain.CurrentDomain.GetAssemblies()
+                .Except(assembliesLoadedBeforeParsingVersion)
+                .Select(i => i.ManifestModule.Name))
+            {
+                NuGetSdkResolverBase.NuGetAssemblies.ShouldNotContain(newlyLoadedAssembly);
+            }
+        }
+
+#endif
         private void VerifyTryGetNuGetVersionForSdk(string version, NuGetVersion expectedVersion, SdkResolverContextBase context = null)
         {
             object parsedVersion;

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.cs.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">{0} se nepodařilo parsovat. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Sadu SDK {0} se nepodařilo přeložit. Balíček byl úspěšně obnoven, ale nebylo možné ho najít.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Sadu SDK {0} se nepodařilo přeložit. Obnovení balíčku bylo úspěšné, ale balíček s ID {1} nebyl nainstalován.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.de.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Fehler beim Analysieren von "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Fehler beim Auflösen von SDK "{0}". Ein Paket wurde erfolgreich wiederhergestellt, aber das Paket wurde nicht gefunden.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Fehler beim Auflösen von SDK "{0}". Die Paketwiederherstellung war erfolgreich, aber es wurde kein Paket mit der ID "{1}" installiert.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.es.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">No se pudo analizar "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">No se pudo resolver el SDK "{0}". Se restauró correctamente un paquete, pero el paquete no se pudo encontrar.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">No se pudo resolver el SDK "{0}". La restauración del paquete se completó correctamente, pero no se instaló un paquete con el id. "{1}".</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.fr.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Impossible d'analyser "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Impossible de résoudre le SDK '{0}'. Un package a été restauré, mais il n'a pas pu être localisé.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Impossible de résoudre le SDK '{0}'. La restauration du package a réussi, mais un package avec l’ID de "{1}" n'a pas été installé.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.it.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Non è stato possibile analizzare "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Non è stato possibile risolvere l'SDK '{0}'. Un pacchetto è stato ripristinato, ma non è stato possibile trovarlo.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Non è stato possibile risolvere l'SDK '{0}'. Il ripristino del pacchetto è riuscito, ma non è stato installato alcun pacchetto con l'ID "{1}".</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ja.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">"{0}" を解析できませんでした。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">SDK '{0}' を解決できませんでした。パッケージは正常に復元されましたが、パッケージを見つけることができませんでした。</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">SDK '{0}' を解決できませんでした。パッケージは正常に復元されましたが、"{1}" の ID を持つパッケージがインストールされていません。</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ko.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">"{0}"을(를) 구문 분석하지 못했습니다. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">SDK '{0}'을(를) 확인하지 못했습니다. 패키지가 복원되었지만 패키지를 찾을 수 없습니다.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">SDK '{0}'을(를) 확인하지 못했습니다. 패키지 복원에 성공했지만 ID가 "{1}"인 패키지가 설치되지 않았습니다.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pl.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Nie można przeanalizować: „{0}”. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Nie można rozpoznać zestawu SDK „{0}”. Pakiet został przywrócony pomyślnie, ale nie można go zlokalizować.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Nie można rozpoznać zestawu SDK „{0}”. Pomyślnie przywrócono pakiet, ale nie zainstalowano pakietu z identyfikatorem „{1}”.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.pt-BR.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Falha ao analisar "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Falha ao resolver o SDK '{0}'. Um pacote foi restaurado com êxito, mas não foi possível localizá-lo.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Falha ao resolver o SDK '{0}'. A restauração do pacote foi bem-sucedida, mas um pacote com a ID de "{1}" não foi instalado.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.ru.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">Не удалось проанализировать "{0}". {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">Не удалось сопоставить SDK "{0}". Пакет восстановлен, но найти пакет не удалось.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">Не удалось сопоставить SDK "{0}". Пакет восстановлен, но пакет с идентификатором "{1}" установлен не был.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.tr.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">"{0}" ayrıştırılamadı. {1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">'{0}' SDK’sı çözümlenemedi. Bir paket başarıyla geri yüklendi ancak bu paket bulunamıyor.</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">'{0}' SDK’sı çözümlenemedi. Paket geri yükleme işlemi başarılı oldu, ancak "{1}" kimlikli bir paket yüklenmedi.</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.xlf
@@ -5,18 +5,15 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hans.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">未能对“{0}”进行分析。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">未能解析 SDK“{0}”。已成功还原了一个包，但无法找到该包。</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">未能解析 SDK“{0}”。包还原已成功，但 ID 为“{1}”的包未安装。</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/NuGetSdkResolver/Resources/xlf/Strings.zh-Hant.xlf
@@ -5,18 +5,18 @@
       <group id="NUGET.MSBUILDSDKRESOLVER/RESOURCES/STRINGS.RESX" datatype="resx" />
       <trans-unit id="FailedToParseGlobalJson">
         <source>Failed to parse "{0}". {1}</source>
-        <target state="new">Failed to parse "{0}". {1}</target>
-        <note/>
+        <target state="translated">無法剖析 "{0}"。{1}</target>
+        <note />
       </trans-unit>
       <trans-unit id="CouldNotFindInstalledPackage">
         <source>Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</source>
-        <target state="new">Failed to resolve SDK '{0}'. A package was successfully restored but the package could not be located.</target>
-        <note/>
+        <target state="translated">無法解析 SDK '{0}'。套件已成功還原，但無法找到該套件。</target>
+        <note />
       </trans-unit>
       <trans-unit id="PackageWasNotInstalled">
         <source>Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</source>
-        <target state="new">Failed to resolve SDK '{0}'. Package restore was successful but a package with the ID of "{1}" was not installed.</target>
-        <note/>
+        <target state="translated">無法解析 SDK '{0}'。套件還原成功，但未安裝識別碼為 "{1}" 的套件。</target>
+        <note />
       </trans-unit>
     </body>
   </file>

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -210,10 +210,6 @@ namespace Microsoft.Build.Shared
             {
                 return CloseHandle(handle);
             }
-
-            [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
-            [DllImport("KERNEL32.DLL")]
-            private static extern bool CloseHandle(IntPtr hObject);
         }
 
         /// <summary>
@@ -1373,6 +1369,11 @@ namespace Microsoft.Build.Shared
             out FILETIME lpLastAccessTime,
             out FILETIME lpLastWriteTime
             );
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+
+        internal static extern bool CloseHandle(IntPtr hObject);
 
 #endregion
 

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -640,13 +640,16 @@ namespace System.Deployment.Internal.CodeSigning
 
             // Setup up XMLDSIG engine.
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(licenseDom);
-            signedXml.SigningKey = rsaPrivateKey;
+            // only needs to change the provider type when RSACryptoServiceProvider is used
+            var rsaCsp = rsaPrivateKey is RSACryptoServiceProvider ?
+                            GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256) : rsaPrivateKey;
+            signedXml.SigningKey = rsaCsp;
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
             if (signer.UseSha256)
                 signedXml.SignedInfo.SignatureMethod = Sha256SignatureMethodUri;
 
             // Add the key information.
-            signedXml.KeyInfo.AddClause(new RSAKeyValue(rsaPrivateKey));
+            signedXml.KeyInfo.AddClause(new RSAKeyValue(rsaCsp));
             signedXml.KeyInfo.AddClause(new KeyInfoX509Data(signer.Certificate, signer.IncludeOption));
 
             // Add the enveloped reference.

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1545,15 +1545,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       We give this treatment to .vcxproj by default since no .vcxproj can target more
       than one framework.
-
-      Likewise if the dependency is for build ordering instead of an assembly reference
-      (ReferenceOutputAssembly=false), skip the checks since we can't know what TF
-      the output would need to be compatible with.
    -->
    <ItemGroup>
-      <_MSBuildProjectReferenceExistent
-        Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and
-                   ('%(Extension)' == '.vcxproj' or '%(ReferenceOutputAssembly)' == 'false')">
+      <_MSBuildProjectReferenceExistent Condition="'%(_MSBuildProjectReferenceExistent.SkipGetTargetFrameworkProperties)' == '' and '%(Extension)' == '.vcxproj'">
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </_MSBuildProjectReferenceExistent>
    </ItemGroup>


### PR DESCRIPTION
Prodcon builds are picking up the current `vs15.7` bits, meaning they were missing the late-breaking bugfixes from 15.6, including one that ASP.NET Core needs (#2922).