### PR TITLE
Add ZipDirectory and Unzip tasks

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1160,7 +1160,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
-    public partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    public sealed partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
     {
         public Unzip() { }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -1294,6 +1294,15 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem XslCompiledDllPath { get { throw null; } set { } }
         public string XslContent { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem XslInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ZipDirectory : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ZipDirectory() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem DestinationFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem SourceDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
 }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1163,16 +1163,12 @@ namespace Microsoft.Build.Tasks
     public sealed partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
     {
         public Unzip() { }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] UnzippedFiles { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1165,6 +1165,7 @@ namespace Microsoft.Build.Tasks
         public Unzip() { }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1298,6 +1298,7 @@ namespace Microsoft.Build.Tasks
         public ZipDirectory() { }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Overwrite { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem SourceDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -1160,6 +1160,21 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        public Unzip() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] UnzippedFiles { get { throw null; } }
+        public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
     public partial class UpdateManifest : Microsoft.Build.Utilities.Task
     {
         public UpdateManifest() { }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -666,6 +666,21 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    {
+        public Unzip() { }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
+        public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] UnzippedFiles { get { throw null; } }
+        public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension
     {
         public Warning() { }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -747,6 +747,7 @@ namespace Microsoft.Build.Tasks
         public ZipDirectory() { }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Overwrite { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem SourceDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -671,6 +671,7 @@ namespace Microsoft.Build.Tasks
         public Unzip() { }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] TouchedFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
-    public partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
+    public sealed partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
     {
         public Unzip() { }
         [Microsoft.Build.Framework.OutputAttribute]
@@ -743,6 +743,15 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem Value { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class ZipDirectory : Microsoft.Build.Tasks.TaskExtension
+    {
+        public ZipDirectory() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem DestinationFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem SourceDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
 }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -669,16 +669,12 @@ namespace Microsoft.Build.Tasks
     public sealed partial class Unzip : Microsoft.Build.Tasks.TaskExtension, Microsoft.Build.Framework.ICancelableTask, Microsoft.Build.Framework.ITask
     {
         public Unzip() { }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] DestinationFiles { get { throw null; } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem DestinationFolder { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool OverwriteReadOnlyFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool SkipUnchangedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] UnzippedFiles { get { throw null; } }
         public void Cancel() { }
         public override bool Execute() { throw null; }
     }

--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5250,6 +5250,7 @@ elementFormDefault="qualified">
             <xs:complexContent>
                 <xs:extension base="msb:TaskType">
                     <xs:attribute name="DestinationFile" use="required" />
+                    <xs:attribute name="Overwrite" type="msb:boolean" />
                     <xs:attribute name="SourceDirectory" type="msb:boolean" />
                 </xs:extension>
             </xs:complexContent>

--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5114,6 +5114,21 @@ elementFormDefault="qualified">
         </xs:complexType>
     </xs:element>
 
+    <xs:element name="Unzip" substitutionGroup="msb:Task">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:TaskType">
+                    <xs:attribute name="DestinationFiles" />
+                    <xs:attribute name="DestinationFolder" use="required" />
+                    <xs:attribute name="OverwriteReadOnlyFiles" type="msb:boolean" />
+                    <xs:attribute name="SkipUnchangedFiles" type="msb:boolean" />
+                    <xs:attribute name="SourceFiles" use="required" />
+                    <xs:attribute name="UnzippedFiles" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
     <xs:element name="UpdateAppxManifestForBundle" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>
@@ -5225,6 +5240,17 @@ elementFormDefault="qualified">
                     <xs:attribute name="RetryDelayMilliseconds" />
                     <xs:attribute name="SkipUnchangedFiles" />
                     <xs:attribute name="SourceUrl" use="required" />
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="ZipDirectory" substitutionGroup="msb:Task">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="msb:TaskType">
+                    <xs:attribute name="DestinationFile" use="required" />
+                    <xs:attribute name="SourceDirectory" type="msb:boolean" />
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Shared;
@@ -603,6 +604,34 @@ namespace Microsoft.Build.UnitTests
         public override void Revert()
         {
             Directory.SetCurrentDirectory(_originalValue);
+        }
+    }
+
+    public class TransientZipArchive : TransientTestState
+    {
+        private TransientZipArchive()
+        {
+        }
+
+        public string Path { get; set; }
+
+        public static TransientZipArchive Create(TransientTestFolder source, TransientTestFolder destination, string filename = "test.zip")
+        {
+            Directory.CreateDirectory(destination.FolderPath);
+
+            string path = System.IO.Path.Combine(destination.FolderPath, filename);
+
+            ZipFile.CreateFromDirectory(source.FolderPath, path);
+
+            return new TransientZipArchive
+            {
+                Path = path
+            };
+        }
+
+        public override void Revert()
+        {
+            FileUtilities.DeleteNoThrow(Path);
         }
     }
 }

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Build.Framework;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.Utilities;
 using Shouldly;

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -71,11 +71,8 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
-#if  RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "Can't figure out how to make CreateDirectory throw on non-Windows")]
-#else
+        [PlatformSpecific(TestPlatforms.Windows)] // Can't figure out how to make CreateDirectory throw on non-Windows
         [Fact]
-#endif
         public void LogsErrorIfDirectoryCannotBeCreated()
         {
             Unzip unzip = new Unzip

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.UnitTests;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests
+{
+    public class Unzip_Tests
+    {
+        private readonly MockEngine _mockEngine = new MockEngine();
+
+        [Fact]
+        public void CanOverwriteReadOnlyFile()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                TransientTestFile file1 = testEnvironment.CreateFile(source, "638AF4AE88A146E09CB69FE1CA7083DC.txt", "file1");
+
+                new FileInfo(file1.Path).IsReadOnly = true;
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, destination);
+
+                Unzip unzip = new Unzip
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFolder = new TaskItem(source.FolderPath),
+                    OverwriteReadOnlyFiles = true,
+                    SkipUnchangedFiles = false,
+                    SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
+                };
+
+                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("638AF4AE88A146E09CB69FE1CA7083DC", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void CanUnzip()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                testEnvironment.CreateFile(source, "BE78A17D30144B549D21F71D5C633F7D.txt", "file1");
+                testEnvironment.CreateFile(source, "A04FF4B88DF14860B7C73A8E75A4FB76.txt", "file2");
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, testEnvironment.CreateFolder(createFolder: true));
+
+                Unzip unzip = new Unzip
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFolder = new TaskItem(destination.FolderPath),
+                    OverwriteReadOnlyFiles = true,
+                    SkipUnchangedFiles = false,
+                    SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
+                };
+
+                unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.FolderPath, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.FolderPath, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfDirectoryCannotBeCreated()
+        {
+            Unzip unzip = new Unzip
+            {
+                BuildEngine = _mockEngine,
+                DestinationFolder = new TaskItem(@"Y:\foo")
+            };
+
+            unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+            _mockEngine.Log.ShouldContain("MSB3911", () => _mockEngine.Log);
+        }
+
+        [Fact]
+        public void LogsErrorIfReadOnlyFileCannotBeOverwitten()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder source = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFolder destination = testEnvironment.CreateFolder(createFolder: false);
+                TransientTestFile file1 = testEnvironment.CreateFile(source, "D6DFD219DACE48F8B86EFCDF98433333.txt", "file1");
+
+                new FileInfo(file1.Path).IsReadOnly = true;
+
+                TransientZipArchive zipArchive = TransientZipArchive.Create(source, destination);
+
+                Unzip unzip = new Unzip
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFolder = new TaskItem(source.FolderPath),
+                    OverwriteReadOnlyFiles = false,
+                    SkipUnchangedFiles = false,
+                    SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
+                };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("D6DFD219DACE48F8B86EFCDF98433333.txt' is denied", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfSourceFileCannotBeOpened()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: false);
+
+                TransientTestFile file = testEnvironment.CreateFile("foo.txt", "foo");
+
+                Unzip unzip = new Unzip
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    SourceFiles = new ITaskItem[] { new TaskItem(file.Path), }
+                };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3913", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfSourceFileDoesNotExist()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: false);
+
+                Unzip unzip = new Unzip
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    SourceFiles = new ITaskItem[] { new TaskItem(Path.Combine(testEnvironment.DefaultTestDirectory.FolderPath, "foo.zip")), }
+                };
+
+                unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3912", () => _mockEngine.Log);
+            }
+        }
+    }
+}

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.Utilities;
@@ -70,19 +71,24 @@ namespace Microsoft.Build.Tasks.UnitTests
             }
         }
 
+#if  RUNTIME_TYPE_NETCORE
+        [Fact(Skip = "Can't figure out how to make CreateDirectory throw on non-Windows")]
+#else
         [Fact]
+#endif
         public void LogsErrorIfDirectoryCannotBeCreated()
         {
             Unzip unzip = new Unzip
             {
                 BuildEngine = _mockEngine,
-                DestinationFolder = new TaskItem(@"Y:\foo")
+                DestinationFolder = new TaskItem(String.Empty)
             };
 
             unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3911", () => _mockEngine.Log);
+            _mockEngine.Log.ShouldContain("MSB3931", () => _mockEngine.Log);
         }
+
 
         [Fact]
         public void LogsErrorIfReadOnlyFileCannotBeOverwitten()
@@ -130,7 +136,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3913", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3933", () => _mockEngine.Log);
             }
         }
 
@@ -150,7 +156,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("MSB3912", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain("MSB3932", () => _mockEngine.Log);
             }
         }
     }

--- a/src/Tasks.UnitTests/ZipDirectory_Tests.cs
+++ b/src/Tasks.UnitTests/ZipDirectory_Tests.cs
@@ -47,11 +47,13 @@ namespace Microsoft.Build.Tasks.UnitTests
                     archive.Entries
                         .Select(i => i.FullName)
                         .ToList()
-                        .ShouldBe(new List<string>
-                        {
-                            "6DE6060259C44DB6B145159376751C22.txt",
-                            "CDA3DD8C25A54A7CAC638A444CB1EAD0.txt"
-                        });
+                        .ShouldBe(
+                            new List<string>
+                            {
+                                "6DE6060259C44DB6B145159376751C22.txt",
+                                "CDA3DD8C25A54A7CAC638A444CB1EAD0.txt"
+                            },
+                            ignoreOrder: true);
                 }
             }
         }

--- a/src/Tasks.UnitTests/ZipDirectory_Tests.cs
+++ b/src/Tasks.UnitTests/ZipDirectory_Tests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.UnitTests;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Build.Tasks.UnitTests
+{
+    public class ZipDirectory_Tests
+    {
+        private readonly MockEngine _mockEngine = new MockEngine();
+
+        [Fact]
+        public void CanZipDirectory()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder sourceFolder = testEnvironment.CreateFolder(createFolder: true);
+
+                testEnvironment.CreateFile(sourceFolder, "6DE6060259C44DB6B145159376751C22.txt", "6DE6060259C44DB6B145159376751C22");
+                testEnvironment.CreateFile(sourceFolder, "CDA3DD8C25A54A7CAC638A444CB1EAD0.txt", "CDA3DD8C25A54A7CAC638A444CB1EAD0");
+
+                string zipFilePath = Path.Combine(testEnvironment.CreateFolder(createFolder: true).FolderPath, "test.zip");
+
+                ZipDirectory zipDirectory = new ZipDirectory
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFile = new TaskItem(zipFilePath),
+                    SourceDirectory = new TaskItem(sourceFolder.FolderPath)
+                };
+
+                zipDirectory.Execute().ShouldBeTrue(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain(sourceFolder.FolderPath, () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(zipFilePath, () => _mockEngine.Log);
+
+                using (FileStream stream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (ZipArchive archive = new ZipArchive(stream, ZipArchiveMode.Read))
+                {
+                    archive.Entries
+                        .Select(i => i.FullName)
+                        .ToList()
+                        .ShouldBe(new List<string>
+                        {
+                            "6DE6060259C44DB6B145159376751C22.txt",
+                            "CDA3DD8C25A54A7CAC638A444CB1EAD0.txt"
+                        });
+                }
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfDestinationExists()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
+
+                TransientTestFile file = testEnvironment.CreateFile("foo.zip", "foo");
+
+                ZipDirectory zipDirectory = new ZipDirectory
+                {
+                    BuildEngine = _mockEngine,
+                    DestinationFile = new TaskItem(file.Path),
+                    SourceDirectory = new TaskItem(folder.FolderPath)
+                };
+
+                zipDirectory.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+                _mockEngine.Log.ShouldContain("MSB3942", () => _mockEngine.Log);
+            }
+        }
+
+        [Fact]
+        public void LogsErrorIfDirectoryDoesNotExist()
+        {
+            ZipDirectory zipDirectory = new ZipDirectory
+            {
+                BuildEngine = _mockEngine,
+                SourceDirectory = new TaskItem(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")))
+            };
+
+            zipDirectory.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+            _mockEngine.Log.ShouldContain("MSB3941", () => _mockEngine.Log);
+        }
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -508,6 +508,7 @@
     <Compile Include="Dependencies.cs" />
     <Compile Include="SystemState.cs" />
     <Compile Include="DependencyFile.cs" />
+    <Compile Include="ZipDirectory.cs" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Compile Include="Al.cs">

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -489,6 +489,7 @@
     <Compile Include="Touch.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Unzip.cs" />
     <Compile Include="VisualBasicParserUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -927,6 +928,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Reflection" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -162,6 +162,7 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.UnregisterAssembly"                    AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR2" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''" />
 
     <UsingTask TaskName="Microsoft.Build.Tasks.UpdateManifest"                        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.Unzip"                                 AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Warning"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -170,6 +170,7 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.XmlPoke"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.XslTransformation"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WinMDExp"                              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.ZipDirectory"                          AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
     <!-- Roslyn tasks are now in an assembly owned and shipped by Roslyn -->
     <UsingTask TaskName="Microsoft.CodeAnalysis.BuildTasks.Csc"                       AssemblyFile="$(RoslynTargetsPath)\Microsoft.Build.Tasks.CodeAnalysis.dll" Condition="'$(MSBuildAssemblyVersion)' != ''" />

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -215,7 +215,7 @@
     <value>MSB3884: Could not find rule set file "{0}".</value>
   <comment>{StrBegin="MSB3884: "}</comment>
   </data>
-  Unzip.ErrorCouldNotMakeFileWriteable
+
   <!--
         The Copy message bucket is: MSB3021 - MSB3030
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -215,7 +215,7 @@
     <value>MSB3884: Could not find rule set file "{0}".</value>
   <comment>{StrBegin="MSB3884: "}</comment>
   </data>
-
+  Unzip.ErrorCouldNotMakeFileWriteable
   <!--
         The Copy message bucket is: MSB3021 - MSB3030
 
@@ -2692,6 +2692,60 @@
   </data>
 
   <!--
+        MSB3931 - MSB3940   Task: Unzip
+        If this bucket overflows, pls. contact 'vsppbdev'.
+  -->
+  <data name="Unzip.ErrorCouldNotCreateDestinationDirectory">
+    <value>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</value>
+    <comment>{StrBegin="MSB3931: "}</comment>
+  </data>
+  <data name="Unzip.ErrorFileDoesNotExist">
+    <value>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</value>
+    <comment>{StrBegin="MSB3932: "}</comment>
+  </data>
+  <data name="Unzip.ErrorCouldNotOpenFile">
+    <value>MSB3933: Failed to open zip file "{0}".  {1}</value>
+    <comment>{StrBegin="MSB3933: "}</comment>
+  </data>
+  <data name="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+    <value>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</value>
+    <comment>{StrBegin="MSB3934: "}</comment>
+  </data>
+  <data name="Unzip.ErrorCouldNotMakeFileWriteable">
+    <value>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</value>
+    <comment>{StrBegin="MSB3935: "}</comment>
+  </data>
+  <data name="Unzip.ErrorCouldNotExtractFile">
+    <value>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</value>
+    <comment>{StrBegin="MSB3936: "}</comment>
+  </data>
+  <data name="Unzip.DidNotUnzipBecauseOfFileMatch">
+    <value>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</value>
+  </data>
+  <data name="Unzip.FileComment">
+    <value>Unzipping file "{0}" to "{1}".</value>
+  </data>
+
+  <!--
+        MSB3941 - MSB3950   Task: ZipDirectory
+        If this bucket overflows, pls. contact 'vsppbdev'.
+  -->
+  <data name="ZipDirectory.ErrorDirectoryDoesNotExist">
+    <value>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</value>
+    <comment>{StrBegin="MSB3941: "}</comment>
+  </data>
+  <data name="ZipDirectory.ErrorFileExists">
+    <value>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</value>
+    <comment>{StrBegin="MSB3942: "}</comment>
+  </data>
+  <data name="ZipDirectory.ErrorFailed">
+    <value>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</value>
+    <comment>{StrBegin="MSB3943: "}</comment>
+  </data>
+  <data name="ZipDirectory.Comment">
+    <value>Zipping directory "{0}" to "{1}".</value>
+  </data>
+  <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
         See the comments above each task's messages for individual task message buckets.
@@ -2771,6 +2825,8 @@
             MSB3901 - MSB3910   Task: Telemetry
             MSB3911 - MSB3920   Task: CodeTaskFactory
             MSB3921 - MSB3930   Task: DownloadFile
+            MSB3931 - MSB3940   Task: Unzip
+            MSB3941 - MSB3950   Task: ZipDirectory
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2358,6 +2358,46 @@
         <target state="translated">MSB3394: Nelze zrušit registraci knihovny typů {0}, protože není zaregistrována.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: {1} je neplatná hodnota parametru {0}.  Platné hodnoty jsou : {2}.</target>
@@ -3072,6 +3112,26 @@
         <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
         <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
         <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2358,6 +2358,46 @@
         <target state="translated">MSB3394: Die Typbibliothek "{0}" ist nicht registriert und kann daher nicht aus der Registrierung entfernt werden.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" ist ein ungültiger Wert für den "{0}"-Parameter.  Gültige Werte sind: {2}</target>
@@ -3072,6 +3112,26 @@
         <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
         <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
         <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
+      </trans-unit>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -301,36 +301,6 @@
         <target state="new">File "{0}" doesn't exist. Skipping.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="new">MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</target>
@@ -2373,6 +2343,46 @@
         <target state="new">MSB3394: Type library "{0}" is not registered, cannot unregister.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="new">MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</target>
@@ -2694,18 +2704,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="new">MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="new">MSB3757: Only one &lt;Code&gt; element can be specified.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="new">MSB4801: The task factory "{0}" is not supported on the .NET Core version of MSBuild.</target>
         <note>{StrBegin="MSB4801: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -121,6 +121,41 @@
         <target state="new">MSB3654: Delay signing requires that at least a public key be specified.  Please either supply a public key using the KeyFile or KeyContainer properties, or disable delay signing.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="new">MSB3881: Fatal Error: more than {0} command line arguments.</target>
@@ -300,6 +335,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="new">File "{0}" doesn't exist. Skipping.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2349,34 +2414,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2704,18 +2769,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="new">MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="new">MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="new">MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="new">MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="new">MSB3757: Only one &lt;Code&gt; element can be specified.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -291,36 +291,6 @@
         <target state="translated">El archivo"{0}" no existe. Se omitirá.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: En este momento están en uso todas las letras de unidad, de la A: a la Z: Como el directorio de trabajo "{0}" es una ruta de acceso UNC, la tarea "Exec" requiere una letra de unidad libre a la que asignar la ruta de acceso UNC. Desconéctese de uno o varios recursos compartidos para liberar letras de unidad, o bien especifique un directorio de trabajo local antes de intentar ejecutar este comando de nuevo.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: La biblioteca de tipos "{0}" no está registrada, por lo que no puede anularse su registro.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" no es un valor válido para el parámetro "{0}".  Los valores válidos son: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: No se encuentra la referencia "{0}". Si el código necesita esta referencia, podrían producirse errores de compilación."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: No se encuentra la referencia "{0}". Si el código necesita esta referencia, podrían producirse errores de compilación."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: El elemento xml "{0}" no es válido bajo el elemento xml "{1}".</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: El elemento xml "{0}" no es válido bajo el elemento xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: Se han encontrado varios elementos xml Code, lo que no se permite. Para corregir este error, quite todos los elementos xml Code adicionales de la tarea.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: Se han encontrado varios elementos xml Code, lo que no se permite. Para corregir este error, quite todos los elementos xml Code adicionales de la tarea.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">El archivo se ha bloqueado por: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: La firma retardada requiere que se especifique al menos una clave pública.  Proporcione una clave pública mediante las propiedades KeyFile o KeyContainer, o deshabilite la firma retardada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Error irrecuperable: más de {0} argumentos de línea de comandos.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">El archivo"{0}" no existe. Se omitirá.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: No se encuentra la referencia "{0}". Si el código necesita esta referencia, podrían producirse errores de compilación."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: No se encuentra la referencia "{0}". Si el código necesita esta referencia, podrían producirse errores de compilación."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: El elemento xml "{0}" no es válido bajo el elemento xml "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: El elemento xml "{0}" no es válido bajo el elemento xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: Se han encontrado varios elementos xml Code, lo que no se permite. Para corregir este error, quite todos los elementos xml Code adicionales de la tarea.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: Se han encontrado varios elementos xml Code, lo que no se permite. Para corregir este error, quite todos los elementos xml Code adicionales de la tarea.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: La signature différée nécessite qu'au moins une clé publique soit spécifiée.  Indiquez une clé publique à l'aide des propriétés KeyFile ou KeyContainer, ou désactivez la signature différée.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Erreur fatale : plus de {0} arguments de ligne de commande.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Le fichier "{0}" n'existe pas. Opération ignorée.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: Impossible de trouver la référence "{0}". Si cette référence est exigée par votre code, cela peut entraîner des erreurs de compilation."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: Impossible de trouver la référence "{0}". Si cette référence est exigée par votre code, cela peut entraîner des erreurs de compilation."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: l'élément xml "{0}" n'est pas valide sous l'élément xml "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: l'élément xml "{0}" n'est pas valide sous l'élément xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: Plusieurs éléments xml de code ont été trouvés, ce qui n'est pas autorisé. Pour corriger ce problème, supprimez les éléments xml de code supplémentaires de la tâche.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: Plusieurs éléments xml de code ont été trouvés, ce qui n'est pas autorisé. Pour corriger ce problème, supprimez les éléments xml de code supplémentaires de la tâche.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -291,36 +291,6 @@
         <target state="translated">Le fichier "{0}" n'existe pas. Opération ignorée.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: Toutes les lettres de lecteur de A: à Z: sont actuellement utilisées. Le répertoire de travail "{0}" étant un chemin UNC, la tâche "Exec" nécessite une lettre de lecteur disponible à laquelle le chemin UNC sera mappé. Déconnectez-vous d'une ou de plusieurs ressources partagées pour libérer des lettres de lecteur ou spécifiez un répertoire de travail local avant de réexécuter cette commande.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: La bibliothèque de types "{0}" n'est pas inscrite, impossible d'annuler l'inscription.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" n'est pas une valeur valide pour le paramètre "{0}".  Valeurs valides : {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: Impossible de trouver la référence "{0}". Si cette référence est exigée par votre code, cela peut entraîner des erreurs de compilation."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: Impossible de trouver la référence "{0}". Si cette référence est exigée par votre code, cela peut entraîner des erreurs de compilation."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: l'élément xml "{0}" n'est pas valide sous l'élément xml "{1}".</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: l'élément xml "{0}" n'est pas valide sous l'élément xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: Plusieurs éléments xml de code ont été trouvés, ce qui n'est pas autorisé. Pour corriger ce problème, supprimez les éléments xml de code supplémentaires de la tâche.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: Plusieurs éléments xml de code ont été trouvés, ce qui n'est pas autorisé. Pour corriger ce problème, supprimez les éléments xml de code supplémentaires de la tâche.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">Le fichier est verrouillé par : "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -291,36 +291,6 @@
         <target state="translated">Il file "{0}" non esiste e verrà ignorato.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: attualmente sono in uso tutte le lettere di unità comprese tra A: e Z:. Poiché la directory di lavoro "{0}" è un percorso UNC, per l'attività "Exec" è necessaria una lettera di unità disponibile a cui mappare il percorso UNC. Eseguire la disconnessione da una o più risorse condivise per rendere disponibili lettere di unità oppure specificare una directory di lavoro locale prima di provare a eseguire nuovamente questo comando.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: non è possibile annullare la registrazione della libreria dei tipi "{0}" perché non è registrata.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" è un valore non valido per il parametro "{0}". I valori validi sono: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: non è stato possibile trovare il riferimento "{0}". Se il riferimento è richiesto dal codice, potrebbero essere generati errori di compilazione."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: non è stato possibile trovare il riferimento "{0}". Se il riferimento è richiesto dal codice, potrebbero essere generati errori di compilazione."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: l'elemento XML "{0}" non è valido nell'elemento XML "{1}".</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: l'elemento XML "{0}" non è valido nell'elemento XML "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: sono stati trovati più elementi XML Code. Ciò non è consentito. Per correggere il problema, rimuovere gli elementi XML Code aggiuntivi dall'attività.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: sono stati trovati più elementi XML Code. Ciò non è consentito. Per correggere il problema, rimuovere gli elementi XML Code aggiuntivi dall'attività.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">Il file è bloccato da: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: la firma ritardata richiede che sia specificata almeno una chiave pubblica. Fornire una chiave pubblica usando le proprietà KeyFile o KeyContainer oppure disabilitare la firma ritardata.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Errore irreversibile: più di {0} argomenti della riga di comando.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Il file "{0}" non esiste e verrà ignorato.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: non è stato possibile trovare il riferimento "{0}". Se il riferimento è richiesto dal codice, potrebbero essere generati errori di compilazione."</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: non è stato possibile trovare il riferimento "{0}". Se il riferimento è richiesto dal codice, potrebbero essere generati errori di compilazione."</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: l'elemento XML "{0}" non è valido nell'elemento XML "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: l'elemento XML "{0}" non è valido nell'elemento XML "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: sono stati trovati più elementi XML Code. Ciò non è consentito. Per correggere il problema, rimuovere gli elementi XML Code aggiuntivi dall'attività.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: sono stati trovati più elementi XML Code. Ciò non è consentito. Per correggere il problema, rimuovere gli elementi XML Code aggiuntivi dall'attività.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: 遅延署名には、最低でも 1 つの公開キーを指定する必要があります。KeyFile または KeyContainer プロパティを使用して公開キーを提供するか、遅延署名を無効にしてください。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 致命的なエラー: コマンド ライン引数が {0} を超えています。</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">ファイル "{0}" は存在しません。省略します。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: 参照 "{0}" が見つかりませんでした。この参照がコードで必要とされる場合は、コンパイル エラーが発生する可能性があります。"</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: 参照 "{0}" が見つかりませんでした。この参照がコードで必要とされる場合は、コンパイル エラーが発生する可能性があります。"</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: xml 要素 "{0}" は xml 要素 "{1}" の下では無効です。</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: xml 要素 "{0}" は xml 要素 "{1}" の下では無効です。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: 複数のコード xml 要素が見つかりました。これは無効です。この問題を解決するには、タスクから余分なコード xml 要素を削除してください。</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: 複数のコード xml 要素が見つかりました。これは無効です。この問題を解決するには、タスクから余分なコード xml 要素を削除してください。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -291,36 +291,6 @@
         <target state="translated">ファイル "{0}" は存在しません。省略します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: A: から Z: までのすべてのドライブ文字は使用中です。作業ディレクトリ "{0}" は UNC パスであるため、"Exec" タスクには UNC パスをマップできる使用可能なドライブ文字が必要です。このコマンドを再度試してみる前に、1 つ以上の共有リソースを切断してドライブ文字を解放するか、ローカルの作業ディレクトリを指定してください。</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: タイプ ライブラリ "{0}" は登録されていないため、登録解除できません。</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" は "{0}" パラメーターに対して無効な値です。有効な値は {2} です。</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: 参照 "{0}" が見つかりませんでした。この参照がコードで必要とされる場合は、コンパイル エラーが発生する可能性があります。"</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: 参照 "{0}" が見つかりませんでした。この参照がコードで必要とされる場合は、コンパイル エラーが発生する可能性があります。"</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: xml 要素 "{0}" は xml 要素 "{1}" の下では無効です。</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: xml 要素 "{0}" は xml 要素 "{1}" の下では無効です。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: 複数のコード xml 要素が見つかりました。これは無効です。この問題を解決するには、タスクから余分なコード xml 要素を削除してください。</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: 複数のコード xml 要素が見つかりました。これは無効です。この問題を解決するには、タスクから余分なコード xml 要素を削除してください。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">このファイルは "{0}" によってロックされています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -291,36 +291,6 @@
         <target state="translated">"{0}" 파일이 없습니다. 건너뜁니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: A:에서 Z:까지 모든 드라이브 문자가 현재 사용 중입니다. 작업 디렉터리 "{0}"이(가) UNC 경로이므로 "Exec" 작업을 수행하려면 UNC 경로를 매핑하는 데 사용할 수 있는 드라이브 문자가 필요합니다. 하나 이상의 공유 리소스에서 연결을 끊어 사용 가능한 드라이브 문자를 만들거나 로컬 작업 디렉터리를 지정한 다음 이 명령을 다시 실행하세요.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: 형식 라이브러리 "{0}"은(는) 등록되어 있지 않으므로 등록을 취소할 수 없습니다.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}"은(는) "{0}" 매개 변수에 사용할 수 없는 값입니다.  유효한 값은 {2}입니다.</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: 참조 "{0}"을(를) 찾을 수 없습니다. 이 참조가 코드에 필요할 경우 컴파일 오류가 발생할 수 있습니다.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: 참조 "{0}"을(를) 찾을 수 없습니다. 이 참조가 코드에 필요할 경우 컴파일 오류가 발생할 수 있습니다.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: xml 요소 "{0}"은(는) xml 요소 "{1}" 아래에서 올바르지 않습니다.</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: xml 요소 "{0}"은(는) xml 요소 "{1}" 아래에서 올바르지 않습니다.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: 여러 코드 xml 요소를 찾았으며 이는 허용되지 않습니다. 이 문제를 해결하려면 작업에서 부가적인 코드 xml을 삭제하세요.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: 여러 코드 xml 요소를 찾았으며 이는 허용되지 않습니다. 이 문제를 해결하려면 작업에서 부가적인 코드 xml을 삭제하세요.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">파일이 "{0}"에 의해 잠겨 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: 서명을 연기하려면 적어도 공개 키를 지정해야 합니다.  KeyFile 또는 KeyContainer 속성을 사용하여 공개 키를 제공하거나 서명 연기를 비활성화하세요.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 심각한 오류: 명령줄 인수가 {0}개를 넘었습니다.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">"{0}" 파일이 없습니다. 건너뜁니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: 참조 "{0}"을(를) 찾을 수 없습니다. 이 참조가 코드에 필요할 경우 컴파일 오류가 발생할 수 있습니다.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: 참조 "{0}"을(를) 찾을 수 없습니다. 이 참조가 코드에 필요할 경우 컴파일 오류가 발생할 수 있습니다.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: xml 요소 "{0}"은(는) xml 요소 "{1}" 아래에서 올바르지 않습니다.</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: xml 요소 "{0}"은(는) xml 요소 "{1}" 아래에서 올바르지 않습니다.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: 여러 코드 xml 요소를 찾았으며 이는 허용되지 않습니다. 이 문제를 해결하려면 작업에서 부가적인 코드 xml을 삭제하세요.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: 여러 코드 xml 요소를 찾았으며 이는 허용되지 않습니다. 이 문제를 해결하려면 작업에서 부가적인 코드 xml을 삭제하세요.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -291,36 +291,6 @@
         <target state="translated">Plik „{0}” nie istnieje. Operacja zostanie pominięta.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: Wszystkie litery dysków od A: do Z: są obecnie zajęte. Ponieważ katalog roboczy „{0}” jest ścieżką UNC, zadanie „Exec” potrzebuje wolnej litery dysku do zamapowania ścieżki UNC. Odłącz się od co najmniej jednego zasobu udostępnionego, aby zwolnić litery dysków, lub określ lokalny katalog roboczy przed ponownym użyciem tego polecenia.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: Biblioteka typów „{0}” nie jest zarejestrowana, nie można wyrejestrować.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: „{1}” jest nieprawidłową wartością parametru „{0}”.  Prawidłowe wartości: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: Nie można odnaleźć odwołania „{0}”. Jeśli to odwołanie jest wymagane przez kod, mogą wystąpić błędy kompilacji.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: Nie można odnaleźć odwołania „{0}”. Jeśli to odwołanie jest wymagane przez kod, mogą wystąpić błędy kompilacji.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: Element XML „{0}” nie jest prawidłowy poniżej elementu XML „{1}”.</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: Element XML „{0}” nie jest prawidłowy poniżej elementu XML „{1}”.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: Znaleziono wiele elementów XML Code. Taka sytuacja jest niedozwolona. Aby rozwiązać ten problem, usuń z zadania wszelkie dodatkowe elementy XML Code.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: Znaleziono wiele elementów XML Code. Taka sytuacja jest niedozwolona. Aby rozwiązać ten problem, usuń z zadania wszelkie dodatkowe elementy XML Code.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">Plik jest zablokowany przez: „{0}”</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: Podpisywanie opóźnione wymaga określenia przynajmniej klucza publicznego.  Podaj klucz publiczny przy użyciu właściwości KeyFile lub KeyContainer albo wyłącz podpisywanie opóźnione.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Błąd krytyczny: liczba argumentów wiersza polecenia większa niż {0}.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Plik „{0}” nie istnieje. Operacja zostanie pominięta.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: Nie można odnaleźć odwołania „{0}”. Jeśli to odwołanie jest wymagane przez kod, mogą wystąpić błędy kompilacji.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: Nie można odnaleźć odwołania „{0}”. Jeśli to odwołanie jest wymagane przez kod, mogą wystąpić błędy kompilacji.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: Element XML „{0}” nie jest prawidłowy poniżej elementu XML „{1}”.</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: Element XML „{0}” nie jest prawidłowy poniżej elementu XML „{1}”.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: Znaleziono wiele elementów XML Code. Taka sytuacja jest niedozwolona. Aby rozwiązać ten problem, usuń z zadania wszelkie dodatkowe elementy XML Code.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: Znaleziono wiele elementów XML Code. Taka sytuacja jest niedozwolona. Aby rozwiązać ten problem, usuń z zadania wszelkie dodatkowe elementy XML Code.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: A assinatura atrasada requer que pelo menos uma chave pública seja especificada.  Forneça uma chave pública usando as propriedades KeyFile ou KeyContainer ou desabilite a assinatura atrasada.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Erro Fatal: mais de {0} argumentos de linha de comando.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">O arquivo "{0}" não existe. Ignorando.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: Não foi possível localizar a referência "{0}". Se essa referência for exigida pelo seu código, poderão ocorrer erros de compilação.”</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: Não foi possível localizar a referência "{0}". Se essa referência for exigida pelo seu código, poderão ocorrer erros de compilação.”</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: o elemento xml "{0}" não é válido sob o elemento xml "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: o elemento xml "{0}" não é válido sob o elemento xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: Vários elementos de Código xml foram encontrados e isso não é permitido. Para corrigir o problema, remova os elementos de Código xml adicionais da tarefa.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: Vários elementos de Código xml foram encontrados e isso não é permitido. Para corrigir o problema, remova os elementos de Código xml adicionais da tarefa.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -291,36 +291,6 @@
         <target state="translated">O arquivo "{0}" não existe. Ignorando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: Todas as letras de unidade de A: a Z: estão em uso no momento. Como o diretório de trabalho "{0}" é um caminho UNC, a tarefa "Exec" precisa de uma letra da unidade livre na qual mapear o caminho UNC. Desconecte um ou mais recursos compartilhados para liberar algumas letras da unidade ou especifique um diretório de trabalho local antes de tentar usar esse comando novamente.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: A biblioteca de tipos "{0}" não está registrada; não é possível cancelar o registro.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" é um nome inválido para o parâmetro "{0}".  Os valores válidos são: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: Não foi possível localizar a referência "{0}". Se essa referência for exigida pelo seu código, poderão ocorrer erros de compilação.”</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: Não foi possível localizar a referência "{0}". Se essa referência for exigida pelo seu código, poderão ocorrer erros de compilação.”</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: o elemento xml "{0}" não é válido sob o elemento xml "{1}".</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: o elemento xml "{0}" não é válido sob o elemento xml "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: Vários elementos de Código xml foram encontrados e isso não é permitido. Para corrigir o problema, remova os elementos de Código xml adicionais da tarefa.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: Vários elementos de Código xml foram encontrados e isso não é permitido. Para corrigir o problema, remova os elementos de Código xml adicionais da tarefa.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">O arquivo é bloqueado por: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -291,36 +291,6 @@
         <target state="translated">Файл "{0}" не существует. Пропускается.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: все буквы дисков (от A: до Z:) сейчас используются. Поскольку рабочий каталог "{0}" указан в виде UNC-пути, задаче Exec требуется свободная буква диска для сопоставления с этим UNC-путем. Перед повторением этой команды отключитесь от одного или нескольких общих ресурсов, чтобы освободить буквы дисков, или укажите локальный рабочий каталог.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: Библиотека типов "{0}" не зарегистрирована. Невозможно отменить ее регистрацию.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" — недопустимое значение для параметра "{0}".  Допустимые значения: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: не удалось найти ссылку "{0}". Если эта ссылка необходима для кода, при компиляции могут возникнуть ошибки.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: не удалось найти ссылку "{0}". Если эта ссылка необходима для кода, при компиляции могут возникнуть ошибки.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: XML-элемент "{0}" недопустим в элементе "{1}".</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: XML-элемент "{0}" недопустим в элементе "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: обнаружено несколько XML-элементов кода; это запрещено. Чтобы устранить эту ошибку, удалите лишние XML-элементы кода из задачи.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: обнаружено несколько XML-элементов кода; это запрещено. Чтобы устранить эту ошибку, удалите лишние XML-элементы кода из задачи.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">"{0}" блокирует этот файл</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: для отложенного подписывания необходимо указать хотя бы один открытый ключ.  Укажите открытый ключ с помощью свойства KeyFile или KeyContainer либо отключите отложенное подписывание.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: неустранимая ошибка: число аргументов командной строки превышает {0}.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">Файл "{0}" не существует. Пропускается.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: не удалось найти ссылку "{0}". Если эта ссылка необходима для кода, при компиляции могут возникнуть ошибки.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: не удалось найти ссылку "{0}". Если эта ссылка необходима для кода, при компиляции могут возникнуть ошибки.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: XML-элемент "{0}" недопустим в элементе "{1}".</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: XML-элемент "{0}" недопустим в элементе "{1}".</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: обнаружено несколько XML-элементов кода; это запрещено. Чтобы устранить эту ошибку, удалите лишние XML-элементы кода из задачи.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: обнаружено несколько XML-элементов кода; это запрещено. Чтобы устранить эту ошибку, удалите лишние XML-элементы кода из задачи.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -291,36 +291,6 @@
         <target state="translated">"{0}" dosyası yok. Atlanıyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: A: ile Z: arasındaki tüm sürücü harfleri şu anda kullanımda. "{0}" çalışma dizini bir UNC yolu olduğundan, "Exec" görevinin UNC yolunu eşleyeceği serbest bir sürücü harfi gerekiyor. Sürücü harflerini serbest bırakmak üzere bir veya birden çok paylaşılan kaynağın bağlantısını kesin veya bu komutu yeniden denemeden önce yerel bir çalışma dizini belirtin.</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: "{0}" tür kitaplığı kaydettirilmemiş, kaydı kaldırılamıyor.</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" değeri, "{0}" parametresi için geçersiz.  Geçerli değerler şunlardır: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: {0} başvurusu bulunamadı. Kodunuz için bu başvuru gerekliyse, derleme hatalarıyla karşılaşabilirsiniz.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: {0} başvurusu bulunamadı. Kodunuz için bu başvuru gerekliyse, derleme hatalarıyla karşılaşabilirsiniz.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: "{0}" xml öğesi "{1}" xml öğesinin altında geçerli değil.</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: "{0}" xml öğesi "{1}" xml öğesinin altında geçerli değil.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: Birden fazla Code xml öğesi bulundu; buna izin verilmiyor. Bu sorunu gidermek için, görevdeki tüm ek Code xml öğelerini kaldırın.</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: Birden fazla Code xml öğesi bulundu; buna izin verilmiyor. Bu sorunu gidermek için, görevdeki tüm ek Code xml öğelerini kaldırın.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">Dosya şunun tarafından kilitlendi: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: Gecikmeli imzalama, en azından bir ortak anahtar belirtilmesini gerektirir.  Lütfen KeyFile veya KeyContainer özelliklerini kullanarak bir ortak anahtar sağlayın veya gecikmeli imzalamayı devre dışı bırakın.</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: Kritik Hata: Komut satırı bağımsız değişkenleri şu sayıdan fazla: {0}.</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">"{0}" dosyası yok. Atlanıyor.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: {0} başvurusu bulunamadı. Kodunuz için bu başvuru gerekliyse, derleme hatalarıyla karşılaşabilirsiniz.</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: {0} başvurusu bulunamadı. Kodunuz için bu başvuru gerekliyse, derleme hatalarıyla karşılaşabilirsiniz.</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: "{0}" xml öğesi "{1}" xml öğesinin altında geçerli değil.</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: "{0}" xml öğesi "{1}" xml öğesinin altında geçerli değil.</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: Birden fazla Code xml öğesi bulundu; buna izin verilmiyor. Bu sorunu gidermek için, görevdeki tüm ek Code xml öğelerini kaldırın.</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: Birden fazla Code xml öğesi bulundu; buna izin verilmiyor. Bu sorunu gidermek için, görevdeki tüm ek Code xml öğelerini kaldırın.</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: 延迟签名要求至少指定一个公钥。请使用 KeyFile 或 KeyContainer 属性提供一个公钥，或者禁用延迟签名。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 严重错误: 超出 {0} 个命令行参数。</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">文件“{0}”不存在。正在跳过。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: 未能找到引用“{0}”。如果代码需要此引用，则可能会出现编译错误。</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: 未能找到引用“{0}”。如果代码需要此引用，则可能会出现编译错误。</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: XML 元素“{0}”在 XML 元素“{1}”下无效。</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: XML 元素“{0}”在 XML 元素“{1}”下无效。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: 已找到多个 Code XML 元素，不允许存在这种情况。若要解决此问题，请从任务中移除任何其他 Code XML 元素。</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: 已找到多个 Code XML 元素，不允许存在这种情况。若要解决此问题，请从任务中移除任何其他 Code XML 元素。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -291,36 +291,6 @@
         <target state="translated">文件“{0}”不存在。正在跳过。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: 所有驱动器号(从 A: 到 Z:)当前都在使用。由于工作目录“{0}”是 UNC 路径，“Exec”任务需要将 UNC 路径映射到一个空闲的驱动器号。请从一个或多个共享资源断开连接以释放驱动器号，或在再次尝试执行此命令前指定本地工作目录。</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: 类型库“{0}”未注册，无法注销。</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: “{1}”是无效的“{0}”参数值。有效值为: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: 未能找到引用“{0}”。如果代码需要此引用，则可能会出现编译错误。</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: 未能找到引用“{0}”。如果代码需要此引用，则可能会出现编译错误。</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: XML 元素“{0}”在 XML 元素“{1}”下无效。</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: XML 元素“{0}”在 XML 元素“{1}”下无效。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: 已找到多个 Code XML 元素，不允许存在这种情况。若要解决此问题，请从任务中移除任何其他 Code XML 元素。</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: 已找到多个 Code XML 元素，不允许存在这种情况。若要解决此问题，请从任务中移除任何其他 Code XML 元素。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">文件被“{0}”锁定。</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -121,6 +121,41 @@
         <target state="translated">MSB3654: 延遲簽署需要至少指定一個公開金鑰。請使用 KeyFile 或 KeyContainer 屬性提供公開金鑰，或停用延遲簽署。</target>
         <note>{StrBegin="MSB3654: "}</note>
       </trans-unit>
+      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
+        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
+        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
+        <note>{StrBegin="MSB3752: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.CompilingAssembly">
+        <source>Compiling task source code</source>
+        <target state="new">Compiling task source code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
+        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
+        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
+        <note>{StrBegin="MSB3756: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
+        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
+        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidCodeType">
+        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
+        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
+        <note>{StrBegin="MSB3759: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
+        <source>MSB3761: The specified task XML is invalid.  {0}</source>
+        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
+        <note>{StrBegin="MSB3761: "}</note>
+      </trans-unit>
+      <trans-unit id="CodeTaskFactory.NoSourceCode">
+        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
+        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
+        <note>{StrBegin="MSB3760: "}</note>
+      </trans-unit>
       <trans-unit id="Compiler.FatalArguments">
         <source>MSB3881: Fatal Error: more than {0} command line arguments.</source>
         <target state="translated">MSB3881: 嚴重錯誤: 命令列引數的數目超過 {0} 個。</target>
@@ -290,6 +325,36 @@
         <source>File "{0}" doesn't exist. Skipping.</source>
         <target state="translated">檔案 "{0}" 不存在。即將略過。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
+        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
+        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.Downloading">
+        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
+        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorDownloading">
+        <source>MSB3923: Failed to download file "{0}".  {1}</source>
+        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3923: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorInvalidUrl">
+        <source>MSB3921: The specified URL "{0}" is not valid.</source>
+        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
+        <note>{StrBegin="MSB3921: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.ErrorUnknownFileName">
+        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
+        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
+        <note>{StrBegin="MSB3922: "}</note>
+      </trans-unit>
+      <trans-unit id="DownloadFile.Retrying">
+        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
+        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
+        <note>{StrBegin="MSB3924: "}</note>
       </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
@@ -2334,34 +2399,34 @@
         <note />
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
-        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
-        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
-        <note>{StrBegin="MSB3911: "}</note>
+        <source>MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3931: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3931: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotExtractFile">
-        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
-        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
-        <note>{StrBegin="MSB3916: "}</note>
+        <source>MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3936: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3936: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
-        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
-        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
-        <note>{StrBegin="MSB3915: "}</note>
+        <source>MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3935: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3935: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorCouldNotOpenFile">
-        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
-        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3913: "}</note>
+        <source>MSB3933: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3933: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3933: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
-        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
-        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
-        <note>{StrBegin="MSB3914: "}</note>
+        <source>MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3934: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3934: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.ErrorFileDoesNotExist">
-        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
-        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3912: "}</note>
+        <source>MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3932: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3932: "}</note>
       </trans-unit>
       <trans-unit id="Unzip.FileComment">
         <source>Unzipping file "{0}" to "{1}".</source>
@@ -2679,18 +2744,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
-        <target state="translated">MSB3755: 找不到參考 "{0}"。如果您的程式碼要求這個參考，可能會發生編譯錯誤。</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
+        <target state="needs-review-translation">MSB3755: 找不到參考 "{0}"。如果您的程式碼要求這個參考，可能會發生編譯錯誤。</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
-        <target state="translated">MSB3756: xml 項目 "{0}" 在 xml 項目 "{1}" 之下無效。</target>
+        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
+        <target state="needs-review-translation">MSB3756: xml 項目 "{0}" 在 xml 項目 "{1}" 之下無效。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
-        <target state="translated">MSB3757: 找到多個程式碼 XML 元素，不允許有這種情況。若要修正此問題，請從工作移除任何額外的程式碼 XML 元素。</target>
+        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
+        <target state="needs-review-translation">MSB3757: 找到多個程式碼 XML 元素，不允許有這種情況。若要修正此問題，請從工作移除任何額外的程式碼 XML 元素。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3054,19 +3119,19 @@
         <note />
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
-        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
-        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
-        <note>{StrBegin="MSB3921: "}</note>
+        <source>MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3941: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3941: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFailed">
-        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
-        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
-        <note>{StrBegin="MSB3923: "}</note>
+        <source>MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3943: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3943: "}</note>
       </trans-unit>
       <trans-unit id="ZipDirectory.ErrorFileExists">
-        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
-        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
-        <note>{StrBegin="MSB3922: "}</note>
+        <source>MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3942: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3942: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -291,36 +291,6 @@
         <target state="translated">檔案 "{0}" 不存在。即將略過。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DownloadFile.DidNotDownloadBecauseOfFileMatch">
-        <source>Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</source>
-        <target state="new">Did not download file from "{0}" to "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes match.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.Downloading">
-        <source>Downloading from "{0}" to "{1}" ({2:N0} bytes).</source>
-        <target state="new">Downloading from "{0}" to "{1}" ({2:N0} bytes).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorDownloading">
-        <source>MSB3923: Failed to download file "{0}".  {1}</source>
-        <target state="new">MSB3923: Failed to download file "{0}".  {1}</target>
-        <note>{StrBegin="MSB3923: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorInvalidUrl">
-        <source>MSB3921: The specified URL "{0}" is not valid.</source>
-        <target state="new">MSB3921: The specified URL "{0}" is not valid.</target>
-        <note>{StrBegin="MSB3921: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.ErrorUnknownFileName">
-        <source>MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</source>
-        <target state="new">MSB3922: Failed to determine a file name from the URL "{0}".  Please specify a file name with the "{1}" parameter.</target>
-        <note>{StrBegin="MSB3922: "}</note>
-      </trans-unit>
-      <trans-unit id="DownloadFile.Retrying">
-        <source>MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</source>
-        <target state="new">MSB3924: Failed to download file "{0}". Beginning retry {1} in {2}ms. {3}</target>
-        <note>{StrBegin="MSB3924: "}</note>
-      </trans-unit>
       <trans-unit id="Exec.AllDriveLettersMappedError">
         <source>MSB3071: All drive letters from A: through Z: are currently in use. Since the working directory "{0}" is a UNC path, the "Exec" task needs a free drive letter to map the UNC path to. Disconnect from one or more shared resources to free up drive letters, or specify a local working directory before attempting this command again.</source>
         <target state="translated">MSB3071: 從 A: 到 Z: 的所有磁碟機代號目前都在使用中。由於工作目錄 "{0}" 是 UNC 路徑，因此 "Exec" 工作需要有可用的磁碟機代號以便對應 UNC 路徑。請先中斷一或多個共用資源的連線以釋放磁碟機代號，或指定本機工作目錄，再嘗試重新執行這個命令。</target>
@@ -2358,6 +2328,46 @@
         <target state="translated">MSB3394: 類型程式庫 "{0}" 並未註冊，因此無法移除註冊。</target>
         <note>{StrBegin="MSB3394: "}</note>
       </trans-unit>
+      <trans-unit id="Unzip.DidNotUnzipBecauseOfFileMatch">
+        <source>Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</source>
+        <target state="new">Did not unzip from file "{0}" to file "{1}" because the "{2}" parameter was set to "{3}" in the project and the files' sizes and timestamps match.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotCreateDestinationDirectory">
+        <source>MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</source>
+        <target state="new">MSB3911: Failed to unzip to directory "{0}" because it could not be created.  {1}</target>
+        <note>{StrBegin="MSB3911: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotExtractFile">
+        <source>MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</source>
+        <target state="new">MSB3916: Failed to open unzip file "{0}" to "{1}".  {2}</target>
+        <note>{StrBegin="MSB3916: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotMakeFileWriteable">
+        <source>MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</source>
+        <target state="new">MSB3915: Failed to unzip file "{0}" because destination file "{1}" is read-only and could not be made writable.  {2}</target>
+        <note>{StrBegin="MSB3915: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorCouldNotOpenFile">
+        <source>MSB3913: Failed to open zip file "{0}".  {1}</source>
+        <target state="new">MSB3913: Failed to open zip file "{0}".  {1}</target>
+        <note>{StrBegin="MSB3913: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorExtractingResultsInFilesOutsideDestination">
+        <source>MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</source>
+        <target state="new">MSB3914: Failed to open unzip file "{0}" to "{1}" because it is outside the destination directory.</target>
+        <note>{StrBegin="MSB3914: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.ErrorFileDoesNotExist">
+        <source>MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</source>
+        <target state="new">MSB3912: Failed to unzip file "{0}" because the file does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3912: "}</note>
+      </trans-unit>
+      <trans-unit id="Unzip.FileComment">
+        <source>Unzipping file "{0}" to "{1}".</source>
+        <target state="new">Unzipping file "{0}" to "{1}".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Vbc.EnumParameterHasInvalidValue">
         <source>MSB3401: "{1}" is an invalid value for the "{0}" parameter.  The valid values are: {2}</source>
         <target state="translated">MSB3401: "{1}" 是 "{0}" 參數的無效值。有效值為: {2}</target>
@@ -2669,18 +2679,18 @@
         <note>{StrBegin="MSB3754: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CouldNotFindReferenceAssembly">
-        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors.</source>
-        <target state="needs-review-translation">MSB3755: 找不到參考 "{0}"。如果您的程式碼要求這個參考，可能會發生編譯錯誤。</target>
+        <source>MSB3755: Could not find reference "{0}". If this reference is required by your code, you may get compilation errors."</source>
+        <target state="translated">MSB3755: 找不到參考 "{0}"。如果您的程式碼要求這個參考，可能會發生編譯錯誤。</target>
         <note>{StrBegin="MSB3755: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.InvalidElementLocation">
-        <source>MSB3756: The element &lt;{0}&gt; is not a valid child of the &lt;{1}&gt; element.  Valid child elements are &lt;Code&gt;, &lt;Reference&gt;, and &lt;Using&gt;.</source>
-        <target state="needs-review-translation">MSB3756: xml 項目 "{0}" 在 xml 項目 "{1}" 之下無效。</target>
+        <source>MSB3756: The xml element "{0}" is not valid under the xml element "{1}".</source>
+        <target state="translated">MSB3756: xml 項目 "{0}" 在 xml 項目 "{1}" 之下無效。</target>
         <note>{StrBegin="MSB3756: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.MultipleCodeNodes">
-        <source>MSB3757: Only one &lt;Code&gt; element can be specified.</source>
-        <target state="needs-review-translation">MSB3757: 找到多個程式碼 XML 元素，不允許有這種情況。若要修正此問題，請從工作移除任何額外的程式碼 XML 元素。</target>
+        <source>MSB3757: Multiple Code xml elements have been found, this is not allowed. To fix this issue remove any additional Code xml elements from the task.</source>
+        <target state="translated">MSB3757: 找到多個程式碼 XML 元素，不允許有這種情況。若要修正此問題，請從工作移除任何額外的程式碼 XML 元素。</target>
         <note>{StrBegin="MSB3757: "}</note>
       </trans-unit>
       <trans-unit id="CodeTaskFactory.CompilerError">
@@ -3038,40 +3048,25 @@
         <target state="translated">檔案鎖定者: "{0}"</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeType">
-        <source>MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</source>
-        <target state="new">MSB3759: The specified code type "{0}" is invalid.  The supported code types are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeLanguage">
-        <source>MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</source>
-        <target state="new">MSB3759: The specified code language "{0}" is invalid.  The supported code languages are "{1}".</target>
-        <note>{StrBegin="MSB3759: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.NoSourceCode">
-        <source>MSB3760: You must specify source code within the Code element or a path to a file containing source code.</source>
-        <target state="new">MSB3760: You must specify source code within the Code element or a path to a file containing source code.</target>
-        <note>{StrBegin="MSB3760: "}</note>
-      </trans-unit>
-      <trans-unit id="CodeTaskFactory.CompilingAssembly">
-        <source>Compiling task source code</source>
-        <target state="new">Compiling task source code</target>
+      <trans-unit id="ZipDirectory.Comment">
+        <source>Zipping directory "{0}" to "{1}".</source>
+        <target state="new">Zipping directory "{0}" to "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidTaskXml">
-        <source>MSB3761: The specified task XML is invalid.  {0}</source>
-        <target state="new">MSB3761: The specified task XML is invalid.  {0}</target>
-        <note>{StrBegin="MSB3761: "}</note>
+      <trans-unit id="ZipDirectory.ErrorDirectoryDoesNotExist">
+        <source>MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3921: Failed to zip directory "{0}" because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3921: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.InvalidCodeElementAttribute">
-        <source>MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</source>
-        <target state="new">MSB3756: The attribute "{0}" is not valid for the &lt;Code&gt; element.  Valid attributes are "Language", "Source", and "Type".</target>
-        <note>{StrBegin="MSB3756: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFailed">
+        <source>MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</source>
+        <target state="new">MSB3923: Failed to zip directory "{0}" to file "{1}".  {2}</target>
+        <note>{StrBegin="MSB3923: "}</note>
       </trans-unit>
-      <trans-unit id="CodeTaskFactory.AttributeEmptyWithElement">
-        <source>MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</source>
-        <target state="new">MSB3752: The "{0}" attribute of the &lt;{1}&gt; element has been set but is empty. If the "{0}" attribute is set it must not be empty.</target>
-        <note>{StrBegin="MSB3752: "}</note>
+      <trans-unit id="ZipDirectory.ErrorFileExists">
+        <source>MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</source>
+        <target state="new">MSB3922: Failed to create zip file "{0}" because it already exists.  Please delete or rename the file and try again.</target>
+        <note>{StrBegin="MSB3922: "}</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to.
         /// </summary>
+        [Required]
         public ITaskItem DestinationFolder { get; set; }
 
         /// <summary>
@@ -81,7 +82,6 @@ namespace Microsoft.Build.Tasks
             }
             catch (Exception e)
             {
-                // TODO: Resource
                 Log.LogErrorFromResources("Unzip.ErrorCouldNotCreateDestinationDirectory", DestinationFolder.ItemSpec, e.Message);
 
                 return false;
@@ -91,7 +91,6 @@ namespace Microsoft.Build.Tasks
             {
                 if (!File.Exists(sourceFile.ItemSpec))
                 {
-                    // TODO: Resource
                     Log.LogErrorFromResources("Unzip.ErrorFileDoesNotExist", sourceFile.ItemSpec);
                     continue;
                 }
@@ -118,7 +117,6 @@ namespace Microsoft.Build.Tasks
                 catch (Exception e)
                 {
                     // Should only be thrown if the archive could not be opened (Access denied, corrupt file, etc)
-                    // TODO: Resource
                     Log.LogErrorFromResources("Unzip.ErrorCouldNotOpenFile", e.Message);
                 }
             }
@@ -142,11 +140,10 @@ namespace Microsoft.Build.Tasks
                 {
                     // ExtractToDirectory() throws an IOException for this but since we're extracting one file at a time
                     // for logging and cancellation, we need to check for it ourselves.
-                    // TODO: Resource
-                    Log.LogErrorFromResources("Unzip.ExtractingResultsInFilesOutsideDestination", destinationPath.FullName, destinationDirectory.FullName);
+                    Log.LogErrorFromResources("Unzip.ErrorExtractingResultsInFilesOutsideDestination", destinationPath.FullName, destinationDirectory.FullName);
                     continue;
                 }
-
+                
                 TaskItem taskItem = new TaskItem(EscapingUtilities.Escape(destinationPath.FullName));
 
                 sourceTaskItem.CopyMetadataTo(taskItem);
@@ -155,8 +152,7 @@ namespace Microsoft.Build.Tasks
 
                 if (ShouldSkipEntry(zipArchiveEntry, destinationPath))
                 {
-                    // TODO: Resource
-                    Log.LogMessageFromResources(MessageImportance.Low, "Copy.DidNotCopyBecauseOfFileMatch", zipArchiveEntry.FullName, destinationPath.FullName, nameof(SkipUnchangedFiles), "true");
+                    Log.LogMessageFromResources(MessageImportance.Low, "Unzip.DidNotUnzipBecauseOfFileMatch", zipArchiveEntry.FullName, destinationPath.FullName, nameof(SkipUnchangedFiles), "true");
                     continue;
                 }
 
@@ -166,8 +162,7 @@ namespace Microsoft.Build.Tasks
                 }
                 catch (Exception e)
                 {
-                    // TODO: Resource
-                    Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotCreateDestinationDirectory", destinationPath.DirectoryName, e.Message);
+                    Log.LogErrorWithCodeFromResources("Unzip.ErrorCouldNotCreateDestinationDirectory", destinationPath.DirectoryName, e.Message);
                     continue;
                 }
 
@@ -179,16 +174,14 @@ namespace Microsoft.Build.Tasks
                     }
                     catch (Exception e)
                     {
-                        // TODO: Resource
-                        Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotMakeFileWriteable", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
+                        Log.LogErrorWithCodeFromResources("Unzip.ErrorCouldNotMakeFileWriteable", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
                         continue;
                     }
                 }
 
                 try
                 {
-                    // TODO: Resource
-                    Log.LogMessageFromResources(MessageImportance.Normal, "Copy.FileComment", zipArchiveEntry.FullName, destinationPath.FullName);
+                    Log.LogMessageFromResources(MessageImportance.Normal, "Unzip.FileComment", zipArchiveEntry.FullName, destinationPath.FullName);
 
                     zipArchiveEntry.ExtractToFile(destinationPath.FullName, overwrite: true);
 
@@ -196,8 +189,7 @@ namespace Microsoft.Build.Tasks
                 }
                 catch (IOException e)
                 {
-                    // TODO: Resource
-                    Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotExtractFile", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
+                    Log.LogErrorWithCodeFromResources("Unzip.ErrorCouldNotExtractFile", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
                 }
             }
         }

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Build.Tasks
 {
@@ -16,9 +17,9 @@ namespace Microsoft.Build.Tasks
     public sealed class Unzip : TaskExtension, ICancelableTask
     {
         /// <summary>
-        /// Stores a value indicating if a cancellation was requested.
+        /// Stores a <see cref="CancellationTokenSource"/> used for cancellation.
         /// </summary>
-        private bool _canceling;
+        private readonly CancellationTokenSource _cancellationToken = new CancellationTokenSource();
 
         /// <summary>
         /// Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to.
@@ -45,7 +46,7 @@ namespace Microsoft.Build.Tasks
         /// <inheritdoc cref="ICancelableTask.Cancel"/>
         public void Cancel()
         {
-            _canceling = true;
+            _cancellationToken.Cancel();
         }
 
         /// <inheritdoc cref="Task.Execute"/>
@@ -63,7 +64,9 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            foreach (ITaskItem sourceFile in SourceFiles.TakeWhile(i => !_canceling))
+            BuildEngine3.Yield();
+
+            foreach (ITaskItem sourceFile in SourceFiles.TakeWhile(i => !_cancellationToken.IsCancellationRequested))
             {
                 if (!File.Exists(sourceFile.ItemSpec))
                 {
@@ -90,6 +93,10 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
                 catch (Exception e)
                 {
                     // Should only be thrown if the archive could not be opened (Access denied, corrupt file, etc)
@@ -97,7 +104,9 @@ namespace Microsoft.Build.Tasks
                 }
             }
 
-            return !_canceling && !Log.HasLoggedErrors;
+            BuildEngine3.Reacquire();
+
+            return !_cancellationToken.IsCancellationRequested && !Log.HasLoggedErrors;
         }
 
         /// <summary>
@@ -108,7 +117,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="destinationDirectory">The <see cref="DirectoryInfo"/> to extract files to.</param>
         private void Extract(ITaskItem sourceTaskItem, ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
         {
-            foreach (ZipArchiveEntry zipArchiveEntry in sourceArchive.Entries.TakeWhile(i => !_canceling))
+            foreach (ZipArchiveEntry zipArchiveEntry in sourceArchive.Entries.TakeWhile(i => !_cancellationToken.IsCancellationRequested))
             {
                 FileInfo destinationPath = new FileInfo(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName));
 
@@ -156,7 +165,7 @@ namespace Microsoft.Build.Tasks
                     using (Stream destination = File.Open(destinationPath.FullName, FileMode.Create, FileAccess.Write, FileShare.None))
                     using (Stream stream = zipArchiveEntry.Open())
                     {
-                        stream.CopyTo(destination);
+                        stream.CopyToAsync(destination, 81920, _cancellationToken.Token);
                     }
 
                     destinationPath.LastWriteTimeUtc = zipArchiveEntry.LastWriteTime.UtcDateTime;

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Microsoft.Build.Tasks
+{
+    /// <summary>
+    /// Represents a task that can extract a .zip archive.
+    /// </summary>
+    public sealed class Unzip : TaskExtension, ICancelableTask
+    {
+        /// <summary>
+        /// Stores a collection of all destination files.
+        /// </summary>
+        private readonly Collection<ITaskItem> _destinationFiles = new Collection<ITaskItem>();
+
+        /// <summary>
+        /// Stores a collection of all files that were unzipped.
+        /// </summary>
+        private readonly Collection<ITaskItem> _unzippedFiles = new Collection<ITaskItem>();
+
+        /// <summary>
+        /// Stores a value indicating if a cancellation was requested.
+        /// </summary>
+        private bool _canceling;
+
+        /// <summary>
+        /// Gets an array of <see cref="ITaskItem"/> objects containing details about all of the destination files.
+        /// </summary>
+        [Output]
+        public ITaskItem[] DestinationFiles => _destinationFiles.ToArray();
+
+        /// <summary>
+        /// Gets or sets a <see cref="ITaskItem"/> with a destination folder path to unzip the files to.
+        /// </summary>
+        public ITaskItem DestinationFolder { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether read-only files should be overwritten.
+        /// </summary>
+        public bool OverwriteReadOnlyFiles { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether files should be skipped if the destination is unchanged.
+        /// </summary>
+        public bool SkipUnchangedFiles { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets an array of <see cref="ITaskItem"/> objects containing the paths to .zip archive files to unzip.
+        /// </summary>
+        [Required]
+        public ITaskItem[] SourceFiles { get; set; }
+
+        /// <summary>
+        /// Gets an array of <see cref="ITaskItem"/> objects containing details about only the files that were unzipped.
+        /// </summary>
+        [Output]
+        public ITaskItem[] UnzippedFiles => _unzippedFiles.ToArray();
+
+        /// <inheritdoc cref="ICancelableTask.Cancel"/>
+        public void Cancel()
+        {
+            _canceling = true;
+        }
+
+        /// <inheritdoc cref="Task.Execute"/>
+        public override bool Execute()
+        {
+            DirectoryInfo destinationDirectory;
+            try
+            {
+                destinationDirectory = Directory.CreateDirectory(DestinationFolder.ItemSpec);
+            }
+            catch (Exception e)
+            {
+                // TODO: Resource
+                Log.LogErrorFromResources("Unzip.ErrorCouldNotCreateDestinationDirectory", DestinationFolder.ItemSpec, e.Message);
+
+                return false;
+            }
+
+            foreach (ITaskItem sourceFile in SourceFiles.TakeWhile(i => !_canceling))
+            {
+                if (!File.Exists(sourceFile.ItemSpec))
+                {
+                    // TODO: Resource
+                    Log.LogErrorFromResources("Unzip.ErrorFileDoesNotExist", sourceFile.ItemSpec);
+                    continue;
+                }
+
+                try
+                {
+                    using (FileStream stream = new FileStream(sourceFile.ItemSpec, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false))
+                    {
+                        using (ZipArchive zipArchive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false))
+                        {
+                            try
+                            {
+                                Extract(sourceFile, zipArchive, destinationDirectory);
+                            }
+                            catch (Exception e)
+                            {
+                                // Unhandled exception in Extract() is a bug!
+                                Log.LogErrorFromException(e, showStackTrace: true);
+                                return false;
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    // Should only be thrown if the archive could not be opened (Access denied, corrupt file, etc)
+                    // TODO: Resource
+                    Log.LogErrorFromResources("Unzip.ErrorCouldNotOpenFile", e.Message);
+                }
+            }
+
+            return !_canceling && !Log.HasLoggedErrors;
+        }
+
+        /// <summary>
+        /// Extracts all files to the specified directory.
+        /// </summary>
+        /// <param name="sourceTaskItem">The original <see cref="ITaskItem"/> containing details about the source file.</param>
+        /// <param name="sourceArchive">The <see cref="ZipArchive"/> containing the files to extract.</param>
+        /// <param name="destinationDirectory">The <see cref="DirectoryInfo"/> to extract files to.</param>
+        private void Extract(ITaskItem sourceTaskItem, ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
+        {
+            foreach (ZipArchiveEntry zipArchiveEntry in sourceArchive.Entries.TakeWhile(i => !_canceling))
+            {
+                FileInfo destinationPath = new FileInfo(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName));
+
+                if (!destinationPath.FullName.StartsWith(destinationDirectory.FullName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // ExtractToDirectory() throws an IOException for this but since we're extracting one file at a time
+                    // for logging and cancellation, we need to check for it ourselves.
+                    // TODO: Resource
+                    Log.LogErrorFromResources("Unzip.ExtractingResultsInFilesOutsideDestination", destinationPath.FullName, destinationDirectory.FullName);
+                    continue;
+                }
+
+                TaskItem taskItem = new TaskItem(EscapingUtilities.Escape(destinationPath.FullName));
+
+                sourceTaskItem.CopyMetadataTo(taskItem);
+
+                _destinationFiles.Add(taskItem);
+
+                if (ShouldSkipEntry(zipArchiveEntry, destinationPath))
+                {
+                    // TODO: Resource
+                    Log.LogMessageFromResources(MessageImportance.Low, "Copy.DidNotCopyBecauseOfFileMatch", zipArchiveEntry.FullName, destinationPath.FullName, nameof(SkipUnchangedFiles), "true");
+                    continue;
+                }
+
+                try
+                {
+                    destinationPath.Directory?.Create();
+                }
+                catch (Exception e)
+                {
+                    // TODO: Resource
+                    Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotCreateDestinationDirectory", destinationPath.DirectoryName, e.Message);
+                    continue;
+                }
+
+                if (OverwriteReadOnlyFiles && destinationPath.IsReadOnly)
+                {
+                    try
+                    {
+                        destinationPath.IsReadOnly = false;
+                    }
+                    catch (Exception e)
+                    {
+                        // TODO: Resource
+                        Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotMakeFileWriteable", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
+                        continue;
+                    }
+                }
+
+                try
+                {
+                    // TODO: Resource
+                    Log.LogMessageFromResources(MessageImportance.Normal, "Copy.FileComment", zipArchiveEntry.FullName, destinationPath.FullName);
+
+                    zipArchiveEntry.ExtractToFile(destinationPath.FullName, overwrite: true);
+
+                    _unzippedFiles.Add(taskItem);
+                }
+                catch (IOException e)
+                {
+                    // TODO: Resource
+                    Log.LogErrorWithCodeFromResources("Copy.ErrorCouldNotExtractFile", zipArchiveEntry.FullName, destinationPath.FullName, e.Message);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines whether or not a file should be skipped when unzipping.
+        /// </summary>
+        /// <param name="zipArchiveEntry">The <see cref="ZipArchiveEntry"/> object containing information about the file in the zip archive.</param>
+        /// <param name="fileInfo">A <see cref="FileInfo"/> object containing information about the destination file.</param>
+        /// <returns><code>true</code> if the file should be skipped, otherwise <code>false</code>.</returns>
+        private bool ShouldSkipEntry(ZipArchiveEntry zipArchiveEntry, FileInfo fileInfo)
+        {
+            return SkipUnchangedFiles
+                   && fileInfo.Exists
+                   && zipArchiveEntry.LastWriteTime == fileInfo.LastWriteTimeUtc
+                   && zipArchiveEntry.Length == fileInfo.Length;
+        }
+    }
+}

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 using System;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -121,7 +119,7 @@ namespace Microsoft.Build.Tasks
                     Log.LogErrorFromResources("Unzip.ErrorExtractingResultsInFilesOutsideDestination", destinationPath.FullName, destinationDirectory.FullName);
                     continue;
                 }
-                
+
                 if (ShouldSkipEntry(zipArchiveEntry, destinationPath))
                 {
                     Log.LogMessageFromResources(MessageImportance.Low, "Unzip.DidNotUnzipBecauseOfFileMatch", zipArchiveEntry.FullName, destinationPath.FullName, nameof(SkipUnchangedFiles), "true");
@@ -154,7 +152,7 @@ namespace Microsoft.Build.Tasks
                 try
                 {
                     Log.LogMessageFromResources(MessageImportance.Normal, "Unzip.FileComment", zipArchiveEntry.FullName, destinationPath.FullName);
-                    
+
                     using (Stream destination = File.Open(destinationPath.FullName, FileMode.Create, FileAccess.Write, FileShare.None))
                     using (Stream stream = zipArchiveEntry.Open())
                     {

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -154,9 +154,14 @@ namespace Microsoft.Build.Tasks
                 try
                 {
                     Log.LogMessageFromResources(MessageImportance.Normal, "Unzip.FileComment", zipArchiveEntry.FullName, destinationPath.FullName);
+                    
+                    using (Stream destination = File.Open(destinationPath.FullName, FileMode.Create, FileAccess.Write, FileShare.None))
+                    using (Stream stream = zipArchiveEntry.Open())
+                    {
+                        stream.CopyTo(destination);
+                    }
 
-                    zipArchiveEntry.ExtractToFile(destinationPath.FullName, overwrite: true);
-
+                    destinationPath.LastWriteTimeUtc = zipArchiveEntry.LastWriteTime.UtcDateTime;
                 }
                 catch (IOException e)
                 {

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Tasks
                         {
                             try
                             {
-                                Extract(sourceFile, zipArchive, destinationDirectory);
+                                Extract(zipArchive, destinationDirectory);
                             }
                             catch (Exception e)
                             {
@@ -112,10 +112,9 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Extracts all files to the specified directory.
         /// </summary>
-        /// <param name="sourceTaskItem">The original <see cref="ITaskItem"/> containing details about the source file.</param>
         /// <param name="sourceArchive">The <see cref="ZipArchive"/> containing the files to extract.</param>
         /// <param name="destinationDirectory">The <see cref="DirectoryInfo"/> to extract files to.</param>
-        private void Extract(ITaskItem sourceTaskItem, ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
+        private void Extract(ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
         {
             foreach (ZipArchiveEntry zipArchiveEntry in sourceArchive.Entries.TakeWhile(i => !_cancellationToken.IsCancellationRequested))
             {

--- a/src/Tasks/ZipDirectory.cs
+++ b/src/Tasks/ZipDirectory.cs
@@ -48,7 +48,16 @@ namespace Microsoft.Build.Tasks
                     return false;
                 }
 
-                File.Delete(destinationFile.FullName);
+                try
+                {
+                    File.Delete(destinationFile.FullName);
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromResources("ZipDirectory.ErrorFailed", sourceDirectory.FullName, destinationFile.FullName, e.Message);
+
+                    return false;
+                }
             }
 
             try

--- a/src/Tasks/ZipDirectory.cs
+++ b/src/Tasks/ZipDirectory.cs
@@ -39,35 +39,44 @@ namespace Microsoft.Build.Tasks
 
             FileInfo destinationFile = new FileInfo(DestinationFile.ItemSpec);
 
-            if (destinationFile.Exists)
-            {
-                if(!Overwrite)
-                {
-                    Log.LogErrorFromResources("ZipDirectory.ErrorFileExists", destinationFile.FullName);
+            BuildEngine3.Yield();
 
-                    return false;
+            try
+            {
+                if (destinationFile.Exists)
+                {
+                    if (!Overwrite)
+                    {
+                        Log.LogErrorFromResources("ZipDirectory.ErrorFileExists", destinationFile.FullName);
+
+                        return false;
+                    }
+
+                    try
+                    {
+                        File.Delete(destinationFile.FullName);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.LogErrorFromResources("ZipDirectory.ErrorFailed", sourceDirectory.FullName, destinationFile.FullName, e.Message);
+
+                        return false;
+                    }
                 }
 
                 try
                 {
-                    File.Delete(destinationFile.FullName);
+                    Log.LogMessageFromResources(MessageImportance.High, "ZipDirectory.Comment", sourceDirectory.FullName, destinationFile.FullName);
+                    ZipFile.CreateFromDirectory(sourceDirectory.FullName, destinationFile.FullName);
                 }
                 catch (Exception e)
                 {
                     Log.LogErrorFromResources("ZipDirectory.ErrorFailed", sourceDirectory.FullName, destinationFile.FullName, e.Message);
-
-                    return false;
                 }
             }
-
-            try
+            finally
             {
-                Log.LogMessageFromResources(MessageImportance.High, "ZipDirectory.Comment", sourceDirectory.FullName, destinationFile.FullName);
-                ZipFile.CreateFromDirectory(sourceDirectory.FullName, destinationFile.FullName);
-            }
-            catch (Exception e)
-            {
-                Log.LogErrorFromResources("ZipDirectory.ErrorFailed", sourceDirectory.FullName, destinationFile.FullName, e.Message);
+                BuildEngine3.Reacquire();
             }
 
             return !Log.HasLoggedErrors;

--- a/src/Tasks/ZipDirectory.cs
+++ b/src/Tasks/ZipDirectory.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace Microsoft.Build.Tasks
+{
+    public sealed class ZipDirectory : TaskExtension
+    {
+        [Required]
+        public ITaskItem DestinationFile { get; set; }
+
+        [Required]
+        public ITaskItem SourceDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            if (!Directory.Exists(SourceDirectory.ItemSpec))
+            {
+                Log.LogErrorFromResources("ZipDirectory.ErrorDirectoryDoesNotExist", SourceDirectory.ItemSpec);
+                return false;
+            }
+
+            if (File.Exists(DestinationFile.ItemSpec))
+            {
+                Log.LogErrorFromResources("ZipDirectory.ErrorFileExists", DestinationFile.ItemSpec);
+
+                return false;
+            }
+
+            try
+            {
+                Log.LogMessageFromResources(MessageImportance.High, "ZipDirectory.Comment", SourceDirectory.ItemSpec, DestinationFile.ItemSpec);
+                ZipFile.CreateFromDirectory(SourceDirectory.ItemSpec, DestinationFile.ItemSpec);
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromResources("ZipDirectory.ErrorFailed", SourceDirectory.ItemSpec, DestinationFile.ItemSpec, e.Message);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}


### PR DESCRIPTION
`ZipDirectory` task zips up a whole directory.  It will fail if the destination file already exists.  Zipping individual files is a lot harder because you have to calculated a base path for all files and make zip entries relative to that.  The code in the CLR that does this is very efficient by reusing string buffers and I didn't want to have to replicate the code.  So for now there's only `ZipDirectory` instead of a more generic `Zip`.

`Unzip` unzips files from an archive to a directory.
* Defaults to skip unzipping files that are already up-to-date
* Logs every file that was unzipped
* Supports cancellation
* Supports overwriting read-only files
* Supports unzipping multiple files to the same directory

Fixes #1781 