### PR TITLE
No toolsversion message when one is not mentioned in the project

### DIFF
--- a/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
+++ b/src/Build.UnitTests/Definition/Project_Internal_Tests.cs
@@ -146,6 +146,14 @@ namespace Microsoft.Build.UnitTests.Definition
             }
         }
 
+        [Fact]
+        public void UsingExplicitToolsVersionShouldBeFalseWhenNoToolsetIsReferencedInProject()
+        {
+            var project = ObjectModelHelpers.CreateInMemoryProject("<Project></Project>");
+
+            project.TestOnlyGetPrivateData.UsingDifferentToolsVersionFromProjectFile.ShouldBeFalse();
+        }
+
         /// <summary>
         /// $(MSBuildToolsVersion) should be set to ToolsVersion evaluated with,
         /// even if it is subsequently changed on the XML (without reevaluation)

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -21,6 +21,7 @@ using Microsoft.Build.Engine.UnitTests;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.BackEnd;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Build.Engine.UnitTests.TestComparers.ProjectInstanceModelTestComparers;
@@ -280,6 +281,18 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             ProjectInstance p = GetSampleProjectInstance();
 
             Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, p.Toolset.ToolsVersion);
+        }
+
+        [Fact]
+        public void UsingExplicitToolsVersionShouldBeFalseWhenNoToolsetIsReferencedInProject()
+        {
+            var projectInstance = new ProjectInstance(
+                new ProjectRootElement(
+                    XmlReader.Create(new StringReader("<Project></Project>")), ProjectCollection.GlobalProjectCollection.ProjectRootElementCache, false, false)
+                );
+
+            projectInstance.UsingDifferentToolsVersionFromProjectFile.ShouldBeFalse();
+
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1080,9 +1080,7 @@ namespace Microsoft.Build.BackEnd
             //
             ConfigureWarningsAsErrorsAndMessages();
 
-            // See comment on ProjectItemInstance.Initialize for full details
-            // We have been asked to build with a tools verison that we don't know about
-            // so we'll report that we're building as if the project had been marked with a known toolsversion instead
+            // See comment on Microsoft.Build.Internal.Utilities.GenerateToolsVersionToUse
             _requestEntry.RequestConfiguration.RetrieveFromCache();
             if (_requestEntry.RequestConfiguration.Project.UsingDifferentToolsVersionFromProjectFile)
             {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3448,16 +3448,11 @@ namespace Microsoft.Build.Evaluation
                         ExplicitToolsVersion,
                         _project._xml.ToolsVersion,
                         Project.ProjectCollection.GetToolset,
-                        Project.ProjectCollection.DefaultToolsVersion
+                        Project.ProjectCollection.DefaultToolsVersion,
+                        out var usingDifferentToolsVersionFromProjectFile
                     );
 
-                // Don't log the message if the toolsversion is different because an explicit toolsversion was specified -- 
-                // in that case the user already knows what they're doing; the point of this warning is to give them a heads
-                // up if we're doing this ourselves for our own reasons. 
-                if (!explicitToolsVersionSpecified && !String.Equals(_originalProjectToolsVersion, toolsVersionToUse, StringComparison.OrdinalIgnoreCase))
-                {
-                    _usingDifferentToolsVersionFromProjectFile = true;
-                }
+                _usingDifferentToolsVersionFromProjectFile = usingDifferentToolsVersionFromProjectFile;
 
                 Toolset = toolsetProvider.GetToolset(toolsVersionToUse);
 

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1008,7 +1008,7 @@ namespace Microsoft.Build.Evaluation
         /// <returns>The ToolsVersion we should use to build this project.  Should never be null.</returns>
         public string GetEffectiveToolsVersion(string explicitToolsVersion, string toolsVersionFromProject)
         {
-            return Utilities.GenerateToolsVersionToUse(explicitToolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion);
+            return Utilities.GenerateToolsVersionToUse(explicitToolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion, out _);
         }
 
         /// <summary>
@@ -1107,7 +1107,7 @@ namespace Microsoft.Build.Evaluation
                     }
                 }
 
-                string effectiveToolsVersion = Utilities.GenerateToolsVersionToUse(toolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion);
+                string effectiveToolsVersion = Utilities.GenerateToolsVersionToUse(toolsVersion, toolsVersionFromProject, GetToolset, DefaultToolsVersion, out _);
                 Project project = _loadedProjects.GetMatchingProjectIfAny(fileName, globalProperties, effectiveToolsVersion);
 
                 if (project == null)

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2082,7 +2082,12 @@ namespace Microsoft.Build.Execution
                         toolsVersion = visualStudioVersion.ToString(CultureInfo.InvariantCulture) + ".0";
                     }
 
-                    string toolsVersionToUse = Utilities.GenerateToolsVersionToUse(explicitToolsVersion: null, toolsVersionFromProject: toolsVersion, getToolset: buildParameters.GetToolset, defaultToolsVersion: Constants.defaultSolutionWrapperProjectToolsVersion);
+                    string toolsVersionToUse = Utilities.GenerateToolsVersionToUse(
+                        explicitToolsVersion: null,
+                        toolsVersionFromProject: toolsVersion,
+                        getToolset: buildParameters.GetToolset,
+                        defaultToolsVersion: Constants.defaultSolutionWrapperProjectToolsVersion,
+                        usingDifferentToolsVersionFromProjectFile: out _);
                     projectInstances = GenerateSolutionWrapper(projectFile, globalProperties, toolsVersionToUse, loggingService, projectBuildEventContext, targetNames, sdkResolverService, submissionId);
                 }
             }
@@ -2525,16 +2530,11 @@ namespace Microsoft.Build.Execution
                 explicitToolsVersion,
                 xml.ToolsVersion,
                 buildParameters.GetToolset,
-                buildParameters.DefaultToolsVersion
+                buildParameters.DefaultToolsVersion,
+                out var usingDifferentToolsVersionFromProjectFile
             );
 
-            // Don't log the message if the toolsversion is different because an explicit toolsversion was specified -- 
-            // in that case the user already knows what they're doing; the point of this warning is to give them a heads
-            // up if we're doing this ourselves for our own reasons. 
-            if (!_explicitToolsVersionSpecified && !String.Equals(_originalProjectToolsVersion, toolsVersionToUse, StringComparison.OrdinalIgnoreCase))
-            {
-                _usingDifferentToolsVersionFromProjectFile = true;
-            }
+            _usingDifferentToolsVersionFromProjectFile = usingDifferentToolsVersionFromProjectFile;
 
             this.Toolset = buildParameters.GetToolset(toolsVersionToUse);
 

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -328,8 +328,9 @@ namespace Microsoft.Build.Internal
         /// <param name="getToolset">Delegate used to test whether a toolset exists for a given ToolsVersion.  May be null, in which
         /// case we act as though that toolset existed.</param>
         /// <param name="defaultToolsVersion">The default ToolsVersion</param>
+        /// <param name="usingDifferentToolsVersionFromProjectFile">true if the project file specifies an explicit toolsversion but a different one is chosen</param>
         /// <returns>The ToolsVersion we should use to build this project.  Should never be null.</returns>
-        internal static string GenerateToolsVersionToUse(string explicitToolsVersion, string toolsVersionFromProject, GetToolset getToolset, string defaultToolsVersion)
+        internal static string GenerateToolsVersionToUse(string explicitToolsVersion, string toolsVersionFromProject, GetToolset getToolset, string defaultToolsVersion, out bool usingDifferentToolsVersionFromProjectFile)
         {
             string toolsVersionToUse = explicitToolsVersion;
 
@@ -441,7 +442,18 @@ namespace Microsoft.Build.Internal
             }
 
             ErrorUtilities.VerifyThrow(!String.IsNullOrEmpty(toolsVersionToUse), "Should always return a ToolsVersion");
+
+            var explicitToolsVersionSpecified = explicitToolsVersion != null;
+            usingDifferentToolsVersionFromProjectFile = UsingDifferentToolsVersionFromProjectFile(toolsVersionFromProject, toolsVersionToUse, explicitToolsVersionSpecified);
+
             return toolsVersionToUse;
+        }
+
+        private static bool UsingDifferentToolsVersionFromProjectFile(string toolsVersionFromProject, string toolsVersionToUse, bool explicitToolsVersionSpecified)
+        {
+            return (!explicitToolsVersionSpecified &&
+                    !string.IsNullOrEmpty(toolsVersionFromProject) &&
+                    !String.Equals(toolsVersionFromProject, toolsVersionToUse, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>


### PR DESCRIPTION
A log message is generated when the toolsversion specified in the project differs from the one msbuild chooses. Now that toolsversion is not required anymore, suppress this message when there is no explicit toolsversion reference in the project file.

![image](https://user-images.githubusercontent.com/2255729/39200564-60a24620-47a1-11e8-997d-f07ea1d7c633.png)
