### PR TITLE
Removed the forced normal priority when creating a new node.

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Build.BackEnd
 
             // Null out the process handles so that the parent process does not wait for the child process
             // to exit before it can exit.
-            uint creationFlags = BackendNativeMethods.NORMALPRIORITYCLASS;
+            uint creationFlags = 0;
             startInfo.dwFlags = BackendNativeMethods.STARTFUSESTDHANDLES;
 
             if (String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDNODEWINDOW")))


### PR DESCRIPTION
The child process will instead inherit the setting from its parent.