### PR TITLE
Add source control information extensibility point

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -721,6 +721,34 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </ItemDefinitionGroup>
 
   <!--
+    Target that allows targets consuming source control confirmation to establish a dependency on targets producing this information.
+
+    Any target that reads SourceRevisionId, PrivateRepositoryUrl, SourceRoot, and other source control properties and items 
+    should depend on this target and be conditioned on '$(SourceControlInformationFeatureSupported)' == 'true'.
+
+    SourceRevisionId property uniquely identifies the source control revision of the repository the project belongs to.
+    For Git repositories this id is a commit hash, for TFVC repositories it's the changeset number, etc.
+
+    PrivateRepositoryUrl property stores the URL of the repository supplied by the CI server or retrieved from source control manager.
+    Targets consuming this property shall not publish its value implicitly as it might inadvertently reveal an internal URL.
+    Instead, they shall only do so if the project sets PublishRepositoryUrl property to true. For example, the NuGet Pack target
+    may include the repository URL in the nuspec file generated for NuGet package produced by the project if PublishRepositoryUrl is true.
+
+    SourceRoot item group lists all source roots that the project source files reside under and their mapping to source control server URLs,
+    if available. This includes both source files under source control as well as source files in source packages. SourceRoot items are 
+    used by compilers to determine path map in deterministic build and by SourceLink provider, which maps local paths to URLs of source files
+    stored on the source control server.
+
+    Source control information provider that sets these properties and items shall execute before this target (by including 
+    InitializeSourceControlInformation in its BeforeTargets) and set source control properties and items that haven't been initialized yet.
+  -->
+  <Target Name="InitializeSourceControlInformation" />
+
+  <PropertyGroup>
+    <SourceControlInformationFeatureSupported>true</SourceControlInformationFeatureSupported>
+  </PropertyGroup>
+
+  <!--
     ***********************************************************************************************
     ***********************************************************************************************
                                                                 Build Section


### PR DESCRIPTION
Adds a few extensibility points to common targets that enable source control and SourceLink package features and fully deterministic compilation.

See https://github.com/tmat/repository-info/blob/master/docs/Readme.md for details.

TODO:
- [x] Replace temp links to Standard CI spec with final links
- [ ] Follow up change in dotnet SDK to include revision id in AssemblyInformationalVersion (https://github.com/dotnet/sdk/pull/2028)
- [ ] Follow up change in C#, VB and F# targets files to use source roots to generate PathMap (https://github.com/dotnet/roslyn/pull/25325)
- [ ] Follow up change in C++ compiler to implement deterministic path mapping and use source roots to generate it
- [ ] Follow up change in NuGet targets to populate RepositoryUrl from PrivateRepositoryUrl (https://github.com/NuGet/NuGet.Client/pull/2081)
- [ ] Create source control and source link packages using these extensibility points

Supersedes https://github.com/Microsoft/msbuild/pull/2960