### PR TITLE
Add source build switches in order to be able to build source-build on windows

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -218,23 +218,26 @@ function Build {
 
   echo "Repo toolset used from: $RepoToolsetBuildProj"
 
-  $createTlb = $true
   if ($DotNetBuildFromSource)
   {
     $solution = Join-Path $RepoRoot "MSBuild.SourceBuild.sln"
-    $createTlb = $false
   }
   else
   {
     $solution = Join-Path $RepoRoot "MSBuild.sln"
   }
 
-  $commonMSBuildArgs = "/m", "/clp:Summary", "/v:$verbosity", "/p:Configuration=$configuration", "/p:Projects=$solution", "/p:CIBuild=$ci", "/p:RepoRoot=$reporoot", "/p:DisableNerdbankVersioning=$DotNetBuildFromSource", "/p:CreateTlb=$createTlb"
+  $commonMSBuildArgs = "/m", "/clp:Summary", "/v:$verbosity", "/p:Configuration=$configuration", "/p:Projects=$solution", "/p:CIBuild=$ci", "/p:RepoRoot=$reporoot"
   if ($ci)
   {
     # Only enable warnaserror on CI runs.  For local builds, we will generate a warning if we can't run EditBin because
     # the C++ tools aren't installed, and we don't want this to fail the build
     $commonMSBuildArgs = $commonMSBuildArgs + "/warnaserror"
+  }
+
+  if ($DotnetBuildFromSource)
+  {
+    $commonMSBuildArgs = $commonMSBuildArgs + "/p:CreateTlb=false"
   }
 
   if ($hostType -ne 'full')


### PR DESCRIPTION
I'm not sure if this should go against master.

The windows build script was missing the DotNetBuildFromSource and DotNetCoreSdkDir parameters in order to build msbuild on source-build as we do for non-Windows.

cc: @rainersigwald @weshaggard 