### PR TITLE
Update FileVersionHash used in node communications

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -535,7 +535,8 @@ namespace Microsoft.Build.BackEnd
 
             // Start the new process.  We pass in a node mode with a node number of 2, to indicate that we 
             // want to start up an MSBuild task host node. 
-            string commandLineArgs = " /nologo /nodemode:2 ";
+            string commandLineArgs = $" /nologo /nodemode:2 /nodereuse:{ComponentHost.BuildParameters.EnableNodeReuse} ";
+
             string msbuildLocation = GetMSBuildLocationFromHostContext(hostContext);
 
             // we couldn't even figure out the location we're trying to launch ... just go ahead and fail.  

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -122,12 +122,7 @@ namespace Microsoft.Build.Internal
                     // them, so just check COMPLUS_InstallRoot.
                     string complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT");
 
-                    // We should also check the file version when COMPLUS_INSTALLROOT is null, because the protocol can change between releases.
-                    // If we don't check, we'll run into issues
-                    string taskhostexe = FileUtilities.ExecutingAssemblyPath;
-                    string majorVersion = FileVersionInfo.GetVersionInfo(taskhostexe).FileMajorPart.ToString();
-
-                    s_fileVersionHash = GetHandshakeHashCode(complusInstallRoot ?? majorVersion);
+                    s_fileVersionHash = GetHandshakeHashCode(complusInstallRoot ?? ThisAssembly.AssemblyInformationalVersion);
                     s_fileVersionChecked = true;
                 }
 


### PR DESCRIPTION
The current handshake for task host communication uses only the assembly
major version portion. This causes issue if the protocol is changed for
any '15' release. Changed the FileVersionHash to hash the full assembly
informational version (which includes the commit hash, e.g.
'15.7.79-preview+g60af12df92').