### PR TITLE
Allow skipped tests for Mono CI jobs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -91,6 +91,7 @@ def CreateJob(script, runtime, osName, isPR, machineAffinityOverride = null, sho
 
         def script = "NA"
         def machineAffinityOverride = null
+        def shouldSkipTestsWhenResultsNotFound = false
 
         runtimes.each { runtime ->
             switch(osName) {
@@ -122,6 +123,7 @@ def CreateJob(script, runtime, osName, isPR, machineAffinityOverride = null, sho
                         // tests are failing on mono right now, so default to
                         // skipping tests
                         script += " -skipTests"
+                        shouldSkipTestsWhenResultsNotFound = true
                     }
 
                     break;
@@ -137,12 +139,13 @@ def CreateJob(script, runtime, osName, isPR, machineAffinityOverride = null, sho
                         // tests are failing on mono right now, so default to
                         // skipping tests
                         script += " -skipTests"
+                        shouldSkipTestsWhenResultsNotFound = true
                     }
 
                     break;
             }
 
-            CreateJob(script, runtime, osName, isPR, machineAffinityOverride)
+            CreateJob(script, runtime, osName, isPR, machineAffinityOverride, shouldSkipTestsWhenResultsNotFound)
         }
     }
 }


### PR DESCRIPTION
We're intentionally skipping tests for these Mono jobs (for now) but then CI was failing anyway:

```
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:05:01.68
[xUnit] [INFO] - Starting to record.
[xUnit] [INFO] - Processing xUnit.Net-v2 (default)
[xUnit] [INFO] - [xUnit.Net-v2 (default)] - No test report file(s) were found with the pattern 'artifacts/**/TestResults/*.xml' relative to '/Users/dotnet-bot/j/w/Microsoft_msbuild/master/innerloop_OSX10.13_Mono_prtest' for the testing framework 'xUnit.Net-v2 (default)'.  Did you enter a pattern relative to the correct directory?  Did you generate the result report(s) for 'xUnit.Net-v2 (default)'?
[xUnit] [ERROR] - No test reports found for the metric 'xUnit.Net' with the resolved pattern 'artifacts/**/TestResults/*.xml'. Configuration error?.
[xUnit] [INFO] - Failing BUILD.
[xUnit] [INFO] - There are errors when processing test results.
[xUnit] [INFO] - Skipping tests recording.
[xUnit] [INFO] - Stop build.
Build step 'Publish xUnit test result report' changed build result to FAILURE
```

https://ci2.dot.net/job/Microsoft_msbuild/job/master/job/innerloop_OSX10.13_Mono_prtest/3/console