### PR TITLE
Move translations from master to vs15.7

### DIFF
--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech s názvy MSBuild_*.failure.txt v adresáři s dočasnými soubory.</target>
+        <target state="translated">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech v {1}, budou mít názvy MSBuild_*.failure.txt. Toto umístění je možné změnit nastavením proměnné prostředí MSBUILDDEBUGPATH na jiný adresář.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">Import souboru {0} do souboru {1} má za následek cyklickou závislost.</target>
+        <target state="translated">Import souboru {0} do souboru {1} má za následek cyklickou závislost.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -638,7 +638,7 @@
       </trans-unit>
       <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
         <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
-        <target state="translated">MSB4096: Položka {0} v seznamu položek {1} nedefinuje hodnotu pro metadata {2}. Chcete-li používat tato metadata, kvalifikujte je zadáním %({1}.{2}) nebo zajistěte, aby všechny položky v tomto seznamu definovaly hodnotu pro tato metadata.</target>
+        <target state="translated">MSB4096: Položka {0} v seznamu položek {1} nedefinuje hodnotu pro metadata {2}.  Chcete-li používat tato metadata, kvalifikujte je zadáním %({1}.{2}) nebo zajistěte, aby všechny položky v tomto seznamu definovaly hodnotu pro tato metadata.</target>
         <note>{StrBegin="MSB4096: "}</note>
       </trans-unit>
       <trans-unit id="ItemListNotAllowedInThisConditional">
@@ -691,7 +691,7 @@
       </trans-unit>
       <trans-unit id="MissingTaskError">
         <source>MSB4036: The "{0}" task was not found. Check the following: 1.) The name of the task in the project file is the same as the name of the task class. 2.) The task class is "public" and implements the Microsoft.Build.Framework.ITask interface. 3.) The task is correctly declared with &lt;UsingTask&gt; in the project file, or in the *.tasks files located in the "{1}" directory.</source>
-        <target state="translated">MSB4036: Nebyla nalezena úloha {0}. Zkontrolujte, zda platí následující skutečnosti: 1.) Název úlohy v souboru projektu je stejný jako název třídy úloh. 2.) Třída úloh je veřejná (public) a implementuje rozhraní Microsoft.Build.Framework.ITask. 3.) Úloha je správně deklarována s elementem &lt;UsingTask&gt; v souboru projektu nebo v souborech *.tasks v adresáři {1}.</target>
+        <target state="translated">MSB4036: Nebyla nalezena úloha {0}. Zkontrolujte, zda platí následující skutečnosti: 1.) Název úlohy v souboru projektu je stejný jako název třídy úloh. 2.) Třída úloh je veřejná (public) a implementuje rozhraní Microsoft.Build.Framework.ITask. 3.) Úloha je správně deklarována s elementem v souboru projektu nebo v souborech *.tasks v adresáři {1}.</target>
         <note>{StrBegin="MSB4036: "}LOCALIZATION: &lt;UsingTask&gt; and "*.tasks" should not be localized.</note>
       </trans-unit>
       <trans-unit id="MSBuildToolsPathIsNotSpecified">
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: Výchozí obor názvů XML projektu musí být oborem názvů XML nástroje MSBuild nebo nesmí být žádným oborem názvů. Pokud je projekt vytvořený ve formátu MSBuild 2003, přidejte do elementu atribut xmlns="{0}". Jestliže byl projekt vytvořený ve starém formátu 1.0 nebo 1.2, převeďte ho na formát MSBuild 2003.</target>
+        <target state="translated">MSB4041: Výchozí nastavení pro obor názvů XML projektu musí být obor názvů XML nástroje MSBuild nebo žádný obor názvů. Pokud je projekt vytvořen ve formátu MSBuild 2003, přidejte do elementu atribut xmlns="{0}". Jestliže byl projekt vytvořen ve starém formátu 1.0 nebo 1.2, převeďte jej na formát MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1017,19 +1017,19 @@
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoClean">
         <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
-        <target state="translated">Webové projekty nepodporují cíl Clean. Pokračuje zpracování zbývajících projektů...</target>
+        <target state="translated">Webové projekty nepodporují cíl Clean.  Pokračuje zpracování zbývajících projektů...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Clean".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoPublish">
         <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
-        <target state="translated">Webové projekty nepodporují cíl Publish. Pokračuje zpracování zbývajících projektů...</target>
+        <target state="translated">Webové projekty nepodporují cíl Publish.  Pokračuje zpracování zbývajících projektů...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Publish".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectSkipped">
         <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
-        <target state="translated">Vynecháno, protože konfigurace $(AspNetConfiguration) není pro tento webový projekt podporována. Pomocí vlastnosti AspNetConfiguration můžete přepsat konfiguraci používanou k sestavování webových projektů, a to přidáním příkazu /p:AspNetConfiguration=&lt;hodnota&gt; do příkazového řádku. Webové projekty nyní podporují pouze konfigurace Debug a Release.</target>
+        <target state="translated">Vynecháno, protože konfigurace $(AspNetConfiguration) není pro tento webový projekt podporována.  Pomocí vlastnosti AspNetConfiguration můžete přepsat konfiguraci používanou k sestavování webových projektů, a to přidáním příkazu /p:AspNetConfiguration= do příkazového řádku. Webové projekty nyní podporují pouze konfigurace Debug a Release.</target>
         <note>
     UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
@@ -1037,7 +1037,7 @@
       </trans-unit>
       <trans-unit id="TargetAlreadyCompleteFailure">
         <source>Target "{0}" skipped. Previously built unsuccessfully.</source>
-        <target state="translated">Cíl {0} byl vynechán. Předchozí sestavení se nezdařilo.</target>
+        <target state="translated">Cíl {0} byl vynechán. Předchozí sestavení se nepovedlo.</target>
         <note />
       </trans-unit>
       <trans-unit id="TargetAlreadyCompleteSuccess">
@@ -1948,7 +1948,7 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: Z úlohy {0} nešlo z {1} vytvořit instanci. Tato verze MSBuildu nepodporuje {2}.</target>
+        <target state="translated">MSB4802: Nelze vytvořit instanci úlohy {0} z {1}. Tato verze nástroje MSBuild nepodporuje {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -2068,7 +2068,7 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Překladač sady SDK založený na NuGet se nepodařilo spustit, protože sestavení NuGet se nenašla. Zkontrolujte instalaci nástroje MSBuild nebo nastavte proměnnou prostředí {0} na složku, která obsahuje požadovaná sestavení NuGet. {1}</target>
+        <target state="translated">MSB4243: Překladač sady SDK založený na NuGet se nepodařilo spustit, protože sestavení NuGet se nenašla.  Zkontrolujte instalaci nástroje MSBuild nebo nastavte proměnnou prostředí {0} na složku, která obsahuje požadovaná sestavení NuGet. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Využití:          Průměrné využití {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: Několik verzí stejné sady SDK {0} nelze zadat. Bude použita verze {1} sady SDK, kterou už určuje {2}, verze {3} bude ignorována.</target>
+        <target state="translated">MSB4240: Více verzí stejné sady SDK {0} nelze zadat. Použije se dříve přeložená sada SDK verze {1} z umístění {2} a verze {3} se bude ignorovat.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: Odkaz na sadu SDK {0} verze {1} byl místo toho přeložen na verzi {2}. Pokud neaktualizujete odkazovanou verzi tak, aby se shodovala, může se používat jiná verze, než kterou očekáváte.</target>
+        <target state="translated">MSB4241: Odkaz na sadu SDK {0} verze {1} byl místo toho přeložen na verzi {2}.  Pokud neaktualizujete odkazovanou verzi tak, aby se shodovala, může se používat jiná verze, než kterou očekáváte.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Herunterfahren. Diagnoseinformationen finden Sie in den Dateien des Verzeichnisses für temporäre Dateien mit dem Namen MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Herunterfahren. Diagnoseinformationen finden Sie in den Dateien namens "MSBuild_*.failure.txt" unter "{1}". Dieser Speicherort kann geändert werden, indem Sie die Umgebungsvariable MSBUILDDEBUGPATH auf ein anderes Verzeichnis festlegen.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -221,7 +221,7 @@
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: MSBuildToolsPath ist nicht identisch mit MSBuildBinPath für die bei "{1}" definierte ToolsVersion {0}. Wenn beide Pfade vorhanden sind, müssen sie identische Werte haben.</target>
+        <target state="translated">MSB4142: MSBuildToolsPath ist nicht identisch mit MSBuildBinPath für die bei "{1}" definierte ToolsVersion "{0}". Falls beide vorhanden sind, müssen sie den identischen Wert haben.</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">Der Import der Datei "{0}" in die Datei "{1}" führt zu einer Ringabhängigkeit.</target>
+        <target state="translated">Der Import der Datei "{0}" in die Datei "{1}" führt zu einer Ringabhängigkeit.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -663,7 +663,7 @@
       </trans-unit>
       <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
         <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
-        <target state="translated">Eine InternalLoggerException kann nur durch das MSBuild-Modul ausgelöst werden. Die öffentlichen Konstruktoren dieser Klasse können nicht verwendet werden, um eine Instanz der Ausnahme zu erstellen.</target>
+        <target state="translated">Eine InternalLoggerException kann nur durch die MSBuild-Engine ausgelöst werden. Die öffentlichen Konstruktoren dieser Klasse können nicht verwendet werden, um eine Instanz der Ausnahme zu erstellen.</target>
         <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
     only the engine is allowed to create and throw this exception.
     LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: Der Standard-XML-Namespace des Projekts muss entweder der MSBuild-XML-Namespace sein, oder es wird kein Namespace festgelegt. Wenn das Projekt im MSBuild 2003-Format erstellt wurde, fügen Sie dem &lt;Project&gt;-Element xmlns="{0}" hinzu. Wenn das Projekt im alten Format 1.0 oder 1.2 erstellt wurde, konvertieren Sie es in das MSBuild 2003-Format.</target>
+        <target state="translated">MSB4041: Der Standard-XML-Namespace des Projekts muss entweder der MSBuild-XML-Namespace oder kein Namespace sein. Wenn das Projekt im MSBuild 2003-Format erstellt wurde, fügen Sie dem &lt;Project&gt;-Element xmlns="{0}" hinzu. Wenn das Projekt im alten Format 1.0 oder 1.2 erstellt wurde, konvertieren Sie es in das MSBuild 2003-Format.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1943,12 +1943,12 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidSdkFormat">
         <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: Der Wert "{0}" ist für eine SDK-Spezifikation nicht gültig. Das Attribut muss eine durch Semikolons getrennte Liste der Paare SDK-Name/Mindestversion (durch Schrägstrich getrennt) sein.</target>
+        <target state="translated">MSB4229: Der Wert "{0}" ist für eine SDK-Spezifikation ungültig. Das Attribut muss eine durch Semikolons getrennte Liste der Paare SDK-Name/Mindestversion (durch Schrägstrich getrennt) sein.</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: Die Aufgabe "{0}" konnte von "{1}" nicht instanziiert werden. MSBuild unterstützt {2} nicht.</target>
+        <target state="translated">MSB4802: Die {0}-Aufgabe konnte nicht aus "{1}" instanziiert werden. Diese Version von MSBuild bietet keine Unterstützung für "{2}".</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: Ungültige binäre Protokollierungsparameter: "{0}". Erwartet: ProjectImports={{None,Embed,ZipFile}} und/oder [LogFile=]filePath.binlog (der Protokolldateiname oder -pfad, muss die Erweiterung ".binlog" aufweisen).</target>
+        <target state="translated">MSB4234: Ungültige binäre Protokollierungsparameter: {0}. Erwartet: ProjectImports={{None,Embed,ZipFile}} und/oder [LogFile=]filePath.binlog (der Protokolldateiname oder -pfad, muss die Erweiterung ".binlog" aufweisen).</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2068,7 +2068,7 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Fehler beim NuGet-basierten SDK-Resolver, weil die NuGet-Assemblys nicht gefunden wurden. Überprüfen Sie Ihre Installation von MSBuild, oder legen Sie die Umgebungsvariable "{0}" auf den Ordner fest, der die erforderlichen NuGet-Assemblys enthält. {1}</target>
+        <target state="translated">MSB4243: Der NuGet-basierte SDK-Resolver konnte nicht ausgeführt werden, weil NuGet-Assemblys nicht gefunden wurden.  Prüfen Sie Ihre Installation von MSBuild, oder legen Sie die Umgebungsvariable "{0}" auf den Ordner fest, der die erforderlichen NuGet-Assemblys enthält. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Auslastung:          {0} Durchschnittliche Auslastung: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: Es können nicht mehrere Versionen für dasselbe SDK "{0}" angegeben werden. Die bereits von "{2}" angegebene SDK-Version "{1}" wird verwendet, die Version "{3}" wird ignoriert.</target>
+        <target state="translated">MSB4240: Es können nicht mehrere Versionen desselben SDK "{0}" angegeben werden. Die zuvor aufgelöste SDK-Version "{1}" am Speicherort "{2}" wird verwendet, und die Version "{3}" wird ignoriert.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: Der SDK-Verweis "{0}" auf Version "{1}" wurde stattdessen in Version "{2}" aufgelöst. Sie könnten eine andere Version als die erwartete verwenden, wenn Sie die referenzierte Version nicht entsprechend aktualisieren.</target>
+        <target state="translated">MSB4241: Der SDK-Verweis "{0}", Version "{1}", wurde stattdessen in Version "{2}" aufgelöst.  Möglicherweise verwenden Sie eine andere Version als die erwartete, wenn Sie die referenzierte Version nicht entsprechend aktualisieren.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos del directorio de archivos temporales denominado MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos en "{1}" y recibirá el nombre MSBuild_*.failure.txt. Esta ubicación se puede cambiar estableciendo la variable de entorno MSBUILDDEBUGPATH en un directorio diferente.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">Si se importa el archivo "{0}" en el archivo "{1}", se producirá una dependencia circular.</target>
+        <target state="translated">Si se importa el archivo "{0}" en el archivo "{1}", se producirá una dependencia circular.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: El espacio de nombres XML predeterminado del proyecto debe ser el espacio de nombres XML de MSBuild o ninguno. Si el proyecto se creó con el formato MSBuild 2003, agregue xmlns="{0}" al elemento &lt;Project&gt;. Si se creó con el formato 1.0 o 1.2 anterior, conviértalo al formato MSBuild 2003.</target>
+        <target state="translated">MSB4041: El espacio de nombres XML predeterminado del proyecto debe ser el espacio de nombres XML de MSBuild o ningún espacio de nombres. Si el proyecto se creó con el formato MSBuild 2003, agregue xmlns="{0}" al elemento &lt;Project&gt;. Si se creó con el formato 1.0 ó 1.2 anterior, conviértalo al formato MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1943,7 +1943,7 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidSdkFormat">
         <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: El valor "{0}" no es válido para una especificación de SDK. El atributo debe ser una lista delimitada por puntos y coma de pares nombre-SDK/versión-mínima, separados por una barra diagonal.</target>
+        <target state="translated">MSB4229: El valor "{0}" no es válido para una especificación SDK. El atributo debe ser una lista delimitada por puntos y coma de pares nombre-SDK/versión-mínima, separados por una barra diagonal.</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
@@ -1983,7 +1983,7 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: Parámetros no válidos del registrador binario: "{0}". Se esperaba: ProjectImports={{None,Embed,ZipFile}} y/o [LogFile=]rutaDeAccesoDelArchivo.binlog (nombre o ruta de acceso del archivo de registro, que debe tener la extensión ".binlog").</target>
+        <target state="translated">MSB4234: Parámetros no válidos del registrador binario: "{0}". Se esperaba: ProjectImports={{None,Embed,ZipFile}} o [LogFile=]rutaDeAccesoDelArchivo.binlog (nombre o ruta de acceso del archivo de registro, que debe tener la extensión ".binlog").</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2068,7 +2068,7 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: La resolución del SDK basado en NuGet no se pudo ejecutar porque no se encontraron los ensamblados de NuGet. Compruebe su instalación de MSBuild o configure la variable del entorno "{0}" en la carpeta que contiene los ensamblados de NuGet requeridos. {1}</target>
+        <target state="translated">MSB4243: La resolución del SDK basado en NuGet no se pudo ejecutar porque no se encontraron los ensamblados de NuGet.  Compruebe su instalación de MSBuild o configure la variable de entorno "{0}" en la carpeta que contiene los ensamblados de NuGet requeridos. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilización:          Utilización media de {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: No se pueden especificar varias versiones del mismo SDK "{0}". Se usará la versión del SDK "{1}" ya especificada por "{2}" y la versión "{3}" se ignorará.</target>
+        <target state="translated">MSB4240: No se pueden especificar varias versiones del mismo SDK "{0}" Se utilizará la versión del SDK previamente resuelta "{1\}" de la ubicación "{2}", y la versión "{3}" se ignorará.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: La referencia del SKD "{0}", versión "{1}", se resolvió en la versión "{2}". Podría estar utilizando una versión diferente de la esperada si no actualiza la versión de referencia para que coincida.</target>
+        <target state="translated">MSB4241: La referencia del SKD "{0}", versión "{1}", se resolvió en la versión "{2}".  Podría estar utilizando una versión diferente de la esperada si no actualiza la versión de referencia para que coincida.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: Fin prématurée du nœud enfant "{0}". Arrêt. Des informations de diagnostic se trouvent dans le répertoire de fichiers temporaires dans des fichiers nommés MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: Fin prématurée du nœud enfant "{0}". Arrêt. Les informations de diagnostic se trouvent dans des fichiers situés dans "{1}", qui se nomment MSBuild_*.failure.txt. Vous pouvez changer l'emplacement en affectant un autre répertoire à la variable d'environnement MSBUILDDEBUGPATH.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -221,7 +221,7 @@
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: MSBuildToolsPath n'est pas identique à MSBuildBinPath pour le ToolsVersion "{0}" défini à "{1}". Si les deux sont présents, ils doivent avoir la même valeur.</target>
+        <target state="translated">MSB4142: MSBuildToolsPath n'est pas identique à MSBuildBinPath pour le ToolsVersion "{0}" défini sur "{1}". Si les deux sont présents, ils doivent avoir la même valeur.</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">L'importation du fichier "{0}" dans le fichier "{1}" produit une dépendance circulaire.</target>
+        <target state="translated">L'importation du fichier "{0}" dans le fichier "{1}" produit une dépendance circulaire.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: l'espace de noms XML par défaut du projet doit être l'espace de noms XML MSBuild ou aucun espace de noms. Si le projet est créé au format MSBuild 2003, ajoutez xmlns="{0}" à l'élément &lt;Project&gt;. Si le projet a été créé avec l'ancien format 1.0 ou 1.2, convertissez-le au format MSBuild 2003.</target>
+        <target state="translated">MSB4041: l'espace de noms XML par défaut du projet doit être l'espace de noms XML MSBuild ou aucun espace de noms. Si le projet a été créé au format MSBuild 2003, ajoutez xmlns="{0}" à l'élément &lt;Project&gt;. S'il a été créé dans des formats antérieurs comme 1.0 ou 1.2, convertissez-le au format MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1943,12 +1943,12 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidSdkFormat">
         <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: La valeur "{0}" n'est pas valide pour une spécification de SDK. L'attribut doit être une liste séparée par des points-virgules de paires nom_SDK/version_minimum, séparées par une barre oblique.</target>
+        <target state="translated">MSB4229: la valeur "{0}" est non valide pour la spécification d'un kit SDK. L'attribut doit être une liste de paires nom/version minimale du kit SDK, délimitées par une barre oblique.</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: La tâche "{0}" n'a pas pu être instanciée à partir de "{1}". Cette version de MSBuild ne prend pas en charge {2}.</target>
+        <target state="translated">MSB4802: impossible d'instancier la tâche "{0}" à partir de "{1}". Cette version de MSBuild ne prend pas en charge {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: Paramètre(s) de l’enregistrement d’événements binaire non valide(s) : "{0}". Attendu(s) : ProjectImports={{None,Embed,ZipFile}} et/ou [LogFile=]filePath.binlog (le chemin ou le nom du fichier journal doit avoir l’extension ".binlog").</target>
+        <target state="translated">MSB4234: paramètres de l'enregistreur d'événements binaire non valides : "{0}". Attendu : ProjectImports={{None,Embed,ZipFile}} et/ou [LogFile=]filePath.binlog (chemin ou nom du fichier journal avec l'extension ".binlog").</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2068,7 +2068,7 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Impossible d'exécuter la résolution de SDK NuGet parce que les assemblys NuGet n'ont pas pu être localisés. Vérifiez votre installation de MSBuild ou définissez la variable d'environnement "{0}" dans le dossier qui contient les assemblys NuGet obligatoires. {1}</target>
+        <target state="translated">MSB4243: le programme de résolution du kit SDK basé sur NuGet n'a pas pu s'exécuter, car les assemblys NuGet sont introuvables.  Vérifiez votre installation de MSBuild, ou affectez à la variable d'environnement "{0}" le dossier qui contient les assemblys NuGet nécessaires. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilisation :          {0} Utilisation moyenne : {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: Impossible de spécifier plusieurs versions du même SDK "{0}". La version du SDK "{1}" déjà spécifiée par "{2}" est utilisée, tandis que la version "{3}" est ignorée.</target>
+        <target state="translated">MSB4240: impossible de spécifier plusieurs versions du même kit SDK "{0}". La version du kit SDK "{1}" résolue à partir de l'emplacement "{2}" va être utilisée. La version "{3}" va être ignorée.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: La référence du SDK "{0}" version "{1}" a été résolue avec la version "{2}" à la place. Vous risquez d'utiliser une version différente de celle attendue si vous ne mettez pas à jour la version référencée correspondante.</target>
+        <target state="translated">MSB4241: la référence du kit SDK "{0}" version "{1}" a été résolue en version "{2}" à la place.  Vous pouvez utiliser une autre version que celle prévue, si vous ne mettez pas à jour la version référencée correspondante.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -23,7 +23,7 @@
       </trans-unit>
       <trans-unit id="BuildInProgress">
         <source>The operation cannot be completed because a build is already in progress.</source>
-        <target state="translated">Non è possibile completare l'operazione perché è già in corso una compilazione.</target>
+        <target state="translated">Impossibile completare l'operazione perché è già in corso una compilazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoBuildInProgress">
@@ -118,7 +118,7 @@
       </trans-unit>
       <trans-unit id="CannotEvaluateItemMetadata">
         <source>MSB4023: Cannot evaluate the item metadata "%({0})". {1}</source>
-        <target state="translated">MSB4023: non è possibile valutare i metadati dell'elemento "%({0})". {1}</target>
+        <target state="translated">MSB4023: impossibile valutare i metadati dell'elemento "%({0})". {1}</target>
         <note>{StrBegin="MSB4023: "}UE: This message is shown when the value of an item metadata cannot be computed for some reason e.g. trying to apply
     %(RootDir) to an item-spec that's not a valid path, would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
@@ -135,7 +135,7 @@
       </trans-unit>
       <trans-unit id="CannotModifyReservedItem">
         <source>MSB4117: The "{0}" item name is reserved, and cannot be used.</source>
-        <target state="translated">MSB4117: il nome di elemento "{0}" è riservato e non può essere usato.</target>
+        <target state="translated">MSB4117: il nome di elemento "{0}" è riservato e non può essere utilizzato.</target>
         <note>{StrBegin="MSB4117: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild items e.g. @(Choose)</note>
       </trans-unit>
       <trans-unit id="CannotModifyReservedItemMetadata">
@@ -145,7 +145,7 @@
       </trans-unit>
       <trans-unit id="CannotModifyReservedProperty">
         <source>MSB4004: The "{0}" property is reserved, and cannot be modified.</source>
-        <target state="translated">MSB4004: non è possibile modificare la proprietà "{0}". È riservata.</target>
+        <target state="translated">MSB4004: impossibile modificare la proprietà "{0}". È riservata.</target>
         <note>{StrBegin="MSB4004: "}UE: This message is shown when the user tries to redefine one of the reserved MSBuild properties e.g. $(MSBuildProjectFile)</note>
       </trans-unit>
       <trans-unit id="CannotPassMultipleItemsIntoScalarParameter">
@@ -164,7 +164,7 @@
       </trans-unit>
       <trans-unit id="CannotReferenceItemMetadataWithoutItemName">
         <source>MSB4095: The item metadata %({0}) is being referenced without an item name.  Specify the item name by using %(itemname.{0}).</source>
-        <target state="translated">MSB4095: riferimento ai metadati dell'elemento %({0}) senza un nome di elemento. Specificare il nome dell'elemento usando il formato %(itemname.{0}).</target>
+        <target state="translated">MSB4095: riferimento ai metadati dell'elemento %({0}) senza un nome di elemento.  Specificare il nome dell'elemento usando il formato %(itemname.{0}).</target>
         <note>{StrBegin="MSB4095: "}</note>
       </trans-unit>
       <trans-unit id="ChildElementsBelowRemoveNotAllowed">
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Chiusura in corso. Le informazioni diagnostiche sono disponibili nei file presenti nella directory dei file temporanei denominata MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Chiusura in corso. Le informazioni diagnostiche sono disponibili nei file presenti in "{1}" contraddistinti dal nome MSBuild_*.failure.txt. Per cambiare questo percorso, impostare la variabile di ambiente MSBUILDDEBUGPATH su una directory diversa.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">L'importazione del file "{0}" nel file "{1}" causa una dipendenza circolare.</target>
+        <target state="translated">L'importazione del file "{0}" nel file "{1}" causa una dipendenza circolare.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -298,7 +298,7 @@
       </trans-unit>
       <trans-unit id="DefaultToolsVersionNotFound">
         <source>MSB4133: A default tools version "{0}" was specified, but its definition could not be found.</source>
-        <target state="translated">MSB4133: la definizione della versione strumenti predefinita "{0}" specificata non è stata trovata.</target>
+        <target state="translated">MSB4133: impossibile trovare la definizione della versione strumenti predefinita "{0}" specificata.</target>
         <note>{StrBegin="MSB4133: "}</note>
       </trans-unit>
       <trans-unit id="DuplicateImport">
@@ -308,7 +308,7 @@
       </trans-unit>
       <trans-unit id="UsedUninitializedProperty">
         <source>MSB4211: The property "{0}" is being set to a value for the first time, but it was already consumed at "{1}".</source>
-        <target state="translated">MSB4211: la proprietà "{0}" verrà impostata su un valore per la prima volta, tuttavia è già stata usata in "{1}".</target>
+        <target state="translated">MSB4211: la proprietà "{0}" verrà impostata su un valore per la prima volta, tuttavia è già stata utilizzata in "{1}".</target>
         <note>{StrBegin="MSB4211: "}</note>
       </trans-unit>
       <trans-unit id="SelfImport">
@@ -350,7 +350,7 @@
       </trans-unit>
       <trans-unit id="ErrorEvaluatingToolsetPropertyExpression">
         <source>MSB4146: Cannot evaluate the property expression "{0}" found at "{1}". {2}</source>
-        <target state="translated">MSB4146: non è possibile valutare l'espressione di proprietà "{0}" trovata in "{1}". {2}</target>
+        <target state="translated">MSB4146: impossibile valutare l'espressione di proprietà "{0}" trovata in "{1}". {2}</target>
         <note>{StrBegin="MSB4146: "}</note>
       </trans-unit>
       <trans-unit id="ErrorWarningMessageNotSupported">
@@ -429,7 +429,7 @@
       </trans-unit>
       <trans-unit id="IllFormedItemListOpenParenthesisInCondition">
         <source>MSB4107: Expected an item list at position {1} in condition "{0}". Did you forget the opening parenthesis after the '@'? To use a literal '@', use '%40' instead.</source>
-        <target state="translated">MSB4107: è previsto un elenco di elementi nella posizione {1} nella condizione "{0}". Si è omessa la parentesi di chiusura dopo '@'? Per usare un valore letterale '@', specificare '%40'.</target>
+        <target state="translated">MSB4107: è previsto un elenco di elementi nella posizione {1} nella condizione "{0}". Si è omessa la parentesi di apertura dopo il simbolo '@'? Per usare un valore letterale '@', usare '%40'.</target>
         <note>{StrBegin="MSB4107: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedItemListQuoteInCondition">
@@ -444,12 +444,12 @@
       </trans-unit>
       <trans-unit id="IllFormedPropertyOpenParenthesisInCondition">
         <source>MSB4110: Expected a property at position {1} in condition "{0}". Did you forget the opening parenthesis after the '$'? To use a literal '$', use '%24' instead.</source>
-        <target state="translated">MSB4110: è prevista una proprietà nella posizione {1} nella condizione "{0}". Si è omessa la parentesi di apertura dopo il simbolo '$'? Per usare un valore letterale '$', specificare '%24'.</target>
+        <target state="translated">MSB4110: è prevista una proprietà nella posizione {1} nella condizione "{0}". Si è omessa la parentesi di apertura dopo il simbolo '$'? Per usare un valore letterale '$', usare '%24'.</target>
         <note>{StrBegin="MSB4110: "}</note>
       </trans-unit>
       <trans-unit id="IllFormedQuotedStringInCondition">
         <source>MSB4101: Expected a closing quote after position {1} in condition "{0}".</source>
-        <target state="translated">MSB4101: è prevista una virgoletta di chiusura dopo la posizione {1} nella condizione "{0}".</target>
+        <target state="translated">MSB4101: prevista una virgoletta di chiusura dopo la posizione {1} nella condizione "{0}".</target>
         <note>{StrBegin="MSB4101: "}</note>
       </trans-unit>
       <trans-unit id="ImportedProjectNotFound">
@@ -459,7 +459,7 @@
       </trans-unit>
       <trans-unit id="ImportedProjectFromExtensionsPathNotFoundFromAppConfig">
         <source>MSB4226: The imported project "{0}" was not found. Also, tried to find "{1}" in the fallback search path(s) for {2} - {3} . These search paths are defined in "{4}". Confirm that the path in the &lt;Import&gt; declaration is correct, and that the file exists on disk in one of the search paths.</source>
-        <target state="translated">MSB4226: il progetto importato "{0}" non è stato trovato. È stato anche effettuato un tentativo di trovare "{1}" nei percorsi di ricerca di fallback per {2} - {3}. Questi percorsi di ricerca sono definiti in "{4}". Verificare che il percorso nella dichiarazione &lt;Import&gt; sia corretto e che il file sia presente sul disco in uno dei percorsi di ricerca.</target>
+        <target state="translated">MSB4226: il progetto importato "{0}" non è stato trovato. È stato anche effettuato un tentativo di trovare "{1}" nei percorsi di ricerca di fallback per {2} - {3} . Questi percorsi di ricerca sono definiti in "{4}". Verificare che il percorso nella dichiarazione &lt;Import&gt; sia corretto e che il file sia presente sul disco in uno dei percorsi di ricerca.</target>
         <note>{StrBegin="MSB4226: "}LOCALIZATION: &lt;Import&gt; should not be localized.</note>
       </trans-unit>
       <trans-unit id="ImportedProjectFromExtensionsPathNotFound">
@@ -469,7 +469,7 @@
       </trans-unit>
       <trans-unit id="IncorrectNumberOfFunctionArguments">
         <source>MSB4089: Incorrect number of arguments to function in condition "{0}". Found {1} argument(s) when expecting {2}.</source>
-        <target state="translated">MSB4089: il numero di argomenti non è corretto per la funzione nella condizione "{0}". Sono stati trovati {1} argomenti ma ne sono previsti {2}.</target>
+        <target state="translated">MSB4089: il numero di argomenti non è corretto per la funzione nella condizione "{0}". N. di argomenti trovati: {1}, previsto: {2}.</target>
         <note>{StrBegin="MSB4089: "}</note>
       </trans-unit>
       <trans-unit id="InvalidAttributeValue">
@@ -578,7 +578,7 @@
       </trans-unit>
       <trans-unit id="InvalidItemFunctionExpression">
         <source>MSB4198: The expression "{0}" cannot be evaluated on item "{1}". {2}</source>
-        <target state="translated">MSB4198: non è possibile valutare l'espressione "{0}" sull'elemento "{1}". {2}</target>
+        <target state="translated">MSB4198: impossibile valutare l'espressione "{0}" sull'elemento "{1}". {2}</target>
         <note>
       {StrBegin="MSB4198: "}
       Double quotes as the expression will typically have single quotes in it.
@@ -638,7 +638,7 @@
       </trans-unit>
       <trans-unit id="ItemDoesNotContainValueForUnqualifiedMetadata">
         <source>MSB4096: The item "{0}" in item list "{1}" does not define a value for metadata "{2}".  In order to use this metadata, either qualify it by specifying %({1}.{2}), or ensure that all items in this list define a value for this metadata.</source>
-        <target state="translated">MSB4096: l'elemento "{0}" nell'elenco di elementi "{1}" non definisce un valore per i metadati "{2}". Per poter usare questi metadati, qualificarli specificando %({1}.{2}) o assicurarsi che tutti gli elementi dell'elenco definiscano un valore per questi metadati.</target>
+        <target state="translated">MSB4096: l'elemento "{0}" nell'elenco di elementi "{1}" non definisce un valore per i metadati "{2}".  Per poter usare questi metadati, qualificarli specificando %({1}.{2}) o accertarsi che tutti gli elementi dell'elenco definiscano un valore per questi metadati.</target>
         <note>{StrBegin="MSB4096: "}</note>
       </trans-unit>
       <trans-unit id="ItemListNotAllowedInThisConditional">
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: come spazio dei nomi XML predefinito del progetto è possibile specificare lo spazio dei nomi XML di MSBuild oppure nessuno spazio dei nomi. Se il progetto viene creato in formato MSBuild 2003, aggiungere xmlns="{0}" all'elemento &lt;Project&gt;. Se il progetto è stato creato nel formato precedente 1.0 o 1.2, convertirlo nel formato MSBuild 2003.</target>
+        <target state="translated">MSB4041: come spazio dei nomi XML predefinito del progetto è possibile specificare lo spazio dei nomi XML di MSBuild oppure nessuno spazio dei nomi. Se il progetto viene modificato nel formato MSBuild 2003, aggiungere xmlns="{0}" all'elemento &lt;Project&gt;. Se il progetto è stato modificato nel formato precedente 1.0 o 1.2, convertirlo al formato MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -970,7 +970,7 @@
       </trans-unit>
       <trans-unit id="SolutionParseErrorReadingProject">
         <source>MSB4046: Error reading project file "{0}": {1}</source>
-        <target state="translated">MSB4046: errore durante la lettura del file di progetto "{0}": {1}</target>
+        <target state="translated">MSB4046: errore durante la lettura del file di progetto "{0}". {1}</target>
         <note>{StrBegin="MSB4046: "}</note>
       </trans-unit>
       <trans-unit id="SolutionParseInvalidProjectFileName">
@@ -1017,19 +1017,19 @@
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoClean">
         <source>Web projects do not support the "Clean" target.  Continuing with remaining projects ...</source>
-        <target state="translated">I progetti Web non supportano la destinazione "Clean". Verranno elaborati i progetti rimanenti...</target>
+        <target state="translated">I progetti Web non supportano la destinazione "Clean".  Verranno elaborati i progetti rimanenti...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Clean".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectNoPublish">
         <source>Web projects do not support the "Publish" target.  Continuing with remaining projects ...</source>
-        <target state="translated">I progetti Web non supportano la destinazione "Publish". Verranno elaborati i progetti rimanenti...</target>
+        <target state="translated">I progetti Web non supportano la destinazione "Publish".  Verranno elaborati i progetti rimanenti...</target>
         <note>UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do not localize "Publish".</note>
       </trans-unit>
       <trans-unit id="SolutionVenusProjectSkipped">
         <source>Skipping because the "$(AspNetConfiguration)" configuration is not supported for this web project.  You can use the AspNetConfiguration property to override the configuration used for building web projects, by adding /p:AspNetConfiguration=&lt;value&gt; to the command line. Currently web projects only support Debug and Release configurations.</source>
-        <target state="translated">L'operazione verrà ignorata. La configurazione "$(AspNetConfiguration)" non è supportata per questo progetto Web. Per eseguire l'override della configurazione usata per la compilazione dei progetti Web, è possibile usare la proprietà AspNetConfiguration, aggiungendo /p:AspNetConfiguration=&lt;valore&gt; alla riga di comando. I progetti Web attualmente supportano solo le configurazioni delle versioni di debug e di rilascio.</target>
+        <target state="translated">L'operazione verrà ignorata. La configurazione "$(AspNetConfiguration)" non è supportata per questo progetto Web.  Per eseguire l'override della configurazione usata per la compilazione dei progetti Web, è possibile usare la proprietà AspNetConfiguration, aggiungendo /p:AspNetConfiguration=&lt;value&gt; alla riga di comando. I progetti Web attualmente supportano solo le configurazioni delle versioni di debug e di rilascio.</target>
         <note>
     UE: This is not an error, so doesn't need an error code.
     LOCALIZATION: Do NOT localize "AspNetConfiguration", "Debug", "Release".
@@ -1212,7 +1212,7 @@
       </trans-unit>
       <trans-unit id="TaskExistsButHasMismatchedIdentityError">
         <source>MSB4214: The "{0}" task has been defined, but cannot be used due to the fact that the identity defined in the UsingTask declaration (Runtime="{1}", Architecture="{2}") does not match the identity specified by the task invocation (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</source>
-        <target state="translated">MSB4214: l'attività "{0}" è stata definita, ma non può essere usata perché l'identità definita nella dichiarazione UsingTask (Runtime="{1}", Architecture="{2}") non corrisponde all'identità specificata dalla chiamata dell'attività (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
+        <target state="translated">MSB4214: l'attività "{0}" è stata definita, ma non può essere utilizzata perché l'identità definita nella dichiarazione UsingTask (Runtime="{1}", Architecture="{2}") non corrisponde all'identità specificata dalla chiamata dell'attività (MSBuildRuntime="{3}", MSBuildArchitecture="{4}").</target>
         <note>{StrBegin="MSB4214: "}LOCALIZATION: Runtime, Architecture, MSBuildRuntime, and MSBuildArchitecture should not be localized.</note>
       </trans-unit>
       <trans-unit id="TaskFinishedFailure">
@@ -1266,7 +1266,7 @@
       </trans-unit>
       <trans-unit id="LoggerCreationError">
         <source>MSB1021: Cannot create an instance of the logger. {0}</source>
-        <target state="translated">MSB1021: non è possibile creare un'istanza del logger. {0}</target>
+        <target state="translated">MSB1021: impossibile creare un'istanza del logger. {0}</target>
         <note>{StrBegin="MSB1021: "}
       UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
       LOCALIZATION: The prefix "MSBxxxx: " should not be localized. {0} contains a message explaining why the
@@ -1320,17 +1320,17 @@
       </trans-unit>
       <trans-unit id="TaskHostAcquireFailed">
         <source>MSB4216: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run.</source>
-        <target state="translated">MSB4216: non è stato possibile eseguire l'attività "{0}" perché MSBuild non è riuscito a creare o connettersi a un host attività con runtime "{1}" e architettura "{2}". Assicurarsi che (1) il runtime e/o l'architettura richiesti siano disponibili nel computer e (2) che l'eseguibile richiesto "{3}" esista e possa essere eseguito.</target>
+        <target state="translated">MSB4216: non è stato possibile eseguire l'attività "{0}" perché MSBuild non è riuscito a creare o connettersi a un host attività con runtime "{1}" e architettura "{2}".  Assicurarsi che (1) il runtime e/o l'architettura richiesti siano disponibili nel computer e (2) che l'eseguibile richiesto "{3}" esista e possa essere eseguito.</target>
         <note>{StrBegin="MSB4216: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunch">
         <source>MSB4221: Could not run the "{0}" task because MSBuild could not create or connect to a task host with runtime "{1}" and architecture "{2}".  Please ensure that (1) the requested runtime and/or architecture are available on the machine, and (2) that the required executable "{3}" exists and can be run. Error {4} {5}.</source>
-        <target state="translated">MSB4221: non è stato possibile eseguire l'attività "{0}" perché MSBuild non è riuscito a creare o connettersi a un host attività con runtime "{1}" e architettura "{2}". Assicurarsi che (1) il runtime e/o l'architettura richiesti siano disponibili nel computer e (2) che l'eseguibile richiesto "{3}" esista e possa essere eseguito. Errore {4} {5}.</target>
+        <target state="translated">MSB4221: non è stato possibile eseguire l'attività "{0}" perché MSBuild non è riuscito a creare o connettersi a un host attività con runtime "{1}" e architettura "{2}".  Assicurarsi che (1) il runtime e/o l'architettura richiesti siano disponibili nel computer e (2) che l'eseguibile richiesto "{3}" esista e possa essere eseguito. Errore {4} {5}.</target>
         <note>{StrBegin="MSB4221: "}</note>
       </trans-unit>
       <trans-unit id="TaskHostNodeFailedToLaunchErrorCodeNet35NotInstalled">
         <source>A task requested launch of the .NET 3.5 version of the MSBuild task host, but .NET 3.5 is not installed on this machine so the task host could not be launched.  To fix this error, please either install .NET 3.5 or retarget your project.</source>
-        <target state="translated">Un'attività ha richiesto l'avvio della versione .NET 3.5 dell'host attività MSBuild, ma .NET 3.5 non è installato nel computer e quindi l'host attività non è stato avviato. Per correggere l'errore, installare .NET 3.5 o specificare un'altra destinazione per il progetto.</target>
+        <target state="translated">Un'attività ha richiesto l'avvio della versione .NET 3.5 dell'host attività MSBuild, ma .NET 3.5 non è installato nel computer e quindi l'host attività non è stato avviato.  Per correggere l'errore, installare .NET 3.5 o specificare un'altra destinazione per il progetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="TaskHostExitedPrematurely">
@@ -1590,24 +1590,24 @@
       </trans-unit>
       <trans-unit id="CantWriteBuildPlan">
         <source>The build plan could not be written.  Check that the build process has permissions to write to {0}.</source>
-        <target state="translated">Non è stato possibile scrivere il piano di compilazione. Verificare che il processo di compilazione abbia autorizzazioni di scrittura su {0}.</target>
+        <target state="translated">Non è stato possibile scrivere il piano di compilazione.  Verificare che il processo di compilazione abbia autorizzazioni di scrittura su {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CacheFileInaccessible">
         <source>The MSBuild cache file "{0}" is inaccessible.  Ensure you have access to the directory and that this file is not deleted during the build.  {1}</source>
-        <target state="translated">Non è possibile accedere al file di cache MSBuild "{0}". Assicurarsi che l'accesso alla directory sia disponibile e che il file non venga eliminato durante la compilazione. {1}</target>
+        <target state="translated">Non è possibile accedere al file di cache MSBuild "{0}".  Assicurarsi che l'accesso alla directory sia disponibile e che il file non venga eliminato durante la compilazione. {1}</target>
         <note>
       LOCALIZATION: "{1}" is a localized message from a CLR/FX exception.
     </note>
       </trans-unit>
       <trans-unit id="CantReadBuildPlan">
         <source>The build plan could not be read.  Check that the build process has permissions to read {0}.</source>
-        <target state="translated">Non è stato possibile leggere il piano di compilazione. Verificare che il processo di compilazione abbia autorizzazioni di lettura per {0}.</target>
+        <target state="translated">Non è stato possibile leggere il piano di compilazione.  Verificare che il processo di compilazione abbia autorizzazioni di lettura per {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="BuildPlanCorrupt">
         <source>The build plan at {0} appears to be corrupt and cannot be used.</source>
-        <target state="translated">Il piano di compilazione in {0} potrebbe essere danneggiato e non è possibile usarlo.</target>
+        <target state="translated">Il piano di compilazione in {0} potrebbe essere danneggiato e non è possibile utilizzarlo.</target>
         <note />
       </trans-unit>
       <trans-unit id="DetailedSummaryHeader">
@@ -1772,7 +1772,7 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="OM_GlobalProperty">
         <source>The "{0}" property is a global property, and cannot be modified.</source>
-        <target state="translated">Non è possibile modificare la proprietà "{0}" perché è globale.</target>
+        <target state="translated">Impossibile modificare la proprietà "{0}" perché è globale.</target>
         <note />
       </trans-unit>
       <trans-unit id="OM_MatchingProjectAlreadyInCollection">
@@ -1845,7 +1845,7 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="MSBuild.ProjectFileNotFoundMessage">
         <source>Skipping project "{0}" because it was not found.</source>
-        <target state="translated">Il progetto "{0}" non è stato trovato e verrà ignorato.</target>
+        <target state="translated">Impossibile trovare il progetto "{0}". Verrà ignorato.</target>
         <note>UE: This message is shown when the user passes a non-existent project file to the MSBuild task, in the "Projects" parameter, and they have specified the SkipNonexistentProjects parameter.</note>
       </trans-unit>
       <trans-unit id="MSBuild.ProjectUpgradeNeededToVcxProj">
@@ -2043,7 +2043,7 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">La destinazione "{0}" è stata ignorata perché non esiste nel progetto e SkipNonexistentTargets è impostato su true.</target>
+        <target state="translated">La destinazione "{0}" è stata ignorata. La destinazione non esiste nel progetto e SkipNonexistentTargets è impostato su true.</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: non è stato possibile eseguire il resolver SDK basato su NuGet perché non sono stati trovati assembly NuGet. Controllare l'installazione di MSBuild oppure impostare la variabile di ambiente "{0}" sulla cartella che contiene gli assembly NuGet richiesti. {1}</target>
+        <target state="translated">MSB4243: non è stato possibile eseguire il resolver SDK basato su NuGet perché non sono stati trovati assembly NuGet.  Controllare l'installazione di MSBuild oppure impostare la variabile di ambiente "{0}" sulla cartella che contiene gli assembly NuGet richiesti. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilizzo:          {0} Utilizzo medio: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: non è possibile specificare più versioni dello stesso SDK "{0}". Verrà usata La versione "{1}" dell'SDK già specificata da "{2}", mentre la versione "{3}" verrà ignorata.</target>
+        <target state="translated">MSB4240: non è possibile specificare più versioni dello stesso SDK "{0}". Verrà usata la versione "{1}" dell'SDK già risolta dal percorso "{2}", mentre la versione "{3}" verrà ignorata.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: la versione "{1}" del riferimento "{0}" all'SDK è stata risolta nella versione "{2}". Se non si aggiorna la versione di riferimento in modo che corrisponda, è possibile che la versione in uso sia diversa da quella prevista.</target>
+        <target state="translated">MSB4241: la versione "{1}" del riferimento "{0}" all'SDK è stata risolta nella versione "{2}".  Se non si aggiorna la versione di riferimento in modo che corrisponda, è possibile che la versione in uso sia diversa da quella prevista.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャットダウンしています。診断情報は、MSBuild_*.failure.txt という名前の一時ファイル ディレクトリのファイル内で見つかる可能性があります。</target>
+        <target state="translated">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャットダウンしています。診断情報は "{1}" のファイル内で見つかる可能性があり、MSBuild_*.failure.txt という名前になります。この場所は変更できます。変更するには、MSBUILDDEBUGPATH 環境変数を別のディレクトリに設定します。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">ファイル "{0}" をファイル "{1}" にインポートすると、循環する依存関係が生じます。</target>
+        <target state="translated">ファイル "{0}" をファイル "{1}" にインポートすると、循環する依存関係が生じます。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: プロジェクトの既定の XML 名前空間は MSBuild の XML 名前空間であるか、名前空間なしである必要があります。プロジェクトが MSBuild 2003 形式で作成されている場合、xmlns="{0}" を &lt;Project&gt; 要素に追加してください。プロジェクトが古い 1.0 または 1.2 形式で作成されている場合、MSBuild 2003 形式に変換してください。</target>
+        <target state="translated">MSB4041: プロジェクトの既定の XML 名前空間は MSBuild の XML 名前空間か、名前空間なしでなければなりません。プロジェクトが MSBuild 2003 形式で作成されている場合、xmlns="{0}" を &lt;Project&gt; 要素に追加してください。プロジェクトが古い 1.0 または 1.2 形式で作成されている場合、MSBuild 2003 形式に変換してください。</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1983,7 +1983,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: バイナリー ロガーのパラメーターが無効です: "{0}"。次のいずれかまたは両方が必要です: ProjectImports={{None,Embed,ZipFile}} および [LogFile=]filePath.binlog (ログ ファイル名またはパス。".binlog" 拡張子が必要)。</target>
+        <target state="translated">MSB4234: バイナリ ロガーのパラメーターが無効です: "{0}"。次のいずれかまたは両方が必要です: ProjectImports={{None,Embed,ZipFile}} および [LogFile=]filePath.binlog (ログ ファイル名またはパス。".binlog" 拡張子が必要)。</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2043,7 +2043,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">ターゲット "{0}" はスキップされました。ターゲットがプロジェクトに存在しないので、SkipNonexistentTargets が true に設定されます。</target>
+        <target state="translated">ターゲット "{0}" を省略しました。ターゲットがプロジェクトに存在しないので、SkipNonexistentTargets が true に設定されます。</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2098,14 +2098,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: 同じ SDK "{0}" の複数のバージョンを指定することはできません。既に "{2}" によって指定されている SDK バージョン "{1}" が使用され、バージョン "{3}" は無視されます。</target>
+        <target state="translated">MSB4240: 同じ SDK "{0}" の複数のバージョンを指定することはできません。場所 "{2}" にある以前に解決された SDK バージョン "{1}" が使用され、バージョン "{3}" は無視されます。</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: SDK 参照 "{0}" のバージョン "{1}" は、代わりにバージョン "{2}" に解決されました。  参照されたバージョンを一致するように更新しない場合、必要なバージョンとは別のバージョンを使用する可能性があります。</target>
+        <target state="translated">MSB4241: SDK 参照 "{0}" のバージョン "{1}" は、代わりにバージョン "{2}" に解決されました。参照されたバージョンを一致するように更新しない場合、必要なバージョンとは別のバージョンを使用する可能性があります。</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료합니다. 임시 파일 디렉터리의 파일(MSBuild_*.failure.txt)에서 진단 정보를 찾을 수 있습니다.</target>
+        <target state="translated">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료합니다. 진단 정보는 “{1}”의 파일에서 MSBuild_*.failure.txt 이름으로 찾을 수 있습니다. 이 위치는 MSBUILDDEBUGPATH 환경 변수를 다른 디렉터리로 설정하여 변경할 수 있습니다.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">"{0}" 파일을 "{1}" 파일로 가져오면 순환 종속성이 발생합니다.</target>
+        <target state="translated">"{0}" 파일을 "{1}" 파일로 가져오면 순환 종속성이 발생합니다.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: 프로젝트의 기본 XML 네임스페이스는 MSBuild XML 네임스페이스이거나 없어야 합니다. 프로젝트를 MSBuild 2003 형식으로 작성한 경우에는 &lt;Project&gt; 요소에 xmlns="{0}"을(를) 추가하고, 프로젝트를 이전 1.0 또는 1.2 형식으로 작성한 경우에는 MSBuild 2003 형식으로 변환하세요.</target>
+        <target state="translated">MSB4041: 프로젝트의 기본 XML 네임스페이스는 MSBuild XML 네임스페이스여야 하거나 네임스페이스가 없어야 합니다. 프로젝트를 MSBuild 2003 형식으로 작성한 경우에는 &lt;Project&gt; 요소에 xmlns="{0}"을(를) 추가하고, 프로젝트를 이전 1.0 또는 1.2 형식으로 작성한 경우에는 MSBuild 2003 형식으로 변환하세요.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1948,7 +1948,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: "{1}"에서 "{0}" 작업을 인스턴스화할 수 없습니다. 이 버전의 MSBuild는 {2}을(를) 지원하지 않습니다.</target>
+        <target state="translated">MSB4802: "{1}"에서 "{0}" 작업을 인스턴스화할 수 없습니다. 이 MSBuild 버전은 {2}을(를) 지원하지 않습니다.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -2043,7 +2043,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">"{0}" 대상을 건너뛰었습니다. 대상이 프로젝트에 없고 SkipNonexistentTargets가 true로 설정되어 있습니다.</target>
+        <target state="translated">"{0}" 대상을 건너뜁니다. 대상이 프로젝트에 없고 SkipNonexistentTargets가 true로 설정되어 있습니다.</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: NuGet 어셈블리를 찾을 수 없어 NuGet 기반 SDK 확인자를 실행하지 못했습니다. MSBuild 설치를 확인하거나 환경 변수 "{0}"을(를) 필요한 NuGet 어셈블리가 포함된 폴더로 설정하세요. {1}</target>
+        <target state="translated">MSB4243: NuGet 어셈블리를 찾을 수 없어 NuGet 기반 SDK 확인자를 실행하지 못했습니다.  MSBuild 설치를 확인하거나 환경 변수 "{0}"을(를) 필요한 NuGet 어셈블리가 포함된 폴더로 설정하세요. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: 동일한 SDK "{0}"의 여러 버전을 지정할 수 없습니다. "{2}"에서 이미 지정한 SDK 버전 "{1}"이(가) 사용되며 "{3}" 버전은 무시됩니다.</target>
+        <target state="translated">MSB4240: 동일한 SDK "{0}"의 여러 버전을 지정할 수 없습니다. "{2}" 위치에서 이전에 확인된 SDK 버전 "{1}"이 사용되고 "{3}" 버전은 무시됩니다.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: SDK 참조 "{0}" 버전 "{1}"이(가) 대신 "{2}" 버전으로 확인되었습니다. 참조된 버전을 일치하도록 업데이트하지 않는 경우 예상과 다른 버전을 사용할 수 있습니다.</target>
+        <target state="translated">MSB4241: SDK 참조 "{0}" 버전 "{1}"이(가) 대신 "{2}" 버전으로 확인되었습니다.  참조된 버전을 일치하도록 업데이트하지 않는 경우 예상과 다른 버전을 사용할 수 있습니다.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Nastąpi zamknięcie. Informacje diagnostyczne znajdują się w katalogu plików tymczasowych o nazwie MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Nastąpi zamknięcie. Informacje diagnostyczne znajdują się w plikach w katalogu „{1}” o nazwie MSBuild_*.failure.txt. Tę lokalizację można zmienić, ustawiając zmienną środowiskową MSBUILDDEBUGPATH na inny katalog.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">Importowanie pliku {0} do pliku {1} powoduje powstanie zależności cyklicznej.</target>
+        <target state="translated">Importowanie pliku {0} do pliku {1} powoduje powstanie zależności cyklicznej.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -1943,12 +1943,12 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidSdkFormat">
         <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: wartość „{0}” jest nieprawidłowa dla specyfikacji zestawu SDK. Atrybut musi mieć postać listy oddzielonych średnikami par nazwy zestawu SDK i minimalnej wersji z ukośnikiem między nimi.</target>
+        <target state="translated">MSB4229: Wartość „{0}” jest nieprawidłowa dla specyfikacji zestawu SDK. Atrybut musi mieć postać listy oddzielonych średnikami par nazwy zestawu SDK i minimalnej wersji z ukośnikiem między nimi.</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: nie można utworzyć wystąpienia zadania „{0}” z elementu „{1}”. Ta wersja programu MSBuild nie obsługuje elementu {2}.</target>
+        <target state="translated">MSB4802: Nie można utworzyć wystąpienia zadania „{0}” na podstawie elementu „{1}”. Ta wersja programu MSBuild nie obsługuje elementu {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: Nieprawidłowe parametry rejestratora binarnego: „{0}”. Oczekiwano: ProjectImports={{None,Embed,ZipFile}} i/lub [LogFile=]ścieżkaPliku.binlog (nazwa lub ścieżka pliku dziennika musi mieć rozszerzenie „binlog”).</target>
+        <target state="translated">MSB4234: Nieprawidłowe parametry rejestratora binarnego: „{0}”. Oczekiwano: ProjectImports={{None,Embed,ZipFile}} i/lub [LogFile=]ścieżkaPliku.binlog (nazwa lub ścieżka pliku dziennika, musi mieć rozszerzenie „binlog”).</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2043,7 +2043,7 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">Element docelowy „{0}” został pominięty. Element docelowy nie istnieje w projekcie, a parametr SkipNonexistentTargets ma wartość true.</target>
+        <target state="translated">Pominięto element docelowy „{0}”. Element docelowy nie istnieje w projekcie, a parametr SkipNonexistentTargets ma wartość true.</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: Nie można uruchomić programu rozpoznawania zestawu SDK opartego na narzędziu NuGet, ponieważ nie można zlokalizować zestawów NuGet. Sprawdź instalację programu MSBuild lub ustaw zmienną środowiskową „{0}” na folder zawierający wymagane zestawy NuGet. {1}</target>
+        <target state="translated">MSB4243: Nie można uruchomić programu rozpoznawania zestawu SDK opartego na narzędziu NuGet, ponieważ nie można zlokalizować zestawów NuGet.  Sprawdź instalację programu MSBuild lub ustaw zmienną środowiskową „{0}” na folder zawierający wymagane zestawy NuGet. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Wykorzystanie:          Średnie wykorzystanie {0}: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: Nie można określić wielu wersji tego samego zestawu SDK „{0}”. Zostanie użyta wersja zestawu SDK „{1}” określona już przez lokalizację „{2}”, a wersja „{3}” zostanie zignorowana.</target>
+        <target state="translated">MSB4240: Nie można określić wielu wersji tego samego zestawu SDK „{0}”. Zostanie użyta wcześniej rozpoznana wersja zestawu SDK „{1}” z lokalizacji „{2}”, a wersja „{3}” zostanie zignorowana.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: Odwołanie do zestawu SDK „{0}” w wersji „{1}” zostało rozpoznane jako wersja „{2}”. Może zostać użyta inna wersja niż oczekiwana, jeśli nie zaktualizujesz wersji określonej w odwołaniu, tak aby była zgodna.</target>
+        <target state="translated">MSB4241: Odwołanie do zestawu SDK „{0}” w wersji „{1}” zostało rozpoznane jako wersja „{2}”.  Może zostać użyta inna wersja niż oczekiwana, jeśli nie zaktualizujesz wersji określonej w odwołaniu, tak aby była zgodna.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. É possível encontrar informações de diagnóstico em arquivos do diretório de arquivos temporários chamado MSBuild_*.failure.txt.</target>
+        <target state="translated">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. Informações de diagnóstico podem ser encontradas em arquivos "{1}" e serão nomeadas MSBuild_*.failure.txt. Essa localização pode ser alterada configurando a variável de ambiente MSBUILDDEBUGPATH para um diretório diferente.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -221,7 +221,7 @@
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: MSBuildToolsPath não é o mesmo que MSBuildBinPath para ToolsVersion"{0}" definido em "{1}". Se ambos estiverem presentes, deverão ter o mesmo valor.</target>
+        <target state="translated">MSB4142: MSBuildToolsPath não é o mesmo que MSBuildBinPath para ToolsVersion "{0}" definido em "{1}". Se ambos estiverem presentes, deverão ter o mesmo valor.</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">A importação do arquivo "{0}" no arquivo "{1}" resultará em uma dependência circular.</target>
+        <target state="translated">A importação do arquivo "{0}" no arquivo "{1}" resultará em uma dependência circular.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: o namespace de XML padrão do projeto deve ser namespace XML do MSBuild ou nenhum namespace. Se o projeto tiver sido criado no formato do MSBuild 2003, adicione xmlns="{0}" ao elemento &lt;Project&gt;. Se o projeto tiver sido criado nos antigos formatos 1.0 ou 1.2, converta-o no formato do MSBuild 2003.</target>
+        <target state="translated">MSB4041: O namespace de XML padrão do projeto precisa ser o namespace de XML do MSBuild ou não ter nenhum namespace. Se o projeto tiver sido criado no formato do MSBuild 2003, adicione xmlns="{0}" ao elemento &lt;Project&gt;. Se o projeto foi criado nos antigos formatos 1.0 ou 1.2, converta-o no formato do MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1943,12 +1943,12 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidSdkFormat">
         <source>MSB4229: The value "{0}" is not valid for an Sdk specification. The attribute should be a semicolon-delimited list of Sdk-name/minimum-version pairs, separated by a forward slash.</source>
-        <target state="translated">MSB4229: o valor "{0}" não é válido para uma especificação de SDK. O atributo deve ser uma lista delimitada por ponto e vírgula de pares de nome de SDK/versão mínima, separados por uma barra.</target>
+        <target state="translated">MSB4229: o valor "{0}" é inválido para uma especificação de SDK. A atributo deve ser um lista delimitada por ponto e vírgula dos pares nome do SDK/versão mínima, separados por uma barra.</target>
         <note>{StrBegin="MSB4229: "}</note>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: a tarefa "{0}" não pôde ser instanciada de "{1}". Essa versão do MSBuild não dá suporte ao {2}.</target>
+        <target state="translated">MSB4802: não foi possível instanciar a tarefa "{0}" de "{1}". Essa versão do MSBuild não é compatível {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: parâmetro de agente binário inválido: "{0}". Esperado: ProjectImports={{None,Embed,ZipFile}} e/ou [LogFile=]filePath.binlog (o nome do arquivo de log ou caminho deve ter a extensão ".binlog").</target>
+        <target state="translated">MSB4234: parâmetros do agente binário inválido: "{0}". Esperado: ProjectImports={{None,Embed,ZipFile}} e/ou [LogFile=]filePath.binlog (o nome do arquivo de log ou o caminho precisa ter a extensão ".binlog").</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2043,7 +2043,7 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">"{0}" de destino ignorado. O destino não existe no projeto e SkipNonexistentTargets está definido como verdadeiro.</target>
+        <target state="translated">Destino "{0}" ignorado. O destino não existe no projeto e SkipNonexistentTargets está definido como verdadeiro.</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: falha ao executar o resolvedor do SDK baseado em NuGet porque não foi possível localizar os assemblies do NuGet. Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" para a pasta que contém os assemblies necessários do NuGet. {1}</target>
+        <target state="translated">MSB4243: o resolvedor do SDK baseado no NuGet não foi executado porque não foi possível localizar os assemblies do NuGet.  Verifique a instalação do MSBuild ou defina a variável de ambiente "{0}" como a pasta que contém os assemblies necessários do NuGet. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2083,7 +2083,7 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ErrorWritingProfilerReport">
         <source>MSBUILD : error MSB4239: Error writing profiling report. {0}</source>
-        <target state="translated">MSBUILD: erro MSB4239: erro ao gravar relatório de criação de perfil. {0}</target>
+        <target state="translated">MSBUILD : erro MSB4239: erro ao gravar relatório de criação de perfil. {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="WritingProfilerReport">
@@ -2098,14 +2098,14 @@ Utilização:          {0} Utilização Média: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: não é possível especificar várias versões do mesmo SDK "{0}". A versão "{1}" do SDK já especificada por "{2}" será usada e a versão "{3}" será ignorada.</target>
+        <target state="translated">MSB4240: não é possível especificar várias versões do mesmo SDK "{0}". A versão do SDK resolvida anteriormente "{1}" da localização "{2}" será usada e a versão "{3}" será ignorada.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: a referência do SDK "{0}" versão "{1}" foi resolvida para a versão "{2}". Talvez você estava usando uma versão diferente que a esperada caso não tenha atualizado a versão referenciada de maneira correspondente.</target>
+        <target state="translated">MSB4241: a referência do SDK "{0}" versão "{1}" foi resolvida para a versão "{2}".  Talvez você esteja usando uma versão diferente que a esperada caso não tenha atualizado a versão referenciada para a correspondência.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: произошел преждевременный выход дочернего узла "{0}". Выполняется завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt каталога временных файлов.</target>
+        <target state="translated">MSB4166: произошел преждевременный выход дочернего узла "{0}". Выполняется завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt, находящихся в "{1}". Это расположение можно изменить, задав другой каталог в переменной среды MSBUILDDEBUGPATH.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -221,7 +221,7 @@
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: MSBuildToolsPath не соответствует MSBuildBinPath для ToolsVersion "{0}", определенной в "{1}". Если установлены оба пути, они должны иметь одинаковое значение.</target>
+        <target state="translated">MSB4142: MSBuildToolsPath не соответствует MSBuildBinPath для версии ToolsVersion "{0}", определенной в "{1}". Если заданы оба пути, они должны иметь одинаковое значение.</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">Импорт файла "{0}" в файл "{1}" приводит к циклической зависимости.</target>
+        <target state="translated">Импорт файла "{0}" в файл "{1}" приводит к циклической зависимости.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: пространством имен XML по умолчанию для этого проекта должно быть пространством имен XML MSBuild (или пространства имен быть не должно). Если проект создан в формате MSBuild 2003, добавьте xmlns="{0}" в элемент &lt;Project&gt;. Если проект был создан в старом формате (1.0 или 1.2), преобразуйте его в формат MSBuild 2003.</target>
+        <target state="translated">MSB4041: этот проект должен иметь пространство имен XML по умолчанию MSBuild либо не иметь никакого пространства имен. Если проект создан в формате MSBuild 2003, добавьте xmlns="{0}" в элемент &lt;Project&gt;. Если проект был создан в старом формате 1.0 или 1.2, преобразуйте его в формат MSBuild 2003.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1948,7 +1948,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: не удалось создать экземпляр задачи "{0}" из "{1}". Установленная версия MSBuild не поддерживает {2}.</target>
+        <target state="translated">MSB4802: не удалось создать экземпляр задачи "{0}" из "{1}". Эта версия MSBuild не поддерживает {2}.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: недопустимые параметры средства ведения двоичного журнала: "{0}". Ожидаются: ProjectImports={{None,Embed,ZipFile}} и (или) [LogFile=]filePath.binlog (имя файла журнала или путь к нему должны иметь расширение ".binlog").</target>
+        <target state="translated">MSB4234: недопустимые параметры средства ведения двоичного журнала: "{0}". Ожидаются: ProjectImports={{None,Embed,ZipFile}} и (или) [LogFile=]filePath.binlog (имя файла журнала или путь к нему должны иметь расширение BINLOG).</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2043,7 +2043,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">Целевой объект "{0}" пропущен. Целевой объект не существует в проекте, а SkipNonexistentTargets имеет значение "Истина".</target>
+        <target state="translated">Целевой объект "{0}" пропущен. Целевой объект не существует в проекте, а SkipNonexistentTargets имеет значение "true".</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: не удалось запустить сопоставитель SDK на базе NuGet, так как не удалось найти сборки NuGet. Проверьте свою установку MSBuild или укажите папку, содержащую требуемые сборки NuGet, в качестве значения переменной среды "{0}". {1}</target>
+        <target state="translated">MSB4243: сбой при запуске сопоставителя SDK на базе NuGet, так как не удалось найти сборки NuGet.  Проверьте свою установку MSBuild или укажите папку, содержащую требуемые сборки NuGet, в переменной среды "{0}". {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: невозможно указать множество версий одного пакета SDK "{0}". Будет использована версия SDK "{1}", уже указанная "{2}", а версия "{3}" будет пропущена.</target>
+        <target state="translated">MSB4240: невозможно указать несколько версий одного пакета SDK "{0}". Будет использована ранее разрешенная версия пакета SDK "{1}" из "{2}", а версия "{3}" будет проигнорирована.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: ссылка на пакет SDK "{0}" версии "{1}" была сопоставлена версии "{2}". Возможно, вы используете версию, отличную от ожидаемой, если вы не обновили версию по ссылке.</target>
+        <target state="translated">MSB4241: ссылка на пакет SDK "{0}" версии "{1}" была разрешена в версию "{2}".  Возможно, вы используете версию, отличную от ожидаемой, если не обновили версию по ссылке.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri geçici dosyalar dizininde MSBuild_*.failure.txt adlı dosyalarda bulunabilir.</target>
+        <target state="translated">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri, "{1}" konumunda bulunabilir ve MSBuild_*.failure.txt olarak adlandırılır. MSBUILDDEBUGPATH ortam değişkeni farklı bir dizine ayarlanarak bu konum değiştirilebilir.</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">"{0}" dosyasını "{1}" dosyasına içeri aktarma işlemi döngüsel bağımlılıkla sonuçlandı.</target>
+        <target state="translated">"{0}" dosyasını "{1}" dosyasına içeri aktarma işlemi döngüsel bağımlılıkla sonuçlandı.</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: Projenin varsayılan XML ad alanı, MSBuild XML ad alanı veya boş olmalıdır. Proje MSBuild 2003 biçiminde yazıldıysa lütfen &lt;Project&gt; öğesine xmlns="{0}" ekleyin. Proje eski 1.0 veya 1.2 biçiminde yazıldıysa lütfen MSBuild 2003 biçimine dönüştürün.</target>
+        <target state="translated">MSB4041: Projenin varsayılan XML ad alanı, MSBuild XML ad alanı olmalı veya herhangi bir ad alanı olmamalıdır. Proje MSBuild 2003 biçiminde yazıldıysa lütfen &lt;Project&gt; öğesine xmlns="{0}" ekleyin. Proje eski 1.0 veya 1.2 biçiminde yazıldıysa lütfen MSBuild 2003 biçimine dönüştürün.</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1948,7 +1948,7 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: "{0}" görevinin örneği "{1}" üzerinden oluşturulamadı. {2}, MSBuild’in bu sürümü tarafından desteklenmiyor</target>
+        <target state="translated">MSB4802: "{0}" görevi "{1}" öğesinden başlatılamadı. Bu MSBuild sürümü, {2} öğesini desteklemiyor.</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: İkili günlükçü parametreleri geçersiz: "{0}". Beklenen: ProjectImports={{None,Embed,ZipFile}} ve/veya [LogFile=]filePath.binlog (günlük dosyası adı veya yolu ".binlog" uzantısına sahip olmalıdır).</target>
+        <target state="translated">MSB4234: Geçersiz ikili günlükçü parametreleri: "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2068,7 +2068,7 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: NuGet bütünleştirilmiş kodları bulunamadığından NuGet tabanlı SDK çözümleyicisi çalıştırılamadı. MSBuild yüklemenizi denetleyin veya "{0}" ortam değişkenini gerekli NuGet bütünleştirilmiş kodlarını içeren klasör olarak ayarlayın. {1}</target>
+        <target state="translated">MSB4243: NuGet bütünleştirilmiş kodları bulunamadığından, NuGet tabanlı SDK çözümleyici çalıştırılamadı.  MSBuild yüklemenizi denetleyin veya "{0}" ortam değişkenini, gerekli NuGet bütünleştirilmiş kodlarını içeren klasöre ayarlayın. {1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Kullanım:             {0} Ortalama Kullanım: {1:###.0}</target>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: "{0}" SDK’sının birden çok sürümü belirtilemez. "{2}" tarafından zaten belirtilen SDK sürümü "{1}" kullanılacak ve "{3}" sürümü yoksayılacak.</target>
+        <target state="translated">MSB4240: Aynı "{0}" SDK’sının birden çok sürümü belirtilemez. "{2}" konumundaki önceden çözümlenen "{1}" SDK sürümü kullanılacak ve "{3}" sürümü yok sayılacak.</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: "{0}" SDK başvurusunun "{1}" sürümü, bunun yerine sürüm "{2}" olarak çözümlendi. Başvurulan sürümü eşleşecek şekilde güncelleştirmezseniz beklenen sürümden farklı bir sürüm kullanıyor olabilirsiniz.</target>
+        <target state="translated">MSB4241: "{0}" SDK başvurusunun "{1}" sürümü, bunun yerine sürüm "{2}" olarak çözümlendi.  Başvurulan sürümü eşleşecek şekilde güncelleştirmezseniz beklenen sürümden farklı bir sürüm kullanıyor olabilirsiniz.</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在临时文件目录中名为 MSBuild_*.failure.txt 的文件内找到诊断信息。</target>
+        <target state="translated">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在“{1}”中的文件中找到诊断信息，并将其命名为 MSBuild_*.failure.txt。通过将 MSBUILDDEBUGPATH 环境变量设为其他目录，可更改此位置。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">若将文件“{0}”导入到文件“{1}”中，将会产生循环依赖项。</target>
+        <target state="translated">若将文件“{0}”导入到文件“{1}”中，将会产生循环依赖项。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -1948,7 +1948,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: 无法从“{1}”实例化“{0}”任务。此版本的 MSBuild 不支持 {2}。</target>
+        <target state="translated">MSB4802: 未能从“{1}”实例化“{0}”任务。MSBuild 的此版本不支持 {2}。</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -1983,7 +1983,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="InvalidBinaryLoggerParameters">
         <source>MSB4234: Invalid binary logger parameter(s): "{0}". Expected: ProjectImports={{None,Embed,ZipFile}} and/or [LogFile=]filePath.binlog (the log file name or path, must have the ".binlog" extension).</source>
-        <target state="translated">MSB4234: 无效的二进制记录器参数: “{0}”。 预期应为: ProjectImports={{None,Embed,ZipFile}} 和/或 [LogFile=]filePath.binlog (日志文件名称或路径必须包含“.binlog” 扩展名)。</target>
+        <target state="translated">MSB4234: 无效的二进制记录器参数:“{0}”。预期应为: ProjectImports={{None,Embed,ZipFile}} 和/或 [LogFile=]filePath.binlog (日志文件名称或路径必须包含“.binlog” 扩展名)。</target>
         <note />
       </trans-unit>
       <trans-unit id="IncludeRemoveOrUpdate">
@@ -2068,7 +2068,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: 基于 NuGet 的 SDK 解析程序运行失败，因为无法找到 NuGet 程序集。请检查你安装的 MSBuild 或将环境变量“{0}”设置为包含所需 NuGet 程序集的文件夹。{1}</target>
+        <target state="translated">MSB4243: 未能运行基于 NuGet 的 SDK 解析程序，因为无法定位 NuGet 程序集。检查 MSBuild 安装或将环境变量“{0}”设为包含所需 NuGet 程序集的文件夹。{1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,7 +2098,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: 无法指定同一 SDK“{0}”的多个版本。将使用已由“{2}”指定的 SDK 版本“{1}”，并忽略版本“{3}”。</target>
+        <target state="translated">MSB4240: 无法指定相同 SDK“{0}”的多个版本。将使用以前从位置“{2}”解析的 SDK 版本“{1}”，将忽略版本“{3}”。</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -174,7 +174,7 @@
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
         <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="needs-review-translation">MSB4166: 子節點 "{0}" 不當結束。即將關閉。在暫存檔目錄名為 MSBuild_*.failure.txt 的檔案中可以找到診斷資訊。</target>
+        <target state="translated">MSB4166: 子節點 "{0}" 不當結束。即將關閉。在 "{1}" 的檔案中可能有診斷資訊，且會命名為 MSBuild_*.failure.txt。可透過將 MSBUILDDEBUGPATH 環境變數設定成不同的目錄來變更此位置。</target>
         <note>{StrBegin="MSB4166: "}</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
@@ -221,7 +221,7 @@
       </trans-unit>
       <trans-unit id="ConflictingValuesOfMSBuildToolsPath">
         <source>MSB4142: MSBuildToolsPath is not the same as MSBuildBinPath for the ToolsVersion "{0}" defined at "{1}". If both are present they must have the same value.</source>
-        <target state="translated">MSB4142: 對於定義在 "{1}" 的 ToolsVersion "{0}"，MSBuildToolsPath 與 MSBuildBinPath 不相同。如果兩者都出現時，它們的值必須相同。</target>
+        <target state="translated">MSB4142: 對於定義於 "{1}" 的 ToolsVersion "{0}"，MSBuildToolsPath 與 MSBuildBinPath 不相同。若兩者都出現時，其值必須相同。</target>
         <note>{StrBegin="MSB4142: "}</note>
       </trans-unit>
       <trans-unit id="DefaultTasksFileFailure">
@@ -241,7 +241,7 @@
       </trans-unit>
       <trans-unit id="ImportIntroducesCircularity">
         <source>Importing the file "{0}" into the file "{1}" results in a circular dependency.</source>
-        <target state="needs-review-translation">將檔案 "{0}" 匯入檔案 "{1}" 會造成循環相依性。</target>
+        <target state="translated">將檔案 "{0}" 匯入檔案 "{1}" 會造成循環相依性。</target>
         <note>
        {0} is a file imported into the file "{1}" such that it results in a circular dependency. For e.g. if t1.targets imports
        t2.targets and t2.targets tries to import t1.targets, then it results in a circular dependency.
@@ -806,7 +806,7 @@
       </trans-unit>
       <trans-unit id="ProjectMustBeInMSBuildXmlNamespace">
         <source>MSB4041: The default XML namespace of the project must be the MSBuild XML namespace or no namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="{0}" to the &lt;Project&gt; element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format.</source>
-        <target state="translated">MSB4041: 專案的預設 XML 命名空間必須是 MSBuild XML 命名空間或沒有命名空間。若使用 MSBuild 2003 格式設計專案，請將 xmlns="{0}" 新增至 &lt;Project&gt; 項目。若是使用舊版的 1.0 或 1.2 格式設計專案，請將專案轉換為 MSBuild 2003 格式。</target>
+        <target state="translated">MSB4041: 專案的預設 XML 命名空間必須是 MSBuild XML 命名空間或沒有命名空間。若使用 MSBuild 2003 格式設計專案，請將 xmlns="{0}" 加入 &lt;Project&gt; 項目中。若是使用舊版的 1.0 或 1.2 格式設計專案，請將專案轉換為 MSBuild 2003 格式。</target>
         <note>{StrBegin="MSB4041: "}UE: This is a Beta 1 message only.
       LOCALIZATION: &lt;Project&gt;, "MSBuild" and "xmlns" should not be localized.</note>
       </trans-unit>
@@ -1948,7 +1948,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TaskInstantiationFailureNotSupported">
         <source>MSB4802: The "{0}" task could not be instantiated from "{1}". This version of MSBuild does not support {2}.</source>
-        <target state="translated">MSB4802: 無法從 "{1}" 具現化 "{0}" 工作。此版的 MSBuild 不支援 {2}。</target>
+        <target state="translated">MSB4802: 無法從 "{1}" 具現化 "{0}" 工作。此版本的 MSBuild 不支援 {2}。</target>
         <note>{StrBegin="MSB4802: "}</note>
       </trans-unit>
       <trans-unit id="InvalidGetPathOfFileAboveParameter">
@@ -2043,7 +2043,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="TargetSkippedWhenSkipNonexistentTargets">
         <source>Target "{0}" skipped. The target does not exist in the project and SkipNonexistentTargets is set to true.</source>
-        <target state="translated">目標 "{0}" 已跳過。目標不在專案中，且 SkipNonexistentTargets 設為 true。</target>
+        <target state="translated">已略過目標 "{0}"。目標不在專案中，且 SkipNonexistentTargets 設為 true。</target>
         <note>LOCALIZATION: Do NOT localize "SkipNonexistentTargets" or "true".</note>
       </trans-unit>
       <trans-unit id="TaskFactoryTaskTypeIsNotSet">
@@ -2068,7 +2068,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="CouldNotRunNuGetSdkResolver">
         <source>MSB4243: The NuGet-based SDK resolver failed to run because NuGet assemblies could not be located.  Check your installation of MSBuild or set the environment variable "{0}" to the folder that contains the required NuGet assemblies. {1}</source>
-        <target state="translated">MSB4243: 因為找不到 NuGet 組件，所以 NuGet 型 SDK 解析程式無法執行。請檢查您的 MSBuild 安裝，或將環境變數 "{0}" 設定為包含必要 NuGet 組件的資料夾。{1}</target>
+        <target state="translated">MSB4243: NuGet 型 SDK 解析程式無法執行，因為找不到 NuGet 組件。請檢查 MSBuild 安裝，或將環境變數 "{0}" 設定為包含必要 NuGet 組件的資料夾。{1}</target>
         <note>{StrBegin="MSB4243: "}</note>
       </trans-unit>
       <trans-unit id="ProjectImportSkippedInvalidFile">
@@ -2098,14 +2098,14 @@ Utilization:          {0} Average Utilization: {1:###.0}</source>
       </trans-unit>
       <trans-unit id="ReferencingMultipleVersionsOfTheSameSdk">
         <source>MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.</source>
-        <target state="needs-review-translation">MSB4240: 無法指定相同 SDK "{0}" 的多個版本。會使用 "{2}" 已指定的 SDK 版本 "{1}"，而版本 "{3}" 則會略過。</target>
+        <target state="translated">MSB4240: 無法指定相同 SDK "{0}" 的多個版本。將會使用來自位置 "{2}" 的已解析 SDK 版本 "{1}"，並忽略版本 "{3}"。</target>
         <note>{StrBegin="MSB4240: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>
       </trans-unit>
       <trans-unit id="SdkResultVersionDifferentThanReference">
         <source>MSB4241: The SDK reference "{0}" version "{1}" was resolved to version "{2}" instead.  You could be using a different version than expected if you do not update the referenced version to match.</source>
-        <target state="translated">MSB4241: SDK 參考 "{0}" 版本 "{1}" 已改為解析成版本 {2}"。若您未將參考的版本更新為符合的版本，您可能使用了與預期不同的版本。</target>
+        <target state="translated">MSB4241: SDK 參考 "{0}" 版本 "{1}" 已改為解析成版本 "{2}"。若您未將參考的版本更新為符合的版本，則可能使用了與預期不同的版本。</target>
         <note>{StrBegin="MSB4241: "}
       LOCALIZATION:  Do not localize the word SDK.
     </note>

--- a/src/Deprecated/Engine/Resources/xlf/Strings.de.xlf
+++ b/src/Deprecated/Engine/Resources/xlf/Strings.de.xlf
@@ -375,7 +375,7 @@
       </trans-unit>
       <trans-unit id="CannotSetDefaultToolsVersionAfterLoadingProjects">
         <source>MSB4134: DefaultToolsVersion cannot be set after a project has been loaded into the Engine.</source>
-        <target state="translated">MSB4134: DefaultToolsVersion darf nicht festgelegt werden, nachdem ein Projekt in das Modul geladen wurde.</target>
+        <target state="translated">MSB4134: DefaultToolsVersion darf nicht festgelegt werden, nachdem ein Projekt in die Engine geladen wurde.</target>
         <note>{StrBegin="MSB4134: "}</note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="tm-suggestion">MSB4134: DefaultToolsVersion darf nicht festgelegt werden, nachdem ein Projekt in das Modul geladen wurde.</target>
@@ -1197,7 +1197,7 @@
       </trans-unit>
       <trans-unit id="InternalLoggerExceptionOnlyThrownByEngine">
         <source>An InternalLoggerException can only be thrown by the MSBuild engine. The public constructors of this class cannot be used to create an instance of the exception.</source>
-        <target state="translated">Eine InternalLoggerException kann nur durch das MSBuild-Modul ausgelöst werden. Die öffentlichen Konstruktoren dieser Klasse können nicht verwendet werden, um eine Instanz der Ausnahme zu erstellen.</target>
+        <target state="translated">Eine InternalLoggerException kann nur durch die MSBuild-Engine ausgelöst werden. Die öffentlichen Konstruktoren dieser Klasse können nicht verwendet werden, um eine Instanz der Ausnahme zu erstellen.</target>
         <note>UE: This message is shown when a user tries to instantiate a special exception called InternalLoggerException through the OM --
     only the engine is allowed to create and throw this exception.
     LOCALIZATION: "InternalLoggerException" and "MSBuild" should not be localized.</note>
@@ -1419,7 +1419,7 @@
       </trans-unit>
       <trans-unit id="ProjectInvalidUnloaded">
         <source>This project object has been unloaded from the MSBuild engine and is no longer valid.</source>
-        <target state="translated">Dieses Projektobjekt wurde aus dem MSBuild-Modul entladen und ist nicht mehr gültig.</target>
+        <target state="translated">Dieses Projektobjekt wurde aus der MSBuild-Engine entladen und ist nicht mehr gültig.</target>
         <note />
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="tm-suggestion">Dieses Projektobjekt wurde aus dem MSBuild-Modul entladen und ist nicht mehr gültig.</target>
@@ -1963,7 +1963,7 @@
       </trans-unit>
       <trans-unit id="STARequired">
         <source>MSB4056: The MSBuild engine must be called on a single-threaded-apartment. Current threading model is "{0}". Proceeding, but some tasks may not function correctly.</source>
-        <target state="translated">MSB4056: Das MSBuild-Modul muss in einem Singlethread-Apartment aufgerufen werden. Das aktuelle Threadmodell ist {0}. Der Vorgang wird fortgesetzt, aber einige Aufgaben werden möglicherweise nicht ordnungsgemäß ausgeführt.</target>
+        <target state="translated">MSB4056: Die MSBuild-Engine muss in einem Singlethread-Apartment aufgerufen werden. Das aktuelle Threadmodell ist {0}. Der Vorgang wird fortgesetzt, aber einige Aufgaben werden möglicherweise nicht ordnungsgemäß ausgeführt.</target>
         <note>{StrBegin="MSB4056: "}</note>
         <alt-trans match-quality="100%" tool="BlackBox/MSR MT">
           <target state-qualifier="tm-suggestion">MSB4056: Das MSBuild-Modul muss in einem Singlethread-Apartment aufgerufen werden. Das aktuelle Threadmodell ist {0}. Der Vorgang wird fortgesetzt, aber einige Aufgaben werden möglicherweise nicht ordnungsgemäß ausgeführt.</target>

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -27,7 +27,7 @@
         <source>Microsoft (R) Build Engine version {0} for {1}
 Copyright (C) Microsoft Corporation. All rights reserved.
 </source>
-        <target state="translated">Microsoft (R)-Buildmodul, Version {0} für {1}
+        <target state="translated">Microsoft (R)-Build-Engine, Version {0} für {1}
 Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
 </target>
         <note>LOCALIZATION: {0} contains the DLL version number. {1} contains the name of a runtime, like ".NET Framework", ".NET Core", or "Mono"</note>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1936,7 +1936,7 @@
       </trans-unit>
       <trans-unit id="ResolveComReference.CannotFindWrapperForTypeLib">
         <source>MSB3283: Cannot find wrapper assembly for type library "{0}". Verify that (1) the COM component is registered correctly and (2) your target platform is the same as the bitness of the COM component. For example, if the COM component is 32-bit, your target platform must not be 64-bit.</source>
-        <target state="translated">MSB3283: 找不到类型库“{0}”的包装器程序集。请验证 (1) 是否已正确注册 COM 组件，以及 (2) 目标平台与 COM 组件的位元是否相同。例如，如果 COM 组件为 32 位，目标平台就不能为 64 位。</target>
+        <target state="translated">MSB3283: 找不到类型库“{0}”的包装器程序集。请验证 (1) 是否已正确注册 COM 组件，以及 (2) 目标平台与 COM 组件的位数是否相同。例如，如果 COM 组件为 32 位，目标平台就不能为 64 位。</target>
         <note>{StrBegin="MSB3283: "}</note>
       </trans-unit>
       <trans-unit id="ResolveComReference.CannotGetPathForTypeLib">


### PR DESCRIPTION
Missed the localization train for vs15.7, so moving over the xlf files from master (already translated) to vs15.7

Closes #3223