### PR TITLE
Fix XmlDocument reader to allow opening files in read-only mode

### DIFF
--- a/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
@@ -363,6 +363,7 @@ namespace Microsoft.Build.UnitTests.Construction
             {
                 var doc = new XmlDocumentWithLocation(loadAsReadOnly: true);
                 doc.Load(_pathToCommonTargets);
+                Assert.True(doc.IsReadOnly);
                 doc.Save(FileUtilities.GetTemporaryFile());
             }
            );
@@ -389,6 +390,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 doc.Load(xmlReader);
             }
 #endif
+            Assert.True(doc.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() => {
                 doc.Save(new MemoryStream());
             });
@@ -414,6 +416,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 doc.Load(xmlReader);
             }
 #endif
+            Assert.True(doc.IsReadOnly);
             Assert.Throws<InvalidOperationException>(() =>
             {
                 doc.Save(new StringWriter());
@@ -440,7 +443,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 doc.Load(xmlReader);
             }
 #endif
-
+            Assert.True(doc.IsReadOnly);
             using (XmlWriter wr = XmlWriter.Create(new FileStream(FileUtilities.GetTemporaryFile(), FileMode.Create)))
             {
                 Assert.Throws<InvalidOperationException>(() =>
@@ -473,6 +476,7 @@ namespace Microsoft.Build.UnitTests.Construction
                     doc.Load(xmlReader);
                 }
 #endif
+                Assert.Equal(readOnly, doc.IsReadOnly);
                 var allNodes = doc.SelectNodes("//*|//@*");
 
                 string locations = String.Empty;

--- a/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -65,6 +65,11 @@ bar", false)]
 
             using (var env = TestEnvironment.Create())
             {
+                // reset all hooks
+                XmlDocumentWithLocation.ClearReadOnlyFlags_UnitTestsOnly();
+                env.SetEnvironmentVariable("MSBUILDLOADALLFILESASREADONLY", null); //clear
+                env.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", null); // clear
+                env.SetEnvironmentVariable("MSBUILDLOADALLFILESASWRITEABLE", null); // clear
                 var testFiles = env.CreateTestProjectWithFiles(projectContents, Array.Empty<string>());
                 ProjectRootElement xml = ProjectRootElement.Open(testFiles.ProjectFile);
 
@@ -91,7 +96,11 @@ bar", false)]
 
             using (var env = TestEnvironment.Create())
             {
+                // set the hook for the desired read-only mode and reset the hook for the other modes
+                XmlDocumentWithLocation.ClearReadOnlyFlags_UnitTestsOnly();
                 env.SetEnvironmentVariable("MSBUILDLOADALLFILESASREADONLY", "1");
+                env.SetEnvironmentVariable("MSBuildLoadMicrosoftTargetsReadOnly", null); // clear
+                env.SetEnvironmentVariable("MSBUILDLOADALLFILESASWRITEABLE", null); // clear
 
                 var testFiles = env.CreateTestProjectWithFiles(projectContents, Array.Empty<string>());
                 ProjectRootElement xml = ProjectRootElement.Open(testFiles.ProjectFile);

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -365,8 +365,8 @@ namespace Microsoft.Build.Construction
                             string windowsFolder = FileUtilities.GetFolderPath(FileUtilities.SpecialFolder.Windows);
 #endif
 
-                            if (directory.StartsWith(windowsFolder, StringComparison.OrdinalIgnoreCase) ||
-                                (directory.StartsWith(FrameworkLocationHelper.programFiles32, StringComparison.OrdinalIgnoreCase)) ||
+                            if ((!String.IsNullOrEmpty(windowsFolder) && directory.StartsWith(windowsFolder, StringComparison.OrdinalIgnoreCase)) ||
+                                (!String.IsNullOrEmpty(FrameworkLocationHelper.programFiles32) && directory.StartsWith(FrameworkLocationHelper.programFiles32, StringComparison.OrdinalIgnoreCase)) ||
                                 (!String.IsNullOrEmpty(FrameworkLocationHelper.programFiles64) && directory.StartsWith(FrameworkLocationHelper.programFiles64, StringComparison.OrdinalIgnoreCase)))
                             {
                                 _loadAsReadOnly = true;

--- a/src/Build/ElementLocation/XmlDocumentWithLocation.cs
+++ b/src/Build/ElementLocation/XmlDocumentWithLocation.cs
@@ -306,6 +306,11 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
+        /// Override IsReadOnly property to correctly indicate the mode to callers
+        /// </summary>
+        public override bool IsReadOnly => _loadAsReadOnly.GetValueOrDefault();
+
+        /// <summary>
         /// Reset state for unit tests that want to set the env var
         /// </summary>
         internal static void ClearReadOnlyFlags_UnitTestsOnly()

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -76,15 +76,16 @@ namespace Microsoft.Build.Internal
 
         private static XmlReader GetXmlReader(string file, StreamReader input, out Encoding encoding)
         {
+            var uri = new Uri(file);
 #if FEATURE_XMLTEXTREADER
-            var reader = new XmlTextReader(file, input) { DtdProcessing = DtdProcessing.Ignore };
+            var reader = new XmlTextReader(uri.AbsoluteUri, input) { DtdProcessing = DtdProcessing.Ignore };
 
             reader.Read();
             encoding = input.CurrentEncoding;
 
             return reader;
 #else
-            var xr = XmlReader.Create(input, new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}, file);
+            var xr = XmlReader.Create(input, new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}, uri.AbsoluteUri);
 
             // Set Normalization = false if possible. Without this, certain line endings will be normalized
             // with \n (specifically in XML comments). Does not throw if if type or property is not found.

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -76,16 +76,16 @@ namespace Microsoft.Build.Internal
 
         private static XmlReader GetXmlReader(string file, StreamReader input, out Encoding encoding)
         {
-            var uri = new Uri(file);
+            string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
 #if FEATURE_XMLTEXTREADER
-            var reader = new XmlTextReader(uri.AbsoluteUri, input) { DtdProcessing = DtdProcessing.Ignore };
+            var reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
 
             reader.Read();
             encoding = input.CurrentEncoding;
 
             return reader;
 #else
-            var xr = XmlReader.Create(input, new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}, uri.AbsoluteUri);
+            var xr = XmlReader.Create(input, new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}, uri);
 
             // Set Normalization = false if possible. Without this, certain line endings will be normalized
             // with \n (specifically in XML comments). Does not throw if if type or property is not found.

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1609,7 +1609,7 @@ namespace Microsoft.Build.UnitTests
         {
             return
                 NativeMethodsShared.IsWindows
-                ? $"@powershell -command &quot;Start-Sleep -Milliseconds {(int)timeSpan.TotalMilliseconds}&quot; &gt;nul"
+                ? $"@powershell -NoLogo -NoProfile -command &quot;Start-Sleep -Milliseconds {(int)timeSpan.TotalMilliseconds}&quot; &gt;nul"
                 : $"sleep {timeSpan.TotalSeconds}";
         }
 


### PR DESCRIPTION
XmlDocumentWithLocation class has the ability to openXML documents in the read-only mode (comments and whitespace is replaced with an empty string). Currently this functionaly is not available, because the XML file location is not passed to the XML reader constructor and thus not available for the XmlDocumentWithLocation for further verification.
Additionally, the IsReadOnly property is now overriden, to correctly inform callers about the read mode of the document.
Added unit tests that cover these scenarios.