### PR TITLE
 Fix race adding configuration in BuildManager

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The singleton instance for the BuildManager.
         /// </summary>
-        static private BuildManager s_singletonInstance;
+        private static BuildManager s_singletonInstance;
 
         /// <summary>
         /// The next build id;
         /// </summary>
-        static private int s_nextBuildId;
+        private static int s_nextBuildId;
 
         /// <summary>
         /// The next build request configuration ID to use.
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Set of active nodes in the system.
         /// </summary>
-        private HashSet<NGen<int>> _activeNodes;
+        private readonly HashSet<NGen<int>> _activeNodes;
 
         /// <summary>
         /// Event signalled when all nodes have shutdown.
@@ -111,7 +111,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Mapping of nodes to the configurations they know about.
         /// </summary>
-        private Dictionary<NGen<int>, HashSet<NGen<int>>> _nodeIdToKnownConfigurations;
+        private readonly Dictionary<NGen<int>, HashSet<NGen<int>>> _nodeIdToKnownConfigurations;
 
         /// <summary>
         /// Flag indicating if we are currently shutting down.  When set, we stop processing packets other than NodeShutdown.
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The name given to this BuildManager as the component host.
         /// </summary>
-        private string _hostName;
+        private readonly string _hostName;
 
         /// <summary>
         /// The parameters with which the build was started.
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Execution
         /// <remarks>
         /// { submissionId, BuildSubmission }
         /// </remarks>
-        private Dictionary<int, BuildSubmission> _buildSubmissions;
+        private readonly Dictionary<int, BuildSubmission> _buildSubmissions;
 
         /// <summary>
         /// Event signalled when all build submissions are complete.
@@ -159,7 +159,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Mapping of unnamed project instances to the file names assigned to them.
         /// </summary>
-        private Dictionary<ProjectInstance, string> _unnamedProjectInstanceToNames;
+        private readonly Dictionary<ProjectInstance, string> _unnamedProjectInstanceToNames;
 
         /// <summary>
         /// The next ID to assign to a project which has no name.
@@ -169,12 +169,12 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The build component factories.
         /// </summary>
-        private BuildComponentFactoryCollection _componentFactories;
+        private readonly BuildComponentFactoryCollection _componentFactories;
 
         /// <summary>
         /// Mapping of submission IDs to their first project started events.
         /// </summary>
-        private Dictionary<int, BuildEventArgs> _projectStartedEvents;
+        private readonly Dictionary<int, BuildEventArgs> _projectStartedEvents;
 
         /// <summary>
         /// Whether a cache has been provided by a project instance, meaning
@@ -186,22 +186,22 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The project started event handler
         /// </summary>
-        private ProjectStartedEventHandler _projectStartedEventHandler;
+        private readonly ProjectStartedEventHandler _projectStartedEventHandler;
 
         /// <summary>
         /// The project finished event handler
         /// </summary>
-        private ProjectFinishedEventHandler _projectFinishedEventHandler;
+        private readonly ProjectFinishedEventHandler _projectFinishedEventHandler;
 
         /// <summary>
         /// The logging exception event handler
         /// </summary>
-        private LoggingExceptionDelegate _loggingThreadExceptionEventHandler;
+        private readonly LoggingExceptionDelegate _loggingThreadExceptionEventHandler;
 
         /// <summary>
         /// Legacy threading semantic data associated with this build manager.
         /// </summary>
-        private LegacyThreadingData _legacyThreadingData;
+        private readonly LegacyThreadingData _legacyThreadingData;
 
         /// <summary>
         /// The worker queue.
@@ -251,9 +251,9 @@ namespace Microsoft.Build.Execution
             _componentFactories.RegisterDefaultFactories();
             _projectStartedEvents = new Dictionary<int, BuildEventArgs>();
 
-            _projectStartedEventHandler = new ProjectStartedEventHandler(OnProjectStarted);
-            _projectFinishedEventHandler = new ProjectFinishedEventHandler(OnProjectFinished);
-            _loggingThreadExceptionEventHandler = new LoggingExceptionDelegate(OnThreadException);
+            _projectStartedEventHandler = OnProjectStarted;
+            _projectFinishedEventHandler = OnProjectFinished;
+            _loggingThreadExceptionEventHandler = OnThreadException;
             _legacyThreadingData = new LegacyThreadingData();
         }
 
@@ -312,59 +312,29 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Retrieves a hosted<see cref="ISdkResolverService"/> instance for resolving SDKs.
         /// </summary>
-        private ISdkResolverService SdkResolverService
-        {
-            get
-            {
-                return (this as IBuildComponentHost).GetComponent(BuildComponentType.SdkResolverService) as ISdkResolverService;
-            }
-        }
+        private ISdkResolverService SdkResolverService => (this as IBuildComponentHost).GetComponent(BuildComponentType.SdkResolverService) as ISdkResolverService;
 
         /// <summary>
         /// Retrieves the logging service associated with a particular build
         /// </summary>
         /// <returns>The logging service.</returns>
-        ILoggingService IBuildComponentHost.LoggingService
-        {
-            get
-            {
-                return _componentFactories.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-            }
-        }
+        ILoggingService IBuildComponentHost.LoggingService => _componentFactories.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
         /// <summary>
         /// Retrieves the name of the component host.
         /// </summary>
-        string IBuildComponentHost.Name
-        {
-            get
-            {
-                return _hostName;
-            }
-        }
+        string IBuildComponentHost.Name => _hostName;
 
         /// <summary>
         /// Retrieves the build parameters associated with this build.
         /// </summary>
         /// <returns>The build parameters.</returns>
-        BuildParameters IBuildComponentHost.BuildParameters
-        {
-            get
-            {
-                return _buildParameters;
-            }
-        }
+        BuildParameters IBuildComponentHost.BuildParameters => _buildParameters;
 
         /// <summary>
         /// Retrieves the LegacyThreadingData associated with a particular build manager
         /// </summary>
-        LegacyThreadingData IBuildComponentHost.LegacyThreadingData
-        {
-            get
-            {
-                return _legacyThreadingData;
-            }
-        }
+        LegacyThreadingData IBuildComponentHost.LegacyThreadingData => _legacyThreadingData;
 
         /// <summary>
         /// Prepares the BuildManager to receive build requests.
@@ -386,14 +356,7 @@ namespace Microsoft.Build.Execution
                 _overallBuildSuccess = true;
 
                 // Clone off the build parameters.
-                if (parameters != null)
-                {
-                    _buildParameters = parameters.Clone();
-                }
-                else
-                {
-                    _buildParameters = new BuildParameters();
-                }
+                _buildParameters = parameters?.Clone() ?? new BuildParameters();
 
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
@@ -480,8 +443,7 @@ namespace Microsoft.Build.Execution
             CultureInfo parentThreadCulture = _buildParameters != null ? _buildParameters.Culture : CultureInfo.CurrentCulture;
             CultureInfo parentThreadUICulture = _buildParameters != null ? _buildParameters.UICulture : CultureInfo.CurrentUICulture;
 
-            WaitCallback callback = new WaitCallback(
-            delegate (object state)
+            void Callback(object state)
             {
                 lock (_syncLock)
                 {
@@ -513,9 +475,9 @@ namespace Microsoft.Build.Execution
                     ShutdownConnectedNodesAsync(true /* abort */);
                     CheckForActiveNodesAndCleanUpSubmissions();
                 }
-            });
+            }
 
-            ThreadPoolExtensions.QueueThreadPoolWorkItemWithCulture(callback, parentThreadCulture, parentThreadUICulture);
+            ThreadPoolExtensions.QueueThreadPoolWorkItemWithCulture(Callback, parentThreadCulture, parentThreadUICulture);
         }
 
         /// <summary>
@@ -535,10 +497,7 @@ namespace Microsoft.Build.Execution
                 // This call clears out the directory.
                 _configCache.ClearConfigurations();
 
-                if (_buildParameters != null)
-                {
-                    _buildParameters.ProjectRootElementCache.DiscardImplicitReferences();
-                }
+                _buildParameters?.ProjectRootElementCache.DiscardImplicitReferences();
             }
         }
 
@@ -663,7 +622,7 @@ namespace Microsoft.Build.Execution
                         // can't tell for sure one way or the other, so err on the side of throwing
                         // the assert, but if there is a result, make sure that it actually has an
                         // exception attached.
-                        if (result == null || result.Exception == null)
+                        if (result?.Exception == null)
                         {
                             allMismatchedProjectStartedEventsDueToLoggerErrors = false;
                             break;
@@ -1207,7 +1166,7 @@ namespace Microsoft.Build.Execution
             _shuttingDown = true;
 
             // If we are aborting, we will NOT reuse the nodes because their state may be compromised by attempts to shut down while the build is in-progress.
-            _nodeManager.ShutdownConnectedNodes(abort ? false : _buildParameters.EnableNodeReuse);
+            _nodeManager.ShutdownConnectedNodes(!abort && _buildParameters.EnableNodeReuse);
 
             // if we are aborting, the task host will hear about it in time through the task building infrastructure;
             // so only shut down the task host nodes if we're shutting down tidily (in which case, it is assumed that all
@@ -1531,12 +1490,8 @@ namespace Microsoft.Build.Execution
                     // UNDONE: (stability) It might be best to trigger the logging service to shut down here,
                     //         since the full build is complete.  This would allow us to ensure all logging messages have been
                     //         drained and all submissions can complete their logging requirements.
-                    BuildResult result = _resultsCache.GetResultsForConfiguration(submission.BuildRequest.ConfigurationId);
-                    if (result == null)
-                    {
-                        // If we had no results, the build aborted before we had a chance to generate any.
-                        result = new BuildResult(submission.BuildRequest, new BuildAbortedException());
-                    }
+                    BuildResult result = _resultsCache.GetResultsForConfiguration(submission.BuildRequest.ConfigurationId) ??
+                                         new BuildResult(submission.BuildRequest, new BuildAbortedException());
 
                     submission.CompleteResults(result);
 
@@ -1615,8 +1570,7 @@ namespace Microsoft.Build.Execution
                             // of which nodes have had configurations specifically assigned to them for building.  However, a node may
                             // have created a configuration based on a build request it needs to wait on.  In this
                             // case we need not send the configuration since it will already have been mapped earlier.
-                            HashSet<NGen<int>> configurationsOnNode = null;
-                            if (!_nodeIdToKnownConfigurations.TryGetValue(response.NodeId, out configurationsOnNode) ||
+                            if (!_nodeIdToKnownConfigurations.TryGetValue(response.NodeId, out var configurationsOnNode) ||
                                !configurationsOnNode.Contains(response.BuildRequest.ConfigurationId))
                             {
                                 IConfigCache configCache = _componentFactories.GetComponent(BuildComponentType.ConfigCache) as IConfigCache;
@@ -1753,7 +1707,7 @@ namespace Microsoft.Build.Execution
                         submission.CompleteLogging(false);
 
                         // Attach the exception to this submission if it does not already have an exception associated with it
-                        if (submission.BuildResult == null || (submission.BuildResult.Exception == null))
+                        if (submission.BuildResult?.Exception == null)
                         {
                             if (submission.BuildResult == null)
                             {
@@ -1778,14 +1732,12 @@ namespace Microsoft.Build.Execution
         {
             lock (_syncLock)
             {
-                BuildEventArgs originalArgs;
-                if (_projectStartedEvents.TryGetValue(e.BuildEventContext.SubmissionId, out originalArgs))
+                if (_projectStartedEvents.TryGetValue(e.BuildEventContext.SubmissionId, out var originalArgs))
                 {
                     if (originalArgs.BuildEventContext.Equals(e.BuildEventContext))
                     {
-                        BuildSubmission submission;
                         _projectStartedEvents.Remove(e.BuildEventContext.SubmissionId);
-                        if (_buildSubmissions.TryGetValue(e.BuildEventContext.SubmissionId, out submission))
+                        if (_buildSubmissions.TryGetValue(e.BuildEventContext.SubmissionId, out var submission))
                         {
                             submission.CompleteLogging(false);
                             CheckSubmissionCompletenessAndRemove(submission);
@@ -1827,7 +1779,7 @@ namespace Microsoft.Build.Execution
                                  : LoggerMode.Asynchronous;
             }
 
-            ILoggingService loggingService = (ILoggingService)Microsoft.Build.BackEnd.Logging.LoggingService.CreateLoggingService(loggerMode, 1 /*This logging service is used for the build manager and the inproc node, therefore it should have the first nodeId*/);
+            ILoggingService loggingService = LoggingService.CreateLoggingService(loggerMode, 1 /*This logging service is used for the build manager and the inproc node, therefore it should have the first nodeId*/);
 
             ((IBuildComponent)loggingService).InitializeComponent(this);
             _componentFactories.ReplaceFactory(BuildComponentType.LoggingService, loggingService as IBuildComponent);
@@ -1862,7 +1814,7 @@ namespace Microsoft.Build.Execution
                         verbosity: LoggerVerbosity.Quiet);
 
                     ForwardingLoggerRecord[] forwardingLogger = { new ForwardingLoggerRecord(new NullLogger(), forwardingLoggerDescription) };
-                    forwardingLoggers = forwardingLoggers == null ? forwardingLogger : forwardingLoggers.Concat(forwardingLogger);
+                    forwardingLoggers = forwardingLoggers?.Concat(forwardingLogger) ?? forwardingLogger;
                 }
 
                 if (forwardingLoggers != null)
@@ -1880,10 +1832,7 @@ namespace Microsoft.Build.Execution
                     throw;
                 }
 
-                if (loggingService != null)
-                {
-                    ShutdownLoggingService(loggingService);
-                }
+                ShutdownLoggingService(loggingService);
 
                 throw;
             }
@@ -1987,9 +1936,9 @@ namespace Microsoft.Build.Execution
                             _noNodesActiveEvent = null;
                         }
 
-                        if (Object.ReferenceEquals(this, BuildManager.s_singletonInstance))
+                        if (ReferenceEquals(this, s_singletonInstance))
                         {
-                            BuildManager.s_singletonInstance = null;
+                            s_singletonInstance = null;
                         }
 
                         _disposed = true;
@@ -2010,14 +1959,8 @@ namespace Microsoft.Build.Execution
             /// </summary>
             public LoggerVerbosity Verbosity
             {
-                get
-                {
-                    return LoggerVerbosity.Normal;
-                }
-
-                set
-                {
-                }
+                get => LoggerVerbosity.Normal;
+                set { }
             }
 
             /// <summary>
@@ -2025,14 +1968,8 @@ namespace Microsoft.Build.Execution
             /// </summary>
             public string Parameters
             {
-                get
-                {
-                    return String.Empty;
-                }
-
-                set
-                {
-                }
+                get => String.Empty;
+                set{ }
             }
 
             /// <summary>


### PR DESCRIPTION
We have crash reports of a race condition in the AddNewConfiguration
method. Adding a lock to the only entry to that method currently without
a lock.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/548385