### PR TITLE
Update .NET CLI and fix change in file pattern match behavior on non-Windows

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -30,7 +30,7 @@
 
   <!-- Toolset Dependencies -->
   <PropertyGroup>
-    <DotNetCliVersion>2.1.300-preview2-008046</DotNetCliVersion>
+    <DotNetCliVersion>2.1.300-preview2-008293</DotNetCliVersion>
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
     <VSWhereVersion>2.2.7</VSWhereVersion>
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -177,11 +177,12 @@ namespace Microsoft.Build.Shared
         /// <returns></returns>
         private static bool ShouldEnforceMatching(string searchPattern)
         {
-            if (!NativeMethodsShared.IsWindows || searchPattern == null)
+            if (searchPattern == null)
             {
                 return false;
             }
-            // NOTE: Windows matches loosely in three cases (in the absence of the * wildcard in the extension):
+            // https://github.com/Microsoft/msbuild/issues/3060
+            // NOTE: Corefx matches loosely in three cases (in the absence of the * wildcard in the extension):
             // 1) if the extension ends with the ? wildcard, it matches files with shorter extensions also e.g. "file.tx?" would
             //    match both "file.txt" and "file.tx"
             // 2) if the extension is three characters, and the filename contains the * wildcard, it matches files with longer


### PR DESCRIPTION
Update .NET CLI from 2.1.300-preview2-008046 to 2.1.300-preview2-008293

This pulls in changes to corefx where non-Windows will now have more consistent behavior with Windows in regards to file pattern matching.  Unfortunately, the behavior in Windows is incorrect for our needs so we now need to manually correct matches on all platforms.

https://github.com/dotnet/corefx/issues/27779

Tracking updating the behavior later here: https://github.com/Microsoft/msbuild/issues/3060