### PR TITLE
Speed up Copy task by 2-3X

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Utilities
     /// </summary>
     internal class Traits
     {
-        private static Traits _instance = new Traits();
+        private static readonly Traits _instance = new Traits();
         public static Traits Instance
         {
             get
@@ -26,6 +26,11 @@ namespace Microsoft.Build.Utilities
 #endif
                 return _instance;
             }
+        }
+
+        public Traits()
+        {
+            EscapeHatches = new EscapeHatches();
         }
 
         public EscapeHatches EscapeHatches { get; }
@@ -47,17 +52,27 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool MSBuildCacheFileEnumerations = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileEnumerations"));
 
-        public Traits()
-        {
-            EscapeHatches = new EscapeHatches();
-        }
-
         public readonly bool EnableAllPropertyFunctions = Environment.GetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS") == "1";
 
         /// <summary>
         /// Enable restore first functionality in MSBuild.exe
         /// </summary>
         public readonly bool EnableRestoreFirst = Environment.GetEnvironmentVariable("MSBUILDENABLERESTOREFIRST") == "1";
+
+        /// <summary>
+        /// Setting the associated environment variable to 1 restores the pre-15.8 single
+        /// threaded (slower) copy behavior. Zero implies Int32.MaxValue, less than zero
+        /// (default) uses the empirical default in Copy.cs, greater than zero can allow
+        /// perf tuning beyond the defaults chosen.
+        /// </summary>
+        public readonly int CopyTaskParallelism = ParseIntFromEnvironmentVariableOrDefault("MSBUILDCOPYTASKPARALLELISM", -1);
+
+        private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
+        {
+            return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)
+                ? result
+                : defaultValue;
+        }
     }
 
     internal class EscapeHatches
@@ -106,10 +121,12 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool WarnOnUninitializedProperty = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY"));
 
-        // MSBUILDUSECASESENSITIVEITEMNAMES is an escape hatch for the fix
-        // for https://github.com/Microsoft/msbuild/issues/1751. It should
-        // be removed (permanently set to false) after establishing that
-        // it's unneeded (at least by the 16.0 timeframe).
+        /// <summary>
+        /// MSBUILDUSECASESENSITIVEITEMNAMES is an escape hatch for the fix
+        /// for https://github.com/Microsoft/msbuild/issues/1751. It should
+        /// be removed (permanently set to false) after establishing that
+        /// it's unneeded (at least by the 16.0 timeframe).
+        /// </summary>
         public readonly bool UseCaseSensitiveItemNames = Environment.GetEnvironmentVariable("MSBUILDUSECASESENSITIVEITEMNAMES") == "1";
 
         /// <summary>
@@ -132,7 +149,6 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool EnsureStdOutForChildNodesIsPrimaryStdout = Environment.GetEnvironmentVariable("MSBUILDENSURESTDOUTFORTASKPROCESSES") == "1";
 
-
         private static bool? ParseNullableBoolFromEnvironmentVariable(string environmentVariable)
         {
             var value = Environment.GetEnvironmentVariable(environmentVariable);
@@ -142,8 +158,7 @@ namespace Microsoft.Build.Utilities
                 return null;
             }
 
-            bool result;
-            if (bool.TryParse(value, out result))
+            if (bool.TryParse(value, out bool result))
             {
                 return result;
             }

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -297,50 +297,50 @@ namespace Microsoft.Build.UnitTests
                     }
                 }
 
-                if (eventArgs is ExternalProjectStartedEventArgs)
+                if (eventArgs is ExternalProjectStartedEventArgs args)
                 {
-                    this.ExternalProjectStartedEvents.Add((ExternalProjectStartedEventArgs) eventArgs);
+                    ExternalProjectStartedEvents.Add(args);
                 }
                 else if (eventArgs is ExternalProjectFinishedEventArgs)
                 {
-                    this.ExternalProjectFinishedEvents.Add((ExternalProjectFinishedEventArgs) eventArgs);
+                    ExternalProjectFinishedEvents.Add((ExternalProjectFinishedEventArgs) eventArgs);
                 }
 
-                if (eventArgs is ProjectStartedEventArgs)
+                if (eventArgs is ProjectStartedEventArgs startedEventArgs)
                 {
-                    this.ProjectStartedEvents.Add((ProjectStartedEventArgs) eventArgs);
+                    ProjectStartedEvents.Add(startedEventArgs);
                 }
                 else if (eventArgs is ProjectFinishedEventArgs)
                 {
-                    this.ProjectFinishedEvents.Add((ProjectFinishedEventArgs) eventArgs);
+                    ProjectFinishedEvents.Add((ProjectFinishedEventArgs) eventArgs);
                 }
                 else if (eventArgs is TargetStartedEventArgs)
                 {
-                    this.TargetStartedEvents.Add((TargetStartedEventArgs) eventArgs);
+                    TargetStartedEvents.Add((TargetStartedEventArgs) eventArgs);
                 }
                 else if (eventArgs is TargetFinishedEventArgs)
                 {
-                    this.TargetFinishedEvents.Add((TargetFinishedEventArgs) eventArgs);
+                    TargetFinishedEvents.Add((TargetFinishedEventArgs) eventArgs);
                 }
                 else if (eventArgs is TaskStartedEventArgs)
                 {
-                    this.TaskStartedEvents.Add((TaskStartedEventArgs) eventArgs);
+                    TaskStartedEvents.Add((TaskStartedEventArgs) eventArgs);
                 }
                 else if (eventArgs is TaskFinishedEventArgs)
                 {
-                    this.TaskFinishedEvents.Add((TaskFinishedEventArgs) eventArgs);
+                    TaskFinishedEvents.Add((TaskFinishedEventArgs) eventArgs);
                 }
                 else if (eventArgs is BuildMessageEventArgs)
                 {
-                    this.BuildMessageEvents.Add((BuildMessageEventArgs) eventArgs);
+                    BuildMessageEvents.Add((BuildMessageEventArgs) eventArgs);
                 }
                 else if (eventArgs is BuildStartedEventArgs)
                 {
-                    this.BuildStartedEvents.Add((BuildStartedEventArgs) eventArgs);
+                    BuildStartedEvents.Add((BuildStartedEventArgs) eventArgs);
                 }
                 else if (eventArgs is BuildFinishedEventArgs)
                 {
-                    this.BuildFinishedEvents.Add((BuildFinishedEventArgs) eventArgs);
+                    BuildFinishedEvents.Add((BuildFinishedEventArgs) eventArgs);
 
                     if (!AllowTaskCrashes)
                     {

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Build.UnitTests
                 }
                 else if (eventArgs is BuildErrorEventArgs)
                 {
-                    BuildErrorEventArgs e = (BuildErrorEventArgs) eventArgs;
+                    var e = (BuildErrorEventArgs) eventArgs;
 
                     string logMessage = string.Format(
                         "{0}({1},{2}): {3} error {4}: {5}",
@@ -288,8 +288,7 @@ namespace Microsoft.Build.UnitTests
                 else
                 {
                     // Log the message unless we are a build finished event and logBuildFinished is set to false.
-                    bool logMessage = !(eventArgs is BuildFinishedEventArgs) ||
-                                      (eventArgs is BuildFinishedEventArgs && LogBuildFinished);
+                    bool logMessage = !(eventArgs is BuildFinishedEventArgs) || LogBuildFinished;
                     if (logMessage)
                     {
                         _fullLog.AppendLine(eventArgs.Message);
@@ -365,12 +364,9 @@ namespace Microsoft.Build.UnitTests
         {
             get
             {
-                if (s_engineResourceManager == null)
-                {
-                     s_engineResourceManager = new ResourceManager("Microsoft.Build.Strings", typeof(ProjectCollection).GetTypeInfo().Assembly);
-                }
-
-                return s_engineResourceManager;
+                return s_engineResourceManager ?? (s_engineResourceManager = new ResourceManager(
+                           "Microsoft.Build.Strings",
+                           typeof(ProjectCollection).GetTypeInfo().Assembly));
             }
         }
 
@@ -400,7 +396,7 @@ namespace Microsoft.Build.UnitTests
         {
             lock (_lockObj)
             {
-                StringReader reader = new StringReader(FullLog);
+                var reader = new StringReader(FullLog);
                 int index = 0;
 
                 string currentLine = reader.ReadLine();

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2039,7 +2039,7 @@ namespace Microsoft.Build.UnitTests
         public CopyHardLink_Tests(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper)
         {
-            this.UseHardLinks = true;
+            UseHardLinks = true;
         }
 
         /// <summary>
@@ -2054,10 +2054,7 @@ namespace Microsoft.Build.UnitTests
             string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
             try
             {
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, true)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                {
-                    sw.Write("This is a source temp file.");
-                }
+                File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                 // Don't create the dest folder, let task do that
 
@@ -2082,12 +2079,7 @@ namespace Microsoft.Build.UnitTests
 
                 me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.HardLinkComment", sourceFile, destFile);
 
-                string destinationFileContents;
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                string destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination hard linked file to contain the contents of source file."
 
                 Assert.Equal(1, t.DestinationFiles.Length);
@@ -2098,17 +2090,10 @@ namespace Microsoft.Build.UnitTests
                 // Now we will write new content to the source file
                 // we'll then check that the destination file automatically
                 // has the same content (i.e. it's been hard linked)
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, false)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                {
-                    sw.Write("This is another source temp file.");
-                }
+                File.WriteAllText(sourceFile, "This is another source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                 // Read the destination file (it should have the same modified content as the source)
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is another source temp file.", destinationFileContents); //"Expected the destination hard linked file to contain the contents of source file. Even after modification of the source"
 
                 ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
@@ -2154,10 +2139,7 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, true)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                {
-                    sw.Write("This is a source temp file.");
-                }
+                File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                 ITaskItem[] sourceFiles = { new TaskItem(sourceFile) };
 
@@ -2186,12 +2168,7 @@ namespace Microsoft.Build.UnitTests
                 // me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.RetryingAsFileCopy", sourceFile, destFile, String.Empty);
                 me.AssertLogContains("0x80070011");
 
-                string destinationFileContents;
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                string destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination file to contain the contents of source file."
 
                 Assert.Equal(1, t.DestinationFiles.Length);
@@ -2202,17 +2179,10 @@ namespace Microsoft.Build.UnitTests
                 // Now we will write new content to the source file
                 // we'll then check that the destination file automatically
                 // has the same content (i.e. it's been hard linked)
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, false)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                {
-                    sw.Write("This is another source temp file.");
-                }
+                File.WriteAllText(sourceFile, "This is another source temp file.");  // HIGHCHAR: Test writes in UTF8 without preamble.
 
                 // Read the destination file (it should have the same modified content as the source)
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination copied file to contain the contents of original source file only."
 
                 ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
@@ -2246,13 +2216,9 @@ namespace Microsoft.Build.UnitTests
 
             try
             {
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, true))    // HIGHCHAR: Test writes in UTF8 without preamble.
-                    sw.Write("This is a source temp file.");
+                File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
-                if (!Directory.Exists(destFolder))
-                {
-                    Directory.CreateDirectory(destFolder);
-                }
+                Directory.CreateDirectory(destFolder);
 
                 // Exhaust the number (1024) of directory entries that can be created for a file
                 // This is 1 + (1 x hard links)
@@ -2291,12 +2257,7 @@ namespace Microsoft.Build.UnitTests
                 // me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.RetryingAsFileCopy", sourceFile, destFile, String.Empty);
                 me.AssertLogContains("0x80070476");
 
-                string destinationFileContents;
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                string destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination file to contain the contents of source file."
 
                 Assert.Equal(1, t.DestinationFiles.Length);
@@ -2307,17 +2268,10 @@ namespace Microsoft.Build.UnitTests
                 // Now we will write new content to the source file
                 // we'll then check that the destination file automatically
                 // has the same content (i.e. it's been hard linked)
-                using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, false)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                {
-                    sw.Write("This is another source temp file.");
-                }
+                File.WriteAllText(sourceFile, "This is another source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                 // Read the destination file (it should have the same modified content as the source)
-                using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                {
-                    destinationFileContents = sr.ReadToEnd();
-                }
-
+                destinationFileContents = File.ReadAllText(destFile);
                 Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination copied file to contain the contents of original source file only."
 
                 ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
@@ -2364,10 +2318,7 @@ namespace Microsoft.Build.UnitTests
                 string destFile = Path.Combine(destFolder, Path.GetFileName(sourceFile));
                 try
                 {
-                    using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, true)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                    {
-                        sw.Write("This is a source temp file.");
-                    }
+                    File.WriteAllText(sourceFile, "This is a source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                     // Don't create the dest folder, let task do that
 
@@ -2393,11 +2344,7 @@ namespace Microsoft.Build.UnitTests
 
                     me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.SymbolicLinkComment", sourceFile, destFile);
 
-                    string destinationFileContents;
-
-                    using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                        destinationFileContents = sr.ReadToEnd();
-
+                    string destinationFileContents = File.ReadAllText(destFile);
                     Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination symbolic linked file to contain the contents of source file."
 
                     Assert.Equal(1, t.DestinationFiles.Length);
@@ -2409,21 +2356,13 @@ namespace Microsoft.Build.UnitTests
                     // we'll then check that the destination file automatically
                     // has the same content (i.e. it's been hard linked)
 
-                    using (StreamWriter sw = FileUtilities.OpenWrite(sourceFile, false)) // HIGHCHAR: Test writes in UTF8 without preamble.
-                    {
-                        sw.Write("This is another source temp file.");
-                    }
+                    File.WriteAllText(sourceFile, "This is another source temp file."); // HIGHCHAR: Test writes in UTF8 without preamble.
 
                     // Read the destination file (it should have the same modified content as the source)
-                    using (StreamReader sr = FileUtilities.OpenRead(destFile))
-                    {
-                        destinationFileContents = sr.ReadToEnd();
-                    }
-
+                    destinationFileContents = File.ReadAllText(destFile);
                     Assert.Equal("This is another source temp file.", destinationFileContents); //"Expected the destination hard linked file to contain the contents of source file. Even after modification of the source"
 
                     ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3891"); // Didn't do retries
-
                 }
                 finally
                 {

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -1369,7 +1369,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(4, t.CopiedFiles.Length);
 
             // Copy calls to different destinations can come in any order when running in parallel.
-            filesActuallyCopied.Select(f => f.Key.Name).ShouldBe(new[] { "a.cs", "b.cs" }, ignoreOrder: true);
+            filesActuallyCopied.Select(f => Path.GetFileName(f.Key.Name)).ShouldBe(new[] { "a.cs", "b.cs" }, ignoreOrder: true);
 
             ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
         }

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -29,12 +29,15 @@ namespace Microsoft.Build.UnitTests
 
         public bool UseSymbolicLinks { get; protected set; }
 
-        /// <summary>
-        /// Max copy parallelism to provide to the Copy task.
-        /// </summary>
-        private const int ParallelismThreadCount = int.MaxValue;
+        public bool UseSingleThreadedCopy
+        {
+            get => _parallelismThreadCount == NoParallelismThreadCount;
+            protected set => _parallelismThreadCount = value ? NoParallelismThreadCount : DefaultParallelismThreadCount;
+        }
 
         private const int NoParallelismThreadCount = 1;
+        private const int DefaultParallelismThreadCount = int.MaxValue;
+        private int _parallelismThreadCount = DefaultParallelismThreadCount;
 
         /// <summary>
         /// Temporarily save off the value of MSBUILDALWAYSOVERWRITEREADONLYFILES, so that we can run 
@@ -79,25 +82,12 @@ namespace Microsoft.Build.UnitTests
             Copy.RefreshInternalEnvironmentValues();
         }
 
+        /// <summary>
+        /// If OnlyCopyIfDifferent is set to "true" then we shouldn't copy over files that
+        /// have the same date and time.
+        /// </summary>
         [Fact]
-        public void DontCopyOverSameFile_Parallel()
-        {
-            DontCopyOverSameFile(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void DontCopyOverSameFile_SingleThreaded()
-        {
-            DontCopyOverSameFile(NoParallelismThreadCount);
-        }
-
-        /*
-        * Method:   DontCopyOverSameFile
-        *
-        * If OnlyCopyIfDifferent is set to "true" then we shouldn't copy over files that
-        * have the same date and time.
-        */
-        private void DontCopyOverSameFile(int parallelism)
+        public void DontCopyOverSameFile()
         {
             string file = FileUtilities.GetTemporaryFile();
             try
@@ -122,7 +112,7 @@ namespace Microsoft.Build.UnitTests
                     UseHardlinksIfPossible = UseHardLinks
                 };
 
-                t.Execute(m.CopyFile, parallelism);
+                t.Execute(m.CopyFile, _parallelismThreadCount);
 
                 // Expect for there to have been no copies.
                 Assert.Equal(0, m.copyCount);
@@ -1329,23 +1319,12 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        [Fact]
-        public void CopyWithDuplicatesUsingFolder_Parallel()
-        {
-            CopyWithDuplicatesUsingFolder(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void CopyWithDuplicatesUsingFolder_SingleThreaded()
-        {
-            CopyWithDuplicatesUsingFolder(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// Copying duplicates should only perform the actual copy once for each unique source/destination pair
         /// but should still produce outputs for all specified source/destination pairs.
         /// </summary>
-        private void CopyWithDuplicatesUsingFolder(int parallelism)
+        [Fact]
+        public void CopyWithDuplicatesUsingFolder()
         {
             string tempPath = Path.GetTempPath();
 
@@ -1383,7 +1362,7 @@ namespace Microsoft.Build.UnitTests
                     filesActuallyCopied.Add(new KeyValuePair<FileState, FileState>(source, dest));
                 }
                 return true;
-            }, parallelism);
+            }, _parallelismThreadCount);
 
             Assert.True(success);
             Assert.Equal(2, filesActuallyCopied.Count);
@@ -1395,23 +1374,12 @@ namespace Microsoft.Build.UnitTests
             ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
         }
 
-        [Fact]
-        private void CopyWithDuplicatesUsingFiles_Parallel()
-        {
-            CopyWithDuplicatesUsingFiles(ParallelismThreadCount);
-        }
-
-        [Fact]
-        private void CopyWithDuplicatesUsingFiles_SingleThreaded()
-        {
-            CopyWithDuplicatesUsingFiles(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// Copying duplicates should only perform the actual copy once for each unique source/destination pair
         /// but should still produce outputs for all specified source/destination pairs.
         /// </summary>
-        private void CopyWithDuplicatesUsingFiles(int parallelism)
+        [Fact]
+        public void CopyWithDuplicatesUsingFiles()
         {
             string tempPath = Path.GetTempPath();
 
@@ -1459,7 +1427,7 @@ namespace Microsoft.Build.UnitTests
                     filesActuallyCopied.Add(new KeyValuePair<FileState, FileState>(source, dest));
                 }
                 return true;
-            }, parallelism);
+            }, _parallelismThreadCount);
 
             Assert.True(success);
             Assert.Equal(4, filesActuallyCopied.Count);
@@ -1680,23 +1648,12 @@ namespace Microsoft.Build.UnitTests
             engine.AssertLogContains("MSB3029");
         }
 
-        [Fact]
-        public void FailureWithNoRetries_Parallel()
-        {
-            FailureWithNoRetries(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void FailureWithNoRetries_SingleThreaded()
-        {
-            FailureWithNoRetries(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// Verifies that we do not log the retrying warning if we didn't request
         /// retries.
         /// </summary>
-        private void FailureWithNoRetries(int parallelism)
+        [Fact]
+        public void FailureWithNoRetries()
         {
             var engine = new MockEngine(true /* log to console */);
             var t = new Copy
@@ -1710,7 +1667,7 @@ namespace Microsoft.Build.UnitTests
             };
             
             var copyFunctor = new CopyFunctor(2, false /* do not throw on failure */);
-            bool result = t.Execute(copyFunctor.Copy, parallelism);
+            bool result = t.Execute(copyFunctor.Copy, _parallelismThreadCount);
 
             Assert.Equal(false, result);
             engine.AssertLogDoesntContain("MSB3026");
@@ -1756,23 +1713,12 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(false, t.UseHardlinksIfPossible);
         }
 
-        [Fact]
-        public void SuccessAfterOneRetry_Parallel()
-        {
-            SuccessAfterOneRetry(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void SuccessAfterOneRetry_SingleThreaded()
-        {
-            SuccessAfterOneRetry(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// Verifies that we get the one retry we ask for after the first attempt fails,
         /// and we get appropriate messages.
         /// </summary>
-        public void SuccessAfterOneRetry(int parallelism)
+        [Fact]
+        public void SuccessAfterOneRetry()
         {
             var engine = new MockEngine(true /* log to console */);
             var t = new Copy
@@ -1786,29 +1732,18 @@ namespace Microsoft.Build.UnitTests
             };
 
             var copyFunctor = new CopyFunctor(2, false /* do not throw on failure */);
-            bool result = t.Execute(copyFunctor.Copy, parallelism);
+            bool result = t.Execute(copyFunctor.Copy, _parallelismThreadCount);
 
             Assert.Equal(true, result);
             engine.AssertLogContains("MSB3026");
             engine.AssertLogDoesntContain("MSB3027");
         }
 
-        [Fact]
-        public void SuccessAfterOneRetryContinueToNextFile_Parallel()
-        {
-            SuccessAfterOneRetryContinueToNextFile(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void SuccessAfterOneRetryContinueToNextFile_SingleThreaded()
-        {
-            SuccessAfterOneRetryContinueToNextFile(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// Verifies that after a successful retry we continue to the next file
         /// </summary>
-        private void SuccessAfterOneRetryContinueToNextFile(int parallelism)
+        [Fact]
+        public void SuccessAfterOneRetryContinueToNextFile()
         {
             var engine = new MockEngine(true /* log to console */);
             var t = new Copy
@@ -1822,7 +1757,7 @@ namespace Microsoft.Build.UnitTests
             };
 
             var copyFunctor = new CopyFunctor(2, false /* do not throw on failure */);
-            bool result = t.Execute(copyFunctor.Copy, parallelism);
+            bool result = t.Execute(copyFunctor.Copy, _parallelismThreadCount);
 
             Assert.Equal(true, result);
             engine.AssertLogContains("MSB3026");
@@ -1833,23 +1768,12 @@ namespace Microsoft.Build.UnitTests
             Assert.True(copyFunctor.FilesCopiedSuccessfully.Any(f => f.Name == FileUtilities.FixFilePath("c:\\source2")));
         }
 
-        [Fact]
-        public void TooFewRetriesReturnsFalse_Parallel()
-        {
-            TooFewRetriesReturnsFalse(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void TooFewRetriesReturnsFalse_SingleThreaded()
-        {
-            TooFewRetriesReturnsFalse(NoParallelismThreadCount);
-        }
-
         /// <summary>
         /// The copy delegate can return false, or throw on failure.
         /// This test tests returning false.
         /// </summary>
-        private void TooFewRetriesReturnsFalse(int parallelism)
+        [Fact]
+        public void TooFewRetriesReturnsFalse()
         {
             var engine = new MockEngine(true /* log to console */);
             var t = new Copy
@@ -1863,30 +1787,20 @@ namespace Microsoft.Build.UnitTests
             };
 
             var copyFunctor = new CopyFunctor(4, false /* do not throw */);
-            bool result = t.Execute(copyFunctor.Copy, parallelism);
+            bool result = t.Execute(copyFunctor.Copy, _parallelismThreadCount);
 
             Assert.Equal(false, result);
             engine.AssertLogContains("MSB3026");
             engine.AssertLogContains("MSB3027");
         }
 
-        [Fact]
-        public void TooFewRetriesThrows_Parallel()
-        {
-            TooFewRetriesThrows(ParallelismThreadCount);
-        }
-
-        [Fact]
-        public void TooFewRetriesThrows_SingleThreaded()
-        {
-            TooFewRetriesThrows(NoParallelismThreadCount);
-        }
 
         /// <summary>
         /// The copy delegate can return false, or throw on failure.
         /// This test tests the throw case.
         /// </summary>
-        private void TooFewRetriesThrows(int parallelism)
+        [Fact]
+        public void TooFewRetriesThrows()
         {
             var engine = new MockEngine(true /* log to console */);
             var t = new Copy
@@ -1900,7 +1814,7 @@ namespace Microsoft.Build.UnitTests
             };
 
             var copyFunctor = new CopyFunctor(3, true /* throw */);
-            bool result = t.Execute(copyFunctor.Copy, parallelism);
+            bool result = t.Execute(copyFunctor.Copy, _parallelismThreadCount);
 
             Assert.Equal(false, result);
             engine.AssertLogContains("MSB3026");
@@ -1973,6 +1887,15 @@ namespace Microsoft.Build.UnitTests
 
                 return null;
             }
+        }
+    }
+
+    public class CopySingleThreaded_Tests : Copy_Tests
+    {
+        public CopySingleThreaded_Tests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+            UseSingleThreadedCopy = true;
         }
     }
 

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -17,6 +17,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,7 +32,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Max copy parallelism to provide to the Copy task.
         /// </summary>
-        public int ParallelismThreadCount { get; set; } = int.MaxValue;
+        private const int ParallelismThreadCount = int.MaxValue;
 
         private const int NoParallelismThreadCount = 1;
 
@@ -1389,16 +1390,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(4, t.CopiedFiles.Length);
 
             // Copy calls to different destinations can come in any order when running in parallel.
-
-            string aPath = Path.Combine(tempPath, "foo", "a.cs");
-            var aCopies = filesActuallyCopied.Where(f => f.Value.Name == aPath).ToList();
-            Assert.Equal(1, aCopies.Count);
-            Assert.Equal(Path.Combine(tempPath, "a.cs"), aCopies[0].Key.Name);
-
-            string bPath = Path.Combine(tempPath, "foo", "b.cs");
-            var bCopies = filesActuallyCopied.Where(f => f.Value.Name == bPath).ToList();
-            Assert.Equal(1, bCopies.Count);
-            Assert.Equal(Path.Combine(tempPath, "b.cs"), bCopies[0].Key.Name);
+            filesActuallyCopied.Select(f => f.Key.Name).ShouldBe(new[] { "a.cs", "b.cs" }, ignoreOrder: true);
 
             ((MockEngine)t.BuildEngine).AssertLogDoesntContain("MSB3026"); // Didn't do retries
         }
@@ -1474,7 +1466,6 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(5, t.CopiedFiles.Length);
 
             // Copy calls to different destinations can come in any order when running in parallel.
-
             string xaPath = Path.Combine(tempPath, "xa.cs");
             var xaCopies = filesActuallyCopied.Where(f => f.Value.Name == xaPath).ToList();
             Assert.Equal(3, xaCopies.Count);

--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -2071,7 +2071,7 @@ namespace Microsoft.Build.UnitTests
                 me.AssertLogContainsMessageFromResource(resourceDelegate, "Copy.HardLinkComment", sourceFile, destFile);
 
                 string destinationFileContents = File.ReadAllText(destFile);
-                Assert.Equal("This is a source temp file.", destinationFileContents); //"Expected the destination hard linked file to contain the contents of source file."
+                Assert.Equal("This is a source temp file.", destinationFileContents);
 
                 Assert.Equal(1, t.DestinationFiles.Length);
                 Assert.Equal(1, t.CopiedFiles.Length);
@@ -2125,7 +2125,7 @@ namespace Microsoft.Build.UnitTests
             }
             catch (Exception)
             {
-                Console.WriteLine("CopyToDestinationFolderWithHardLinkFallbackNetwork test could not access the network as expected.");
+                Console.WriteLine("CopyToDestinationFolderWithHardLinkFallbackNetwork test could not access the network.");
                 // Something caused us to not be able to access our "network" share, don't fail.
                 return;
             }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -362,7 +362,10 @@ namespace Microsoft.Build.Tasks
 
             // Track successfully copied subset.
             List <ITaskItem> destinationFilesSuccessfullyCopied;
-            bool success = parallelism == 1
+
+            // Use single-threaded code path when requested or when there is only copy to make
+            // (no need to create all the parallel infrastructure for that case).
+            bool success = parallelism == 1 || DestinationFiles.Length == 1
                 ? CopySingleThreaded(copyFile, out destinationFilesSuccessfullyCopied)
                 : CopyParallel(copyFile, parallelism, out destinationFilesSuccessfullyCopied);
 
@@ -374,15 +377,14 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Original copy code that performs single-threaded copies.
-        /// Kept as-is for comparison to parallel algo. We can eliminate this algo once that has enough mileage
-        /// (parallelism=1 can be handled by the ActionBlock in the parallel implementation).
+        /// Used for single-file copies and when parallelism is 1.
         /// </summary>
         private bool CopySingleThreaded(
             CopyFileWithState copyFile,
             out List<ITaskItem> destinationFilesSuccessfullyCopied)
         {
             bool success = true;
-            destinationFilesSuccessfullyCopied = new List<ITaskItem>();
+            destinationFilesSuccessfullyCopied = new List<ITaskItem>(DestinationFiles.Length);
 
             // Set of files we actually copied and the location from which they were originally copied.  The purpose
             // of this collection is to let us skip copying duplicate files.  We will only copy the file if it 
@@ -542,7 +544,7 @@ namespace Microsoft.Build.Tasks
             partitionCopyActionBlock.Completion.GetAwaiter().GetResult();
 
             // Assemble an in-order list of destination items that succeeded.
-            destinationFilesSuccessfullyCopied = new List<ITaskItem>(successIndices.Count);
+            destinationFilesSuccessfullyCopied = new List<ITaskItem>(DestinationFiles.Length);
             int[] successIndicesSorted = successIndices.ToArray();
             Array.Sort(successIndicesSorted);
             foreach (int successIndex in successIndicesSorted)

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Build.Tasks
                 sourceIndices.Add(i);
             }
 
-            var successIndices = new ConcurrentBag<int>();
+            var successFlags = new IntPtr[DestinationFiles.Length];  // Lockless flags updated from each thread.
             var actionBlockOptions = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = parallelism };
             var partitionCopyActionBlock = new ActionBlock<List<int>>(
                 async (List<int> partition) =>
@@ -523,7 +523,7 @@ namespace Microsoft.Build.Tasks
                         if (copyComplete)
                         {
                             sourceItem.CopyMetadataTo(destItem);
-                            successIndices.Add(fileIndex);
+                            successFlags[fileIndex] = (IntPtr)1;
                         }
                     }
                 },
@@ -545,11 +545,12 @@ namespace Microsoft.Build.Tasks
 
             // Assemble an in-order list of destination items that succeeded.
             destinationFilesSuccessfullyCopied = new List<ITaskItem>(DestinationFiles.Length);
-            int[] successIndicesSorted = successIndices.ToArray();
-            Array.Sort(successIndicesSorted);
-            foreach (int successIndex in successIndicesSorted)
+            for (int i = 0; i < successFlags.Length; i++)
             {
-                destinationFilesSuccessfullyCopied.Add(DestinationFiles[successIndex]);
+                if (successFlags[i] != (IntPtr)0)
+                {
+                    destinationFilesSuccessfullyCopied.Add(DestinationFiles[i]);
+                }
             }
 
             return success;

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Tasks
 
         #region Properties
 
-        private bool _canceling;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         // Bool is just a placeholder, we're mainly interested in a threadsafe key set.
         private readonly ConcurrentDictionary<string, bool> _directoriesKnownToExist = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
@@ -125,7 +125,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public void Cancel()
         {
-            _canceling = true;
+            _cancellationTokenSource.Cancel();
         }
 
         #region ITask Members
@@ -372,7 +372,7 @@ namespace Microsoft.Build.Tasks
             // copiedFiles contains only the copies that were successful.
             CopiedFiles = destinationFilesSuccessfullyCopied.ToArray();
 
-            return success && !_canceling;
+            return success && !_cancellationTokenSource.IsCancellationRequested;
         }
 
         /// <summary>
@@ -396,7 +396,7 @@ namespace Microsoft.Build.Tasks
                 StringComparer.OrdinalIgnoreCase);
 
             // Now that we have a list of destinationFolder files, copy from source to destinationFolder.
-            for (int i = 0; i < SourceFiles.Length && !_canceling; ++i)
+            for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
                 bool copyComplete = false;
                 string destPath = DestinationFiles[i].ItemSpec;
@@ -469,7 +469,7 @@ namespace Microsoft.Build.Tasks
                 DestinationFiles.Length, // Set length to common case of 1:1 source->dest.
                 StringComparer.OrdinalIgnoreCase);
 
-            for (int i = 0; i < SourceFiles.Length && !_canceling; ++i)
+            for (int i = 0; i < SourceFiles.Length && !_cancellationTokenSource.IsCancellationRequested; ++i)
             {
                 ITaskItem destItem = DestinationFiles[i];
                 string destPath = destItem.ItemSpec;
@@ -484,14 +484,18 @@ namespace Microsoft.Build.Tasks
 
             // Lockless flags updated from each thread - each needs to be a processor word for atomicity.
             var successFlags = new IntPtr[DestinationFiles.Length];
-            var actionBlockOptions = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = parallelism };
+            var actionBlockOptions = new ExecutionDataflowBlockOptions
+            {
+                MaxDegreeOfParallelism = parallelism,
+                CancellationToken = _cancellationTokenSource.Token
+            };
             var partitionCopyActionBlock = new ActionBlock<List<int>>(
                 async (List<int> partition) =>
                 {
                     // Break from synchronous thread context of caller to get onto thread pool thread.
                     await System.Threading.Tasks.Task.Yield();
 
-                    for (int partitionIndex = 0; partitionIndex < partition.Count; partitionIndex++)
+                    for (int partitionIndex = 0; partitionIndex < partition.Count && !_cancellationTokenSource.IsCancellationRequested; partitionIndex++)
                     {
                         int fileIndex = partition[partitionIndex];
                         ITaskItem sourceItem = SourceFiles[fileIndex];
@@ -536,7 +540,7 @@ namespace Microsoft.Build.Tasks
                 if (!partitionAccepted)
                 {
                     // Retail assert...
-                    ErrorUtilities.VerifyThrow(partitionAccepted,
+                    ErrorUtilities.VerifyThrow(false,
                         "Failed posting a file copy to an ActionBlock. Should not happen with block at max int capacity.");
                 }
             }
@@ -661,8 +665,7 @@ namespace Microsoft.Build.Tasks
                     // If we got here, then the file's time and size match AND
                     // the user set the SkipUnchangedFiles flag which means we
                     // should skip matching files.
-                    Log.LogMessageFromResources
-                    (
+                    Log.LogMessageFromResources(
                         MessageImportance.Low,
                         "Copy.DidNotCopyBecauseOfFileMatch",
                         sourceFileState.Name,
@@ -674,10 +677,17 @@ namespace Microsoft.Build.Tasks
                 // We only do the cheap check for identicalness here, we try the more expensive check
                 // of comparing the fullpaths of source and destination to see if they are identical,
                 // in the exception handler lower down.
-                else if (0 != String.Compare(sourceFileState.Name, destinationFileState.Name, StringComparison.OrdinalIgnoreCase))
+                else if (0 != String.Compare(
+                             sourceFileState.Name,
+                             destinationFileState.Name,
+                             StringComparison.OrdinalIgnoreCase))
                 {
                     success = DoCopyWithRetries(sourceFileState, destinationFileState, copyFile);
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                success = false;
             }
             catch (PathTooLongException e)
             {
@@ -700,7 +710,7 @@ namespace Microsoft.Build.Tasks
         {
             int retries = 0;
 
-            while (!_canceling)
+            while (!_cancellationTokenSource.IsCancellationRequested)
             {
                 try
                 {
@@ -709,6 +719,10 @@ namespace Microsoft.Build.Tasks
                     {
                         return result.Value;
                     }
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
                 {

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -878,20 +878,16 @@ namespace Microsoft.Build.Tasks
         }
 
     	private static int GetParallelismFromEnvironment()
-        {
-            string parallelismSetting = Environment.GetEnvironmentVariable("MSBuildCopyThreadParallelism");
-            if (int.TryParse(parallelismSetting, out int parallelism) && parallelism >= 0)
-            {
-                if (parallelism == 0)
-                {
-                    parallelism = int.MaxValue;
-                }
-            }
-            else
-            {
-                parallelism = DefaultCopyParallelism;
-            }
-
+	    {
+	        int parallelism = Traits.Instance.CopyTaskParallelism;
+	        if (parallelism < 0)
+	        {
+	            parallelism = DefaultCopyParallelism;
+	        }
+            else if (parallelism == 0)
+	        {
+	            parallelism = int.MaxValue;
+	        }
             return parallelism;
         }
     }

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -108,7 +108,9 @@ namespace Microsoft.Build.Tasks
         [Output]
         public ITaskItem[] DestinationFiles { get; set; }
 
-        // Subset that were successfully copied
+        /// <summary>
+        /// The subset of files that were successfully copied.
+        /// </summary>
         [Output]
         public ITaskItem[] CopiedFiles { get; private set; }
 

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -948,6 +948,7 @@
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24.0" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
     <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" ExcludeAssets="All" />
@@ -961,6 +962,7 @@
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Resources.Writer" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" ExcludeAssets="All" />
@@ -969,7 +971,6 @@
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">
     <PackageReference Include="System.Reflection.Metadata" Version="1.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <!--
       Content items in this project are used to copy files to the output directory but we don't

--- a/src/Utilities.UnitTests/Logger_Tests.cs
+++ b/src/Utilities.UnitTests/Logger_Tests.cs
@@ -2,13 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
-using System.Resources;
-using System.Reflection;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
 

--- a/src/Utilities/Logger.cs
+++ b/src/Utilities/Logger.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Runtime.InteropServices;
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 


### PR DESCRIPTION
For #3330 
- Kept original single-thread copy task for single-thread operation and added new TPL ActionBlock based parallel implementation.
- All UTs pass with old and new implementations
- See empirical time comparison numbers in table in Copy.cs. ~2X faster for SSD and ~3x for spinny disk.

