### PR TITLE
Avoid hangs with node reuse on non-Windows

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -140,11 +140,7 @@ namespace Microsoft.Build.Execution
         /// By default, it is enabled.
         /// </summary>
 #if FEATURE_NODE_REUSE
-        /// <remarks>
-        /// Enable node reuse by default only on Windows for now
-        /// due to https://github.com/Microsoft/msbuild/issues/3161
-        /// </remarks>
-        private bool _enableNodeReuse = NativeMethodsShared.IsWindows;
+        private bool _enableNodeReuse = true;
 #else
         private bool _enableNodeReuse = false;
 #endif

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -475,6 +475,9 @@ namespace Microsoft.Build.BackEnd
             {
                 if (!Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
                 {
+                    // Redirect the streams of worker nodes so that this MSBuild.exe's
+                    // parent doesn't wait on idle worker nodes to close streams
+                    // after the build is complete.
                     startInfo.hStdError = BackendNativeMethods.InvalidHandle;
                     startInfo.hStdInput = BackendNativeMethods.InvalidHandle;
                     startInfo.hStdOutput = BackendNativeMethods.InvalidHandle;
@@ -510,6 +513,12 @@ namespace Microsoft.Build.BackEnd
                 processStartInfo.Arguments = commandLineArgs;
                 if (!Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
                 {
+                    // Redirect the streams of worker nodes so that this MSBuild.exe's
+                    // parent doesn't wait on idle worker nodes to close streams
+                    // after the build is complete.
+                    processStartInfo.RedirectStandardInput = true;
+                    processStartInfo.RedirectStandardOutput = true;
+                    processStartInfo.RedirectStandardError = true;
                     processStartInfo.CreateNoWindow = (creationFlags | BackendNativeMethods.CREATENOWINDOW) == BackendNativeMethods.CREATENOWINDOW;
                 }
                 processStartInfo.UseShellExecute = false;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                 int cpuCount = 1;
 #if FEATURE_NODE_REUSE
-                bool enableNodeReuse = NativeMethodsShared.IsWindows;
+                bool enableNodeReuse = true;
 #else
                 bool enableNodeReuse = false;
 #endif
@@ -2110,7 +2110,7 @@ namespace Microsoft.Build.CommandLine
         {
             bool enableNodeReuse;
 #if FEATURE_NODE_REUSE
-            enableNodeReuse = NativeMethodsShared.IsWindows;
+            enableNodeReuse = true;
 #else
             enableNodeReuse = false;
 #endif


### PR DESCRIPTION
There were two problems leading to #3161. I reverted the only-on-Windows mitigation for that and fixed the problems.

First, dotnet/corefx#28791 means that the named pipe connection behavior we'd been relying on on Windows didn't work on UNIXy platforms, because the pipe could be connected and it would just go nowhere. I fixed that by wrapping a timeout around the wait-for-handshake-reply code to give up if it isn't speedy.

Then, tests (in other repos) that ran `MSBuild /m /nr:true` (by default) were hanging for a very long time, because they were waiting for any newly-spawned worker nodes to hit their idle timeout. See 
the commit message of e604f5f for details.