### PR TITLE
Preserve ProjectStarted GlobalProperties in binary log

### DIFF
--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Build.UnitTests
                 properties: new List<DictionaryEntry>() { new DictionaryEntry("Key", "Value") },
                 items: new List<DictionaryEntry>() { new DictionaryEntry("Key", new MyTaskItem() { ItemSpec = "TestItemSpec" }) },
                 parentBuildEventContext: new BuildEventContext(7, 8, 9, 10, 11, 12),
-                globalProperties: null, // we do not serialize GlobalProperties
+                globalProperties: new Dictionary<string, string>() { { "GlobalKey", "GlobalValue" } },
                 toolsVersion: "15.0");
             args.BuildEventContext = new BuildEventContext(1, 2, 3, 4, 5, 6);
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Build.Logging
         //   - new EvaluationFinished.ProfilerResult
         // version 6:
         //   -  Ids and parent ids for the evaluation locations
-        internal const int FileFormatVersion = 6;
+        // version 7:
+        //   -  Include ProjectStartedEventArgs.GlobalProperties
+        internal const int FileFormatVersion = 7;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -274,6 +274,17 @@ namespace Microsoft.Build.Logging
             var projectId = ReadInt32();
             var targetNames = ReadString();
             var toolsVersion = ReadOptionalString();
+
+            Dictionary<string, string> globalProperties = null;
+
+            if (fileFormatVersion > 6)
+            {
+                if (ReadBoolean())
+                {
+                    globalProperties = ReadStringDictionary();
+                }
+            }
+
             var propertyList = ReadPropertyList();
             var itemList = ReadItems();
 
@@ -286,7 +297,7 @@ namespace Microsoft.Build.Logging
                 propertyList,
                 itemList,
                 parentContext,
-                null,
+                globalProperties,
                 toolsVersion);
             SetCommonFields(e, fields);
             return e;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -166,6 +166,16 @@ namespace Microsoft.Build.Logging
             Write(e.TargetNames);
             WriteOptionalString(e.ToolsVersion);
 
+            if (e.GlobalProperties == null)
+            {
+                Write(false);
+            }
+            else
+            {
+                Write(true);
+                Write(e.GlobalProperties);
+            }
+
             WriteProperties(e.Properties);
 
             WriteItems(e.Items);


### PR DESCRIPTION
The lack of this meant that some operations done by a logger (like figuring out why a project was built multiple times) weren't possible with only the binary log, but worked fine directly attached to a real build.