### PR TITLE
Upgrade to netcoreapp2.1

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -24,16 +24,16 @@
                 "bin/Microsoft.Build.Conversion/net46/Microsoft.Build.Engine.dll",
                 "bin/Microsoft.Build.Conversion/net46/Microsoft.Build.Conversion.Core.dll",
 
-                "bin/MSBuild/netcoreapp2.0/MSBuild.dll",
-                "bin/MSBuild/netcoreapp2.0/Microsoft.Build.dll",
-                "bin/MSBuild/netcoreapp2.0/Microsoft.Build.Framework.dll",
-                "bin/MSBuild/netcoreapp2.0/Microsoft.Build.Tasks.Core.dll",
-                "bin/MSBuild/netcoreapp2.0/Microsoft.Build.Utilities.Core.dll",
+                "bin/MSBuild/netcoreapp2.1/MSBuild.dll",
+                "bin/MSBuild/netcoreapp2.1/Microsoft.Build.dll",
+                "bin/MSBuild/netcoreapp2.1/Microsoft.Build.Framework.dll",
+                "bin/MSBuild/netcoreapp2.1/Microsoft.Build.Tasks.Core.dll",
+                "bin/MSBuild/netcoreapp2.1/Microsoft.Build.Utilities.Core.dll",
 
-                "bin/MSBuild/netcoreapp2.0/*/*.resources.dll",
+                "bin/MSBuild/netcoreapp2.1/*/*.resources.dll",
 
-                "bin/MSBuild/netcoreapp2.0/SdkResolvers/NuGet.MSBuildSdkResolver/NuGet.MSBuildSdkResolver.dll",
-                "bin/MSBuild/netcoreapp2.0/SdkResolvers/NuGet.MSBuildSdkResolver/*/NuGet.MSBuildSdkResolver.resources.dll",
+                "bin/MSBuild/netcoreapp2.1/SdkResolvers/NuGet.MSBuildSdkResolver/NuGet.MSBuildSdkResolver.dll",
+                "bin/MSBuild/netcoreapp2.1/SdkResolvers/NuGet.MSBuildSdkResolver/*/NuGet.MSBuildSdkResolver.resources.dll",
 
                 "bin/ref/Microsoft.Build.Framework.Package/*/Microsoft.Build.Framework.dll",
                 "bin/ref/Microsoft.Build.Package/*/Microsoft.Build.dll",

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -230,7 +230,7 @@ function Build {
     }
     else
     {
-      $msbuildToUse = Join-Path $bootstrapRoot "netcoreapp2.0\MSBuild\\MSBuild.dll"
+      $msbuildToUse = Join-Path $bootstrapRoot "netcoreapp2.1\MSBuild\\MSBuild.dll"
     }
 
     # Use separate artifacts folder for stage 2

--- a/build/build.sh
+++ b/build/build.sh
@@ -288,7 +288,7 @@ function Build {
 
     if [ $hostType = "core" ]
     then
-      msbuildToUse=$(QQ "$bootstrapRoot/netcoreapp2.0/MSBuild/MSBuild.dll")
+      msbuildToUse=$(QQ "$bootstrapRoot/netcoreapp2.1/MSBuild/MSBuild.dll")
     else
       ErrorHostType
     fi

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,8 +26,8 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
 
     <!-- Target frameworks for Exe and unit test projects (ie projects with runtime output) -->
-    <RuntimeOutputTargetFrameworks>netcoreapp2.0</RuntimeOutputTargetFrameworks>
-    <RuntimeOutputTargetFrameworks Condition="'$(OsEnvironment)'=='windows'">net46;netcoreapp2.0</RuntimeOutputTargetFrameworks>
+    <RuntimeOutputTargetFrameworks>netcoreapp2.1</RuntimeOutputTargetFrameworks>
+    <RuntimeOutputTargetFrameworks Condition="'$(OsEnvironment)'=='windows'">net46;netcoreapp2.1</RuntimeOutputTargetFrameworks>
 
     <!-- Don't automatically append target framework to output path, since we want to put the Platform Target beforehand, if it's not AnyCPU -->
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -15,6 +15,10 @@
   <ItemGroup>
     <!-- Include SDKs from the Stage 0 .NET Core SDK -->
     <Content Include="$(RepoRoot)artifacts\.dotnet\$(DotNetCliVersion)\sdk\$(DotNetCliVersion)\Sdks\**\*" LinkBase="Sdks" CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- This file is needed so the dotnet CLI knows how to map preview SDK versions to tfms (because tfms do not have preview information on them) -->
+    <!-- This is because according to semver, 2.1.0-preview is not >= 2.1.0 -->
+    <Content Include="$(RepoRoot)artifacts\.dotnet\$(DotNetCliVersion)\sdk\$(DotNetCliVersion)\Microsoft.NETCoreSdk.BundledVersions.props" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Package/Localization/Localization.csproj
+++ b/src/Package/Localization/Localization.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <NuspecFile>Microsoft.Build.Localization.nuspec</NuspecFile>
     <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>


### PR DESCRIPTION
This resolves issues debugging when using types that are available only in 2.1 runtime. Regardless of this change, CLI will be on 2.1 so this change should be safe.