### PR TITLE
Expose sdk resolution in Project

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -451,7 +451,9 @@ namespace Microsoft.Build.Framework
     public abstract partial class SdkResult
     {
         protected SdkResult() { }
-        public bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual string Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }
     public abstract partial class SdkResultFactory
     {

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -452,6 +452,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResult() { }
         public virtual string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual Microsoft.Build.Framework.SdkReference SdkReference { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -450,7 +450,9 @@ namespace Microsoft.Build.Framework
     public abstract partial class SdkResult
     {
         protected SdkResult() { }
-        public bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual string Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }
     public abstract partial class SdkResultFactory
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -451,6 +451,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResult() { }
         public virtual string Path { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
+        public virtual Microsoft.Build.Framework.SdkReference SdkReference { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual bool Success { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
         public virtual string Version { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]protected set { } }
     }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Build.Construction
         internal ProjectImportElement() { }
         public Microsoft.Build.Construction.ImplicitImportLocation ImplicitImportLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string MinimumVersion { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ProjectElement OriginalElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Project { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation ProjectLocation { get { throw null; } }
         public string Sdk { get { throw null; } set { } }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -839,9 +839,10 @@ namespace Microsoft.Build.Evaluation
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ResolvedImport
     {
-        public Microsoft.Build.Construction.ProjectRootElement ImportedProject { get { throw null; } }
-        public Microsoft.Build.Construction.ProjectImportElement ImportingElement { get { throw null; } }
-        public bool IsImported { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectRootElement ImportedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectImportElement ImportingElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsImported { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.SdkResult SdkResult { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("SubToolsetVersion={SubToolsetVersion} #Properties={_properties.Count}")]
     public partial class SubToolset

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Build.Construction
         internal ProjectImportElement() { }
         public Microsoft.Build.Construction.ImplicitImportLocation ImplicitImportLocation { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string MinimumVersion { get { throw null; } set { } }
+        public Microsoft.Build.Construction.ProjectElement OriginalElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public string Project { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation ProjectLocation { get { throw null; } }
         public string Sdk { get { throw null; } set { } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -839,9 +839,10 @@ namespace Microsoft.Build.Evaluation
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ResolvedImport
     {
-        public Microsoft.Build.Construction.ProjectRootElement ImportedProject { get { throw null; } }
-        public Microsoft.Build.Construction.ProjectImportElement ImportingElement { get { throw null; } }
-        public bool IsImported { get { throw null; } }
+        public Microsoft.Build.Construction.ProjectRootElement ImportedProject { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Construction.ProjectImportElement ImportingElement { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public bool IsImported { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        public Microsoft.Build.Framework.SdkResult SdkResult { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("SubToolsetVersion={SubToolsetVersion} #Properties={_properties.Count}")]
     public partial class SubToolset

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -42,7 +42,12 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath");
 
-            result.ShouldBeNull();
+            result.Success.ShouldBeFalse();
+            result.ShouldNotBeNull();
+            result.SdkReference.ShouldNotBeNull();
+            result.SdkReference.Name.ShouldBe("notfound");
+            result.SdkReference.Version.ShouldBe("referencedVersion");
+            result.SdkReference.MinimumVersion.ShouldBe("minimumVersion");
 
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver2 running");

--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using System;
+using Microsoft.Build.Definition;
 using Microsoft.Build.Unittest;
 using Xunit;
 
@@ -852,11 +853,10 @@ namespace Microsoft.Build.UnitTests.Preprocessor
             {
                 string testSdkDirectory = env.CreateFolder().FolderPath;
 
-                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolverFileMapping(
-                    new Dictionary<string, string>
-                    {
-                        {"MSBuildUnitTestSdk", testSdkDirectory}
-                    });
+                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
+                {
+                    {"MSBuildUnitTestSdk", testSdkDirectory}
+                }));
 
 
                 string sdkPropsPath = Path.Combine(testSdkDirectory, "Sdk.props");
@@ -943,12 +943,11 @@ namespace Microsoft.Build.UnitTests.Preprocessor
                 string sdk1 = env.CreateFolder().FolderPath;
                 string sdk2 = env.CreateFolder().FolderPath;
 
-                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolverFileMapping(
-                    new Dictionary<string, string>
-                    {
-                        {"MSBuildUnitTestSdk1", sdk1},
-                        {"MSBuildUnitTestSdk2", sdk2},
-                    });
+                var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
+                {
+                    {"MSBuildUnitTestSdk1", sdk1},
+                    {"MSBuildUnitTestSdk2", sdk2},
+                }));
 
                 string sdkPropsPath1 = Path.Combine(sdk1, "Sdk.props");
                 string sdkTargetsPath1 = Path.Combine(sdk1, "Sdk.targets");

--- a/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
@@ -509,7 +509,8 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
             for (var i = 0; i < 2; i++)
             {
-                var importingElement = imports[i].ImportingElement;
+                var import = imports[i];
+                var importingElement = import.ImportingElement;
                 importingElement.Sdk.ShouldBe(SdkName + $"/{version}");
                 importingElement.ParsedSdkReference.Name.ShouldBe(SdkName);
                 importingElement.ParsedSdkReference.Version.ShouldBe(expectedVersion);
@@ -522,6 +523,15 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                     : ImplicitImportLocation.Bottom;
 
                 importingElement.ImplicitImportLocation.ShouldBe(implicitLocation);
+
+                import.SdkResult.SdkReference.ShouldBeSameAs(importingElement.ParsedSdkReference);
+
+                var expectedSdkPath = i == 0
+                    ? _sdkPropsPath
+                    : _sdkTargetsPath;
+
+                import.SdkResult.Path.ShouldBe(Path.GetDirectoryName(expectedSdkPath));
+                import.SdkResult.Version.ShouldBeEmpty();
             }
         }
 

--- a/src/Build.UnitTests/InternalEngineHelpers.cs
+++ b/src/Build.UnitTests/InternalEngineHelpers.cs
@@ -20,13 +20,11 @@ namespace Microsoft.Build.Unittest
 {
     internal static class SdkUtilities
     {
-        public static ProjectOptions CreateProjectOptionsWithResolverFileMapping(Dictionary<string, string> mapping)
+        public static ProjectOptions CreateProjectOptionsWithResolver(SdkResolver resolver)
         {
-            var resolver = new FileBasedMockSdkResolver(mapping);
-
             var context = EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
             var sdkService = (SdkResolverService)context.SdkResolverService;
-            sdkService.InitializeForTests(null, new List<SdkResolver>(){resolver});
+            sdkService.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
             return new ProjectOptions
             {

--- a/src/Build.UnitTests/InternalEngineHelpers.cs
+++ b/src/Build.UnitTests/InternalEngineHelpers.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Unittest
 
             public ConfigurableMockSdkResolver(SdkResult result)
             {
-                _resultMap = new Dictionary<string, SdkResult> { [result.Sdk.Name] = result };
+                _resultMap = new Dictionary<string, SdkResult> { [result.SdkReference.Name] = result };
             }
 
             public ConfigurableMockSdkResolver(Dictionary<string, SdkResult> resultMap)

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             }
 
             if (result != null &&
-                !SdkResolverService.IsReferenceSameVersion(sdk, result.Sdk.Version) &&
+                !SdkResolverService.IsReferenceSameVersion(sdk, result.SdkReference.Version) &&
                 !SdkResolverService.IsReferenceSameVersion(sdk, result.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <param name="sdkReferenceLocation">The <see cref="ElementLocation"/> of the element which referenced the SDK.</param>
         /// <param name="solutionPath">The full path to the solution file, if any, that is resolving the SDK.</param>
         /// <param name="projectPath">The full path to the project file that is resolving the SDK.</param>
-        /// <returns>An <see cref="SdkResult"/> containing information about the resolved SDK if it could be resolved, otherwise <code>null</code>.</returns>
+        /// <returns>An <see cref="SdkResult"/> containing information about the resolved SDK. If no resolver was able to resolve it, then <see cref="Framework.SdkResult.Success"/> == false. </returns>
         SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath);
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                         // Get the node manager and send the response back to the node that requested the SDK
                         INodeManager nodeManager = Host.GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
-                        nodeManager.SendData(request.NodeId, response ?? new SdkResult());
+                        nodeManager.SendData(request.NodeId, response);
                     }
                 }));
             }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverCachingWrapper.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverCachingWrapper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             }
 
             if (result != null &&
-                !SdkResolverService.IsReferenceSameVersion(sdk, result.Sdk.Version) &&
+                !SdkResolverService.IsReferenceSameVersion(sdk, result.SdkReference.Version) &&
                 !SdkResolverService.IsReferenceSameVersion(sdk, result.Version))
             {
                 // MSB4240: Multiple versions of the same SDK "{0}" cannot be specified. The previously resolved SDK version "{1}" from location "{2}" will be used and the version "{3}" will be ignored.

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                 }
             }
 
-            return null;
+            return new SdkResult(sdk, null, null);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public SdkResult(SdkReference sdkReference, IEnumerable<string> errors, IEnumerable<string> warnings)
         {
             Success = false;
-            Sdk = sdkReference;
+            SdkReference = sdkReference;
             Errors = errors;
             Warnings = warnings;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public SdkResult(SdkReference sdkReference, string path, string version, IEnumerable<string> warnings)
         {
             Success = true;
-            Sdk = sdkReference;
+            SdkReference = sdkReference;
             _path = path;
             _version = version;
             Warnings = warnings;
@@ -46,11 +46,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         public IEnumerable<string> Errors { get; }
 
-        public string Path => _path;
+        public override string Path => _path;
 
-        public SdkReference Sdk { get; }
+        public override SdkReference SdkReference { get; protected set; }
 
-        public string Version => _version;
+        public override string Version => _version;
 
         public IEnumerable<string> Warnings { get; }
         public void Translate(INodePacketTranslator translator)

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -113,6 +113,13 @@ namespace Microsoft.Build.Construction
         public ImplicitImportLocation ImplicitImportLocation { get; internal set; }
 
         /// <summary>
+        /// If the import is an implicit one (<see cref="ImplicitImportLocation"/> != None) then this element points
+        /// to the original element which generated this implicit import.
+        /// </summary>
+        public ProjectElement OriginalElement { get; internal set; }
+
+
+        /// <summary>
         /// <see cref="SdkReference"/> if applicable to this import element.
         /// </summary>
         internal SdkReference ParsedSdkReference { get; set; }
@@ -132,7 +139,12 @@ namespace Microsoft.Build.Construction
         /// Creates an implicit ProjectImportElement as if it was in the project.
         /// </summary>
         /// <returns></returns>
-        internal static ProjectImportElement CreateImplicit(string project, ProjectRootElement containingProject, ImplicitImportLocation implicitImportLocation, SdkReference sdkReference)
+        internal static ProjectImportElement CreateImplicit(
+            string project,
+            ProjectRootElement containingProject,
+            ImplicitImportLocation implicitImportLocation,
+            SdkReference sdkReference,
+            ProjectElement originalElement)
         {
             XmlElementWithLocation element = containingProject.CreateElement(XMakeElements.import);
             return new ProjectImportElement(element, containingProject)
@@ -140,7 +152,8 @@ namespace Microsoft.Build.Construction
                 Project = project,
                 Sdk = sdkReference.ToString(),
                 ImplicitImportLocation = implicitImportLocation,
-                ParsedSdkReference = sdkReference
+                ParsedSdkReference = sdkReference,
+                OriginalElement = originalElement
             };
         }
 

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1919,8 +1919,8 @@ namespace Microsoft.Build.Construction
             {
                 foreach (var referencedSdk in ParseSdks(sdkAttribute, SdkLocation))
                 {
-                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk));
-                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk));
+                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk, this));
+                    nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk, this));
                 }
             }
 
@@ -1931,8 +1931,8 @@ namespace Microsoft.Build.Construction
                     sdkNode.XmlElement.GetAttribute("Version"),
                     sdkNode.XmlElement.GetAttribute("MinimumVersion"));
 
-                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk));
-                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk));
+                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk, sdkNode));
+                nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk, sdkNode));
             }
 
             return nodes;

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1914,10 +1914,10 @@ namespace Microsoft.Build.Construction
         {
             var nodes = new List<ProjectImportElement>();
 
-            string sdk = Sdk;
-            if (!string.IsNullOrWhiteSpace(sdk))
+            string sdkAttribute = Sdk;
+            if (!string.IsNullOrWhiteSpace(sdkAttribute))
             {
-                foreach (var referencedSdk in ParseSdks(sdk, SdkLocation))
+                foreach (var referencedSdk in ParseSdks(sdkAttribute, SdkLocation))
                 {
                     nodes.Add(ProjectImportElement.CreateImplicit("Sdk.props", currentProjectOrImport, ImplicitImportLocation.Top, referencedSdk));
                     nodes.Add(ProjectImportElement.CreateImplicit("Sdk.targets", currentProjectOrImport, ImplicitImportLocation.Bottom, referencedSdk));

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -34,6 +34,7 @@ using Microsoft.Build.Globbing;
 using Microsoft.Build.Utilities;
 using EvaluationItemSpec = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
 using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemExpressionFragment<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -692,17 +693,17 @@ namespace Microsoft.Build.Evaluation
                     return true;
                 }
 
-                foreach (Triple<ProjectImportElement, ProjectRootElement, int> triple in _data.ImportClosure)
+                foreach (var import in _data.ImportClosure)
                 {
-                    if (triple.Second.Version != triple.Third || _evaluatedVersion < triple.Third)
+                    if (import.ImportedProject.Version != import.VersionEvaluated || _evaluatedVersion < import.VersionEvaluated)
                     {
                         if (s_debugEvaluation)
                         {
-                            string reason = triple.Second.LastDirtyReason;
+                            string reason = import.ImportedProject.LastDirtyReason;
 
                             if (reason != null)
                             {
-                                Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because {0} [{1} - {2}] [PC Hash {3}]", reason, FullPath, (triple.Second.FullPath == FullPath ? String.Empty : triple.Second.FullPath), _projectCollection.GetHashCode()));
+                                Trace.WriteLine(String.Format(CultureInfo.InvariantCulture, "MSBUILD: Is dirty because {0} [{1} - {2}] [PC Hash {3}]", reason, FullPath, (import.ImportedProject.FullPath == FullPath ? String.Empty : import.ImportedProject.FullPath), _projectCollection.GetHashCode()));
                             }
                         }
 
@@ -861,11 +862,11 @@ namespace Microsoft.Build.Evaluation
             {
                 List<ResolvedImport> imports = new List<ResolvedImport>(_data.ImportClosure.Count - 1 /* outer project */);
 
-                foreach (Triple<ProjectImportElement, ProjectRootElement, int> import in _data.ImportClosure)
+                foreach (var import in _data.ImportClosure)
                 {
-                    if (import.First != null) // Exclude outer project itself
+                    if (import.ImportingElement != null) // Exclude outer project itself
                     {
-                        imports.Add(new ResolvedImport(this, import.First, import.Second));
+                        imports.Add(import);
                     }
                 }
 
@@ -884,11 +885,11 @@ namespace Microsoft.Build.Evaluation
 
                 List<ResolvedImport> imports = new List<ResolvedImport>(_data.ImportClosureWithDuplicates.Count - 1 /* outer project */);
 
-                foreach (Triple<ProjectImportElement, ProjectRootElement, int> import in _data.ImportClosureWithDuplicates)
+                foreach (var import in _data.ImportClosureWithDuplicates)
                 {
-                    if (import.First != null) // Exclude outer project itself
+                    if (import.ImportingElement != null) // Exclude outer project itself
                     {
-                        imports.Add(new ResolvedImport(this, import.First, import.Second));
+                        imports.Add(import);
                     }
                 }
 
@@ -1679,7 +1680,7 @@ namespace Microsoft.Build.Evaluation
         {
             // Implicit imports exist in the import closure but not in the project XML so the ImplicitImportLocation.Top
             // imports need to be returned before walking the project XML
-            foreach (ProjectRootElement import in _data.ImportClosure.Where(i => i.First?.ImplicitImportLocation == ImplicitImportLocation.Top).Select(i => i.Second))
+            foreach (ProjectRootElement import in _data.ImportClosure.Where(i => i.ImportingElement?.ImplicitImportLocation == ImplicitImportLocation.Top).Select(i => i.ImportedProject))
             {
                 foreach (ProjectElement child in GetLogicalProject(import.AllChildren))
                 {
@@ -1694,7 +1695,7 @@ namespace Microsoft.Build.Evaluation
 
             // Implicit imports exist in the import closure but not in the project XML so the ImplicitImportLocation.Bottom
             // imports need to be returned before walking the project XML
-            foreach (ProjectRootElement import in _data.ImportClosure.Where(i => i.First?.ImplicitImportLocation == ImplicitImportLocation.Bottom).Select(i => i.Second))
+            foreach (ProjectRootElement import in _data.ImportClosure.Where(i => i.ImportingElement?.ImplicitImportLocation == ImplicitImportLocation.Bottom).Select(i => i.ImportedProject))
             {
                 foreach (ProjectElement child in GetLogicalProject(import.AllChildren))
                 {
@@ -2393,12 +2394,12 @@ namespace Microsoft.Build.Evaluation
         /// <returns>True if this project is or imports the xml file; false otherwise.</returns>
         internal bool UsesProjectRootElement(ProjectRootElement xmlRootElement)
         {
-            if (Object.ReferenceEquals(this.Xml, xmlRootElement))
+            if (object.ReferenceEquals(this.Xml, xmlRootElement))
             {
                 return true;
             }
 
-            if (_data.ImportClosure.Any(triple => Object.ReferenceEquals(triple.Second, xmlRootElement)))
+            if (_data.ImportClosure.Any(import => object.ReferenceEquals(import.ImportedProject, xmlRootElement)))
             {
                 return true;
             }
@@ -2757,9 +2758,11 @@ namespace Microsoft.Build.Evaluation
 
             if (_data.ImportClosure != null)
             {
-                foreach (Triple<ProjectImportElement, ProjectRootElement, int> triple in _data.ImportClosure)
+                foreach (var import in _data.ImportClosure)
                 {
-                    highestXmlVersion = (highestXmlVersion < triple.Third) ? triple.Third : highestXmlVersion;
+                    highestXmlVersion = (highestXmlVersion < import.VersionEvaluated)
+                        ? import.VersionEvaluated
+                        : highestXmlVersion;
                 }
             }
 
@@ -2944,7 +2947,7 @@ namespace Microsoft.Build.Evaluation
                 else
                 {
                     // Get the project root elements of all the imports resulting from this import statement (there could be multiple if there is a wild card).
-                    IEnumerable<ProjectRootElement> children = _data.ImportClosure.Where(triple => Object.ReferenceEquals(triple.First, import)).Select(triple => triple.Second);
+                    IEnumerable<ProjectRootElement> children = _data.ImportClosure.Where(resolvedImport => object.ReferenceEquals(resolvedImport.ImportingElement, import)).Select(triple => triple.ImportedProject);
 
                     foreach (ProjectRootElement child in children)
                     {
@@ -3359,7 +3362,7 @@ namespace Microsoft.Build.Evaluation
             /// Complete list of all imports pulled in during evaluation.
             /// This includes the outer project itself.
             /// </summary>
-            internal List<Triple<ProjectImportElement, ProjectRootElement, int>> ImportClosure
+            internal List<ResolvedImport> ImportClosure
             {
                 get;
                 private set;
@@ -3369,7 +3372,7 @@ namespace Microsoft.Build.Evaluation
             /// Complete list of all imports pulled in during evaluation including duplicate imports.
             /// This includes the outer project itself.
             /// </summary>
-            internal List<Triple<ProjectImportElement, ProjectRootElement, int>> ImportClosureWithDuplicates
+            internal List<ResolvedImport> ImportClosureWithDuplicates
             {
                 get;
                 private set;
@@ -3416,8 +3419,8 @@ namespace Microsoft.Build.Evaluation
                 this.Expander = new Expander<ProjectProperty, ProjectItem>(this.Properties, _items);
                 this.ItemDefinitions = new RetrievableEntryHashSet<ProjectItemDefinition>(MSBuildNameIgnoreCaseComparer.Default);
                 this.Targets = new RetrievableEntryHashSet<ProjectTargetInstance>(StringComparer.OrdinalIgnoreCase);
-                this.ImportClosure = new List<Triple<ProjectImportElement, ProjectRootElement, int>>();
-                this.ImportClosureWithDuplicates = new List<Triple<ProjectImportElement, ProjectRootElement, int>>();
+                this.ImportClosure = new List<ResolvedImport>();
+                this.ImportClosureWithDuplicates = new List<ResolvedImport>();
                 this.AllEvaluatedProperties = new List<ProjectProperty>();
                 this.AllEvaluatedItemDefinitionMetadata = new List<ProjectMetadata>();
                 this.AllEvaluatedItems = new List<ProjectItem>();
@@ -3431,7 +3434,7 @@ namespace Microsoft.Build.Evaluation
 
                 // Include the main project in the list of imports, as this list is 
                 // used to figure out if any of them have changed.
-                RecordImport(null, _project._xml, _project._xml.Version);
+                RecordImport(null, _project._xml, _project._xml.Version, null);
 
                 string toolsVersionToUse = ExplicitToolsVersion;
                 ElementLocation toolsVersionLocation = _project._xml.ProjectFileLocation;
@@ -3655,7 +3658,7 @@ namespace Microsoft.Build.Evaluation
             /// </remarks>
             public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
-                ImportClosure.Add(new Triple<ProjectImportElement, ProjectRootElement, int>(importElement, import, versionEvaluated));
+                ImportClosure.Add(new ResolvedImport(Project, importElement, import, versionEvaluated, sdkResult));
                 RecordImportWithDuplicates(importElement, import, versionEvaluated);
             }
 
@@ -3664,7 +3667,7 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public void RecordImportWithDuplicates(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
             {
-                ImportClosureWithDuplicates.Add(new Triple<ProjectImportElement, ProjectRootElement, int>(importElement, import, versionEvaluated));
+                ImportClosureWithDuplicates.Add(new ResolvedImport(Project, importElement, import, versionEvaluated, null));
             }
 
             /// <summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3653,7 +3653,7 @@ namespace Microsoft.Build.Evaluation
             /// If they are dirtied, though, they might affect the evaluated project; and that's why we record them. 
             /// Mostly these will be common imports, so they'll be shared anyway.
             /// </remarks>
-            public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
+            public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
                 ImportClosure.Add(new Triple<ProjectImportElement, ProjectRootElement, int>(importElement, import, versionEvaluated));
                 RecordImportWithDuplicates(importElement, import, versionEvaluated);

--- a/src/Build/Definition/ResolvedImport.cs
+++ b/src/Build/Definition/ResolvedImport.cs
@@ -7,6 +7,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
@@ -26,55 +27,40 @@ namespace Microsoft.Build.Evaluation
     public struct ResolvedImport
     {
         /// <summary>
-        /// Element doing the import
-        /// </summary>
-        private ProjectImportElement _importingElement;
-
-        /// <summary>
-        /// One of the files it causes to import
-        /// </summary>
-        private ProjectRootElement _importedProject;
-
-        /// <summary>
-        /// Whether the importing element is itself imported.
-        /// </summary>
-        private bool _isImported;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ResolvedImport"/> struct.
         /// </summary>
-        internal ResolvedImport(Project project, ProjectImportElement importingElement, ProjectRootElement importedProject)
+        internal ResolvedImport(Project project, ProjectImportElement importingElement, ProjectRootElement importedProject, int versionEvaluated, SdkResult sdkResult)
         {
-            ErrorUtilities.VerifyThrowInternalNull(importingElement, "parent");
             ErrorUtilities.VerifyThrowInternalNull(importedProject, "child");
 
-            _importingElement = importingElement;
-            _importedProject = importedProject;
-            _isImported = !ReferenceEquals(project.Xml, importingElement.ContainingProject);
+            ImportingElement = importingElement;
+            ImportedProject = importedProject;
+            SdkResult = sdkResult;
+            VersionEvaluated = versionEvaluated;
+            IsImported = importingElement != null && !ReferenceEquals(project.Xml, importingElement.ContainingProject);
         }
 
         /// <summary>
         /// Gets the element doing the import.
+        /// Null if this is the top project
         /// </summary>
-        public ProjectImportElement ImportingElement
-        {
-            get { return _importingElement; }
-        }
+        public ProjectImportElement ImportingElement { get; }
 
         /// <summary>
         /// Gets one of the imported projects.
         /// </summary>
-        public ProjectRootElement ImportedProject
-        {
-            get { return _importedProject; }
-        }
+        public ProjectRootElement ImportedProject { get; }
+
+        /// <summary>
+        /// Non null if this import was an sdk import.
+        /// </summary>
+        public SdkResult SdkResult { get; }
+
+        internal int VersionEvaluated { get; }
 
         /// <summary>
         /// Whether the importing element is itself imported.
         /// </summary>
-        public bool IsImported
-        {
-            get { return _isImported; }
-        }
+        public bool IsImported { get; }
     }
 }

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2136,9 +2136,9 @@ namespace Microsoft.Build.Evaluation
                 var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
 
                 // Combine SDK path with the "project" relative path
-                var sdkRootPath = _sdkResolverService.ResolveSdk(_submissionId, importElement.ParsedSdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath)?.Path;
+                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, importElement.ParsedSdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath);
 
-                if (string.IsNullOrEmpty(sdkRootPath))
+                if (!sdkResult.Success)
                 {
                     if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports))
                     {
@@ -2165,7 +2165,7 @@ namespace Microsoft.Build.Evaluation
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "CouldNotResolveSdk", importElement.ParsedSdkReference.ToString());
                 }
 
-                project = Path.Combine(sdkRootPath, project);
+                project = Path.Combine(sdkResult.Path, project);
             }
 
             ExpandAndLoadImportsFromUnescapedImportExpression(directoryOfImportingFile, importElement, project,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -933,7 +933,7 @@ namespace Microsoft.Build.Evaluation
 
                 UpdateDefaultTargets(currentProjectOrImport);
 
-                // Get all the implicit imports (e.g. <Project Sdk="" />, but not <Import Sdk="" />)
+                // Get all the implicit imports (e.g. <Project Sdk="" />, or <Sdk Name="" />, but not <Import Sdk="" />)
                 List<ProjectImportElement> implicitImports = currentProjectOrImport.GetImplicitImportNodes(currentProjectOrImport);
 
                 // Evaluate the "top" implicit imports as if they were the first entry in the file.

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1824,8 +1824,8 @@ namespace Microsoft.Build.Evaluation
 
                 foreach (ProjectRootElement importedProjectRootElement in importedProjectRootElements)
                 {
-                    _data.RecordImport(importElement, importedProjectRootElement, importedProjectRootElement.Version);
-
+                    _data.RecordImport(importElement, importedProjectRootElement, importedProjectRootElement.Version, sdkResult);
+                    
                     PerformDepthFirstPass(importedProjectRootElement);
                 }
             }

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Collections;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.BackEnd.SdkResolution;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -289,7 +290,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Record an import opened during evaluation, if appropriate.
         /// </summary>
-        void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated);
+        void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult);
 
         /// <summary>
         /// Record an import opened during evaluation, if appropriate.

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Collections;
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.BackEnd;
+using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 
@@ -280,9 +281,9 @@ namespace Microsoft.Build.Evaluation
                 _wrappedData.InitializeForEvaluation(toolsetProvider);
             }
 
-            public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
+            public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)
             {
-                _wrappedData.RecordImport(importElement, import, versionEvaluated);
+                _wrappedData.RecordImport(importElement, import, versionEvaluated, sdkResult);
             }
 
             public void RecordImportWithDuplicates(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -34,6 +34,7 @@ using System.Runtime.CompilerServices;
 using System.Linq;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Utilities;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.Execution
 {
@@ -1391,7 +1392,11 @@ namespace Microsoft.Build.Execution
         /// Record an import opened during evaluation.
         /// Does nothing: not needed for project instances.
         /// </summary>
-        void IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated)
+        void IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.RecordImport(
+            ProjectImportElement importElement,
+            ProjectRootElement import,
+            int versionEvaluated,
+            SdkResult sdkResult)
         {
         }
 

--- a/src/Framework/Sdk/SdkResult.cs
+++ b/src/Framework/Sdk/SdkResult.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Framework
 
         /// <summary>
         ///     Resolved version of the SDK.
-        ///     Can be null if the resolver did not provide a version (e.g. a path based resolver)
+        ///     Can be null or empty if the resolver did not provide a version (e.g. a path based resolver)
         /// 
         ///     Null if <see cref="Success"/> == false
         /// </summary>

--- a/src/Framework/Sdk/SdkResult.cs
+++ b/src/Framework/Sdk/SdkResult.cs
@@ -15,6 +15,26 @@ namespace Microsoft.Build.Framework
         /// <summary>
         ///     Indicates the resolution was successful.
         /// </summary>
-        public bool Success { get; protected set; }
+        public virtual bool Success { get; protected set; }
+
+        /// <summary>
+        ///     Resolved path to the SDK.
+        /// 
+        ///     Null if <see cref="Success"/> == false
+        /// </summary>
+        public virtual string Path { get; protected set; }
+
+        /// <summary>
+        ///     Resolved version of the SDK.
+        ///     Can be null if the resolver did not provide a version (e.g. a path based resolver)
+        /// 
+        ///     Null if <see cref="Success"/> == false
+        /// </summary>
+        public virtual string Version { get; protected set; }
+
+        /// <summary>
+        ///     The Sdk reference
+        /// </summary>
+        public virtual SdkReference SdkReference { get; protected set; }
     }
 }


### PR DESCRIPTION
- `ProjectImportElement.OriginalElement` points to the original `ProjectElement` which generated implicit imports (`ProjectRootElement` or `ProjectSdkElement`).
- `ResolvedImport.SdkResult` points to sdk resolution results.

`Project.Imports.Where(i -> i.SdkResult != null)` retrieves all `ResolvedImports` that came from sdks, with pointers to the `SdkResult` and the import element. This should allow VS to display the sdks a Project imports, and to navigate to the real elements which generated those imports.

Closes #3203