### PR TITLE
Enable PGO in microbuild

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,11 @@
 ﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
   <!-- Import the repo root props -->
   <Import Project="..\Directory.Build.props"/>
 
   <!-- Import common project settings provided by RepoToolset -->
   <Import Project="$(RepoToolsetDir)Settings.props" />
+
+  <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.props" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4'))" />
 
   <!-- Override project defaults provided by Repo toolset -->
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -124,6 +124,8 @@
     </PropertyGroup>
   </Target>
 
+  <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4'))" />
+
   <!-- Import parent targets -->
   <Import Project="..\Directory.Build.targets"/>
 


### PR DESCRIPTION
Repotoolset's mechanism is mysterious and does not magically work for our repo, so we're manually importing the microbuild plugin for PGO.