### PR TITLE
Disable macOS CI

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -14,7 +14,10 @@ def imageVersionMap = ['Windows_NT':'latest-dev15-5',
                        'Ubuntu16.04':'20170731']
 
 [true, false].each { isPR ->
-    ['Windows_NT', 'OSX10.13', 'Ubuntu14.04', 'Ubuntu16.04'].each {osName ->
+    ['Windows_NT',
+     // 'OSX10.13', TEMPORARY disabled for https://github.com/dotnet/core-eng/issues/2808
+     'Ubuntu14.04',
+     'Ubuntu16.04'].each {osName ->
         def runtimes = ['CoreCLR']
 
         if (osName == 'Windows_NT') {


### PR DESCRIPTION
Avoid red CI tests by just disabling Mac testing until https://github.com/dotnet/core-eng/issues/2808 gets fixed.