### PR TITLE
Add test for reproduce Filename metadata problem on Unix.

### DIFF
--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -440,7 +440,8 @@ namespace Microsoft.Build.Shared
                         }
                         else
                         {
-                            modifiedItemSpec = Path.GetFileNameWithoutExtension(itemSpec);
+                            // Fix path to avoid problem with Path.GetFileNameWithoutExtension when backslashes in itemSpec on Unix
+                            modifiedItemSpec = Path.GetFileNameWithoutExtension(FixFilePath(itemSpec));
                         }
                     }
                     else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase) == 0)


### PR DESCRIPTION
I found a problem with slashes in metadata evaluation. I created repro test for this problem. But I'm not sure where I should fix it. Please help me find the right place.