### PR TITLE
[mono] Update bootstrap msbuild/mono used to get the fix for handling

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -456,7 +456,7 @@ fi
 
 msbuildToUse="msbuild"
 MONO_MSBUILD_DIR="$ArtifactsDir/mono-msbuild"
-MSBUILD_DOWNLOAD_URL="https://github.com/mono/msbuild/releases/download/v0.05/mono_msbuild_port2-394a6b5e.zip"
+MSBUILD_DOWNLOAD_URL="https://github.com/mono/msbuild/releases/download/0.06/mono_msbuild_xplat-master-3c930fa8.zip"
 MSBUILD_ZIP="$ArtifactsDir/msbuild.zip"
 
 log=false


### PR DESCRIPTION
.. signed nugets. Without this the CI builds failed with:

```
	/Users/dotnet-bot/j/w/Microsoft_msbuild/master/innerloop_OSX10.13_MonoTest_prtest/artifacts/mono-msbuild/NuGet.targets(104,5): error : Value cannot be null. [/Users/dotnet-bot/j/w/Microsoft_msbuild/master/innerloop_OSX10.13_MonoTest_prtest/src/Build/Microsoft.Build.csproj]
	/Users/dotnet-bot/j/w/Microsoft_msbuild/master/innerloop_OSX10.13_MonoTest_prtest/artifacts/mono-msbuild/NuGet.targets(104,5): error : Parameter name: keyValue [/Users/dotnet-bot/j/w/Microsoft_msbuild/master/innerloop_OSX10.13_MonoTest_prtest/src/Build/Microsoft.Build.csproj]
```