### PR TITLE
Fix MSBuildTaskHost

### DIFF
--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>net35</TargetFramework>    
     <OutputType>Exe</OutputType>
     <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'AnyCPU'">x86</PlatformTarget>
 
     <!-- Set RuntimeIdentifiers so that NuGet will restore for both AnyCPU as well as x86 and x64.
          This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64

--- a/src/MSBuildTaskHost/OutOfProcTaskHost.cs
+++ b/src/MSBuildTaskHost/OutOfProcTaskHost.cs
@@ -88,13 +88,20 @@ namespace Microsoft.Build.CommandLine
         /// </returns>
         internal static ExitType Execute()
         {
-#if FEATURE_DEBUG_LAUNCH
-            // Provide Hook for debugger
-            if (Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART") == "1")
+            switch (Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART"))
             {
-                Debugger.Launch();
-            }
+#if FEATURE_DEBUG_LAUNCH
+                case "1":
+                    Debugger.Launch();
+                    break;
 #endif
+                case "2":
+                    // Sometimes easier to attach rather than deal with JIT prompt
+                    Process currentProcess = Process.GetCurrentProcess();
+                    Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
+                    Console.ReadLine();
+                    break;
+            }
 
             bool restart = false;
             do

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Name of the MSBuild process(es)
         /// </summary>
-        private static readonly string[] s_msBuildProcess = {"MSBUILD"};
+        private static readonly string[] s_msBuildProcess = {"MSBUILD", "MSBUILDTASKHOST"};
 
         /// <summary>
         /// Name of MSBuild executable files.
@@ -152,7 +152,7 @@ namespace Microsoft.Build.Shared
 
             // First check if we're in a VS installation
             if (NativeMethodsShared.IsWindows &&
-                Regex.IsMatch(msBuildExe, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*MSBuild\.exe", RegexOptions.IgnoreCase))
+                Regex.IsMatch(msBuildExe, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*MSBuild(?:TaskHost)?\.exe", RegexOptions.IgnoreCase))
             {
                 return new BuildEnvironment(
                     BuildEnvironmentMode.VisualStudio,

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "15.7-preview",
   "assemblyVersion": "15.1",
-  "buildNumberOffset": "10",
+  "buildNumberOffset": "20",
   "cloudBuild": {
     "buildNumber": {
       "enabled": true,


### PR DESCRIPTION
* Extend MSBUILDDEBUGONSTART support for TaskHost
* 32BITREQ for MSBuildTaskHost
* Find MSBuild environment in TaskHost

This hasn't worked since the build upgrade :(

TODO:
- [ ] Add `MSBuildTaskHost.exe` to the bootstrap folder. Currently it's not there and MSBuild apparently ignores using it when it's not without any error. The VS insertion logic is all OK though as far as I can tell, just testing locally is a pain (manually copy it from bin to bootstrap).
- [ ] This doesn't seem the most elegant way to make the output x86-only. MSBuild.exe is but we didn't have to explicitly set `PlatformTarget` somehow? Maybe because `net35` doesn't `StartWith("net4")` somewhere?
- [ ] There's actually an unhandled exception thrown when running BuildEnvironmentHelper in CLR2. I think it's from the new `CheckIfRunningTests` reflection craziness. My change just exits out earlier so we never hit the type load exception. There's no reason to progress further in the logic so this is good enough, but that other thing should be fixed too.