### PR TITLE
Update to RepoToolset 1.0.0-beta-62705-01

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -36,7 +36,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>2.1.300-preview2-008046</DotNetCliVersion>
-    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62512-02</RoslynToolsRepoToolsetVersion>
+    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
     <VSWhereVersion>2.2.7</VSWhereVersion>
 
     <GenApiVersion>2.1.0-prerelease-02404-02</GenApiVersion>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -26,11 +26,6 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
     <!-- Tell repo toolset not to define the GetBuildVersion target, as it would conflict with NerdBank.GitVersioning -->
     <DefineGetBuildVersionTargetForVsix>false</DefineGetBuildVersionTargetForVsix>
-
-    <!-- Use later version of XliffTasks which has a fix for .resx files consumed by multiple projects.
-         See https://github.com/dotnet/xliff-tasks/pull/34 -->
-    <XliffTasksVersion>0.2.0-beta-000081</XliffTasksVersion>
-
   </PropertyGroup>
 
   <!-- Toolset Dependencies -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,14 @@
     <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
     <ErrorOnOutOfDateXlf>true</ErrorOnOutOfDateXlf>
 
+    <UpdateXlfOnBuild Condition="'$(CIBuild)' != 'true'">true</UpdateXlfOnBuild>
+
+    <!-- Workaround that can be removed when we update machines to 15.6.
+         Use Satellite assembly generation task from Microsoft.NET.Sdk even when building with
+         full Framework MSBuild.  This will support public signing, is deterministic, and always
+         generates them as AnyCPU. -->
+    <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
+
     <!-- Work around issue where bootstrapped TaskHostTask seems to be loading the wrong assemblies.
          https://github.com/Microsoft/msbuild/issues/2865-->
     <GenerateResourceMSBuildArchitecture>CurrentArchitecture</GenerateResourceMSBuildArchitecture>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,8 +39,6 @@
     <UpdateXlfOnBuild>true</UpdateXlfOnBuild>
     <ErrorOnOutOfDateXlf>true</ErrorOnOutOfDateXlf>
 
-    <UpdateXlfOnBuild Condition="'$(CIBuild)' != 'true'">true</UpdateXlfOnBuild>
-
     <!-- Workaround that can be removed when we update machines to 15.6.
          Use Satellite assembly generation task from Microsoft.NET.Sdk even when building with
          full Framework MSBuild.  This will support public signing, is deterministic, and always


### PR DESCRIPTION
The new toolset includes fixes required by Orchestrated and Source builds.