### PR TITLE
Set MSBuildAllProjects automatically to the project and all imports

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -21,6 +21,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 using Xunit;
 
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -2008,7 +2009,15 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 // All those properties which aren't defined in any file. Examples are global properties, environment properties, etc.
                 IEnumerable<ProjectProperty> nonImportedProperties = project.Properties.Where(property => property.Xml == null);
 
-                Assert.Equal(allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates.Count, nonImportedProperties.Count());
+                int expectedCount = allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates.Count;
+
+                if (!Traits.Instance.EscapeHatches.EnableLegacyMSBuildAllProjects)
+                {
+                    // Add an expected property for the magic MSBuildAllProjects
+                    expectedCount++;
+                }
+
+                Assert.Equal(expectedCount, nonImportedProperties.Count());
 
                 // Now check and make sure they all match.  If we get through the entire foreach without triggering an Assert.Fail(), then
                 // they do.

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2351,7 +2351,7 @@ namespace Microsoft.Build.Evaluation
                             imports.Add(importedProjectElement);
 
                             // Store a pointer to the newest project to be set later as MSBuildAllProjects
-                            if (importedProjectElement.TimeLastChanged > _newestProject.TimeLastChanged)
+                            if (importedProjectElement.LastWriteTimeWhenRead > _newestProject.LastWriteTimeWhenRead)
                             {
                                 _newestProject = importedProjectElement;
                             }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -699,7 +699,7 @@ namespace Microsoft.Build.Evaluation
                     PerformDepthFirstPass(_projectRootElement);
                 }
 
-                if (!Traits.Instance.EscapeHatches.EnableLegacyMSBuildAllProjects)
+                if (!Traits.Instance.EscapeHatches.EnableLegacyMSBuildAllProjects && _newestProject?.FullPath != null)
                 {
                     if (_msbuildAllProjectsWasSet)
                     {

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Build.Internal
         internal const string version = "MSBuildVersion";
         internal const string osName = "OS";
         internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";
+        // This is not technically reserved but is set automatically
+        internal const string allProjects = "MSBuildAllProjects";
 
         /// <summary>
         /// Lookup for reserved property names

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1674,6 +1674,12 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION:  Do not localize the word SDK.
     </comment>
   </data>
+  <data name="MSBuildAllProjectsIgnored" UESanitized="false" Visibility="Public">
+    <value>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</value>
+    <comment>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1675,7 +1675,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
   <data name="MSBuildAllProjectsIgnored" UESanitized="false" Visibility="Public">
-    <value>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</value>
+    <value>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</value>
     <comment>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -2118,8 +2118,8 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -2117,6 +2117,13 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -2118,8 +2118,8 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -2117,6 +2117,13 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</target>
         <target state="new">MSB4244: The SDK resolver assembly "{0}" could not be loaded. {1}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</target>
         <note>{StrBegin="MSB4244: "}</note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -2117,6 +2117,13 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -2118,8 +2118,8 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -2117,6 +2117,13 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -2118,8 +2118,8 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -2118,8 +2118,8 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -2117,6 +2117,13 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -2118,8 +2118,8 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -2117,6 +2117,13 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -2118,8 +2118,8 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -2117,6 +2117,13 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -2117,6 +2117,13 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -2118,8 +2118,8 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -2117,6 +2117,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
+      <trans-unit id="MSBuildAllProjectsIgnored">
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <note>
+      LOCALIZATION:  Do not localize the word MSBuildAllProjects.
+    </note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -2118,8 +2118,8 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
     </note>
       </trans-unit>
       <trans-unit id="MSBuildAllProjectsIgnored">
-        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
-        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be the newest project or import.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
+        <source>The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</source>
+        <target state="new">The property 'MSBuildAllProjects' was ignored and set automatically to be this project and all imports.  You can set the environment variable 'MSBUILDENABLEMSBUILDALLPROJECTS' to '1' to disable this feature.</target>
         <note>
       LOCALIZATION:  Do not localize the word MSBuildAllProjects.
     </note>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -127,6 +127,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool UseAutoRunWhenLaunchingProcessUnderCmd = Environment.GetEnvironmentVariable("MSBUILDUSERAUTORUNINCMD") == "1";
 
+        public readonly bool EnableLegacyMSBuildAllProjects = Environment.GetEnvironmentVariable("MSBUILDENABLEMSBUILDALLPROJECTS") == "1";
+
         private static bool? ParseNullableBoolFromEnvironmentVariable(string environmentVariable)
         {
             var value = Environment.GetEnvironmentVariable(environmentVariable);


### PR DESCRIPTION
* Set MSBuildAllProjects after first pass to the project and all imports, sorted descending by last modified 
* Log a low importance message that the property was ignored and set automatically
* Add escape hatch to disable the functionality

Fixes #1299