### PR TITLE
Remove package dependency on Microsoft.NETCore.App (vs15.7)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -63,7 +63,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" PrivateAssets="All"/>
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
   </ItemGroup>
   


### PR DESCRIPTION
Prepping this in case we need it.

This dependency should not leak into our NuGet packages. This was added as the result of a bug (see https://github.com/dotnet/sdk/issues/2204) and causes issues like the ones listed in #3228.