### PR TITLE
HighEntropyVA by default for .NET Standard/Core

### DIFF
--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
@@ -104,7 +104,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Prefer32Bit Condition="'$(Prefer32Bit)' == ''">false</Prefer32Bit>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetingClr2Framework)' != 'true' and '$(TargetFrameworkVersion)' != 'v4.0'">
+  <PropertyGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(TargetingClr2Framework)' != 'true' and '$(TargetFrameworkVersion)' != 'v4.0') or '$(TargetFrameworkIdentifier)' == '.NETCoreApp' or '$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <HighEntropyVA Condition="'$(HighEntropyVA)' == ''">true</HighEntropyVA>
   </PropertyGroup>
 


### PR DESCRIPTION
The check that turned this on for "new enough" runtimes predated .NET
Standard and .NET Core, but anything that targets them is by definition
new enough to have it by default, since .NET Core is new and .NET
Standard 1.0 is .NET 4.5.

Fixes #2912.