### PR TITLE
Minor changes to CreateTypeLib

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -139,7 +139,7 @@
       <TlbExpAssemblyPaths Include="@(_TlbExpAssemblyPaths->'%(SlashlessPath)')" />
     </ItemGroup>
 
-    <Exec Command="tlbexp.exe $(TlbExpVerbosity) /NOLOGO /asmpath:@(TlbExpAssemblyPaths->'&quot;%(Identity)&quot;', ' /asmpath:') $(TargetPath) /out:$(TargetDir)$(TargetName).tlb" />
+    <Exec Command="tlbexp.exe $(TlbExpVerbosity) /NOLOGO @(TlbExpAssemblyPaths->'/asmpath:&quot;%(Identity)&quot;', ' ') $(TargetPath) /out:$(TargetDir)$(TargetName).tlb" />
   </Target>
 
   <!-- Import parent targets -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -125,6 +125,12 @@
   </Target>
 
   <Target Name="CreateTypeLib" BeforeTargets="AfterBuild" Condition="'$(CreateTlb)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <!-- Provide a mechanism for turning on verbose TlbExp output for diagnosing issues -->
+    <PropertyGroup>
+      <TlbExpVerbosity Condition="'$(VerboseTlbExp)' == 'true'">/verbose</TlbExpVerbosity>
+      <TlbExpVerbosity Condition="'$(VerboseTlbExp)' != 'true'">/silent</TlbExpVerbosity>
+    </PropertyGroup>
+
     <ItemGroup>
       <_TlbExpAssemblyPaths Include="$(TargetDir);$(TargetFrameworkDirectory)" />
       <_TlbExpAssemblyPaths>
@@ -133,7 +139,7 @@
       <TlbExpAssemblyPaths Include="@(_TlbExpAssemblyPaths->'%(SlashlessPath)')" />
     </ItemGroup>
 
-    <Exec Command="tlbexp.exe /silent /NOLOGO /asmpath:@(TlbExpAssemblyPaths->'&quot;%(Identity)&quot;', ' /asmpath:') $(TargetPath) /out:$(TargetDir)$(TargetName).tlb" />
+    <Exec Command="tlbexp.exe $(TlbExpVerbosity) /NOLOGO /asmpath:@(TlbExpAssemblyPaths->'&quot;%(Identity)&quot;', ' /asmpath:') $(TargetPath) /out:$(TargetDir)$(TargetName).tlb" />
   </Target>
 
   <!-- Import parent targets -->


### PR DESCRIPTION
1. Make it possible to get verbose output from tlbexp. This is useful for debugging issues with .tlb generation.
2. Slightly simplify how we generate the `/asmpath` argument.

What I *really* wanted to do was explicitly specify the type lib references using the `/tlbrefpath` and `/tlbreference` arguments rather than letting tlbexp find them magically. Unfortunately this quickly devolves into specifying the location of things like mscorlib.tlb and stdole2.tlb, which aren't part of an SDK or reference assemblies (at least, not that I can find). The VS repo solves this by having copies of these files checked-in. I don't want to go down that path, so I've given up and just let tlbexp find the referenced type libs on its own. This is probably fine for the purposes of MSBuild--it's not like those type libraries are going to change.