### PR TITLE
Add dummy project to set GitBuildVersion

### DIFF
--- a/build/SetMicrobuildVersion/SetMicrobuildVersion.csproj
+++ b/build/SetMicrobuildVersion/SetMicrobuildVersion.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.Net.Sdk">
+
+   <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+
+   <ItemGroup>
+      <PackageReference Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
+   </ItemGroup>
+</Project>


### PR DESCRIPTION
We'll call this project first in Microbuild to set the version, before the swix plugin gets installed