### PR TITLE
GetReferenceAssemblyPaths needs GetFrameworkPaths

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -1168,7 +1168,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="GetReferenceAssemblyPaths"
-      DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)">
+      DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn);GetFrameworkPaths">
 
     <!-- if TargetFrameworkDirectory doesn't have a custom value, clear it out; that way we can get reference paths and target framework directories all in the right order -->
     <PropertyGroup>


### PR DESCRIPTION
GetReferenceAssemblyPaths references
`@(_CombinedTargetFrameworkDirectoriesItem)` and other properties/items
that get defined (for .NET projects) in `GetFrameworkPaths`, but did
not depend on it. Dependencies were enforced by listing
GetFrameworkPaths first whenever dependencies existed, but that is hard
to enforce, and when missed caused dotnet/sdk#1730.

I'm adding this explicitly rather than appending to the already-existent
but undefined `$(GetReferenceAssemblyPathsDependsOn)` because a GitHub
search found a few projects (mostly Mono-related) that _override_ rather
than append to GetReferenceAssemblyPathsDependsOn. That was safe because
no released MSBuild ever defined anything in that property, but could
introduce problems if we started defining it.

Fixes #3196.