### PR TITLE
Preserve CWD in RequestBuilder_Tests

### DIFF
--- a/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/RequestBuilder_Tests.cs
@@ -38,12 +38,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
         private IRequestBuilder _requestBuilder;
         private int _nodeRequestId;
 
+        private string _originalWorkingDirectory;
+
         public void LoggingException(Exception e)
         {
         }
 
         public RequestBuilder_Tests()
         {
+            _originalWorkingDirectory = Directory.GetCurrentDirectory();
             _nodeRequestId = 1;
             _host = new MockHost();
             _host.RequestBuilder = new RequestBuilder();
@@ -63,9 +66,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             ((IBuildComponent)_requestBuilder).ShutdownComponent();
             _host = null;
+
+            // Normally, RequestBuilder ensures that this gets reset before completing
+            // requests, but we call it in odd ways here so restore it manually
+            // to keep the overall test invariant happy.
+            Directory.SetCurrentDirectory(_originalWorkingDirectory);
         }
 
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/2926")]
+        [Fact]
         public void TestSimpleBuildRequest()
         {
             BuildRequestConfiguration configuration = CreateTestProject(1);
@@ -83,6 +91,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 targetBuilder.SetResultsToReturn(result);
 
                 _requestBuilder.BuildRequest(GetNodeLoggingContext(), entry);
+
                 WaitForEvent(_buildRequestCompletedEvent, "Build Request Completed");
                 Assert.Equal(BuildRequestEntryState.Complete, entry.State);
                 Assert.Equal(entry, _buildRequestCompleted_Entry);
@@ -94,7 +103,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
         }
 
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/2926")]
+        [Fact]
         public void TestSimpleBuildRequestCancelled()
         {
             BuildRequestConfiguration configuration = CreateTestProject(1);
@@ -110,6 +119,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 BuildResult result = new BuildResult(request);
                 result.AddResultsForTarget("target1", GetEmptySuccessfulTargetResult());
                 targetBuilder.SetResultsToReturn(result);
+
                 _requestBuilder.BuildRequest(GetNodeLoggingContext(), entry);
 
                 Thread.Sleep(500);
@@ -126,7 +136,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
         }
 
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/2926")]
+        [Fact]
         public void TestRequestWithReference()
         {
             BuildRequestConfiguration configuration = CreateTestProject(1);
@@ -165,7 +175,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             }
         }
 
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/2926")]
+        [Fact]
         public void TestRequestWithReferenceCancelled()
         {
             BuildRequestConfiguration configuration = CreateTestProject(1);


### PR DESCRIPTION
Fixes #2926 by preserving the working directory manually for these tests
since RequestBuilder only does it for you in the "normal" calling
patterns.