### PR TITLE
Emit logo in MSBuild repo builds

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -122,7 +122,7 @@ function InstallRepoToolset {
 
   if (!(Test-Path -Path $RepoToolsetBuildProj)) {
     $ToolsetProj = Join-Path $PSScriptRoot "Toolset.proj"
-    $msbuildArgs = "/t:restore", "/m", "/nologo", "/clp:Summary", "/warnaserror", "/v:$verbosity"
+    $msbuildArgs = "/t:restore", "/m", "/clp:Summary", "/warnaserror", "/v:$verbosity"
     $msbuildArgs = AddLogCmd "Toolset" $msbuildArgs
     # Piping to Out-Null is important here, as otherwise the MSBuild output will be included in the return value
     # of the function (Powershell handles return values a bit... weirdly)
@@ -187,7 +187,7 @@ function Build {
 
   $solution = Join-Path $RepoRoot "MSBuild.sln"
 
-  $commonMSBuildArgs = "/m", "/nologo", "/clp:Summary", "/v:$verbosity", "/p:Configuration=$configuration", "/p:SolutionPath=$solution", "/p:CIBuild=$ci"
+  $commonMSBuildArgs = "/m", "/clp:Summary", "/v:$verbosity", "/p:Configuration=$configuration", "/p:SolutionPath=$solution", "/p:CIBuild=$ci"
   if ($ci)
   {
     # Only enable warnaserror on CI runs.  For local builds, we will generate a warning if we can't run EditBin because
@@ -275,7 +275,7 @@ function Build {
 
   if ($ci)
   {
-#    CallMSBuild $ToolsetProj /t:restore /m /nologo /clp:Summary /warnaserror /v:$verbosity @logCmd | Out-Null
+#    CallMSBuild $ToolsetProj /t:restore /m /clp:Summary /warnaserror /v:$verbosity @logCmd | Out-Null
     git status | Out-Null
     git --no-pager diff HEAD --word-diff=plain --exit-code | Out-Null
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -224,7 +224,7 @@ function InstallRepoToolset {
   if [ ! -d "$RepoToolsetBuildProj" ]
   then
     ToolsetProj="$ScriptRoot/Toolset.proj"
-    CallMSBuild $(QQ $ToolsetProj) /t:restore /m /nologo /clp:Summary /warnaserror /v:$verbosity $logCmd
+    CallMSBuild $(QQ $ToolsetProj) /t:restore /m /clp:Summary /warnaserror /v:$verbosity $logCmd
   fi
 }
 
@@ -265,7 +265,7 @@ function Build {
 
   solution="$RepoRoot/MSBuild.sln"
 
-  commonMSBuildArgs="/m /nologo /clp:Summary /v:$verbosity /p:Configuration=$configuration /p:SolutionPath=$(QQ $solution) /p:CIBuild=$ci"
+  commonMSBuildArgs="/m /clp:Summary /v:$verbosity /p:Configuration=$configuration /p:SolutionPath=$(QQ $solution) /p:CIBuild=$ci"
 
   # Only enable warnaserror on CI runs.
   if $ci


### PR DESCRIPTION
Often, the MSBuild version is a bit noisy. But in our own repo, it's extremely helpful to know which version of MSBuild is running the build: an LKG? the just-built one?

So drop all instance of /nologo from MSBuild invocations here.