### PR TITLE
Initialize repotoolset so source-build can supply a built version.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -278,19 +278,36 @@ function InstallDotNetCli {
 }
 
 function InstallRepoToolset {
+  CreateDirectory "$RepoToolsetDir"
   ReadJson "$RepoRoot/global.json" "RoslynTools.RepoToolset"
   RepoToolsetVersion=$readjsonvalue
-  RepoToolsetDir="$NuGetPackageRoot/roslyntools.repotoolset/$RepoToolsetVersion/tools"
-  RepoToolsetBuildProj="$RepoToolsetDir/Build.proj"
+  RepoToolsetLocationFile="$RepoToolsetDir/$RepoToolsetVersion.txt"
+
+  if [[ -a "$RepoToolsetLocationFile" ]]; then
+    local path=`cat $RepoToolsetLocationFile`
+    if [[ -a "$path" ]]; then
+      RepoToolsetBuildProj=$path
+      return
+    fi
+  fi
+  if [[ "$restore" != true ]]; then
+    ExitIfError 2 "Toolset version $RepoToolsetVersion has not been restored."
+  fi
 
   echo "Using repo tools version: $readjsonvalue"
+  local proj="$RepoToolsetDir/restore.proj"
+  echo '<Project Sdk="RoslynTools.RepoToolset"/>' > $proj
 
   local logCmd=$(GetLogCmd Toolset)
+  CallMSBuild $(QQ $proj) /t:__WriteToolsetLocation /m /nologo /clp:None /warnaserror $logCmd /p:__ToolsetLocationOutputFile=$RepoToolsetLocationFile
+  local lastexitcode=$?
 
-  if [ ! -d "$RepoToolsetBuildProj" ]
-  then
-    local ToolsetProj="$ScriptRoot/Toolset.csproj"
-    CallMSBuild $(QQ $ToolsetProj) /t:build /m /clp:Summary /warnaserror /v:$verbosity $logCmd $properties
+  ExitIfError $lastexitcode "Failed to restore toolset (exit code '$lastexitcode')."
+
+  RepoToolsetBuildProj=`cat $RepoToolsetLocationFile`
+
+  if [[ ! -a "$RepoToolsetBuildProj" ]]; then
+    ExitIfError 3 "Invalid toolset path: $RepoToolsetBuildProj"
   fi
 }
 
@@ -392,6 +409,7 @@ ArtifactsConfigurationDir="$ArtifactsDir/$configuration"
 PackagesDir="$ArtifactsConfigurationDir/packages"
 LogDir="$ArtifactsConfigurationDir/log"
 VersionsProps="$ScriptRoot/Versions.props"
+RepoToolsetDir="$ArtifactsDir/toolset"
 
 #https://github.com/dotnet/source-build
 if $dotnetBuildFromSource

--- a/build/build.sh
+++ b/build/build.sh
@@ -282,6 +282,8 @@ function InstallRepoToolset {
   ReadJson "$RepoRoot/global.json" "RoslynTools.RepoToolset"
   RepoToolsetVersion=$readjsonvalue
   RepoToolsetLocationFile="$RepoToolsetDir/$RepoToolsetVersion.txt"
+  
+  echo "Using repo tools version: $readjsonvalue"
 
   if [[ -a "$RepoToolsetLocationFile" ]]; then
     local path=`cat $RepoToolsetLocationFile`
@@ -294,7 +296,6 @@ function InstallRepoToolset {
     ExitIfError 2 "Toolset version $RepoToolsetVersion has not been restored."
   fi
 
-  echo "Using repo tools version: $readjsonvalue"
   local proj="$RepoToolsetDir/restore.proj"
   echo '<Project Sdk="RoslynTools.RepoToolset"/>' > $proj
 


### PR DESCRIPTION
For source-build 2.1 RC this was a patch for msbuild to enable source-build to supply the version of repotoolset that was source-built.  This moves the changes into msbuild so the patch can be removed.

cc @cdmihai