### PR TITLE
Prodcon dependency uptake

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -40,7 +40,7 @@
             ]
         },
         {
-            "certificate": null,
+            "certificate": "NuGet",
             "strongName": null,
             "values": [
                 "packages/*.nupkg"

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -43,6 +43,7 @@
 
   <!-- Production Dependencies -->
   <PropertyGroup>
+    <MicrosoftNETCoreAppVersion>2.1.0-preview2-26406-04</MicrosoftNETCoreAppVersion>
   </PropertyGroup>
 
   <!-- Test Dependencies -->

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -30,7 +30,9 @@
 
   <!-- Toolset Dependencies -->
   <PropertyGroup>
-    <DotNetCliVersion>2.1.300-preview2-008293</DotNetCliVersion>
+    <DotNetCliVersion>2.1.300-preview2-008530</DotNetCliVersion>
+    <!-- We are pretty much always on a preview SDK. No need to warn about it. -->
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
     <VSWhereVersion>2.2.7</VSWhereVersion>
 

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftNetCompilersVersion>2.4.0</MicrosoftNetCompilersVersion>
     <MicrosoftNetCoreCompilersVersion>2.6.0-beta3-62309-01</MicrosoftNetCoreCompilersVersion>
     <MicrosoftCodeAnalysisBuildTasksVersion>3.0.0-beta1-61516-01</MicrosoftCodeAnalysisBuildTasksVersion>
-    <NuGetPackageVersion>4.7.0-preview3.5039</NuGetPackageVersion>
+    <NuGetPackageVersion>4.7.0-rtm.5081</NuGetPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.0.0</MicrosoftExtensionsDependencyModelVersion>
     <!--<NuGetVersion>4.6.0-rtm-4822</NuGetVersion>-->
     <ShouldlyVersion>3.0.0</ShouldlyVersion>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -44,16 +44,22 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <MicrosoftNETCoreAppVersion>2.1.0-preview2-26406-04</MicrosoftNETCoreAppVersion>
-  </PropertyGroup>
+
+    <!-- MSBuild custom overall switch -->
+    <NuGetPackageVersion>4.7.0-rtm.5081</NuGetPackageVersion>
+
+    <!-- Prodcon-overrideable, using repo-toolset naming convention -->
+    <NuGetBuildTasksVersion>$(NuGetPackageVersion)</NuGetBuildTasksVersion>
+    <NuGetCommandsVersion>$(NuGetPackageVersion)</NuGetCommandsVersion>
+    <NuGetProtocolVersion>$(NuGetPackageVersion)</NuGetProtocolVersion>
+</PropertyGroup>
 
   <!-- Test Dependencies -->
   <PropertyGroup>
     <MicrosoftNetCompilersVersion>2.4.0</MicrosoftNetCompilersVersion>
     <MicrosoftNetCoreCompilersVersion>2.6.0-beta3-62309-01</MicrosoftNetCoreCompilersVersion>
     <MicrosoftCodeAnalysisBuildTasksVersion>3.0.0-beta1-61516-01</MicrosoftCodeAnalysisBuildTasksVersion>
-    <NuGetPackageVersion>4.7.0-rtm.5081</NuGetPackageVersion>
     <MicrosoftExtensionsDependencyModelVersion>2.0.0</MicrosoftExtensionsDependencyModelVersion>
-    <!--<NuGetVersion>4.6.0-rtm-4822</NuGetVersion>-->
     <ShouldlyVersion>3.0.0</ShouldlyVersion>
   </PropertyGroup>
 

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -611,6 +611,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void ExpandItemVectorFunctionsBuiltIn_InvalidCharsError()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -875,6 +876,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPathAndMetadataItemFunctionPathTooLong()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -896,6 +898,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -936,6 +939,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPathAndMetadataItemFunctionPathTooLong2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -957,6 +961,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPathAndMetadataItemFunctionInvalidWindowsPathChars2()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"
@@ -1018,6 +1023,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPathAndMetadataItemInvalidWindowsPathChars3()
         {
             MockLogger logger = Helpers.BuildProjectWithNewOMExpectFailure(@"

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -140,11 +140,7 @@ namespace Microsoft.Build.Execution
         /// By default, it is enabled.
         /// </summary>
 #if FEATURE_NODE_REUSE
-        /// <remarks>
-        /// Enable node reuse by default only on Windows for now
-        /// due to https://github.com/Microsoft/msbuild/issues/3161
-        /// </remarks>
-        private bool _enableNodeReuse = NativeMethodsShared.IsWindows;
+        private bool _enableNodeReuse = true;
 #else
         private bool _enableNodeReuse = false;
 #endif

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -475,6 +475,9 @@ namespace Microsoft.Build.BackEnd
             {
                 if (!Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
                 {
+                    // Redirect the streams of worker nodes so that this MSBuild.exe's
+                    // parent doesn't wait on idle worker nodes to close streams
+                    // after the build is complete.
                     startInfo.hStdError = BackendNativeMethods.InvalidHandle;
                     startInfo.hStdInput = BackendNativeMethods.InvalidHandle;
                     startInfo.hStdOutput = BackendNativeMethods.InvalidHandle;
@@ -510,6 +513,12 @@ namespace Microsoft.Build.BackEnd
                 processStartInfo.Arguments = commandLineArgs;
                 if (!Traits.Instance.EscapeHatches.EnsureStdOutForChildNodesIsPrimaryStdout)
                 {
+                    // Redirect the streams of worker nodes so that this MSBuild.exe's
+                    // parent doesn't wait on idle worker nodes to close streams
+                    // after the build is complete.
+                    processStartInfo.RedirectStandardInput = true;
+                    processStartInfo.RedirectStandardOutput = true;
+                    processStartInfo.RedirectStandardError = true;
                     processStartInfo.CreateNoWindow = (creationFlags | BackendNativeMethods.CREATENOWINDOW) == BackendNativeMethods.CREATENOWINDOW;
                 }
                 processStartInfo.UseShellExecute = false;

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -137,6 +137,10 @@
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
+
+    <!-- For prodcon builds, we want to be able to float the compile-time version
+         of .NET Core references separately from the CLI version -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -63,6 +63,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -23,9 +23,9 @@
 
   <ItemGroup>
     <!-- Include NuGet build tasks -->
-    <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
     <!-- Include NuGet.targets from NuGet.Build.Tasks package.  Ideally, this should probably be in contentFiles in the package so we don't have to do this. -->
-    <Content Include="$(NuGetPackageRoot)nuget.build.tasks\$(NuGetPackageVersion)\runtimes\any\native\NuGet.targets" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(NuGetPackageRoot)nuget.build.tasks\$(NuGetBuildTasksVersion)\runtimes\any\native\NuGet.targets" CopyToOutputDirectory="PreserveNewest" />
     
     <!-- Include DependencyModel libraries. -->
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1348,6 +1348,7 @@ namespace Microsoft.Build.UnitTests
         /// Verifies that when the /profileevaluation switch is used with invalid filenames an error is shown.
         /// </summary>
         [MemberData(nameof(GetInvalidFilenames))]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         [Theory]
         public void ProcessProfileEvaluationInvalidFilename(string filename)
         {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Build.CommandLine
 #endif
                 int cpuCount = 1;
 #if FEATURE_NODE_REUSE
-                bool enableNodeReuse = NativeMethodsShared.IsWindows;
+                bool enableNodeReuse = true;
 #else
                 bool enableNodeReuse = false;
 #endif
@@ -2110,7 +2110,7 @@ namespace Microsoft.Build.CommandLine
         {
             bool enableNodeReuse;
 #if FEATURE_NODE_REUSE
-            enableNodeReuse = NativeMethodsShared.IsWindows;
+            enableNodeReuse = true;
 #else
             enableNodeReuse = false;
 #endif

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -8,6 +8,7 @@
     <TargetFramework>net35</TargetFramework>    
     <OutputType>Exe</OutputType>
     <PlatformTarget Condition="'$(Platform)' == 'x64'">x64</PlatformTarget>
+    <PlatformTarget Condition="'$(Platform)' == 'AnyCPU'">x86</PlatformTarget>
 
     <!-- Set RuntimeIdentifiers so that NuGet will restore for both AnyCPU as well as x86 and x64.
          This is important for the MSBuild.VSSetup project, which "references" both the x86 and x64

--- a/src/MSBuildTaskHost/OutOfProcTaskHost.cs
+++ b/src/MSBuildTaskHost/OutOfProcTaskHost.cs
@@ -88,13 +88,20 @@ namespace Microsoft.Build.CommandLine
         /// </returns>
         internal static ExitType Execute()
         {
-#if FEATURE_DEBUG_LAUNCH
-            // Provide Hook for debugger
-            if (Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART") == "1")
+            switch (Environment.GetEnvironmentVariable("MSBUILDDEBUGONSTART"))
             {
-                Debugger.Launch();
-            }
+#if FEATURE_DEBUG_LAUNCH
+                case "1":
+                    Debugger.Launch();
+                    break;
 #endif
+                case "2":
+                    // Sometimes easier to attach rather than deal with JIT prompt
+                    Process currentProcess = Process.GetCurrentProcess();
+                    Console.WriteLine($"Waiting for debugger to attach ({currentProcess.MainModule.FileName} PID {currentProcess.Id}).  Press enter to continue...");
+                    Console.ReadLine();
+                    break;
+            }
 
             bool restart = false;
             do

--- a/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
+++ b/src/NuGetSdkResolver/NuGet.MSBuildSdkResolver.csproj
@@ -10,8 +10,8 @@
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" Private="false"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Commands" Version="$(NuGetPackageVersion)" />
-    <PackageReference Include="NuGet.Protocol" Version="$(NuGetPackageVersion)" />
+    <PackageReference Include="NuGet.Commands" Version="$(NuGetCommandsVersion)" />
+    <PackageReference Include="NuGet.Protocol" Version="$(NuGetProtocolVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Name of the MSBuild process(es)
         /// </summary>
-        private static readonly string[] s_msBuildProcess = {"MSBUILD"};
+        private static readonly string[] s_msBuildProcess = {"MSBUILD", "MSBUILDTASKHOST"};
 
         /// <summary>
         /// Name of MSBuild executable files.
@@ -152,7 +152,7 @@ namespace Microsoft.Build.Shared
 
             // First check if we're in a VS installation
             if (NativeMethodsShared.IsWindows &&
-                Regex.IsMatch(msBuildExe, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*MSBuild\.exe", RegexOptions.IgnoreCase))
+                Regex.IsMatch(msBuildExe, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*MSBuild(?:TaskHost)?\.exe", RegexOptions.IgnoreCase))
             {
                 return new BuildEnvironment(
                     BuildEnvironmentMode.VisualStudio,

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -121,9 +121,8 @@ namespace Microsoft.Build.UnitTests
         /// Exercises FileUtilities.ItemSpecModifiers.GetItemSpecModifier on a bad path.
         /// </summary>
         [Fact]
-        [Trait("Category", "mono-osx-failing")]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
+        [PlatformSpecific(TestPlatforms.Windows)] // On Unix there no invalid file name characters
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void GetItemSpecModifierOnBadPath()
         {
             Assert.Throws<InvalidOperationException>(() =>
@@ -136,9 +135,8 @@ namespace Microsoft.Build.UnitTests
         /// Exercises FileUtilities.ItemSpecModifiers.GetItemSpecModifier on a bad path.
         /// </summary>
         [Fact]
-        [Trait("Category", "mono-osx-failing")]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
+        [PlatformSpecific(TestPlatforms.Windows)] // On Unix there no invalid file name characters
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void GetItemSpecModifierOnBadPath2()
         {
             Assert.Throws<InvalidOperationException>(() =>
@@ -147,6 +145,7 @@ namespace Microsoft.Build.UnitTests
             }
            );
         }
+
         private static void TestGetItemSpecModifierOnBadPath(string currentDirectory)
         {
             try
@@ -453,6 +452,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void NormalizePathBadUNC1()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -464,6 +464,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void NormalizePathBadUNC2()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -475,6 +476,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void NormalizePathBadUNC3()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -522,14 +524,15 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void NormalizePathInvalid()
         {
+            string filePath = @"c:\aardvark\|||";
+
             Assert.Throws<ArgumentException>(() =>
             {
-                string filePath = @"c:\aardvark\|||";
-                Assert.Equal(null, FileUtilities.NormalizePath(filePath));
-            }
-           );
+                FileUtilities.NormalizePath(filePath);
+            });
         }
 
         [Fact]

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -540,6 +540,7 @@ namespace Microsoft.Build.UnitTests
         /// Make sure we do not retry when the source file has a misplaced colon
         /// </summary>
         [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void DoNotRetryCopyNotSupportedException()
         {
             if (!NativeMethodsShared.IsWindows)
@@ -905,6 +906,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // "Under Unix all filenames are valid and this test is not useful"
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void OutputsOnlyIncludeSuccessfulCopies()
         {
             string temp = Path.GetTempPath();

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -93,8 +93,12 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Timeout()
         {
-            // On non-Windows the exit code of a killed process is SIGTERM (143)
-            int expectedExitCode = NativeMethodsShared.IsWindows ? -1 : 143;
+            // On non-Windows the exit code of a killed sh should be
+            // SIGTERM (15) + exited-due-to-signal (128) = 143.
+            // On .NET Core 2.1 preview2 + High Sierra it's consistently
+            // just 128 for some reason.
+            int expectedExitCode = NativeMethodsShared.IsWindows ? -1 :
+                    NativeMethodsShared.IsOSX ? 128 : 143;
 
             Exec exec = PrepareExec(NativeMethodsShared.IsWindows ? ":foo \n goto foo" : "while true; do sleep 1; done");
             exec.Timeout = 5;

--- a/src/Tasks.UnitTests/FileStateTests.cs
+++ b/src/Tasks.UnitTests/FileStateTests.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Build.UnitTests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // On Unix there no invalid file name characters
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void BadChars()
         {
             var state = new FileState("|");

--- a/src/Tasks.UnitTests/FindUnderPath_Tests.cs
+++ b/src/Tasks.UnitTests/FindUnderPath_Tests.cs
@@ -34,13 +34,10 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // On Unix there no invalid file name characters
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidFile()
         {
-            if (!NativeMethodsShared.IsWindows)
-            {
-                return; // "Cannot have invalid characters in file name on Unix"
-            }
-
             FindUnderPath t = new FindUnderPath();
             t.BuildEngine = new MockEngine();
 
@@ -55,13 +52,10 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)] // On Unix there no invalid file name characters
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void InvalidPath()
         {
-            if (!NativeMethodsShared.IsWindows)
-            {
-                return; // "Cannot have invalid characters in file name on Unix"
-            }
-
             FindUnderPath t = new FindUnderPath();
             t.BuildEngine = new MockEngine();
 

--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -2495,6 +2495,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void Regress25163_OutputResourcesContainsInvalidPathCharacters()
         {
             string resourcesFile = null;

--- a/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
@@ -3133,6 +3133,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)] // No invalid characters on Unix
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, ".NET Core 2.1+ no longer validates paths: https://github.com/dotnet/corefx/issues/27779#issuecomment-371253486")]
         public void ResolveFromDirectoryInvalidChar()
         {
             Dictionary<TargetPlatformSDK, TargetPlatformSDK> targetPlatform =

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "15.7-preview",
   "assemblyVersion": "15.1",
-  "buildNumberOffset": "10",
+  "buildNumberOffset": "20",
   "cloudBuild": {
     "buildNumber": {
       "enabled": true,


### PR DESCRIPTION
This builds on https://github.com/Microsoft/msbuild/pull/3185 and additionally restructures dependencies so that prodcon can ensure a coherent version of everything.

That required:
* Nothing for net46 (irrelevant to prodcon)
* Nothing for netstandard2.0/netcoreapp2.0 (depends on released bits, no coherency needed)
* Separating the 2.1 toolset we use to build from the 2.1 packages we reference for netcoreapp2.1.
* Specifying dependencies for things that get overridden with the right naming convention
  * Since we use repo-toolset, this is _not_ the normal prodcon convention
