### PR TITLE
Quote path to MSBuild when using CreateProcess

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Build.BackEnd
                 if (NativeMethodsShared.IsWindows)
                 {
                     // Repeat the executable name in the args to suit CreateProcess
-                    commandLineArgs = exeName + " " + commandLineArgs;
+                    commandLineArgs = "\"" + exeName + "\" " + commandLineArgs;
                 }
 #endif
 


### PR DESCRIPTION
`CreateProcess()` takes an argument that is the program to execute and
another argument that's the entire command line, including the program.

MSBuild parses the full command line to read its arguments.

The combination of these behaviors caused problems when creating MSBuild
worker nodes on Windows via CreateProcess if the path to MSBuild.dll
contains a space. The process gets created fine (the space in
`lpApplicationName` doesn't cause a problem) but the command line is
split in a confusing way, because we think, say, `C:\Program` and
`Files\dotnet\dotnet.exe` are separate arguments.

To avoid this, quote `exeName` when adding it to the command line, just
as we quoted `msbuildLocation`.

Fixes #3142.