### PR TITLE
Exclude MSBuild.pdb from Microsoft.Build.Runtime

### DIFF
--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -319,6 +319,11 @@
         The build output was copied to _PackageFiles and must be cleared or we'll get package analysis warnings about duplicate files
       -->
       <_BuildOutputInPackage Remove="@(_BuildOutputInPackage)" />
+
+      <!--
+        Clear _TargetPathsToSymbols so that pdbs don't end up in the package
+      -->
+      <_TargetPathsToSymbols Remove="@(_TargetPathsToSymbols)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
For some reason the official build is including MSBuild.dll which causes errors when consuming the package