### PR TITLE
Fix master source-build

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -47,6 +47,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <VisualStudioSetupInteropVersion>1.16.30</VisualStudioSetupInteropVersion>
+    <MicrosoftNETCoreAppVersion Condition="'$(DotNetBuildFromSource)' == 'true'">2.1.0-rc1</MicrosoftNETCoreAppVersion>
 
     <!-- MSBuild custom overall switch -->
     <NuGetPackageVersion>4.8.0-preview1.5185</NuGetPackageVersion>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -128,6 +128,11 @@
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>
+
+    <!-- For source-build, we want to be able to float the compile-time version
+         of .NET Core references separately from the CLI version
+         workaround to: https://github.com/Microsoft/msbuild/issues/3344 -->
+    <DisableImplicitFrameworkReferences Condition="'$(DotNetBuildFromSource)' == 'true'">true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -62,6 +62,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppVersion)" Condition="'$(TargetFramework)' == 'netcoreapp2.1' AND '$(DotNetBuildFromSource)' == 'true'" PrivateAssets="All"/>
     <PackageReference Condition="'$(DisableNerdbankVersioning)' != 'true'" Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
   </ItemGroup>
   


### PR DESCRIPTION
In 15.7_sourcebuild we set explicitly the MicrosoftNETCoreAppVersion and add the packagereference to Microsoft.NETCore.App to assure we get the right version of reference assemblies to build against. My theory here is that we use the full msbuild to build the *.sln and not dotnet msbuild to build and that is causing to take VS's sdk instead of the bootstraped cli.

Just for reference this is what we have in 15.7_sourcebuild:

https://github.com/Microsoft/msbuild/blob/vs15.7_sourcebuild/src/Directory.Build.props#L63

https://github.com/Microsoft/msbuild/blob/vs15.7_sourcebuild/build/Versions.props#L50

cc: @rainersigwald @cdmihai 

