### PR TITLE
DebuggerDisplay parsed conditional expressions

### DIFF
--- a/src/Build/Evaluation/Conditionals/AndExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/AndExpressionNode.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
-using System;
-
 using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -14,6 +10,7 @@ namespace Microsoft.Build.Evaluation
     /// Performs logical AND on children
     /// Does not update conditioned properties table
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class AndExpressionNode : OperatorExpressionNode
     {
         /// <summary>
@@ -47,6 +44,8 @@ namespace Microsoft.Build.Evaluation
                 return RightChild.BoolEvaluate(state);
             }
         }
+
+        internal override string DebuggerDisplay => $"(and {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
 
         #region REMOVE_COMPAT_WARNING
         private bool _possibleAndCollision = true;

--- a/src/Build/Evaluation/Conditionals/EqualExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/EqualExpressionNode.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for equality
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class EqualExpressionNode : MultipleComparisonNode
     {
         /// <summary>
@@ -38,5 +35,7 @@ namespace Microsoft.Build.Evaluation
         {
             return String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
         }
+
+        internal override string DebuggerDisplay => $"(== {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/GenericExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/GenericExpressionNode.cs
@@ -69,6 +69,12 @@ namespace Microsoft.Build.Evaluation
             return BoolEvaluate(state);
         }
 
+        /// <summary>
+        /// Get display string for this node for use in the debugger.
+        /// </summary>
+        internal virtual string DebuggerDisplay { get; }
+
+
         #region REMOVE_COMPAT_WARNING
         internal virtual bool PossibleAndCollision
         {

--- a/src/Build/Evaluation/Conditionals/GreaterThanExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/GreaterThanExpressionNode.cs
@@ -7,12 +7,14 @@ using System.IO;
 using System;
 
 using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for left > right
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class GreaterThanExpressionNode : NumericComparisonExpressionNode
     {
         /// <summary>
@@ -61,5 +63,7 @@ namespace Microsoft.Build.Evaluation
             // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
             return false;
         }
+
+        internal override string DebuggerDisplay => $"(> {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/GreaterThanOrEqualExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/GreaterThanOrEqualExpressionNode.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for left >= right
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class GreaterThanOrEqualExpressionNode : NumericComparisonExpressionNode
     {
         /// <summary>
@@ -61,5 +58,7 @@ namespace Microsoft.Build.Evaluation
             // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
             return false;
         }
+
+        internal override string DebuggerDisplay => $"(>= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/LessThanExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/LessThanExpressionNode.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for left &lt; right
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class LessThanExpressionNode : NumericComparisonExpressionNode
     {
         /// <summary>
@@ -61,5 +58,7 @@ namespace Microsoft.Build.Evaluation
             // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
             return true;
         }
+
+        internal override string DebuggerDisplay => $"(< {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/LessThanOrEqualExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/LessThanOrEqualExpressionNode.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for left &lt;= right
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class LessThanOrEqualExpressionNode : NumericComparisonExpressionNode
     {
         /// <summary>
@@ -61,5 +58,7 @@ namespace Microsoft.Build.Evaluation
             // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
             return true;
         }
+
+        internal override string DebuggerDisplay => $"(<= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/NotEqualExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/NotEqualExpressionNode.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
     /// <summary>
     /// Compares for inequality
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class NotEqualExpressionNode : MultipleComparisonNode
     {
         /// <summary>
@@ -38,5 +35,7 @@ namespace Microsoft.Build.Evaluation
         {
             return !String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
         }
+
+        internal override string DebuggerDisplay => $"(!= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/NotExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/NotExpressionNode.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
-using System;
-
-using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -14,6 +9,7 @@ namespace Microsoft.Build.Evaluation
     /// Performs logical NOT on left child
     /// Does not update conditioned properties table
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class NotExpressionNode : OperatorExpressionNode
     {
         /// <summary>
@@ -44,5 +40,7 @@ namespace Microsoft.Build.Evaluation
         {
             return "!" + LeftChild.GetExpandedValue(state);
         }
+
+        internal override string DebuggerDisplay => $"(not {LeftChild.DebuggerDisplay})";
     }
 }

--- a/src/Build/Evaluation/Conditionals/NumericExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/NumericExpressionNode.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
+using System.Diagnostics;
 
 using Microsoft.Build.Shared;
 
@@ -13,6 +11,7 @@ namespace Microsoft.Build.Evaluation
     /// <summary>
     /// Represents a number - evaluates as numeric.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class NumericExpressionNode : OperandExpressionNode
     {
         private string _value;
@@ -103,5 +102,7 @@ namespace Microsoft.Build.Evaluation
         internal override void ResetState()
         {
         }
+
+        internal override string DebuggerDisplay => $"#\"{_value}\")";
     }
 }

--- a/src/Build/Evaluation/Conditionals/OperatorExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/OperatorExpressionNode.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
-
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
@@ -15,11 +11,6 @@ namespace Microsoft.Build.Evaluation
     /// </summary>
     internal abstract class OperatorExpressionNode : GenericExpressionNode
     {
-        /// <summary>
-        /// Storage for the left and right children of the operator
-        /// </summary>
-        private GenericExpressionNode _leftChild, _rightChild;
-
         /// <summary>
         /// Numeric evaluation is never allowed for operators
         /// </summary>
@@ -89,34 +80,26 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         internal override void ResetState()
         {
-            if (_leftChild != null)
+            if (LeftChild != null)
             {
-                _leftChild.ResetState();
+                LeftChild.ResetState();
             }
 
-            if (_rightChild != null)
+            if (RightChild != null)
             {
-                _rightChild.ResetState();
+                RightChild.ResetState();
             }
         }
 
         /// <summary>
         /// Storage for the left child
         /// </summary>
-        internal GenericExpressionNode LeftChild
-        {
-            set { _leftChild = value; }
-            get { return _leftChild; }
-        }
+        internal GenericExpressionNode LeftChild { set; get; }
 
         /// <summary>
         /// Storage for the right child
         /// </summary>
-        internal GenericExpressionNode RightChild
-        {
-            set { _rightChild = value; }
-            get { return _rightChild; }
-        }
+        internal GenericExpressionNode RightChild { set; get; }
 
         #region REMOVE_COMPAT_WARNING
         internal override bool DetectAnd()

--- a/src/Build/Evaluation/Conditionals/OrExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/OrExpressionNode.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
-using System;
-
 using Microsoft.Build.Shared;
+using System.Diagnostics;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -14,6 +10,7 @@ namespace Microsoft.Build.Evaluation
     /// Performs logical OR on children
     /// Does not update conditioned properties table
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class OrExpressionNode : OperatorExpressionNode
     {
         /// <summary>
@@ -47,6 +44,8 @@ namespace Microsoft.Build.Evaluation
                 return RightChild.BoolEvaluate(state);
             }
         }
+
+        internal override string DebuggerDisplay => $"(or {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
 
         #region REMOVE_COMPAT_WARNING
         private bool _possibleOrCollision = true;

--- a/src/Build/Evaluation/Conditionals/StringExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/StringExpressionNode.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Globalization;
-using System.IO;
 using System;
+using System.Diagnostics;
 
 using Microsoft.Build.Shared;
 
@@ -13,6 +11,7 @@ namespace Microsoft.Build.Evaluation
     /// <summary>
     /// Node representing a string
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     internal sealed class StringExpressionNode : OperandExpressionNode
     {
         private string _value;
@@ -141,5 +140,7 @@ namespace Microsoft.Build.Evaluation
         {
             _cachedExpandedValue = null;
         }
+
+        internal override string DebuggerDisplay => $"\"{_value}\"";
     }
 }


### PR DESCRIPTION
When trying to explain how the parser worked for dotnet/project-system#3510 I was annoyed at what it took to step through and understand the parse.

With this change, the debugger now shows pretty values.