### PR TITLE
Build and sign VSIX VS insertion project.

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -42,6 +42,13 @@
             "values": [
                 "packages/*.nupkg"
             ]
+        },
+        {
+            "certificate": "Vsix",
+            "strongName": null,
+            "values": [
+                "VSSetup/Insertion/*.vsix"
+            ]
         }
     ],
     "exclude": [

--- a/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
+++ b/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
@@ -2,7 +2,8 @@
    <!-- AssemblyName must be set before importing Sdk.props to set the vsix file name. -->
    <PropertyGroup>
        <AssemblyName>Microsoft.Build</AssemblyName>
-       <ShouldSkipProject Condition="'$(MonoBuild)' == 'true' or '$(OsEnvironment)' != 'windows'">true</ShouldSkipProject>
+       <ShouldSkipProject>false</ShouldSkipProject>
+       <ShouldSkipProject Condition="'$(MonoBuild)' == 'true' or '$(MSBuildRuntimeType)' != 'Full'">true</ShouldSkipProject>
    </PropertyGroup>
 
    <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
@@ -40,7 +41,7 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(RepoRoot)build\ProducesNoOutput.Settings.props" Condition="!$(ShouldSkipProject)"/>
+  <Import Project="$(RepoRoot)build\ProducesNoOutput.Settings.props" Condition="$(ShouldSkipProject)"/>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 </Project>

--- a/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
+++ b/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
@@ -40,7 +40,7 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(RepoRoot)build\ProducesNoOutput.Settings.props" Condition="$(ShouldSkipProject)"/>
+  <Import Project="$(RepoRoot)build\ProducesNoOutput.Settings.props" Condition="!$(ShouldSkipProject)"/>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 </Project>


### PR DESCRIPTION
Condition on including the `ProducesNoOutput` props file was inverted and that import clears all the content items so nothing gets produced.