### PR TITLE
[unix] Fix rebuilds caused by resx containing fileref with windows pa…

### DIFF
--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Tasks
                         {
                             ResXFileRef resxFileRef = ((ResXDataNode)dictEntry.Value).FileRef;
                             if (resxFileRef != null)
-                                retVal.Add(resxFileRef.FileName);
+                                retVal.Add(FileUtilities.MaybeAdjustFilePath(resxFileRef.FileName));
                         }
                     }
                 }


### PR DESCRIPTION
…th (#44)

When running on !windows, if a resx contains a fileRef like ..

```
  <data name="TextFile1" type="System.Resources.ResXFileRef, System.Windows.Forms">
	<value>..\Resources\TextFile1.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
  </data>
```

.. with the path containing backslashes, then we end up treating the whole
thing as filename and thus subsequent checks for file changes etc fail. This
causes the resx to be processed every time `GenerateResource` task is run, which
can cause costly rebuilds.

Issue: https://github.com/mono/mono/issues/7184