### PR TITLE
Add property to suppress error from GetReferenceAssemblyPaths when the path can't be found

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -632,6 +632,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string[] ReferenceAssemblyPaths { get { throw null; } }
         public string RootPath { get { throw null; } set { } }
+        public bool SuppressNotFoundError { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetFrameworkMoniker { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public string TargetFrameworkMonikerDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -390,6 +390,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public string[] ReferenceAssemblyPaths { get { throw null; } }
         public string RootPath { get { throw null; } set { } }
+        public bool SuppressNotFoundError { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetFrameworkMoniker { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public string TargetFrameworkMonikerDisplayName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
+++ b/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
@@ -171,6 +171,24 @@ namespace Microsoft.Build.UnitTests
             engine.AssertLogContains("ERROR MSB3644: " + message);
         }
 
+        [Fact]
+        public void TestSuppressNotFoundError()
+        {
+            MockEngine engine = new MockEngine();
+            GetReferenceAssemblyPaths getReferencePaths = new GetReferenceAssemblyPaths();
+            getReferencePaths.BuildEngine = engine;
+            // Make a framework which does not exist, intentional misspelling of framework
+            getReferencePaths.TargetFrameworkMoniker = ".NetFramewok, Version=v99.0";
+            getReferencePaths.SuppressNotFoundError = true;
+            bool success = getReferencePaths.Execute();
+            Assert.True(success);
+            string[] returnedPaths = getReferencePaths.ReferenceAssemblyPaths;
+            Assert.Equal(0, returnedPaths.Length);
+            string displayName = getReferencePaths.TargetFrameworkMonikerDisplayName;
+            Assert.Null(displayName);
+            Assert.Equal(0, engine.Errors);
+        }
+
         /// <summary>
         /// Test the case where there is a good target framework moniker passed in.
         /// </summary>

--- a/src/Tasks/GetReferenceAssemblyPaths.cs
+++ b/src/Tasks/GetReferenceAssemblyPaths.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Build.Tasks
         }
 
         /// <summary>
+        /// If set to true, the task will not generate an error (or a warning) if the reference assemblies cannot be found.
+        /// This allows the task to be used to check whether reference assemblies for a framework are available.
+        /// </summary>
+        public bool SuppressNotFoundError { get; set; }
+
+        /// <summary>
         /// Gets the display name for the targetframeworkmoniker
         /// </summary>
         [Output]
@@ -285,11 +291,14 @@ namespace Microsoft.Build.Tasks
                 pathsToReturn = ToolLocationHelper.GetPathToReferenceAssemblies(rootPath, frameworkmoniker);
             }
 
-            // No reference assembly paths could be found, log an error so an invalid build will not be produced.
-            // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).
-            if (pathsToReturn.Count == 0)
+            if (!SuppressNotFoundError)
             {
-                Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
+                // No reference assembly paths could be found, log an error so an invalid build will not be produced.
+                // 1/26/16: Note this was changed from a warning to an error (see GitHub #173).
+                if (pathsToReturn.Count == 0)
+                {
+                    Log.LogErrorWithCodeFromResources("GetReferenceAssemblyPaths.NoReferenceAssemblyDirectoryFound", frameworkmoniker.ToString());
+                }
             }
 
             return pathsToReturn;


### PR DESCRIPTION
This should allow the .NET SDK to check if a given targeting pack is installed, and if not, fall back to referencing a NuGet package with the reference assemblies.

The full proposal is here: https://github.com/dotnet/designs/pull/33