### PR TITLE
 Fix serialization issue with AssemblyNameExtension

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -27,7 +27,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CULTUREINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CLONE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BINARY_SERIALIZATION_EVENTARGS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>

--- a/src/Shared/AssemblyNameComparer.cs
+++ b/src/Shared/AssemblyNameComparer.cs
@@ -15,32 +15,32 @@ namespace Microsoft.Build.Shared
     /// IKeyComparer implementation that compares AssemblyNames for using in Hashtables.
     /// </summary>
     [Serializable]
-    sealed internal class AssemblyNameComparer : IComparer, IEqualityComparer, IEqualityComparer<AssemblyNameExtension>
+    internal sealed class AssemblyNameComparer : IComparer, IEqualityComparer, IEqualityComparer<AssemblyNameExtension>
     {
         /// <summary>
         /// Comparer for two assembly name extensions
         /// </summary>
-        internal readonly static IComparer Comparer = new AssemblyNameComparer(false);
+        internal static readonly IComparer Comparer = new AssemblyNameComparer(false);
 
         /// <summary>
         /// Comparer for two assembly name extensions
         /// </summary>
-        internal readonly static IComparer ComparerConsiderRetargetable = new AssemblyNameComparer(true);
+        internal static readonly IComparer ComparerConsiderRetargetable = new AssemblyNameComparer(true);
 
         /// <summary>
         /// Comparer for two assembly name extensions
         /// </summary>
-        internal readonly static IEqualityComparer<AssemblyNameExtension> GenericComparer = Comparer as IEqualityComparer<AssemblyNameExtension>;
+        internal static readonly IEqualityComparer<AssemblyNameExtension> GenericComparer = Comparer as IEqualityComparer<AssemblyNameExtension>;
 
         /// <summary>
         /// Comparer for two assembly name extensions
         /// </summary>
-        internal readonly static IEqualityComparer<AssemblyNameExtension> GenericComparerConsiderRetargetable = ComparerConsiderRetargetable as IEqualityComparer<AssemblyNameExtension>;
+        internal static readonly IEqualityComparer<AssemblyNameExtension> GenericComparerConsiderRetargetable = ComparerConsiderRetargetable as IEqualityComparer<AssemblyNameExtension>;
 
         /// <summary>
         /// Should the comparer consider the retargetable flag when doing comparisons
         /// </summary>
-        private bool considerRetargetableFlag;
+        private readonly bool considerRetargetableFlag;
 
         /// <summary>
         /// Private construct so there's only one instance.
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Treat o1 and o2 as AssemblyNames. Are they equal?
         /// </summary>
-        new public bool Equals(object o1, object o2)
+        public new bool Equals(object o1, object o2)
         {
             AssemblyNameExtension a1 = (AssemblyNameExtension)o1;
             AssemblyNameExtension a2 = (AssemblyNameExtension)o2;

--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -350,15 +350,7 @@ namespace Microsoft.Build.Shared
             {
                 // Is there a string?
                 CreateAssemblyName();
-#if FEATURE_ASSEMBLYNAME_CULTUREINFO
                 return asAssemblyName.CultureInfo;
-#else
-                if (asAssemblyName.CultureName == null)
-                {
-                    return null;
-                }
-                return new CultureInfo(asAssemblyName.CultureName);
-#endif
             }
         }
 
@@ -752,7 +744,6 @@ namespace Microsoft.Build.Shared
         internal static bool CompareCultures(AssemblyName a, AssemblyName b)
         {
             // Do the Cultures match?
-#if FEATURE_ASSEMBLYNAME_CULTUREINFO
             CultureInfo aCulture = a.CultureInfo;
             CultureInfo bCulture = b.CultureInfo;
             if (aCulture == null)
@@ -764,31 +755,7 @@ namespace Microsoft.Build.Shared
                 bCulture = CultureInfo.InvariantCulture;
             }
 
-            if (aCulture.LCID != bCulture.LCID)
-            {
-                return false;
-            }
-
-            return true;
-#else
-            string aCulture = a.CultureName;
-            string bCulture = b.CultureName;
-            if (aCulture == null)
-            {
-                aCulture = CultureInfo.InvariantCulture.Name;
-            }
-            if (bCulture == null)
-            {
-                bCulture = CultureInfo.InvariantCulture.Name;
-            }
-
-            if (aCulture != bCulture)
-            {
-                return false;
-            }
-
-            return true;
-#endif
+            return aCulture.LCID == bCulture.LCID;
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/AssemblyNameEx_Tests.cs
+++ b/src/Shared/UnitTests/AssemblyNameEx_Tests.cs
@@ -220,11 +220,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// General equals comparison validator.
         /// </summary>
-#if FEATURE_ASSEMBLYNAME_CULTUREINFO
         [Fact]
-#else
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/252")]
-#endif
         public void Equals()
         {
             // For each pair of assembly strings...
@@ -265,11 +261,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// General equals comparison validator when we are ignoring the version numbers in the name.
         /// </summary>
-#if FEATURE_ASSEMBLYNAME_CULTUREINFO
         [Fact]
-#else
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/252")]
-#endif
         public void EqualsIgnoreVersion()
         {
             // For each pair of assembly strings...

--- a/src/Shared/UnitTests/AssemblyNameEx_Tests.cs
+++ b/src/Shared/UnitTests/AssemblyNameEx_Tests.cs
@@ -5,8 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Build.Shared;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -675,6 +678,69 @@ namespace Microsoft.Build.UnitTests
             Assert.True(assemblies[0].Equals(x));
             Assert.True(assemblies[1].Equals(z));
             Assert.True(assemblies[2].Equals(y));
+        }
+
+        [Theory]
+        [InlineData("System.Xml")]
+        [InlineData("System.XML, Version=2.0.0.0")]
+        [InlineData("System.Xml, Culture=de-DE")]
+        [InlineData("System.Xml, Version=10.0.0.0, Culture=en, PublicKeyToken=b03f5f7f11d50a3a, Retargetable=Yes")]
+        [InlineData("System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
+        public void VerifyAssemblyNameExSerialization(string assemblyName)
+        {
+            AssemblyNameExtension assemblyNameOriginal = new AssemblyNameExtension(assemblyName);
+            AssemblyNameExtension assemblyNameDeserialized;
+
+            byte[] bytes;
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                BinaryFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(ms, assemblyNameOriginal);
+
+                bytes = ms.ToArray();
+            }
+
+            using (MemoryStream ms = new MemoryStream(bytes))
+            {
+                BinaryFormatter formatter = new BinaryFormatter();
+                assemblyNameDeserialized = (AssemblyNameExtension) formatter.Deserialize(ms);
+            }
+
+            assemblyNameDeserialized.ShouldBe(assemblyNameOriginal);
+        }
+
+        [Fact]
+        public void VerifyAssemblyNameExSerializationWithRemappedFrom()
+        {
+            
+            AssemblyNameExtension assemblyNameOriginal = new AssemblyNameExtension("System.Xml, Version=10.0.0.0, Culture=en, PublicKeyToken=b03f5f7f11d50a3a");
+            AssemblyNameExtension assemblyRemappedFrom = new AssemblyNameExtension("System.Xml, Version=9.0.0.0, Culture=en, PublicKeyToken=b03f5f7f11d50a3a");
+            assemblyRemappedFrom.MarkImmutable();
+            assemblyNameOriginal.AddRemappedAssemblyName(assemblyRemappedFrom);
+            assemblyNameOriginal.RemappedFromEnumerator.Count().ShouldBe(1);
+
+            AssemblyNameExtension assemblyNameDeserialized;
+
+            byte[] bytes;
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                BinaryFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(ms, assemblyNameOriginal);
+
+                bytes = ms.ToArray();
+            }
+
+            using (MemoryStream ms = new MemoryStream(bytes))
+            {
+                BinaryFormatter formatter = new BinaryFormatter();
+                assemblyNameDeserialized = (AssemblyNameExtension)formatter.Deserialize(ms);
+            }
+
+            assemblyNameDeserialized.Equals(assemblyNameOriginal).ShouldBeTrue();
+            assemblyNameDeserialized.RemappedFromEnumerator.Count().ShouldBe(1);
+            assemblyNameDeserialized.RemappedFromEnumerator.First().ShouldBe(assemblyRemappedFrom);
         }
     }
 }

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Build.Tasks
         // Current version for serialization. This should be changed when breaking changes
         // are made to this class.
         // Note: Consider that changes can break VS2015 RTM which did not have a version check.
-        // Version 4 - VS2017.7:
+        // Version 4/5 - VS2017.7:
         //   Unify .NET Core + Full Framework. Custom serialization on some types that are no
         //   longer [Serializable].
-        private const byte CurrentSerializationVersion = 4;
+        private const byte CurrentSerializationVersion = 5;
 
         // Version this instance is serialized with.
         private byte _serializedVersion = CurrentSerializationVersion;


### PR DESCRIPTION
There were some subtle issues with AssemblyNameExtension serialization:
* Added hasAN and hasCI to indicate whether an AssemblyName or CultureInfo was serialized (and used them correctly).
* Switched from CultureInfo Name -> LCID. The default invariant culture has no Name, but has an LCID.
* Serialized the remappedFrom HashSet field.
* Added unit tests to verify serialization is correct.

It wasn't trivial to repro (originally) so I verified a lot of this manually and did some cleanup on the way. Verified it fixes the issue in the repro. I removed `FEATURE_ASSEMBLYNAME_CULTUREINFO` since it was only used in AssemblyNameExtension and no longer needed for `netstandard2.0`