### PR TITLE
Fix unhandled exception when tooltask process exits at a certain moment during cancelation

### DIFF
--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -158,7 +158,7 @@
     </comment>
   </data>
   <data name="Shared.KillingProcess">
-    <value>MSB5002: The task executable "{0}" has not completed within the specified limit of {1} milliseconds, terminating.</value>
+    <value>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</value>
     <comment>{StrBegin="MSB5002: "}</comment>
   </data>
   <data name="Shared.ParameterCannotBeNull" UESanitized="false" Visibility="Public">
@@ -251,7 +251,7 @@
     <comment>{StrBegin="MSB5020: "}</comment>
   </data>
   <data name="Shared.KillingProcessByCancellation">
-    <value>MSB5021: The task executable "{0}" and its child processes are being terminated in order to cancel the build.</value>
+    <value>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</value>
     <comment>{StrBegin="MSB5021: "}</comment>
   </data>
   <data name="Shared.CanNotFindValidMSBuildLocation">

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -158,7 +158,7 @@
     </comment>
   </data>
   <data name="Shared.KillingProcess">
-    <value>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</value>
+    <value>MSB5002: The task executable "{0}" has not completed within the specified limit of {1} milliseconds, terminating.</value>
     <comment>{StrBegin="MSB5002: "}</comment>
   </data>
   <data name="Shared.ParameterCannotBeNull" UESanitized="false" Visibility="Public">
@@ -251,7 +251,7 @@
     <comment>{StrBegin="MSB5020: "}</comment>
   </data>
   <data name="Shared.KillingProcessByCancellation">
-    <value>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</value>
+    <value>MSB5021: The task executable "{0}" and its child processes are being terminated in order to cancel the build.</value>
     <comment>{StrBegin="MSB5021: "}</comment>
   </data>
   <data name="Shared.CanNotFindValidMSBuildLocation">

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: Spustitelný soubor úlohy nebyl dokončen v zadaném limitu {0} milisekund. Proces bude ukončen.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: Spustitelný soubor úlohy nebyl dokončen v zadaném limitu {0} milisekund. Proces bude ukončen.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: Úloha {0} a její podřízené procesy budou ukončeny z důvodu zrušení sestavení.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: Úloha {0} a její podřízené procesy budou ukončeny z důvodu zrušení sestavení.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: Die ausführbare Datei der Aufgabe wurde nicht in der vorgegebenen Zeit von {0} Millisekunden abgeschlossen. Der Vorgang wird beendet.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: Die ausführbare Datei der Aufgabe wurde nicht in der vorgegebenen Zeit von {0} Millisekunden abgeschlossen. Der Vorgang wird beendet.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: "{0}" und untergeordnete Prozesse werden beendet, um den Buildvorgang abzubrechen.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: "{0}" und untergeordnete Prozesse werden beendet, um den Buildvorgang abzubrechen.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.en.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.en.xlf
@@ -146,8 +146,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="new">MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="new">MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -269,8 +269,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="new">MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="new">MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="Shared.CanNotFindValidMSBuildLocation">

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: La tarea ejecutable no se completó dentro del límite de {0} milisegundos especificado. Finalizando la tarea.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: La tarea ejecutable no se completó dentro del límite de {0} milisegundos especificado. Finalizando la tarea.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: Se están finalizando "{0}" y sus procesos secundarios para cancelar la compilación.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: Se están finalizando "{0}" y sus procesos secundarios para cancelar la compilación.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: La tâche exécutable n'a pas été terminée dans le délai spécifié de {0} millisecondes, arrêt.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: La tâche exécutable n'a pas été terminée dans le délai spécifié de {0} millisecondes, arrêt.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: "{0}" et ses processus enfants sont en cours d'arrêt de manière à pouvoir annuler la génération.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: "{0}" et ses processus enfants sont en cours d'arrêt de manière à pouvoir annuler la génération.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: l'esecuzione del file eseguibile dell'attività non è stata completata entro il limite specificato di {0} millisecondi e verrà terminata.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: l'esecuzione del file eseguibile dell'attività non è stata completata entro il limite specificato di {0} millisecondi e verrà terminata.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: "{0}" e i processi figlio verranno terminati per annullare la compilazione.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: "{0}" e i processi figlio verranno terminati per annullare la compilazione.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: 実行可能なタスクは、指定された制限 ({0} ミリ秒) 内で完了しませんでした。中止します。</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: 実行可能なタスクは、指定された制限 ({0} ミリ秒) 内で完了しませんでした。中止します。</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: ビルドを取り消すため、"{0}" とその子プロセスを終了しています。</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: ビルドを取り消すため、"{0}" とその子プロセスを終了しています。</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: 작업 실행 파일이 지정한 제한 시간인 {0}밀리초 안에 완료되지 않았으므로 종료합니다.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: 작업 실행 파일이 지정한 제한 시간인 {0}밀리초 안에 완료되지 않았으므로 종료합니다.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: 빌드를 취소하기 위해 "{0}" 및 자식 프로세스가 종료되고 있습니다.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: 빌드를 취소하기 위해 "{0}" 및 자식 프로세스가 종료되고 있습니다.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: Plik wykonywalny zadania nie zakończył pracy w określonym limicie czasu ({0} ms). Kończenie.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: Plik wykonywalny zadania nie zakończył pracy w określonym limicie czasu ({0} ms). Kończenie.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: Proces „{0}” i jego procesy podrzędne zostaną zakończone w celu anulowania kompilacji.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: Proces „{0}” i jego procesy podrzędne zostaną zakończone w celu anulowania kompilacji.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: A tarefa executável não foi concluída dentro do limite especificado de {0} milissegundos; encerrando.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: A tarefa executável não foi concluída dentro do limite especificado de {0} milissegundos; encerrando.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: "{0}" e seus processos filhos estão sendo encerrados para cancelar a compilação.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: "{0}" e seus processos filhos estão sendo encerrados para cancelar a compilação.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: исполняемый файл задачи не выполнен за {0} мс. Выполнение прекращается.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: исполняемый файл задачи не выполнен за {0} мс. Выполнение прекращается.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: Для отмены сборки выполняется завершение "{0}" и его дочерних процессов.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: Для отмены сборки выполняется завершение "{0}" и его дочерних процессов.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: Görev yürütülebilir dosyası, belirtilen {0} milisaniye sınırı içinde tamamlanmadı, sonlandırılıyor.</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: Görev yürütülebilir dosyası, belirtilen {0} milisaniye sınırı içinde tamamlanmadı, sonlandırılıyor.</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: Oluşturma işlemini iptal etmek için "{0}" ve alt işlemleri sonlandırılıyor.</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: Oluşturma işlemini iptal etmek için "{0}" ve alt işlemleri sonlandırılıyor.</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: 任务可执行文件未在指定的 {0} 毫秒限制内完成，正在终止。</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: 任务可执行文件未在指定的 {0} 毫秒限制内完成，正在终止。</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: 正在终止“{0}”及其子进程，以便取消生成。</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: 正在终止“{0}”及其子进程，以便取消生成。</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -141,8 +141,8 @@
     </note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcess">
-        <source>MSB5002: The task executable has not completed within the specified limit of {0} milliseconds, terminating.</source>
-        <target state="translated">MSB5002: 工作可執行檔沒有在指定的 {0} 毫秒時限內完成，正在終止。</target>
+        <source>MSB5002: Terminating the task executable "{0}" because it did not finish within the specified limit of {1} milliseconds.</source>
+        <target state="needs-review-translation">MSB5002: 工作可執行檔沒有在指定的 {0} 毫秒時限內完成，正在終止。</target>
         <note>{StrBegin="MSB5002: "}</note>
       </trans-unit>
       <trans-unit id="Shared.ParameterCannotBeNull">
@@ -259,8 +259,8 @@
         <note>{StrBegin="MSB5020: "}</note>
       </trans-unit>
       <trans-unit id="Shared.KillingProcessByCancellation">
-        <source>MSB5021: "{0}" and its child processes are being terminated in order to cancel the build.</source>
-        <target state="translated">MSB5021: 為了取消建置，正在終止 "{0}" 及其子處理序。</target>
+        <source>MSB5021: Terminating the task executable "{0}" and its child processes because the build was canceled.</source>
+        <target state="needs-review-translation">MSB5021: 為了取消建置，正在終止 "{0}" 及其子處理序。</target>
         <note>{StrBegin="MSB5021: "}</note>
       </trans-unit>
       <trans-unit id="OM_NotSupportedReadOnlyCollection">

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1079,16 +1079,27 @@ namespace Microsoft.Build.Utilities
             // kill the process if it's not finished yet
             if (!proc.HasExited)
             {
+                string processName;
+                try
+                {
+                    processName = proc.ProcessName;
+                }
+                catch (InvalidOperationException)
+                {
+                    // Process exited in the small interval since we checked HasExited
+                    return;
+                }
+
                 if (!isBeingCancelled)
                 {
                     ErrorUtilities.VerifyThrow(Timeout != System.Threading.Timeout.Infinite,
                         "A time-out value must have been specified or the task must be cancelled.");
 
-                    LogShared.LogWarningWithCodeFromResources("Shared.KillingProcess", this.Timeout);
+                    LogShared.LogWarningWithCodeFromResources("Shared.KillingProcess", processName, this.Timeout);
                 }
                 else
                 {
-                    LogShared.LogWarningWithCodeFromResources("Shared.KillingProcessByCancellation", proc.ProcessName);
+                    LogShared.LogWarningWithCodeFromResources("Shared.KillingProcessByCancellation", processName);
                 }
 
                 int timeout = 5000;


### PR DESCRIPTION
Fixes #3028

I can't really test this. I do see from inspection of the Process code that ProcessName getter will only throw in the situation where the process has exited.