### PR TITLE
RI vs15.7

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -124,7 +124,11 @@ namespace Microsoft.Build.Execution
         /// By default, it is enabled.
         /// </summary>
 #if FEATURE_NODE_REUSE
-        private bool _enableNodeReuse = true;
+        /// <remarks>
+        /// Enable node reuse by default only on Windows for now
+        /// due to https://github.com/Microsoft/msbuild/issues/3161
+        /// </remarks>
+        private bool _enableNodeReuse = NativeMethodsShared.IsWindows;
 #else
         private bool _enableNodeReuse = false;
 #endif

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -177,7 +177,13 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         public void ShutdownAllNodes()
         {
-            ShutdownAllNodes(NodeProviderOutOfProc.GetHostHandshake(ComponentHost.BuildParameters.EnableNodeReuse), NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
+            // if no BuildParameters were specified for this build,
+            // we must be trying to shut down idle nodes from some
+            // other, completed build. If they're still around,
+            // they must have been started with node reuse.
+            bool nodeReuse = ComponentHost.BuildParameters?.EnableNodeReuse ?? true;
+
+            ShutdownAllNodes(NodeProviderOutOfProc.GetHostHandshake(nodeReuse), NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -115,16 +115,7 @@ namespace Microsoft.Build.BackEnd
             // INodePacketFactory
             INodePacketFactory factory = new NodePacketFactory();
 
-            // Find proper msbuild executable name
-            string msbuildExeName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
-
-            if (String.IsNullOrEmpty(msbuildExeName))
-            {
-                msbuildExeName = "MSBuild.exe";
-            }
-
-            // Search for all instances of the msbuild process and create a list of them
-            List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(Path.GetFileNameWithoutExtension(msbuildExeName)));
+            List<Process> nodeProcesses = GetPossibleRunningNodes();
 
             // Find proper MSBuildTaskHost executable name
             string msbuildtaskhostExeName = NodeProviderOutOfProcTaskHost.TaskHostNameForClr2TaskHost;
@@ -180,39 +171,38 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            if (String.IsNullOrEmpty(msbuildLocation))
-            {
-                msbuildLocation = "MSBuild.exe";
-            }
-
 #if FEATURE_NODE_REUSE
-            var candidateProcesses = GetPossibleRunningNodes(msbuildLocation);
-
-            CommunicationsUtilities.Trace("Attempting to connect to each existing msbuild.exe process in turn to establish node {0}...", nodeId);
-            foreach (Process nodeProcess in candidateProcesses)
+            // Try to connect to idle nodes if node reuse is enabled.
+            if (_componentHost.BuildParameters.EnableNodeReuse)
             {
-                if (nodeProcess.Id == Process.GetCurrentProcess().Id)
-                {
-                    continue;
-                }
+                var candidateProcesses = GetPossibleRunningNodes(msbuildLocation);
 
-                // Get the full context of this inspection so that we can always skip this process when we have the same taskhost context
-                string nodeLookupKey = GetProcessesToIgnoreKey(hostHandshake, clientHandshake, nodeProcess.Id);
-                if (_processesToIgnore.Contains(nodeLookupKey))
+                CommunicationsUtilities.Trace("Attempting to connect to each existing msbuild.exe process in turn to establish node {0}...", nodeId);
+                foreach (Process nodeProcess in candidateProcesses)
                 {
-                    continue;
-                }
+                    if (nodeProcess.Id == Process.GetCurrentProcess().Id)
+                    {
+                        continue;
+                    }
 
-                // We don't need to check this again
-                _processesToIgnore.Add(nodeLookupKey);
+                    // Get the full context of this inspection so that we can always skip this process when we have the same taskhost context
+                    string nodeLookupKey = GetProcessesToIgnoreKey(hostHandshake, clientHandshake, nodeProcess.Id);
+                    if (_processesToIgnore.Contains(nodeLookupKey))
+                    {
+                        continue;
+                    }
 
-                // Attempt to connect to each process in turn.
-                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, 0 /* poll, don't wait for connections */, hostHandshake, clientHandshake);
-                if (nodeStream != null)
-                {
-                    // Connection successful, use this node.
-                    CommunicationsUtilities.Trace("Successfully connected to existed node {0} which is PID {1}", nodeId, nodeProcess.Id);
-                    return new NodeContext(nodeId, nodeProcess.Id, nodeStream, factory, terminateNode);
+                    // We don't need to check this again
+                    _processesToIgnore.Add(nodeLookupKey);
+
+                    // Attempt to connect to each process in turn.
+                    Stream nodeStream = TryConnectToProcess(nodeProcess.Id, 0 /* poll, don't wait for connections */, hostHandshake, clientHandshake);
+                    if (nodeStream != null)
+                    {
+                        // Connection successful, use this node.
+                        CommunicationsUtilities.Trace("Successfully connected to existed node {0} which is PID {1}", nodeId, nodeProcess.Id);
+                        return new NodeContext(nodeId, nodeProcess.Id, nodeStream, factory, terminateNode);
+                    }
                 }
             }
 #endif
@@ -290,8 +280,13 @@ namespace Microsoft.Build.BackEnd
             return null;
         }
 
-        private List<Process> GetPossibleRunningNodes(string msbuildLocation)
+        private List<Process> GetPossibleRunningNodes(string msbuildLocation = null)
         {
+            if (String.IsNullOrEmpty(msbuildLocation))
+            {
+                msbuildLocation = "MSBuild.exe";
+            }
+
             var expectedProcessName = Path.GetFileNameWithoutExtension(GetCurrentHost() ?? msbuildLocation);
 
             List<Process> nodeProcesses = new List<Process>(Process.GetProcessesByName(expectedProcessName));
@@ -604,17 +599,26 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+#if RUNTIME_TYPE_NETCORE
+        private static string CurrentHost;
+#endif
+
         /// <summary>
-        /// Identify the .NET host of the current process
+        /// Identify the .NET host of the current process.
         /// </summary>
         /// <returns>The full path to the executable hosting the current process, or null if running on Full Framework on Windows.</returns>
         private static string GetCurrentHost()
         {
 #if RUNTIME_TYPE_NETCORE
-            using (Process currentProcess = Process.GetCurrentProcess())
+            if (CurrentHost == null)
             {
-                return currentProcess.MainModule.FileName;
+                using (Process currentProcess = Process.GetCurrentProcess())
+                {
+                    CurrentHost = currentProcess.MainModule.FileName;
+                }
             }
+
+            return CurrentHost;
 #else
             return null;
 #endif

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                 int cpuCount = 1;
 #if FEATURE_NODE_REUSE
-                bool enableNodeReuse = true;
+                bool enableNodeReuse = NativeMethodsShared.IsWindows;
 #else
                 bool enableNodeReuse = false;
 #endif
@@ -2110,7 +2110,7 @@ namespace Microsoft.Build.CommandLine
         {
             bool enableNodeReuse;
 #if FEATURE_NODE_REUSE
-            enableNodeReuse = true;
+            enableNodeReuse = NativeMethodsShared.IsWindows;
 #else
             enableNodeReuse = false;
 #endif


### PR DESCRIPTION
Specially handled: `version.json` was taken from `master` directly, so that it didn't pick up the version-bump from vs15.7 after preview3. Supersedes #3164.