### PR TITLE
Add support for overriding MSBuildExtensionsPath search paths via a property

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1900,8 +1900,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     "dotv",
                     new Dictionary<string, ProjectImportPathMatch>
                     {
-                        {"a", new ProjectImportPathMatch("a", new List<string> {"b", "c"})},
-                        {"d", new ProjectImportPathMatch("d", new List<string> {"e", "f"})}
+                        {"a", new ProjectImportPathMatch("a", "b;c")},
+                        {"d", new ProjectImportPathMatch("d", "e;f")}
                     }
                 );
 

--- a/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Build.UnitTests.Definition
                             <property name=""MSBuildExtensionsPath64"" value=""c:\foo64;c:\bar64""/>
                          </searchPaths>
                          <searchPaths os=""osx"">
-                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo""/>
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo;$(FallbackPaths)""/>
                             <property name=""MSBuildExtensionsPath32"" value=""/tmp/foo32;/tmp/bar32""/>
                          </searchPaths>
                          <searchPaths os=""unix"">
@@ -557,7 +557,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             Assert.Equal(allPaths.GetElement(1).OS, "osx");
             Assert.Equal(allPaths.GetElement(1).PropertyElements.Count, 2);
-            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo;$(FallbackPaths)");
             Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath32").Value, @"/tmp/foo32;/tmp/bar32");
 
             Assert.Equal(allPaths.GetElement(2).OS, "unix");
@@ -578,7 +578,7 @@ namespace Microsoft.Build.UnitTests.Definition
             }
             else if (NativeMethodsShared.IsOSX)
             {
-                CheckPathsTable(pathsTable, "MSBuildExtensionsPath", new string[] {"/tmp/foo"});
+                CheckPathsTable(pathsTable, "MSBuildExtensionsPath", new string[] {"/tmp/foo", "$(FallbackPaths)"});
                 CheckPathsTable(pathsTable, "MSBuildExtensionsPath32", new string[] {"/tmp/foo32", "/tmp/bar32"});
             }
             else
@@ -591,11 +591,16 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             Assert.True(pathsTable.ContainsKey(kind));
             var paths = pathsTable[kind];
-            Assert.Equal(paths.SearchPaths.Count, expectedPaths.Length);
 
-            for (int i = 0; i < paths.SearchPaths.Count; i ++)
+            // Property expansion would be done in the context of an
+            // actual project. So, without that, pathsTable would
+            // have the unexpanded strings.
+            var searchPaths = paths.GetExpandedSearchPaths(p => p);
+            Assert.Equal(searchPaths.Count, expectedPaths.Length);
+
+            for (int i = 0; i < searchPaths.Count; i ++)
             {
-                Assert.Equal(paths.SearchPaths[i], expectedPaths[i]);
+                Assert.Equal(searchPaths[i], expectedPaths[i]);
             }
         }
 

--- a/src/Build.UnitTests/Definition/Toolset_Tests.cs
+++ b/src/Build.UnitTests/Definition/Toolset_Tests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties,
                 subToolsets, "c:\\foo", "4.0", new Dictionary<string, ProjectImportPathMatch>
                 {
-                    ["MSBuildExtensionsPath"] = new ProjectImportPathMatch("MSBuildExtensionsPath", new List<string> {@"c:\foo"})
+                    ["MSBuildExtensionsPath"] = new ProjectImportPathMatch("MSBuildExtensionsPath", @"c:\foo")
                 });
 
             ((INodePacketTranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
@@ -162,7 +162,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             Assert.NotNull(t2.ImportPropertySearchPathsTable);
             Assert.Equal(1, t2.ImportPropertySearchPathsTable.Count);
-            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].SearchPaths[0]);
+            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].GetExpandedSearchPaths(p => p)[0]);
         }
 
         [Fact]

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
 
@@ -14,18 +15,30 @@ namespace Microsoft.Build.Evaluation
     internal class ProjectImportPathMatch : INodePacketTranslatable
     {
         /// <summary>
+        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
+        /// the config file
+        /// </summary>
+        private static char s_separatorForExtensionsPathSearchPaths = ';';
+
+        /// <summary>
         /// ProjectImportPathMatch instance representing no fall-back
         /// </summary>
-        public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, new List<string>());
+        public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, string.Empty);
 
-        internal ProjectImportPathMatch(string propertyName, List<string> searchPaths)
+        internal ProjectImportPathMatch(string propertyName, string propertyValue)
         {
             ErrorUtilities.VerifyThrowArgumentNull(propertyName, nameof(propertyName));
-            ErrorUtilities.VerifyThrowArgumentNull(searchPaths, nameof(searchPaths));
+            ErrorUtilities.VerifyThrowArgumentNull(propertyValue, nameof(propertyValue));
 
             PropertyName = propertyName;
-            SearchPaths = searchPaths;
+            PropertyValue = propertyValue;
             MsBuildPropertyFormat = $"$({PropertyName})";
+
+            // cache the result for @propertyValue="" case also
+            if (!ProjectImportPathMatch.HasPropertyReference(propertyValue) || string.IsNullOrEmpty(propertyValue))
+            {
+                SearchPathsWithNoExpansionRequired = ProjectImportPathMatch.SplitSearchPaths(propertyValue);
+            }
         }
 
         public ProjectImportPathMatch(INodePacketTranslator translator)
@@ -39,6 +52,11 @@ namespace Microsoft.Build.Evaluation
         public string PropertyName;
 
         /// <summary>
+        /// String representation of the property value
+        /// </summary>
+        public string PropertyValue;
+
+        /// <summary>
         /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
         /// </summary>
         public string MsBuildPropertyFormat;
@@ -46,14 +64,43 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Enumeration of the search paths for the property.
         /// </summary>
-        public List<string> SearchPaths;
+        private List<string> SearchPathsWithNoExpansionRequired;
 
         public void Translate(INodePacketTranslator translator)
         {
             translator.Translate(ref PropertyName);
+            translator.Translate(ref PropertyValue);
             translator.Translate(ref MsBuildPropertyFormat);
-            translator.Translate(ref SearchPaths);
+            translator.Translate(ref SearchPathsWithNoExpansionRequired);
         }
+
+        /// <summary>
+        /// Gets the list of search paths with any property references expanded using @expandPropertyReferences
+        /// <param name="expandPropertyReferences">Func that expands properties in a string</param>
+        /// <returns>List of expanded search paths</returns>
+        /// </summary>
+        public IList<string> GetExpandedSearchPaths(Func<string, string> expandPropertyReferences)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(expandPropertyReferences, nameof(expandPropertyReferences));
+
+            /// If SearchPathsWithNoExpansionRequired is not-null, then it means that the PropertyValue
+            /// did not have any property reference and so we just return the list we prepared during
+            /// construction.
+            return SearchPathsWithNoExpansionRequired ?? ProjectImportPathMatch.SplitSearchPaths(expandPropertyReferences(PropertyValue));
+        }
+
+        /// <summary>
+        /// Splits @fullString on @s_separatorForExtensionsPathSearchPaths
+        /// </summary>
+        /// FIXME: handle ; in path on Unix
+        private static List<string> SplitSearchPaths(string fullString) => fullString
+                                                                        .Split(new[] {s_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries)
+                                                                        .Distinct().ToList();
+
+        /// <summary>
+        /// Returns true if @value might have a property reference
+        /// </summary>
+        private static bool HasPropertyReference(string value) => value.Contains("$(");
 
         /// <summary>
         /// Factory for serialization.

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -41,12 +41,6 @@ namespace Microsoft.Build.Evaluation
         private bool _configurationReadAttempted = false;
 
         /// <summary>
-        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
-        /// the config file
-        /// </summary>
-        private char _separatorForExtensionsPathSearchPaths = ';';
-
-        /// <summary>
         /// Cached values of tools version -> project import search paths table
         /// </summary>
         private readonly Dictionary<string, Dictionary<string, ProjectImportPathMatch>> _projectImportSearchPathsCache;
@@ -239,13 +233,7 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
-                //FIXME: handle ; in path on Unix
-                var paths = property.Value
-                    .Split(new[] {_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries)
-                    .Distinct()
-                    .Where(path => !string.IsNullOrEmpty(path));
-
-                pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, paths.ToList()));
+                pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, property.Value));
             }
 
             return pathsTable;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1936,9 +1936,11 @@ namespace Microsoft.Build.Evaluation
             var fallbackSearchPathMatch = _data.Toolset.GetProjectImportSearchPaths(importElement.Project);
             sdkResult = null;
 
+            IList<string> onlyFallbackSearchPaths = fallbackSearchPathMatch.GetExpandedSearchPaths(fallbackPath => _data.ExpandString(fallbackPath));
+
             // no reference or we need to lookup only the default path,
             // so, use the Import path
-            if (fallbackSearchPathMatch.Equals(ProjectImportPathMatch.None))
+            if (fallbackSearchPathMatch.Equals(ProjectImportPathMatch.None) || onlyFallbackSearchPaths.Count == 0)
             {
                 List<ProjectRootElement> projects;
                 ExpandAndLoadImportsFromUnescapedImportExpressionConditioned(directoryOfImportingFile, importElement, out projects, out sdkResult);
@@ -1990,15 +1992,16 @@ namespace Microsoft.Build.Evaluation
             // Adding the value of $(MSBuildExtensionsPath*) property to the list of search paths
             var prop = _data.GetProperty(fallbackSearchPathMatch.PropertyName);
 
-            var pathsToSearch = new string[fallbackSearchPathMatch.SearchPaths.Count + 1];
-            pathsToSearch[0] = prop?.EvaluatedValue;                       // The actual value of the property, with no fallbacks
-            fallbackSearchPathMatch.SearchPaths.CopyTo(pathsToSearch, 1);  // The list of fallbacks, in order
-            
+            var expandedPathsToSearch = new List<string>();
+            expandedPathsToSearch.Add(prop?.EvaluatedValue);                       // The actual value of the property, with no fallbacks
+
+            expandedPathsToSearch.AddRange(onlyFallbackSearchPaths);
+
             string extensionPropertyRefAsString = fallbackSearchPathMatch.MsBuildPropertyFormat;
 
             _evaluationLoggingContext.LogComment(MessageImportance.Low, "SearchPathsForMSBuildExtensionsPath",
                                         extensionPropertyRefAsString,
-                                        String.Join(";", pathsToSearch));
+                                        String.Join(";", expandedPathsToSearch));
 
             bool atleastOneExactFilePathWasLookedAtAndNotFound = false;
 
@@ -2010,14 +2013,12 @@ namespace Microsoft.Build.Evaluation
             // Try every extension search path, till we get a Hit:
             // 1. 1 or more project files loaded
             // 2. 1 or more project files *found* but ignored (like circular, self imports)
-            foreach (var extensionPath in pathsToSearch)
+            foreach (var extensionPathExpanded in expandedPathsToSearch)
             {
                 // In the rare case that the property we've enabled for search paths hasn't been defined
                 // we will skip it, but continue with other paths in the fallback order.
-                if (string.IsNullOrEmpty(extensionPath))
+                if (string.IsNullOrEmpty(extensionPathExpanded))
                     continue;
-
-                string extensionPathExpanded = _data.ExpandString(extensionPath);
 
                 if (!_fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded))
                 {
@@ -2077,7 +2078,7 @@ namespace Microsoft.Build.Evaluation
                 atleastOneExactFilePathWasLookedAtAndNotFound &&
                 (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) == 0)
             {
-                ThrowForImportedProjectWithSearchPathsNotFound(fallbackSearchPathMatch, importElement);
+                ThrowForImportedProjectWithSearchPathsNotFound(fallbackSearchPathMatch, onlyFallbackSearchPaths, importElement);
             }
 
             return allProjects;
@@ -2657,7 +2658,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="searchPathMatch">MSBuildExtensionsPath reference kind found in the Project attribute of the Import element</param>
         /// <param name="importElement">The importing element for this import</param>
         /// </summary>
-        private void ThrowForImportedProjectWithSearchPathsNotFound(ProjectImportPathMatch searchPathMatch, ProjectImportElement importElement)
+        private void ThrowForImportedProjectWithSearchPathsNotFound(ProjectImportPathMatch searchPathMatch, IList<string> onlyFallbackSearchPaths, ProjectImportElement importElement)
         {
             var extensionsPathProp = _data.GetProperty(searchPathMatch.PropertyName);
             string importExpandedWithDefaultPath;
@@ -2681,8 +2682,6 @@ namespace Microsoft.Build.Evaluation
                 importExpandedWithDefaultPath = importElement.Project;
                 relativeProjectPath = importElement.Project;
             }
-
-            var onlyFallbackSearchPaths = searchPathMatch.SearchPaths.Select(s => _data.ExpandString(s)).ToList();
 
             string stringifiedListOfSearchPaths = StringifyList(onlyFallbackSearchPaths);
 

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -115,6 +115,11 @@
             <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
           </searchPaths>
+          <searchPaths os="osx">
+            <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+          </searchPaths>
         </projectImportSearchPaths>
       </toolset>
     </msbuildToolsets>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -116,9 +116,9 @@
             <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
           </searchPaths>
           <searchPaths os="osx">
-            <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
-            <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
-            <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath32" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath64" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
           </searchPaths>
         </projectImportSearchPaths>
       </toolset>


### PR DESCRIPTION
Add property allowing users to override fallback paths for MSBuildExtensionsPath.

For OSX, this essentially sets the fallback paths to:

`<property name="MSBuildExtensionsPath" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/" />`

.. whichs allows the default fallback paths to be overridden by setting
a property - `$(MSBuildExtensionsPathFallbackPathsOverride)`.

One of the useful use cases for this is to be able to run tests with
in-tree builds of assemblies/targets meant for
`$(MSBuildExtensionsPath)/`. Simply changing `$(MSBuildExtensionsPath)` would
mean that the in-tree builds of the custom frameworks would work but the
default ones would not be found!