### PR TITLE
Add a ReferenceCopyLocalOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5817,9 +5817,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This target performs population of the Built project output group dependencies.
     ============================================================
     -->
+  <PropertyGroup>
+    <BuiltProjectOutputGroupDependenciesDependsOn>
+      $(BuiltProjectOutputGroupDependenciesDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </BuiltProjectOutputGroupDependenciesDependsOn>
+  </PropertyGroup>
+
   <Target
       Name="BuiltProjectOutputGroupDependencies"
-      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
+      DependsOnTargets="$(BuiltProjectOutputGroupDependenciesDependsOn)"
       Returns="@(BuiltProjectOutputGroupDependency)">
 
     <ItemGroup>
@@ -5839,10 +5846,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This target performs population of the dependencies for the debug symbols project output group.
     ============================================================
     -->
+  <PropertyGroup>
+    <DebugSymbolsProjectOutputGroupDependenciesDependsOn>
+      $(DebugSymbolsProjectOutputGroupDependenciesDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </DebugSymbolsProjectOutputGroupDependenciesDependsOn>
+  </PropertyGroup>
+  
   <Target
       Name="DebugSymbolsProjectOutputGroupDependencies"
       Condition="'$(DebugSymbols)'!='false'"
-      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
+      DependsOnTargets="$(DebugSymbolsProjectOutputGroupDependenciesDependsOn)"
       Returns="@(DebugSymbolsProjectOutputGroupDependency)">
 
     <!-- This item represents dependent PDB's -->
@@ -5859,9 +5873,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This target performs population of the dependencies for the satellite files project output group.
     ============================================================
     -->
+  <PropertyGroup>
+    <SatelliteDllsProjectOutputGroupDependenciesDependsOn>
+      $(SatelliteDllsProjectOutputGroupDependenciesDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </SatelliteDllsProjectOutputGroupDependenciesDependsOn>
+  </PropertyGroup>
+
   <Target
       Name="SatelliteDllsProjectOutputGroupDependencies"
-      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
+      DependsOnTargets="$(SatelliteDllsProjectOutputGroupDependenciesDependsOn)"
       Returns="@(SatelliteDllsProjectOutputGroupDependency)">
 
     <!-- This item represents dependent satellites -->
@@ -5878,10 +5899,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This target performs population of the dependencies for the documentation project output group.
     ============================================================
     -->
+  <PropertyGroup>
+    <DocumentationProjectOutputGroupDependenciesDependsOn>
+      $(DocumentationProjectOutputGroupDependenciesDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </DocumentationProjectOutputGroupDependenciesDependsOn>
+  </PropertyGroup>
+
   <Target
       Name="DocumentationProjectOutputGroupDependencies"
       Condition="'$(DocumentationFile)'!=''"
-      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
+      DependsOnTargets="$(DocumentationProjectOutputGroupDependenciesDependsOn)"
       Returns="@(DocumentationProjectOutputGroupDependency)">
 
     <!-- This item represents dependent XMLs -->
@@ -5898,9 +5926,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     This target performs population of the dependencies for the GenerateSerializationAssemblies project output group.
     ============================================================
     -->
+  <PropertyGroup>
+    <SGenFilesOutputGroupDependenciesDependsOn>
+      $(SGenFilesOutputGroupDependenciesDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </SGenFilesOutputGroupDependenciesDependsOn>
+  </PropertyGroup>
+
   <Target
       Name="SGenFilesOutputGroupDependencies"
-      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
+      DependsOnTargets="$(SGenFilesOutputGroupDependenciesDependsOn)"
       Returns="@(SGenFilesOutputGroupDependency)">
 
     <!-- This item represents sgen xml serializer dll's -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5945,6 +5945,33 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
+  <!--
+    ============================================================
+                                        ReferenceCopyLocalPathsOutputGroup
+
+    Exposes the set of items that should be copied locally based on the project's references.
+    ============================================================
+    -->
+  <PropertyGroup>
+    <ReferenceCopyLocalPathsOutputGroupDependsOn>
+      $(ReferenceCopyLocalPathsOutputGroupDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </ReferenceCopyLocalPathsOutputGroupDependsOn>
+  </PropertyGroup>
+
+  <Target
+      Name="ReferenceCopyLocalPathsOutputGroup"
+      DependsOnTargets="$(ReferenceCopyLocalPathsOutputGroupDependsOn)"
+      Returns="@(ReferenceCopyLocalPathsOutputGroupOutput)">
+
+    <ItemGroup>
+      <ReferenceCopyLocalPathsOutputGroupOutput Include="@(ReferenceCopyLocalPaths)">
+        <TargetPath>%(ReferenceCopyLocalPaths.DestinationSubDirectory)%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)</TargetPath>
+      </ReferenceCopyLocalPathsOutputGroupOutput>
+    </ItemGroup>
+
+  </Target>
+
   <PropertyGroup>
     <CodeAnalysisTargets Condition="'$(CodeAnalysisTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeAnalysis\Microsoft.CodeAnalysis.targets</CodeAnalysisTargets>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -5781,6 +5781,23 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
+                                        CommonOutputGroupsDependsOn
+
+    Dependencies common to many of the *OutputGroupDependencies targets.
+    ============================================================
+    -->
+  <PropertyGroup>
+    <CommonOutputGroupsDependsOn>
+      $(CommonOutputGroupsDependsOn);
+      BuildOnlySettings;
+      PrepareForBuild;
+      AssignTargetPaths;
+      ResolveReferences
+    </CommonOutputGroupsDependsOn>
+  </PropertyGroup>
+  
+  <!--
+    ============================================================
                                         AllProjectOutputGroupsDependencies
     ============================================================
     -->
@@ -5802,7 +5819,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="BuiltProjectOutputGroupDependencies"
-      DependsOnTargets="BuildOnlySettings;PrepareForBuild;AssignTargetPaths;ResolveReferences"
+      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
       Returns="@(BuiltProjectOutputGroupDependency)">
 
     <ItemGroup>
@@ -5825,7 +5842,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="DebugSymbolsProjectOutputGroupDependencies"
       Condition="'$(DebugSymbols)'!='false'"
-      DependsOnTargets="BuildOnlySettings;PrepareForBuild;AssignTargetPaths;ResolveReferences"
+      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
       Returns="@(DebugSymbolsProjectOutputGroupDependency)">
 
     <!-- This item represents dependent PDB's -->
@@ -5844,7 +5861,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="SatelliteDllsProjectOutputGroupDependencies"
-      DependsOnTargets="BuildOnlySettings;PrepareForBuild;AssignTargetPaths;ResolveReferences"
+      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
       Returns="@(SatelliteDllsProjectOutputGroupDependency)">
 
     <!-- This item represents dependent satellites -->
@@ -5864,7 +5881,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="DocumentationProjectOutputGroupDependencies"
       Condition="'$(DocumentationFile)'!=''"
-      DependsOnTargets="BuildOnlySettings;PrepareForBuild;AssignTargetPaths;ResolveReferences"
+      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
       Returns="@(DocumentationProjectOutputGroupDependency)">
 
     <!-- This item represents dependent XMLs -->
@@ -5883,7 +5900,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
       Name="SGenFilesOutputGroupDependencies"
-      DependsOnTargets="BuildOnlySettings;PrepareForBuild;AssignTargetPaths;ResolveReferences"
+      DependsOnTargets="$(CommonOutputGroupsDependsOn)"
       Returns="@(SGenFilesOutputGroupDependency)">
 
     <!-- This item represents sgen xml serializer dll's -->


### PR DESCRIPTION
Fixes #3069.

There are a number of places where we need to get the set of items produced by a project's references and needed for packaging purposes or just running the code on the target platform. These may well be different from the reference passed to the compiler (e.g., a NuGet package may have a single `ref` assembly for compiling but multiple `lib` assemblies for different runtimes) and may not be code at all (e.g. PDBs or resource assemblies). As noted in #3069 a number of individual project types have implemented their own targets to collect this information, with varying levels of correctness.

This change adds a new `ReferenceCopyLocalPathsOutputGroup` to Microsoft.Common.CurrentVersion.targets to make this functionality centrally available to anyone who needs it. It also does some refactoring to make it a little easier to extend the other output groups.
