### PR TITLE
Log a telemetry event on SDK resolution

### DIFF
--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
@@ -237,6 +239,16 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogFatalBuildError(BuildEventContext, exception, file);
+        }
+
+        /// <summary>
+        /// Logs a telemetry event.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="properties">The list of properties associated with the event.</param>
+        internal void LogTelemetry(string eventName, IDictionary<string, string> properties)
+        {
+            LoggingService.LogTelemetry(BuildEventContext, eventName, properties);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -146,6 +146,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                         loggingContext.LogWarning(null, new BuildEventFileInfo(sdkReferenceLocation), "SdkResultVersionDifferentThanReference", sdk.Name, sdk.Version, result.Version);
                     }
 
+                    loggingContext.LogTelemetry("SdkResolved", new Dictionary<string, string>
+                    {
+                        {"SdkName", sdk.Name},
+                        {"SdkVersion", sdk.Version},
+                        {"SdkMinimumVersion", sdk.MinimumVersion},
+                        {"ResolvedVersion", result.Version}
+                    });
+
                     // Associate the element location of the resolved SDK reference
                     result.ElementLocation = sdkReferenceLocation;
 


### PR DESCRIPTION
Log the SDK name, requested version, and the actual version returned
from the resolver service for an SDK. Note this will fire once per SDK
per build request or in VS once per new evaluation context.