### PR TITLE
Avoid netcoreapp package dependency

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -47,7 +47,6 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <VisualStudioSetupInteropVersion>1.16.30</VisualStudioSetupInteropVersion>
-    <MicrosoftNETCoreAppVersion>2.1.0-preview2-26406-04</MicrosoftNETCoreAppVersion>
 
     <!-- MSBuild custom overall switch -->
     <NuGetPackageVersion>4.8.0-preview1.5158</NuGetPackageVersion>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -128,10 +128,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
-
-    <!-- For prodcon builds, we want to be able to float the compile-time version
-         of .NET Core references separately from the CLI version -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -60,7 +60,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" PrivateAssets="All"/>
     <PackageReference Condition="'$(DisableNerdbankVersioning)' != 'true'" Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
   </ItemGroup>
   

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -53,7 +53,13 @@
 
     <Compile Include="$(RepoRoot)src\Shared\UnitTests\TestAssemblyInfo.cs" />
     <Compile Include="$(RepoRoot)src\Shared\UnitTests\TestProgram.cs" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <!-- Work around https://github.com/dotnet/sdk/issues/2204 by explicitly setting
+         PrivateAssets to keep this reference (auto-added when targeting netcoreapp*)
+         from making it into our NuGet packages. -->
+    <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- GenAPI settings -->


### PR DESCRIPTION
Removes the machinery required to fix the version of our `Microsoft.NETCore.App` dependency and returns to the implicit reference.

Works around dotnet/sdk#2204 by updating the implicit reference with `PrivateAssets="All"`.