### PR TITLE
Avoid RuntimeInformation on full sln parse

### DIFF
--- a/src/Build/Construction/Solution/ProjectInSolution.cs
+++ b/src/Build/Construction/Solution/ProjectInSolution.cs
@@ -158,8 +158,14 @@ namespace Microsoft.Build.Construction
             get { return _relativePath; }
             internal set
             {
+#if NETFRAMEWORK && !MONO
+                // Avoid loading System.Runtime.InteropServices.RuntimeInformation in full-framework
+                // cases. It caused https://github.com/NuGet/Home/issues/6918.
+                _relativePath = value;
+#else
                 _relativePath = FileUtilities.MaybeAdjustFilePath(value,
                                                     baseDirectory:this.ParentSolution.SolutionFileDirectory ?? String.Empty);
+#endif
             }
         }
 


### PR DESCRIPTION
We started (transitively) requiring
System.Runtime.InteropServices.RuntimeInformation when using
`SolutionFile.Parse` after #2963. The assembly-level dependency is
longstanding. But since it wasn't needed in NuGet's calling pattern,
many versions of NuGet are broken on older (pre-4.7.1) .NET Frameworks.

Work around the assembly load by avoiding the adjustment filepath on
full-Framework MSBuild (where it's not necessary anyway).

Closes #3282.