### PR TITLE
Ignore missing imports during restore

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1025,7 +1025,7 @@ namespace Microsoft.Build.Execution
     {
         ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
-        IgnoreMissingAndInvalidImports = 64,
+        IgnoreMissingEmptyAndInvalidImports = 64,
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ProvideSubsetOfStateAfterBuild = 32,

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1025,6 +1025,7 @@ namespace Microsoft.Build.Execution
     {
         ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
+        IgnoreMissingAndInvalidImports = 64,
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ProvideSubsetOfStateAfterBuild = 32,

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1020,6 +1020,7 @@ namespace Microsoft.Build.Execution
     {
         ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
+        IgnoreMissingAndInvalidImports = 64,
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ProvideSubsetOfStateAfterBuild = 32,

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1020,7 +1020,7 @@ namespace Microsoft.Build.Execution
     {
         ClearCachesAfterBuild = 8,
         IgnoreExistingProjectState = 4,
-        IgnoreMissingAndInvalidImports = 64,
+        IgnoreMissingEmptyAndInvalidImports = 64,
         None = 0,
         ProvideProjectStateAfterBuild = 2,
         ProvideSubsetOfStateAfterBuild = 32,

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -76,6 +76,12 @@ namespace Microsoft.Build.Execution
         /// explicitly-requested properties, items, and metadata.
         /// </summary>
         ProvideSubsetOfStateAfterBuild = 1 << 5,
+
+        /// <summary>
+        /// When this flag is present, projects loaded during build will ignore missing imports (<see cref="ProjectLoadSettings.IgnoreMissingImports"/> and <see cref="ProjectLoadSettings.IgnoreInvalidImports"/>).
+        /// This is especially useful during a restore since some imports might come from packages that haven't been restored yet.
+        /// </summary>
+        IgnoreMissingEmptyAndInvalidImports = 1 << 6,
     }
 
     /// <summary>

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1126,6 +1126,15 @@ namespace Microsoft.Build.BackEnd
                     // Do we have a matching configuration?
                     BuildRequestConfiguration matchingConfig = globalConfigCache.GetMatchingConfiguration(request.Config);
                     BuildRequest newRequest = null;
+
+                    BuildRequestDataFlags buildRequestDataFlags = request.BuildRequestDataFlags;
+
+                    if (issuingEntry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports))
+                    {
+                        // If the issuing build requested to ignore missing, empty, and invalid imports, this entry should also
+                        buildRequestDataFlags |= BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports;
+                    }
+
                     if (matchingConfig == null)
                     {
                         // No configuration locally, are we already waiting for it?
@@ -1151,7 +1160,7 @@ namespace Microsoft.Build.BackEnd
                         newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(),
                             request.Config.ConfigurationId, request.Targets, issuingEntry.Request.HostServices,
                             issuingEntry.Request.BuildEventContext, issuingEntry.Request,
-                            request.BuildRequestDataFlags);
+                            buildRequestDataFlags);
 
                         issuingEntry.WaitForResult(newRequest);
 
@@ -1168,7 +1177,7 @@ namespace Microsoft.Build.BackEnd
                         newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(),
                             matchingConfig.ConfigurationId, request.Targets, issuingEntry.Request.HostServices,
                             issuingEntry.Request.BuildEventContext, issuingEntry.Request,
-                            request.BuildRequestDataFlags);
+                            buildRequestDataFlags);
 
                         IResultsCache resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
                         ResultsCacheResponse response = resultsCache.SatisfyRequest(newRequest, matchingConfig.ProjectInitialTargets, matchingConfig.ProjectDefaultTargets, matchingConfig.GetAfterTargetsForDefaultTargets(newRequest), skippedResultsAreOK: false);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1155,6 +1155,14 @@ namespace Microsoft.Build.BackEnd
             // Get the hosted ISdkResolverService.  This returns either the MainNodeSdkResolverService or the OutOfProcNodeSdkResolverService depending on who created the current RequestBuilder
             ISdkResolverService sdkResolverService = _componentHost.GetComponent(BuildComponentType.SdkResolverService) as ISdkResolverService;
 
+            // Use different project load settings if the build request indicates to do so
+            ProjectLoadSettings projectLoadSettings = _componentHost.BuildParameters.ProjectLoadSettings;
+
+            if (_requestEntry.Request.BuildRequestDataFlags.HasFlag(BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports))
+            {
+                projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
+            }
+
             return new ProjectInstance(
                 _requestEntry.RequestConfiguration.ProjectFullPath,
                 globalProperties,
@@ -1169,8 +1177,9 @@ namespace Microsoft.Build.BackEnd
                     BuildEventContext.InvalidProjectContextId,
                     BuildEventContext.InvalidTargetId,
                     BuildEventContext.InvalidTaskId),
-                    sdkResolverService,
-                    _requestEntry.Request.SubmissionId);
+                sdkResolverService,
+                _requestEntry.Request.SubmissionId,
+                projectLoadSettings);
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Build.Execution
         /// Assumes the project path is already normalized.
         /// Used by the RequestBuilder.
         /// </summary>
-        internal ProjectInstance(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, int submissionId)
+        internal ProjectInstance(string projectFile, IDictionary<string, string> globalProperties, string toolsVersion, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService, int submissionId, ProjectLoadSettings? projectLoadSettings)
         {
             ErrorUtilities.VerifyThrowArgumentLength(projectFile, "projectFile");
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(toolsVersion, "toolsVersion");
@@ -392,7 +392,7 @@ namespace Microsoft.Build.Execution
 
             ProjectRootElement xml = ProjectRootElement.OpenProjectOrSolution(projectFile, globalProperties, toolsVersion, buildParameters.ProjectRootElementCache, false /*Not explicitly loaded*/);
 
-            Initialize(xml, globalProperties, toolsVersion, null, 0 /* no solution version specified */, buildParameters, loggingService, buildEventContext, sdkResolverService, submissionId);
+            Initialize(xml, globalProperties, toolsVersion, null, 0 /* no solution version specified */, buildParameters, loggingService, buildEventContext, sdkResolverService, submissionId, projectLoadSettings);
         }
 
         /// <summary>
@@ -2496,7 +2496,7 @@ namespace Microsoft.Build.Execution
         /// Tools version may be null.
         /// Does not set mutability.
         /// </summary>
-        private void Initialize(ProjectRootElement xml, IDictionary<string, string> globalProperties, string explicitToolsVersion, string explicitSubToolsetVersion, int visualStudioVersionFromSolution, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService = null, int submissionId = BuildEventContext.InvalidSubmissionId)
+        private void Initialize(ProjectRootElement xml, IDictionary<string, string> globalProperties, string explicitToolsVersion, string explicitSubToolsetVersion, int visualStudioVersionFromSolution, BuildParameters buildParameters, ILoggingService loggingService, BuildEventContext buildEventContext, ISdkResolverService sdkResolverService = null, int submissionId = BuildEventContext.InvalidSubmissionId, ProjectLoadSettings? projectLoadSettings = null)
         {
             ErrorUtilities.VerifyThrowArgumentNull(xml, "xml");
             ErrorUtilities.VerifyThrowArgumentLengthIfNotNull(explicitToolsVersion, "toolsVersion");
@@ -2584,7 +2584,7 @@ namespace Microsoft.Build.Execution
             _initialGlobalsForDebugging = Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Evaluate(
                 this,
                 xml,
-                buildParameters.ProjectLoadSettings,
+                projectLoadSettings ?? buildParameters.ProjectLoadSettings, /* Use override ProjectLoadSettings if specified */
                 buildParameters.MaxNodeCount,
                 buildParameters.EnvironmentPropertiesInternal,
                 loggingService,


### PR DESCRIPTION
Some shipped SDKs have imports that are property based but are missing conditions.  This makes it impossible to retrofit them with a NuGet package since NuGet restore won't succeed because an import is missing.  This change makes it so that during Restore, projects are loaded with the ProjectLoadSettings that ignore missing, empty, and invalid imports.  This is what Visual Studio uses so that it can load projects that haven't been restored yet.  The build would still fail if there are missing imports.

Treat `/Target:Restore` the same as `/Restore` without a build