### PR TITLE
Expand logFile at the end of the script

### DIFF
--- a/scripts/EnumerateMSBuild.ps1
+++ b/scripts/EnumerateMSBuild.ps1
@@ -16,8 +16,6 @@ Param(
 
 # Set log file (and get the full path) and delete if it exists.
 $logFile = "msbuild_versions.txt"
-$logFile = Get-ChildItem -File -Path $logFile
-
 If((Test-Path -Path $logFile))
 {
     Remove-Item -Path $logFile
@@ -64,6 +62,9 @@ $gacPath = ${env:windir} + "\assembly"
 Write-Log "Looking for MSBuild in the GAC: $gacPath"
 Get-ChildItem -File -Path "$gacPath" -Recurse "Microsoft.Build*.dll" -Exclude "*.ni.dll" | % VersionInfo | Format-Table -AutoSize InternalName, ProductVersion, FileName | Out-File $logFile -Width 1000 -Append unicode
 Write-Log "********************" -LogToConsole $False
+
+# Expand full path for the output message
+$logFile = Get-ChildItem -File -Path $logFile
 
 Write-Host
 Write-Host "Output saved to $logFile"


### PR DESCRIPTION
If the file didn't exist Get-ChildItem (what was using to expand the
full path) fail and logFile would be null. Moving that to the end.