### PR TITLE
Honor MSBUILDDEBUGPATH when dumping exception information to file

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -192,7 +192,7 @@ function Build {
   {
     # Only enable warnaserror on CI runs.  For local builds, we will generate a warning if we can't run EditBin because
     # the C++ tools aren't installed, and we don't want this to fail the build
-    $commonMSBuildArgs = $commonMSBuildArgs + "/warnaserror" 
+    $commonMSBuildArgs = $commonMSBuildArgs + "/warnaserror"
   }
 
   if ($hostType -ne 'full')
@@ -201,7 +201,7 @@ function Build {
     $emptySignToolDataPath = [io.path]::combine($RepoRoot, 'build', 'EmptySignToolData.json')
     $commonMSBuildArgs = $commonMSBuildArgs + "/p:SignToolDataPath=`"$emptySignToolDataPath`""
   }
-  
+
   # Only test using stage 0 MSBuild if -bootstrapOnly is specified
   $testStage0 = $false
   if ($bootstrapOnly)
@@ -257,7 +257,7 @@ function Build {
         # Kill compiler server and MSBuild node processes from bootstrapped MSBuild (otherwise a second build will fail to copy files in use)
         foreach ($process in Get-Process | Where-Object {'msbuild', 'dotnet', 'vbcscompiler' -contains $_.Name})
         {
-          
+
           if ([string]::IsNullOrEmpty($process.Path))
           {
             Write-Host "Process $($process.Id) $($process.Name) does not have a Path. Skipping killing it."
@@ -358,6 +358,7 @@ try {
 
     $env:TEMP = $TempDir
     $env:TMP = $TempDir
+    $env:MSBUILDDEBUGPATH = $TempDir
   }
 
   if (!($env:NUGET_PACKAGES)) {

--- a/build/build.sh
+++ b/build/build.sh
@@ -22,7 +22,7 @@ verbosity="minimal"
 hostType="core"
 properties=""
 
-function Help() { 
+function Help() {
   echo "Common settings:"
   echo "  -configuration <value>  Build configuration Debug, Release"
   echo "  -verbosity <value>      Msbuild verbosity (q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic])"
@@ -147,7 +147,7 @@ function CallMSBuild {
     commandLine="$msbuildHost $msbuildToUse $*"
   fi
 
-  echo ============= MSBuild command ============= 
+  echo ============= MSBuild command =============
   echo "$commandLine"
   echo ===========================================
 
@@ -235,7 +235,7 @@ function ErrorHostType {
 
 function Build {
   InstallDotNetCli
-  
+
   # don't double quote this otherwise the csc tooltask will fail with double double-quotting
   export DOTNET_HOST_PATH="$DOTNET_INSTALL_DIR/dotnet"
 
@@ -370,6 +370,7 @@ then
 
   export TEMP="$TempDir"
   export TMP="$TempDir"
+  export MSBUILDDEBUGPATH="$TempDir"
 fi
 
 if [ -z $NUGET_PACKAGES ]

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Build.Execution
         private ActionBlock<Action> _workQueue;
 
         /// <summary>
-        /// Flag indicating we have disposed. 
+        /// Flag indicating we have disposed.
         /// </summary>
         private bool _disposed = false;
 
@@ -630,8 +630,8 @@ namespace Microsoft.Build.Execution
                 ShutdownConnectedNodesAsync(false /* normal termination */);
                 _noNodesActiveEvent.WaitOne();
 
-                // Wait for all of the actions in the work queue to drain.  Wait() could throw here if there was an unhandled exception 
-                // in the work queue, but the top level exception handler there should catch everything and have forwarded it to the 
+                // Wait for all of the actions in the work queue to drain.  Wait() could throw here if there was an unhandled exception
+                // in the work queue, but the top level exception handler there should catch everything and have forwarded it to the
                 // OnThreadException method in this class already.
                 _workQueue.Complete();
 
@@ -658,11 +658,11 @@ namespace Microsoft.Build.Execution
                     {
                         BuildResult result = _resultsCache.GetResultsForConfiguration(projectStartedEvent.Value.BuildEventContext.ProjectInstanceId);
 
-                        // It's valid to have a mismatched project started event IFF that particular 
-                        // project had some sort of unhandled exception.  If there is no result, we 
-                        // can't tell for sure one way or the other, so err on the side of throwing 
-                        // the assert, but if there is a result, make sure that it actually has an 
-                        // exception attached. 
+                        // It's valid to have a mismatched project started event IFF that particular
+                        // project had some sort of unhandled exception.  If there is no result, we
+                        // can't tell for sure one way or the other, so err on the side of throwing
+                        // the assert, but if there is a result, make sure that it actually has an
+                        // exception attached.
                         if (result == null || result.Exception == null)
                         {
                             allMismatchedProjectStartedEventsDueToLoggerErrors = false;
@@ -672,7 +672,7 @@ namespace Microsoft.Build.Execution
 
                     Debug.Assert(allMismatchedProjectStartedEventsDueToLoggerErrors, "There was a mismatched project started event not caused by an exception result");
                 }
-#endif 
+#endif
             }
             finally
             {
@@ -743,7 +743,7 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
-        /// Dispose of the build manager. 
+        /// Dispose of the build manager.
         /// </summary>
         public void Dispose()
         {
@@ -925,7 +925,7 @@ namespace Microsoft.Build.Execution
                 // We've already processed it, nothing to do.
                 return;
             }
-            
+
             ErrorUtilities.VerifyThrow(FileUtilities.IsSolutionFilename(config.ProjectFullPath), "{0} is not a solution", config.ProjectFullPath);
             ProjectInstance[] instances = ProjectInstance.LoadSolutionForBuild(config.ProjectFullPath, config.GlobalProperties, config.ExplicitToolsVersionSpecified ? config.ToolsVersion : null, _buildParameters, ((IBuildComponentHost)this).LoggingService, request.BuildEventContext, false /* loaded by solution parser*/, config.TargetNames, SdkResolverService, request.SubmissionId);
 
@@ -1009,7 +1009,7 @@ namespace Microsoft.Build.Execution
                 }
                 catch (Exception ex)
                 {
-                    // These need to go to the main thread exception handler.  We can't rethrow here because that will just silently stop the 
+                    // These need to go to the main thread exception handler.  We can't rethrow here because that will just silently stop the
                     // action block.  Instead, send them over to the main handler for the BuildManager.
                     this.OnThreadException(ex);
                 }
@@ -1074,7 +1074,7 @@ namespace Microsoft.Build.Execution
                         break;
 
                     case NodePacketType.NodeShutdown:
-                        // Remove the node from the list of active nodes.  When they are all done, we have shut down fully                                        
+                        // Remove the node from the list of active nodes.  When they are all done, we have shut down fully
                         NodeShutdown shutdownPacket = ExpectPacketType<NodeShutdown>(packet, NodePacketType.NodeShutdown);
                         HandleNodeShutdown(node, shutdownPacket);
                         break;
@@ -1192,9 +1192,9 @@ namespace Microsoft.Build.Execution
             // If we are aborting, we will NOT reuse the nodes because their state may be compromised by attempts to shut down while the build is in-progress.
             _nodeManager.ShutdownConnectedNodes(abort ? false : _buildParameters.EnableNodeReuse);
 
-            // if we are aborting, the task host will hear about it in time through the task building infrastructure; 
+            // if we are aborting, the task host will hear about it in time through the task building infrastructure;
             // so only shut down the task host nodes if we're shutting down tidily (in which case, it is assumed that all
-            // tasks are finished building and thus that there's no risk of a race between the two shutdown pathways).  
+            // tasks are finished building and thus that there's no risk of a race between the two shutdown pathways).
             if (!abort)
             {
                 _taskHostNodeManager.ShutdownConnectedNodes(_buildParameters.EnableNodeReuse);
@@ -1323,7 +1323,7 @@ namespace Microsoft.Build.Execution
             else if (unresolvedConfiguration.Project != null && resolvedConfiguration.Project == null)
             {
                 // Workaround for https://github.com/Microsoft/msbuild/issues/1748
-                // If the submission has a project instance but the existing configuration does not, it probably means that the project was 
+                // If the submission has a project instance but the existing configuration does not, it probably means that the project was
                 // built on another node (e.g. the project was encountered as a p2p reference and scheduled to a node).
                 // Add a dummy property to force cache invalidation in the scheduler and the nodes.
                 // TODO find a better solution than a dummy property
@@ -1363,7 +1363,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private void HandleNewRequest(int node, BuildRequestBlocker blocker)
         {
-            // If we received any solution files, populate their configurations now.          
+            // If we received any solution files, populate their configurations now.
             if (blocker.BuildRequests != null)
             {
                 foreach (BuildRequest request in blocker.BuildRequests)
@@ -1424,7 +1424,7 @@ namespace Microsoft.Build.Execution
             {
                 // If the result has Default and Initial targets, we populate the configuration cache with them if it
                 // doesn't already have entries.  This can happen if we created a configuration based on a request from
-                // an external node, but hadn't yet received a result since we may not have loaded the Project locally 
+                // an external node, but hadn't yet received a result since we may not have loaded the Project locally
                 // and thus wouldn't know what the default and initial targets were.
                 if (configuration.ProjectDefaultTargets == null)
                 {
@@ -1458,7 +1458,7 @@ namespace Microsoft.Build.Execution
                     foreach (BuildSubmission submission in _buildSubmissions.Values)
                     {
                         BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, BuildEventContext.InvalidNodeId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                        loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node);
+                        loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath);
                     }
                 }
                 else if (shutdownPacket.Reason == NodeShutdownReason.Error && _buildSubmissions.Values.Count == 0)
@@ -1467,7 +1467,7 @@ namespace Microsoft.Build.Execution
                     if (shutdownPacket.Exception != null)
                     {
                         ILoggingService loggingService = ((IBuildComponentHost)this).GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-                        loggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", shutdownPacket.Exception.ToString());
+                        loggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", shutdownPacket.Exception.ToString(), ExceptionHandling.DebugDumpPath);
                         OnThreadException(shutdownPacket.Exception);
                     }
                 }
@@ -1694,7 +1694,7 @@ namespace Microsoft.Build.Execution
         {
             if (null == _nodeConfiguration)
             {
-                // Get the remote loggers                
+                // Get the remote loggers
                 ILoggingService loggingService = ((IBuildComponentHost)this).GetComponent(BuildComponentType.LoggingService) as ILoggingService;
                 List<LoggerDescription> remoteLoggers = new List<LoggerDescription>(loggingService.LoggerDescriptions);
 
@@ -1927,8 +1927,8 @@ namespace Microsoft.Build.Execution
             }
             finally
             {
-                // Even if an exception is thrown, we want to make sure we null out the logging service so that 
-                // we don't try to shut it down again in some other cleanup code. 
+                // Even if an exception is thrown, we want to make sure we null out the logging service so that
+                // we don't try to shut it down again in some other cleanup code.
                 _componentFactories.ReplaceFactory(BuildComponentType.LoggingService, (IBuildComponent)null);
             }
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -187,7 +187,7 @@
     <comment>{StrBegin="MSB4162: "}</comment>
   </data>
   <data name="ChildExitedPrematurely" UESanitized="false" Visibility="Public">
-    <value>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</value>
+    <value>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</value>
     <comment>{StrBegin="MSB4166: "}</comment>
   </data>
   <data name="ChooseMustContainWhen" UESanitized="false" Visibility="Public">
@@ -245,7 +245,7 @@
     <value>Importing the file "{0}" into the file "{1}" results in a circular dependency.</value>
     <comment>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </comment>
   </data>
   <data name="SearchPathsForMSBuildExtensionsPath">
@@ -299,11 +299,11 @@
   <data name="UsedUninitializedProperty" Visibility="Public">
     <value>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</value>
     <comment>{StrBegin="MSB4211: "}</comment>
-  </data>  
+  </data>
   <data name="SelfImport" Visibility="Public">
     <value>MSB4210: "{0}" is attempting to import itself, directly or indirectly. This is most likely a build authoring error. The import will be ignored.</value>
     <comment>{StrBegin="MSB4210: "}</comment>
-  </data>  
+  </data>
   <data name="DuplicateProjectExtensions" UESanitized="false" Visibility="Public">
     <value>MSB4079: The &lt;ProjectExtensions&gt; element occurs more than once.</value>
     <comment>{StrBegin="MSB4079: "}</comment>
@@ -927,16 +927,16 @@
     <value>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</value>
     <comment>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</comment>
   </data>
-  
+
   <!-- ====================================================================== -->
-  
+
   <!-- TargetStartedEventArgs: Project and File paths are different -->
   <data name="TargetStartedFileProject" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}" from project "{2}":</value>
-  </data>  
+  </data>
   <data name="TargetStartedFileProjectEntry" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}" from project "{2}" (entry point):</value>
-  </data>    
+  </data>
   <data name="TargetStartedFileProjectDepends" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}" from project "{2}" (target "{3}" depends on it):</value>
   </data>
@@ -945,15 +945,15 @@
   </data>
   <data name="TargetStartedFileProjectAfter" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}" from project "{2}" (designated to run after target "{3}"):</value>
-  </data> 
-  
+  </data>
+
   <!-- TargetStartedEventArgs: Project and File paths are the same -->
   <data name="TargetStarted" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in project "{1}":</value>
-  </data>  
+  </data>
   <data name="TargetStartedProjectEntry" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in project "{1}" (entry point):</value>
-  </data>    
+  </data>
   <data name="TargetStartedProjectDepends" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in project "{1}" (target "{2}" depends on it):</value>
   </data>
@@ -962,28 +962,28 @@
   </data>
   <data name="TargetStartedProjectAfter" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in project "{1}" (designated to run after target "{2}"):</value>
-  </data>   
-  
+  </data>
+
   <!-- Serial logger low verbosity -->
   <data name="TargetStartedPrefix" UESanitized="false" Visibility="Public">
     <value>Target {0}:</value>
   </data>
-  
+
   <!-- Serial logger high verbosity -->
   <data name="TargetStartedFromFile" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}":</value>
   </data>
-  
+
   <!-- Parallel logger low verbosity -->
   <data name="TargetStartedPrefixInProject" UESanitized="false" Visibility="Public">
     <value>Target {0} from project "{1}":</value>
   </data>
-  
+
   <!-- Parallel logger high verbosity -->
   <data name="TargetStartedFromFileInProject" UESanitized="false" Visibility="Public">
     <value>Target "{0}" in file "{1}" from project "{2}":</value>
   </data>
-  
+
   <!-- Log messages for item/property group -->
   <data name="ItemGroupIncludeLogMessagePrefix" UESanitized="false" Visibility="Public">
     <value>Added Item(s): </value>
@@ -994,7 +994,7 @@
   <data name="PropertyGroupLogMessage" UESanitized="false" Visibility="Public">
     <value>Set Property: {0}={1}</value>
   </data>
-  
+
   <!-- Log messages for target outputs -->
   <data name="OutputItemParameterMessagePrefix" UESanitized="false" Visibility="Public">
     <value>Output Item(s): </value>
@@ -1002,9 +1002,9 @@
   <data name="OutputPropertyLogMessage" UESanitized="false" Visibility="Public">
     <value>Output Property: {0}={1}</value>
   </data>
-  
+
   <!-- ====================================================================== -->
-  
+
   <data name="TaskContinuedDueToContinueOnError" UESanitized="false" Visibility="Public">
       <value>Build continuing because "{0}" on the task "{1}" is set to "{2}".</value>
   </data>
@@ -1122,7 +1122,7 @@
   </data>
   <data name="TaskParameterPrefix" UESanitized="false" Visibility="Public">
     <value>Task Parameter:</value>
-  </data>  
+  </data>
   <data name="TaskPerformanceSummary" UESanitized="false" Visibility="Public">
     <value>Task Performance Summary:</value>
   </data>
@@ -1461,7 +1461,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <data name="OM_CannotSaveFileLoadedAsReadOnly">
     <value>Project or targets file "{0}" was loaded in read-only mode, and cannot be saved.</value>
-  </data>  
+  </data>
   <!-- #################################################################################################-->
   <!-- ############################## Evaluation-model-related strings #################################-->
   <!-- #################################################################################################-->
@@ -1501,10 +1501,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <value>The project XML file "{0}" cannot be unloaded because at least one project "{1}" is still loaded which references that project XML.</value>
   </data>
   <data name="OM_ProjectInstanceImmutable">
-    <value>Instance object was created as immutable.</value>    
+    <value>Instance object was created as immutable.</value>
   </data>
   <data name="OM_NotEvaluatedBecauseShouldEvaluateForDesignTimeIsFalse">
-    <value>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</value>    
+    <value>The specified API "{0}" is not available because ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition was set when loading this project.</value>
   </data>
   <!-- #################################################################################################-->
   <!-- ############################## Execution-model-related strings #################################-->
@@ -1572,7 +1572,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>LOCALIZATION:  Do not localize the words "RunEachTargetSeparately", "BuildingInParallel", or "StopOnFirstFailure".</comment>
   </data>
 
-  <!-- 
+  <!--
   Some General properties replicated from tasks for MSBuild task
   TODO: Are these ever used anywhere else?
   -->
@@ -1598,13 +1598,13 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="General.ProjectUndefineProperties">
     <value>Removing Properties for project "{0}":</value>
   </data>
-  
+
   <!-- Engine errors for features not supported on .NET Core have the arbitrarily-chosen 48 prefix -->
   <data name="TaskInstantiationFailureNotSupported" xml:space="preserve">
     <value>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</value>
     <comment>{StrBegin="MSB4802: "}</comment>
   </data>
-  
+
   <data name="InvalidGetPathOfFileAboveParameter">
     <value>The parameter '{0}' can only be a file name and cannot include a directory.</value>
   </data>
@@ -1627,7 +1627,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="ProjectImportSkippedFalseCondition">
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</value>
   </data>
-  
+
   <data name="ProjectImportSkippedNoMatches">
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to no matching files.</value>
   </data>
@@ -1676,12 +1676,12 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
-        
+
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
         Next message code should be MSB4245.
-              
+
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech s názvy MSBuild_*.failure.txt v adresáři s dočasnými soubory.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech s názvy MSBuild_*.failure.txt v adresáři s dočasnými soubory.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">Import souboru {0} do souboru {1} má za následek cyklickou závislost.</target>
+        <target state="needs-review-translation">Import souboru {0} do souboru {1} má za následek cyklickou závislost.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Herunterfahren. Diagnoseinformationen finden Sie in den Dateien des Verzeichnisses für temporäre Dateien mit dem Namen MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Herunterfahren. Diagnoseinformationen finden Sie in den Dateien des Verzeichnisses für temporäre Dateien mit dem Namen MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">Der Import der Datei "{0}" in die Datei "{1}" führt zu einer Ringabhängigkeit.</target>
+        <target state="needs-review-translation">Der Import der Datei "{0}" in die Datei "{1}" führt zu einer Ringabhängigkeit.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -244,7 +244,7 @@
         <target state="new">Importing the file "{0}" into the file "{1}" results in a circular dependency.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos del directorio de archivos temporales denominado MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos del directorio de archivos temporales denominado MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">Si se importa el archivo "{0}" en el archivo "{1}", se producirá una dependencia circular.</target>
+        <target state="needs-review-translation">Si se importa el archivo "{0}" en el archivo "{1}", se producirá una dependencia circular.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: Fin prématurée du nœud enfant "{0}". Arrêt. Des informations de diagnostic se trouvent dans le répertoire de fichiers temporaires dans des fichiers nommés MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: Fin prématurée du nœud enfant "{0}". Arrêt. Des informations de diagnostic se trouvent dans le répertoire de fichiers temporaires dans des fichiers nommés MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">L'importation du fichier "{0}" dans le fichier "{1}" produit une dépendance circulaire.</target>
+        <target state="needs-review-translation">L'importation du fichier "{0}" dans le fichier "{1}" produit une dépendance circulaire.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Chiusura in corso. Le informazioni diagnostiche sono disponibili nei file presenti nella directory dei file temporanei denominata MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Chiusura in corso. Le informazioni diagnostiche sono disponibili nei file presenti nella directory dei file temporanei denominata MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">L'importazione del file "{0}" nel file "{1}" causa una dipendenza circolare.</target>
+        <target state="needs-review-translation">L'importazione del file "{0}" nel file "{1}" causa una dipendenza circolare.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャットダウンしています。診断情報は、MSBuild_*.failure.txt という名前の一時ファイル ディレクトリのファイル内で見つかる可能性があります。</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャットダウンしています。診断情報は、MSBuild_*.failure.txt という名前の一時ファイル ディレクトリのファイル内で見つかる可能性があります。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">ファイル "{0}" をファイル "{1}" にインポートすると、循環する依存関係が生じます。</target>
+        <target state="needs-review-translation">ファイル "{0}" をファイル "{1}" にインポートすると、循環する依存関係が生じます。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료합니다. 임시 파일 디렉터리의 파일(MSBuild_*.failure.txt)에서 진단 정보를 찾을 수 있습니다.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료합니다. 임시 파일 디렉터리의 파일(MSBuild_*.failure.txt)에서 진단 정보를 찾을 수 있습니다.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">"{0}" 파일을 "{1}" 파일로 가져오면 순환 종속성이 발생합니다.</target>
+        <target state="needs-review-translation">"{0}" 파일을 "{1}" 파일로 가져오면 순환 종속성이 발생합니다.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Nastąpi zamknięcie. Informacje diagnostyczne znajdują się w katalogu plików tymczasowych o nazwie MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Nastąpi zamknięcie. Informacje diagnostyczne znajdują się w katalogu plików tymczasowych o nazwie MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">Importowanie pliku {0} do pliku {1} powoduje powstanie zależności cyklicznej.</target>
+        <target state="needs-review-translation">Importowanie pliku {0} do pliku {1} powoduje powstanie zależności cyklicznej.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. É possível encontrar informações de diagnóstico em arquivos do diretório de arquivos temporários chamado MSBuild_*.failure.txt.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. É possível encontrar informações de diagnóstico em arquivos do diretório de arquivos temporários chamado MSBuild_*.failure.txt.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">A importação do arquivo "{0}" no arquivo "{1}" resultará em uma dependência circular.</target>
+        <target state="needs-review-translation">A importação do arquivo "{0}" no arquivo "{1}" resultará em uma dependência circular.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: произошел преждевременный выход дочернего узла "{0}". Выполняется завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt каталога временных файлов.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: произошел преждевременный выход дочернего узла "{0}". Выполняется завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt каталога временных файлов.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">Импорт файла "{0}" в файл "{1}" приводит к циклической зависимости.</target>
+        <target state="needs-review-translation">Импорт файла "{0}" в файл "{1}" приводит к циклической зависимости.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri geçici dosyalar dizininde MSBuild_*.failure.txt adlı dosyalarda bulunabilir.</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri geçici dosyalar dizininde MSBuild_*.failure.txt adlı dosyalarda bulunabilir.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">"{0}" dosyasını "{1}" dosyasına içeri aktarma işlemi döngüsel bağımlılıkla sonuçlandı.</target>
+        <target state="needs-review-translation">"{0}" dosyasını "{1}" dosyasına içeri aktarma işlemi döngüsel bağımlılıkla sonuçlandı.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在临时文件目录中名为 MSBuild_*.failure.txt 的文件内找到诊断信息。</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在临时文件目录中名为 MSBuild_*.failure.txt 的文件内找到诊断信息。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">若将文件“{0}”导入到文件“{1}”中，将会产生循环依赖项。</target>
+        <target state="needs-review-translation">若将文件“{0}”导入到文件“{1}”中，将会产生循环依赖项。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -173,8 +173,8 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in the temporary files directory named MSBuild_*.failure.txt.</source>
-        <target state="translated">MSB4166: 子節點 "{0}" 不當結束。即將關閉。在暫存檔目錄名為 MSBuild_*.failure.txt 的檔案中可以找到診斷資訊。</target>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
+        <target state="needs-review-translation">MSB4166: 子節點 "{0}" 不當結束。即將關閉。在暫存檔目錄名為 MSBuild_*.failure.txt 的檔案中可以找到診斷資訊。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,10 +241,10 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="translated">將檔案 "{0}" 匯入檔案 "{1}" 會造成循環相依性。</target>
+        <target state="needs-review-translation">將檔案 "{0}" 匯入檔案 "{1}" 會造成循環相依性。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
-       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency. 
+       t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
     </note>
       </trans-unit>
       <trans-unit id="SearchPathsForMSBuildExtensionsPath">

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -31,6 +31,30 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class ExceptionHandling
     {
+        private static readonly string s_debugDumpPath;
+
+        static ExceptionHandling()
+        {
+            s_debugDumpPath = GetDebugDumpPath();
+        }
+
+        /// <summary>
+        /// Gets the location of the directory used for diagnostic log files.
+        /// </summary>
+        /// <returns></returns>
+        private static string GetDebugDumpPath()
+        {
+            string debugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            return !string.IsNullOrEmpty(debugPath)
+                    ? debugPath
+                    : Path.GetTempPath();
+        }
+
+        /// <summary>
+        /// The directory used for diagnostic log files.
+        /// </summary>
+        internal static string DebugDumpPath => s_debugDumpPath;
+
 #if !BUILDINGAPPXTASKS
         /// <summary>
         /// The filename that exceptions will be dumped to
@@ -65,7 +89,7 @@ namespace Microsoft.Build.Shared
                 return true;
             }
 
-#if !CLR2COMPATIBILITY            
+#if !CLR2COMPATIBILITY
             // Check if any critical exceptions
             var aggregateException = e as AggregateException;
 
@@ -207,7 +231,7 @@ namespace Microsoft.Build.Shared
 #if FEATURE_VARIOUS_EXCEPTIONS
                 || e is CustomAttributeFormatException  // thrown if a custom attribute on a data type is formatted incorrectly
                 || e is InvalidFilterCriteriaException  // thrown in FindMembers when the filter criteria is not valid for the type of filter you are using
-                || e is TargetException                 // thrown when an attempt is made to invoke a non-static method on a null object.  This may occur because the caller does not 
+                || e is TargetException                 // thrown when an attempt is made to invoke a non-static method on a null object.  This may occur because the caller does not
                                                         //     have access to the member, or because the target does not define the member, and so on.
 #endif
                 || e is MissingFieldException           // thrown when code in a dependent assembly attempts to access a missing field in an assembly that was modified.
@@ -293,30 +317,26 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static void DumpExceptionToFile(Exception ex)
         {
-            //  Locking on a type is not recommended.  However, we are doing it here to be extra cautious about compatibility because 
-            //  this method previously had a [MethodImpl(MethodImplOptions.Synchronized)] attribute, which does lock on the type when 
+            //  Locking on a type is not recommended.  However, we are doing it here to be extra cautious about compatibility because
+            //  this method previously had a [MethodImpl(MethodImplOptions.Synchronized)] attribute, which does lock on the type when
             //  applied to a static method.
             lock (typeof(ExceptionHandling))
             {
                 if (s_dumpFileName == null)
                 {
                     Guid guid = Guid.NewGuid();
-                    string dumpDirEnv = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
-                    string dumpDir = !string.IsNullOrEmpty(dumpDirEnv)
-                            ? dumpDirEnv
-                            : Path.GetTempPath();
 
                     // For some reason we get Watson buckets because GetTempPath gives us a folder here that doesn't exist.
                     // Either because %TMP% is misdefined, or because they deleted the temp folder during the build.
-                    if (!Directory.Exists(dumpDir))
+                    if (!Directory.Exists(DebugDumpPath))
                     {
                         // If this throws, no sense catching it, we can't log it now, and we're here
                         // because we're a child node with no console to log to, so die
-                        Directory.CreateDirectory(dumpDir);
+                        Directory.CreateDirectory(DebugDumpPath);
                     }
 
                     var pid = Process.GetCurrentProcess().Id;
-                    s_dumpFileName = Path.Combine(dumpDir, $"MSBuild_pid-{pid}_{guid:n}.failure.txt");
+                    s_dumpFileName = Path.Combine(DebugDumpPath, $"MSBuild_pid-{pid}_{guid:n}.failure.txt");
 
                     using (StreamWriter writer = FileUtilities.OpenWrite(s_dumpFileName, append: true))
                     {


### PR DESCRIPTION
Currently trying to figure out why the build is failing inside an Alpine Linux docker container, but I can't get the log files because the container file system is automatically cleaned up.

This supports setting MSBUILDDEBUGPATH to control where MSBuild dump files are written.

cref https://github.com/Microsoft/msbuild/issues/1038

cc @cdmihai
