### PR TITLE
Skip tf-compat checks for solution dependencies

### DIFF
--- a/src/Tasks/ResolveProjectBase.cs
+++ b/src/Tasks/ResolveProjectBase.cs
@@ -293,6 +293,7 @@ namespace Microsoft.Build.Tasks
                     item.SetMetadata("ReferenceOutputAssembly", "false");
                     item.SetMetadata("LinkLibraryDependencies", "false");
                     item.SetMetadata("CopyLocal", "false");
+                    item.SetMetadata("SkipGetTargetFrameworkProperties", "true");
 
                     updatedProjectReferenceList.Add(item);
                 }


### PR DESCRIPTION
Explicitly opts synthetic project references injected by solution
dependencies out of the TargetFramework-compatibility/find-best-match
dance instituted in 15.x for .NET Standard support.

Fixes #1915 and the most common cause of #2661.

Note: I proposed this in https://github.com/Microsoft/msbuild/pull/2867, but we decided not to take it, as it seemed redundant with the change to ignore TF compat when `ReferenceOutputAssembly=false`. But that had to be rolled back, because several repos depended on TF checks in that case. This is more scoped: it affects only solution build order dependencies. Hopefully that means that it only unblocks people and doesn't create new breaks.