### PR TITLE
Fix issue generating pdb files.

### DIFF
--- a/src/Deprecated/Conversion/Microsoft.Build.Conversion.csproj
+++ b/src/Deprecated/Conversion/Microsoft.Build.Conversion.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <Description>This package contains the $(MSBuildProjectName) assembly which contains logic for converting projects.  NOTE: This assembly is deprecated.</Description>
     <IncludeSatelliteOutputInPack>false</IncludeSatelliteOutputInPack>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <!-- Source Files -->

--- a/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
+++ b/src/Deprecated/Engine/Microsoft.Build.Engine.csproj
@@ -13,6 +13,7 @@
     <IsPackable>true</IsPackable>
     <Description>This package contains the $(MSBuildProjectName) assembly which contains the legacy compatibility shim for the MSBuild engine.  NOTE: This assembly is deprecated.</Description>
     <IncludeSatelliteOutputInPack>false</IncludeSatelliteOutputInPack>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,8 +9,8 @@
   <!-- Override project defaults provided by Repo toolset -->
   <PropertyGroup>
     <!-- Set DebugType.  This logic is repeated in Directory.Build.targets, because xunit.core.targets overrides it -->
-    <DebugType Condition=" '$(TargetFramework)' == '' ">full</DebugType>
-    <DebugType Condition=" '$(TargetFramework)' != '' ">embedded</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == '' and '$(DebugType)' == ''">full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' != '' and '$(DebugType)' == ''">embedded</DebugType>
     <DebugType Condition="$(TargetFramework.StartsWith('net4')) And '$(MonoBuild)' != 'true'">full</DebugType>
 
     <!-- Some hash code implementations may overflow -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -4,8 +4,8 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
     <!-- Repeat setting DebugType (already set in Directory.Build.props, but repeat here because because xunit.core.targets overrides it) -->
-    <DebugType Condition=" '$(TargetFramework)' == '' ">full</DebugType>
-    <DebugType Condition=" '$(TargetFramework)' != '' ">embedded</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' == '' and '$(DebugType)' == ''">full</DebugType>
+    <DebugType Condition=" '$(TargetFramework)' != '' and '$(DebugType)' == ''">embedded</DebugType>
     <DebugType Condition="$(TargetFramework.StartsWith('net4')) And '$(MonoBuild)' != 'true'">full</DebugType>
   </PropertyGroup>
 

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -22,6 +22,7 @@
          out of memory problems on large trees -->
     <LargeAddressAware>true</LargeAddressAware>
     <ApplicationIcon>..\MSBuild\MSBuild.ico</ApplicationIcon>
+    <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
MSBuildTaskHost was not generating a pdb file. Changing the property to
honor the value if already set (as xunit targets do) and explicitly set
DebugType to full on projects that were not generating them correctly.