### PR TITLE
Do not throw an InvalidProjectFileException if ProjectLoadSettings.IgnoreMissingImports is specified

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectSdkImplicitImport_Tests.cs
@@ -435,6 +435,30 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             sdk.MinimumVersion.ShouldBe(minimumSdkVersion);
         }
 
+        /// <summary>
+        /// Verifies that when <see cref="ProjectLoadSettings.IgnoreMissingImports"/> is set that we don't throw an <see cref="InvalidProjectFileException"/> when an SDK cannot be found.
+        /// </summary>
+        [Fact]
+        public void IgnoreMissingImportsSdkNotFoundDoesNotThrow()
+        {
+            const string projectContents = @"
+<Project Sdk=""Does.Not.Exist"">
+  <PropertyGroup>
+    <Success>true</Success>
+  </PropertyGroup>
+</Project>
+";
+            ProjectRootElement rootElement = ObjectModelHelpers.CreateInMemoryProjectRootElement(projectContents);
+
+            Project project = new Project(rootElement,
+                globalProperties: null,
+                toolsVersion: null,
+                projectCollection: new ProjectCollection(),
+                loadSettings: ProjectLoadSettings.IgnoreMissingImports);
+
+            project.GetPropertyValue("Success").ShouldBe("true");
+        }
+
         public void Dispose()
         {
             _env.Dispose();

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2499,6 +2499,28 @@ namespace Microsoft.Build.Evaluation
 
                 if (string.IsNullOrEmpty(sdkRootPath))
                 {
+                    if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports))
+                    {
+                        ProjectImportedEventArgs eventArgs = new ProjectImportedEventArgs(
+                            importElement.Location.Line,
+                            importElement.Location.Column,
+                            ResourceUtilities.GetResourceString("CouldNotResolveSdk"),
+                            importElement.ParsedSdkReference.ToString())
+                        {
+                            BuildEventContext = _evaluationLoggingContext.BuildEventContext,
+                            UnexpandedProject = importElement.Project,
+                            ProjectFile = importElement.ContainingProject.FullPath,
+                            ImportedProjectFile = null,
+                            ImportIgnored = true,
+                        };
+
+                        _evaluationLoggingContext.LogBuildEvent(eventArgs);
+
+                        projects = new List<ProjectRootElement>();
+
+                        return;
+                    }
+
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "CouldNotResolveSdk", importElement.ParsedSdkReference.ToString());
                 }
 


### PR DESCRIPTION
InvalidProjectFileExceptions cause modal dialogs in Visual Studio which so we should respect `ProjectLoadSettings`.

Related to https://github.com/dotnet/project-system/issues/3240