### PR TITLE
Remove WaitForDebugger from our "public" API

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -950,7 +950,6 @@ namespace Microsoft.Build.Execution
         public BuildManager() { }
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
-        public static bool WaitForDebugger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -946,7 +946,6 @@ namespace Microsoft.Build.Execution
         public BuildManager() { }
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
-        public static bool WaitForDebugger { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }

--- a/src/ExcludeAPIList.txt
+++ b/src/ExcludeAPIList.txt
@@ -1,4 +1,5 @@
-﻿T:Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances
+﻿P:Microsoft.Build.Execution.BuildManager.WaitForDebugger
+T:Microsoft.VisualStudio.Setup.Configuration.IEnumSetupInstances
 T:Microsoft.VisualStudio.Setup.Configuration.InstanceState
 T:Microsoft.VisualStudio.Setup.Configuration.ISetupConfiguration
 T:Microsoft.VisualStudio.Setup.Configuration.ISetupConfiguration2


### PR DESCRIPTION
This property is public, but only exists in debug builds, which are
never "official" builds (not distributed in NuGet packages or in VS).

This also caused a builds run with `-configuration Release` to edit the
API files, removing WaitForDebugger.

Remove it from the API permananently and tell GenAPI to stop adding it.