### PR TITLE
.NET Core node reuse redux

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -25,6 +25,7 @@
                 "bin/Microsoft.Build.Conversion/net46/Microsoft.Build.Conversion.Core.dll",
 
                 "bin/MSBuild/netcoreapp2.0/MSBuild.dll",
+                "bin/MSBuild/netcoreapp2.0/Microsoft.Build.dll",
 
                 "bin/MSBuild/netcoreapp2.1/MSBuild.dll",
                 "bin/MSBuild/netcoreapp2.1/Microsoft.Build.dll",

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1093,7 +1093,7 @@ namespace Microsoft.Build.Execution
     }
     public partial class OutOfProcNode
     {
-        public OutOfProcNode(string clientToServerPipeHandle, string serverToClientPipeHandle) { }
+        public OutOfProcNode() { }
         public Microsoft.Build.Execution.NodeEngineShutdownReason Run(bool enableReuse, out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
         public Microsoft.Build.Execution.NodeEngineShutdownReason Run(out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
     }

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -3445,7 +3445,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
                     var parameters = new BuildParameters
                     {
-                        DisableInProcNode = true
+                        DisableInProcNode = true,
+                        EnableNodeReuse = false,
                     };
 
                     manager.BeginBuild(parameters);
@@ -3514,6 +3515,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var buildParameters = new BuildParameters(_projectCollection)
             {
                 DisableInProcNode = true,
+                EnableNodeReuse = false,
                 Loggers = new ILogger[] {_logger}
             };
 
@@ -3604,6 +3606,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 var parameters = new BuildParameters(_projectCollection)
                 {
                     DisableInProcNode = true,
+                    EnableNodeReuse = false,
                     Loggers = new ILogger[] {_logger}
                 };
 
@@ -3685,6 +3688,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             var buildParameters = new BuildParameters(_projectCollection)
             {
                 DisableInProcNode = true,
+                EnableNodeReuse = false,
                 Loggers = new ILogger[] { _logger }
             };
 

--- a/src/Build.UnitTests/EvaluationProfiler_Tests.cs
+++ b/src/Build.UnitTests/EvaluationProfiler_Tests.cs
@@ -252,6 +252,7 @@ namespace Microsoft.Build.Engine.UnitTests
                 ShutdownInProcNodeOnBuildFinish = true,
                 Loggers = new ILogger[] { profilerLogger },
                 DisableInProcNode = true, // This is actually important since we also want to test the serialization of the events
+                EnableNodeReuse = false,
                 ProjectLoadSettings = ProjectLoadSettings.ProfileEvaluation
             };
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Build.BackEnd
             int retries = NodeCreationRetries;
             while (retries-- > 0)
             {
-#if FEATURE_NODE_REUSE
+#if FEATURE_NET35_TASKHOST
                 // We will also check to see if .NET 3.5 is installed in the case where we need to launch a CLR2 OOP TaskHost.
                 // Failure to detect this has been known to stall builds when Windows pops up a related dialog.
                 // It's also a waste of time when we attempt several times to launch multiple MSBuildTaskHost.exe (CLR2 TaskHost)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -290,16 +290,15 @@ namespace Microsoft.Build.BackEnd
                 msbuildLocation = "MSBuild.exe";
             }
 
-
             msbuildName = Path.GetFileNameWithoutExtension(msbuildLocation);
 
-            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(msbuildName));
+            var expectedProcessName = Path.GetFileNameWithoutExtension(GetCurrentHost()) ?? msbuildName;
+
+            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(expectedProcessName));
 
             // Trivial sort to try to prefer most recently used nodes
-            nodeProcesses.Sort
-            (
-                delegate(Process left, Process right) { return left.Id - right.Id; }
-            );
+            nodeProcesses.Sort((left, right) => left.Id - right.Id);
+
             return nodeProcesses;
         }
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -15,9 +15,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
-#if FEATURE_SECURITY_PERMISSIONS
 using System.Security.Permissions;
-#endif
 
 using Microsoft.Build.Shared;
 using Microsoft.Build.Exceptions;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -163,44 +163,11 @@ namespace Microsoft.Build.BackEnd
             }
 #endif
 
-            if (String.IsNullOrEmpty(msbuildLocation))
-            {
-                msbuildLocation = _componentHost.BuildParameters.NodeExeLocation;
-            }
-
-            if (String.IsNullOrEmpty(msbuildLocation))
-            {
-                string msbuildExeName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
-
-                if (!String.IsNullOrEmpty(msbuildExeName))
-                {
-                    // we assume that MSBUILD_EXE_NAME is, in fact, just the name.  
-                    msbuildLocation = Path.Combine(msbuildExeName, ".exe");
-                }
-            }
-
-            if (String.IsNullOrEmpty(msbuildLocation))
-            {
-                msbuildLocation = "MSBuild.exe";
-            }
-
-#if FEATURE_NODE_REUSE
-            string msbuildName = Path.GetFileNameWithoutExtension(msbuildLocation);
-
-            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(msbuildName));
-
-            // Trivial sort to try to prefer most recently used nodes
-            nodeProcesses.Sort
-                (
-                delegate (Process left, Process right)
-                {
-                    return left.Id - right.Id;
-                }
-
-                );
+            string msbuildName;
+            var candidateProcesses = GetPossibleRunningNodes(out msbuildName, ref msbuildLocation);
 
             CommunicationsUtilities.Trace("Attempting to connect to each existing msbuild.exe process in turn to establish node {0}...", nodeId);
-            foreach (Process nodeProcess in nodeProcesses)
+            foreach (Process nodeProcess in candidateProcesses)
             {
                 if (nodeProcess.Id == Process.GetCurrentProcess().Id)
                 {
@@ -226,7 +193,6 @@ namespace Microsoft.Build.BackEnd
                     return new NodeContext(nodeId, nodeProcess.Id, nodeStream, factory, terminateNode);
                 }
             }
-#endif
 
             // None of the processes we tried to connect to allowed a connection, so create a new one.
             // We try this in a loop because it is possible that there is another MSBuild multiproc
@@ -299,6 +265,42 @@ namespace Microsoft.Build.BackEnd
             // We were unable to launch a node.
             CommunicationsUtilities.Trace("FAILED TO CONNECT TO A CHILD NODE");
             return null;
+        }
+
+        private List<Process> GetPossibleRunningNodes(out string msbuildName, ref string msbuildLocation)
+        {
+            if (String.IsNullOrEmpty(msbuildLocation))
+            {
+                msbuildLocation = _componentHost.BuildParameters.NodeExeLocation;
+            }
+
+            if (String.IsNullOrEmpty(msbuildLocation))
+            {
+                string msbuildExeName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
+
+                if (!String.IsNullOrEmpty(msbuildExeName))
+                {
+                    // we assume that MSBUILD_EXE_NAME is, in fact, just the name.
+                    msbuildLocation = Path.Combine(msbuildExeName, ".exe");
+                }
+            }
+
+            if (String.IsNullOrEmpty(msbuildLocation))
+            {
+                msbuildLocation = "MSBuild.exe";
+            }
+
+
+            msbuildName = Path.GetFileNameWithoutExtension(msbuildLocation);
+
+            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(msbuildName));
+
+            // Trivial sort to try to prefer most recently used nodes
+            nodeProcesses.Sort
+            (
+                delegate(Process left, Process right) { return left.Id - right.Id; }
+            );
+            return nodeProcesses;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -489,8 +489,7 @@ namespace Microsoft.Build.BackEnd
 
 #if RUNTIME_TYPE_NETCORE
             // Run the child process with the same host as the currently-running process.
-            string pathToHost;
-            using (Process currentProcess = Process.GetCurrentProcess()) pathToHost = currentProcess.MainModule.FileName;
+            var pathToHost = GetCurrentHost();
             commandLineArgs = "\"" + msbuildLocation + "\" " + commandLineArgs;
 
             ProcessStartInfo processStartInfo = new ProcessStartInfo();
@@ -569,6 +568,22 @@ namespace Microsoft.Build.BackEnd
 
             CommunicationsUtilities.Trace("Successfully launched msbuild.exe node with PID {0}", childProcessId);
             return childProcessId;
+#endif
+        }
+
+        /// <summary>
+        /// Identify the .NET host of the current process
+        /// </summary>
+        /// <returns>The full path to the executable hosting the current process, or null if running on Full Framework on Windows.</returns>
+        private static string GetCurrentHost()
+        {
+#if RUNTIME_TYPE_NETCORE
+            using (Process currentProcess = Process.GetCurrentProcess())
+            {
+                return currentProcess.MainModule.FileName;
+            }
+#else
+            return null;
 #endif
         }
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(RuntimeOutputTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Build</RootNamespace>
     <AssemblyName>Microsoft.Build</AssemblyName>
 
@@ -10,7 +10,8 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 
-    <GenerateReferenceAssemblySources>true</GenerateReferenceAssemblySources>
+    <!-- Generate API only for the more limited .NET Core flavor. -->
+    <GenerateReferenceAssemblySources Condition="'$(TargetFramework)' != 'netcoreapp2.0'">true</GenerateReferenceAssemblySources>
     <CreateTlb>true</CreateTlb>
     <IsPackable>true</IsPackable>
     <Description>This package contains the $(MSBuildProjectName) assembly which is used to create, edit, and evaluate MSBuild projects.</Description>
@@ -32,11 +33,13 @@
     <Reference Include="System.Configuration" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.IO.Pipes.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
   </ItemGroup>
@@ -73,9 +76,6 @@
     </Compile>
     <Compile Include="..\Shared\Compat\defaultbinder.cs">
       <Link>SharedUtilities\Compat\defaultbinder.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Compat\PipeSecurity.cs">
-      <Link>SharedUtilities\Compat\PipeSecurity.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -135,8 +135,8 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -87,6 +87,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_PRIORITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MULTIPLE_TOOLSETS</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
+    <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NET35_TASKHOST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_INVOKEMEMBER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETINTERFACE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_USERINTERACTIVE</DefineConstants>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -54,6 +54,7 @@
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_INSTALLED_MSBUILD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_LEGACY_GETFULLPATH</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_OSVERSION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PERFORMANCE_COUNTERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
@@ -130,6 +131,12 @@
     <DefineConstants>$(DefineConstants);FEATURE_PROCESSSTARTINFO_ENVIRONMENT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);USE_MSBUILD_DLL_EXTN</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
+    <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_PIPE_SECURITY</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -67,6 +67,7 @@
     <GenAPIAssemblyName Condition="'$(GenAPIAssemblyName)' == ''">$(MSBuildProjectName)</GenAPIAssemblyName>
     <GenAPIShortFrameworkIdentifier Condition="$(TargetFramework.StartsWith('net4'))">net</GenAPIShortFrameworkIdentifier>
     <GenAPIShortFrameworkIdentifier Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</GenAPIShortFrameworkIdentifier>
+    <GenAPIShortFrameworkIdentifier Condition="$(TargetFramework.StartsWith('netcoreapp'))">netstandard</GenAPIShortFrameworkIdentifier>
     <GenAPITargetPath>$(RepoRoot)ref\$(GenAPIAssemblyName)\$(GenAPIShortFrameworkIdentifier)\$(GenAPIAssemblyName).cs</GenAPITargetPath>
   </PropertyGroup>
   

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Build.BackEnd
                 PipeOptions.Asynchronous | PipeOptions.WriteThrough,
                 PipeBufferSize, // Default input buffer
                 PipeBufferSize  // Default output buffer
-#if FEATURE_PIPE_SECURITY
+#if FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR
                 , security,
                 HandleInheritability.None
 #endif

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -44,11 +44,33 @@ public class MSBuildTestAssemblyFixture : IDisposable
 
         //  Use a project-specific temporary path
         //  This is so multiple test projects can be run in parallel without sharing the same temp directory
-        string newTempPath = Path.Combine(AppContext.BaseDirectory, "TestTemp");
+        var subdirectory = Path.GetRandomFileName();
 
-        _testEnvironment.CreateFolder(newTempPath);
+        string newTempPath = Path.Combine(Path.GetTempPath(), subdirectory);
+        var assemblyTempFolder = _testEnvironment.CreateFolder(newTempPath);
 
-        _testEnvironment.SetTempPath(newTempPath);
+        _testEnvironment.SetTempPath(assemblyTempFolder.FolderPath);
+
+        _testEnvironment.CreateFile(
+            transientTestFolder: assemblyTempFolder,
+            fileName: "MSBuild_Tests.txt",
+            contents: $"Temporary test folder for tests from {AppContext.BaseDirectory}");
+
+        // Ensure that we stop looking for a D.B.rsp at the root of the test temp
+        _testEnvironment.CreateFile(
+            transientTestFolder: assemblyTempFolder,
+            fileName: "Directory.Build.rsp",
+            contents: string.Empty);
+
+        _testEnvironment.CreateFile(
+            transientTestFolder: assemblyTempFolder,
+            fileName: "Directory.Build.props",
+            contents: "<Project />");
+
+        _testEnvironment.CreateFile(
+            transientTestFolder: assemblyTempFolder,
+            fileName: "Directory.Build.targets",
+            contents: "<Project />");
     }
 
     /// <summary>

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -189,7 +189,12 @@ namespace Microsoft.Build.UnitTests
 
         public TransientTestFile CreateFile(string fileName, string contents = "")
         {
-            var file = WithTransientTestState(new TransientTestFile(DefaultTestDirectory.FolderPath, Path.GetFileNameWithoutExtension(fileName), Path.GetExtension(fileName)));
+            return CreateFile(DefaultTestDirectory, fileName, contents);
+        }
+
+        public TransientTestFile CreateFile(TransientTestFolder transientTestFolder, string fileName, string contents = "")
+        {
+            var file = WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, Path.GetFileNameWithoutExtension(fileName), Path.GetExtension(fileName)));
             File.WriteAllText(file.Path, contents);
 
             return file;


### PR DESCRIPTION
Enable node reuse for .NET Core (runtime 2.1+).

Interesting features:
* Attempts to connect to _every_ `dotnet` process, with no attempt to find only ones that are running MSBuild.
* There's an absolute length limit on the named pipe path of 108 chars on Linux. Tests setting custom temp dirs in deep paths ran afoul of this, so I changed the temp-path allocation strategy, which also required test-infrastructure changes that Mihai helped me figure out.
* I'm using the new `PipeOptions.CurrentUserOnly` as the only security mechanism on 2.1 and not running the old Windows-only validation code even on Windows.
* Long-lived worker nodes exposed #3091, which also manifested as a test hang. I fixed this in two ways:
  * Avoid `/nodereuse:true` in tests by explicitly setting it to `false` everywhere.
  * Changed process spawning on Windows to use the old `CreateProcess` codepath that explicitly stops inheriting stdout/stdin/stderr. See #3092 for proof that this works (Win tests don't hang) _without_ the test changes above.

For that last change, I highly recommend turning ignore-whitespace mode on for the diff; it's pretty clear when you do and baffling when you don't.