### PR TITLE
Avoid handshake timeout on Windows

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -366,7 +366,11 @@ namespace Microsoft.Build.BackEnd
                 nodeStream.WriteLongForHandshake(hostHandshake);
 
                 CommunicationsUtilities.Trace("Reading handshake from pipe {0}", pipeName);
+#if NETCOREAPP2_1
+                long handshake = nodeStream.ReadLongForHandshake(timeout);
+#else
                 long handshake = nodeStream.ReadLongForHandshake();
+#endif
 
                 if (handshake != clientHandshake)
                 {

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -422,7 +422,11 @@ namespace Microsoft.Build.BackEnd
                     // it will cause the host to reject us; new hosts expect 00 and old hosts expect F5 or 06).
                     try
                     {
-                        long handshake = localReadPipe.ReadLongForHandshake(/* reject these leads */ new byte[] { 0x5F, 0x60 }, 0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */);
+                        long handshake = localReadPipe.ReadLongForHandshake(/* reject these leads */ new byte[] { 0x5F, 0x60 }, 0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */
+#if NETCOREAPP2_1
+                            , ClientConnectTimeout /* wait a long time for the handshake from this side */
+#endif
+                            );
 
 #if FEATURE_SECURITY_PERMISSIONS
                         WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();


### PR DESCRIPTION
The old version of this code didn't have a timeout when reading the
handshake packet, and appeared to be reliable. The timeout was required
to work around a cross-platform design limitation: the pipe always
connects on *nix systems, even when nothing is listening to it.

This caused failures on Windows (#3214), because the timeout was
exceeded there. For maximum robustness, avoid the timeout entirely on
Windows.