### PR TITLE
Avoid error when TargetFrameworkProfile is \r

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -72,7 +72,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '' and '$(TargetFrameworkVersion)' != ''">
-    <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == '' and '$(TargetFrameworkProfile)' != ''">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)</TargetFrameworkMoniker>
+    <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == '' and '$([System.String]::IsNullOrWhitespace($(TargetFrameworkProfile)))' != 'true'">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)</TargetFrameworkMoniker>
     <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
 
     <!-- When working off a packaged reference assemblies, do not go to machine-global locations. This property is target-framework-specific, so it cannot be overridden in msbuild.exe.config once and for all. -->


### PR DESCRIPTION
Project System telemetry indicates a significant number of failures that
report

```
The expression "[System.IO.Path]::Combine(D:\Temp\, .NETFramework,Version=v4.5,Profile=
 .AssemblyAttributes.cs)" cannot be evaluated. Illegal characters in path. C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\Microsoft.Common.CurrentVersion.targets
```

This seems to be because the XML entity for a carriage return gets
embedded in the file. We don't currently know what would cause that.

This is a tactical fix: instead of comparing against '', explicitly
use `String.IsNullOrWhitespace` which knows about all kinds of
whitespace, even bare \r.

Closes #3197.