### PR TITLE
Code cleanup in Tasks\R*.cs

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -805,10 +805,10 @@ namespace Microsoft.Build.Tasks
         public RegisterAssembly() { }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem AssemblyListFile { get { throw null; } set { } }
-        public bool CreateCodeBase { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem AssemblyListFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool CreateCodeBase { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
         public void ReportEvent(System.Runtime.InteropServices.ExporterEventKind kind, int code, string msg) { }
         public object ResolveRef(System.Reflection.Assembly assemblyToResolve) { throw null; }
@@ -819,7 +819,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Directories { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] RemovedDirectories { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] RemovedDirectories { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public partial class RemoveDuplicates : Microsoft.Build.Tasks.TaskExtension
@@ -835,17 +835,17 @@ namespace Microsoft.Build.Tasks
     public sealed partial class RequiresFramework35SP1Assembly : Microsoft.Build.Tasks.TaskExtension
     {
         public RequiresFramework35SP1Assembly() { }
-        public Microsoft.Build.Framework.ITaskItem[] Assemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Assemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool CreateDesktopShortcut { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
-        public string ErrorReportUrl { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem[] ReferencedAssemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string ErrorReportUrl { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ReferencedAssemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public bool RequiresMinimumFramework35SP1 { get { throw null; } set { } }
-        public bool SigningManifests { get { throw null; } set { } }
-        public string SuiteName { get { throw null; } set { } }
+        public bool RequiresMinimumFramework35SP1 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SigningManifests { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SuiteName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
@@ -919,77 +919,77 @@ namespace Microsoft.Build.Tasks
     public sealed partial class ResolveCodeAnalysisRuleSet : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveCodeAnalysisRuleSet() { }
-        public string CodeAnalysisRuleSet { get { throw null; } set { } }
-        public string[] CodeAnalysisRuleSetDirectories { get { throw null; } set { } }
-        public string MSBuildProjectDirectory { get { throw null; } set { } }
+        public string CodeAnalysisRuleSet { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string[] CodeAnalysisRuleSetDirectories { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MSBuildProjectDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
+        public string ResolvedCodeAnalysisRuleSet { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class ResolveComReference : Microsoft.Build.Tasks.AppDomainIsolatedTaskExtension
     {
         public ResolveComReference() { }
-        public bool DelaySign { get { throw null; } set { } }
+        public bool DelaySign { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string[] EnvironmentVariables { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public bool ExecuteAsTool { get { throw null; } set { } }
-        public bool IncludeVersionInInteropName { get { throw null; } set { } }
-        public string KeyContainer { get { throw null; } set { } }
-        public string KeyFile { get { throw null; } set { } }
-        public bool NoClassMembers { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem[] ResolvedAssemblyReferences { get { throw null; } set { } }
+        public bool ExecuteAsTool { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool IncludeVersionInInteropName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string KeyContainer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string KeyFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool NoClassMembers { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedAssemblyReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ResolvedFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ResolvedModules { get { throw null; } set { } }
-        public string SdkToolsPath { get { throw null; } set { } }
-        public bool Silent { get { throw null; } set { } }
-        public string StateFile { get { throw null; } set { } }
-        public string TargetFrameworkVersion { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedModules { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string SdkToolsPath { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Silent { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string StateFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetFrameworkVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetProcessorArchitecture { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem[] TypeLibNames { get { throw null; } set { } }
-        public string WrapperOutputDirectory { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem[] TypeLibNames { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string WrapperOutputDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public partial class ResolveKeySource : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveKeySource() { }
-        public int AutoClosePasswordPromptShow { get { throw null; } set { } }
-        public int AutoClosePasswordPromptTimeout { get { throw null; } set { } }
-        public string CertificateFile { get { throw null; } set { } }
-        public string CertificateThumbprint { get { throw null; } set { } }
-        public string KeyFile { get { throw null; } set { } }
+        public int AutoClosePasswordPromptShow { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int AutoClosePasswordPromptTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CertificateFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CertificateThumbprint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string KeyFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedKeyContainer { get { throw null; } set { } }
+        public string ResolvedKeyContainer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedKeyFile { get { throw null; } set { } }
+        public string ResolvedKeyFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedThumbprint { get { throw null; } set { } }
-        public bool ShowImportDialogDespitePreviousFailures { get { throw null; } set { } }
-        public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
+        public string ResolvedThumbprint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ShowImportDialogDespitePreviousFailures { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SuppressAutoClosePasswordPrompt { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class ResolveManifestFiles : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveManifestFiles() { }
-        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { get { throw null; } set { } }
-        public Microsoft.Build.Framework.ITaskItem EntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem DeploymentManifestEntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public Microsoft.Build.Framework.ITaskItem EntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.ITaskItem[] ExtraFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] Files { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] ManagedAssemblies { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] NativeAssemblies { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] OutputAssemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] OutputAssemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem OutputDeploymentManifestEntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem OutputDeploymentManifestEntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem OutputEntryPoint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] OutputFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] OutputFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public Microsoft.Build.Framework.ITaskItem[] PublishFiles { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] SatelliteAssemblies { get { throw null; } set { } }
-        public bool SigningManifests { get { throw null; } set { } }
-        public string TargetCulture { get { throw null; } set { } }
+        public bool SigningManifests { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string TargetCulture { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetFrameworkVersion { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
@@ -999,17 +999,17 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.RequiredAttribute]
         public string[] AdditionalSearchPaths { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainedComComponents { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainedComComponents { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseEtcFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseEtcFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseTlbFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainedLooseTlbFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainedPrerequisiteAssemblies { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainedPrerequisiteAssemblies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainedTypeLibraries { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainedTypeLibraries { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ContainingReferenceFiles { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ContainingReferenceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] NativeReferences { get { throw null; } set { } }
         public override bool Execute() { throw null; }
@@ -1017,11 +1017,11 @@ namespace Microsoft.Build.Tasks
     public partial class ResolveNonMSBuildProjectOutput : Microsoft.Build.Tasks.ResolveProjectBase
     {
         public ResolveNonMSBuildProjectOutput() { }
-        public string PreresolvedProjectOutputs { get { throw null; } set { } }
+        public string PreresolvedProjectOutputs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] ResolvedOutputPaths { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedOutputPaths { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] UnresolvedProjectReferences { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public abstract partial class ResolveProjectBase : Microsoft.Build.Tasks.TaskExtension
@@ -1039,8 +1039,8 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] DisallowedSDKDependencies { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] InstalledSDKs { get { throw null; } set { } }
-        public bool LogResolutionErrorsAsWarnings { get { throw null; } set { } }
-        public bool Prefer32Bit { get { throw null; } set { } }
+        public bool LogResolutionErrorsAsWarnings { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool Prefer32Bit { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string ProjectName { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskItem[] References { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
@@ -1055,7 +1055,7 @@ namespace Microsoft.Build.Tasks
         public string TargetPlatformIdentifier { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string TargetPlatformVersion { get { throw null; } set { } }
-        public bool WarnOnMissingPlatformVersion { get { throw null; } set { } }
+        public bool WarnOnMissingPlatformVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class RoslynCodeTaskFactory : Microsoft.Build.Framework.ITaskFactory

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Directories { get { throw null; } set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public Microsoft.Build.Framework.ITaskItem[] RemovedDirectories { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] RemovedDirectories { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public partial class RemoveDuplicates : Microsoft.Build.Tasks.TaskExtension
@@ -577,29 +577,29 @@ namespace Microsoft.Build.Tasks
     public sealed partial class ResolveCodeAnalysisRuleSet : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveCodeAnalysisRuleSet() { }
-        public string CodeAnalysisRuleSet { get { throw null; } set { } }
-        public string[] CodeAnalysisRuleSetDirectories { get { throw null; } set { } }
-        public string MSBuildProjectDirectory { get { throw null; } set { } }
+        public string CodeAnalysisRuleSet { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string[] CodeAnalysisRuleSetDirectories { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MSBuildProjectDirectory { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedCodeAnalysisRuleSet { get { throw null; } }
+        public string ResolvedCodeAnalysisRuleSet { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         public override bool Execute() { throw null; }
     }
     public partial class ResolveKeySource : Microsoft.Build.Tasks.TaskExtension
     {
         public ResolveKeySource() { }
-        public int AutoClosePasswordPromptShow { get { throw null; } set { } }
-        public int AutoClosePasswordPromptTimeout { get { throw null; } set { } }
-        public string CertificateFile { get { throw null; } set { } }
-        public string CertificateThumbprint { get { throw null; } set { } }
-        public string KeyFile { get { throw null; } set { } }
+        public int AutoClosePasswordPromptShow { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public int AutoClosePasswordPromptTimeout { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CertificateFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string CertificateThumbprint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string KeyFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedKeyContainer { get { throw null; } set { } }
+        public string ResolvedKeyContainer { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedKeyFile { get { throw null; } set { } }
+        public string ResolvedKeyFile { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
-        public string ResolvedThumbprint { get { throw null; } set { } }
-        public bool ShowImportDialogDespitePreviousFailures { get { throw null; } set { } }
-        public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
+        public string ResolvedThumbprint { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool ShowImportDialogDespitePreviousFailures { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public bool SuppressAutoClosePasswordPrompt { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public abstract partial class ResolveProjectBase : Microsoft.Build.Tasks.TaskExtension

--- a/src/Tasks.UnitTests/ResolveComReference_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveComReference_Tests.cs
@@ -5,10 +5,7 @@
 
 using System;
 using System.Collections;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Collections.Generic;
-
 
 // TYPELIBATTR clashes with the one in InteropServices.
 using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
@@ -16,28 +13,19 @@ using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Tasks;
-using Microsoft.Build.Shared;
 using Xunit;
 using ItemMetadataNames = Microsoft.Build.Tasks.ItemMetadataNames;
 
 namespace Microsoft.Build.UnitTests
 {
-    /*
-     * Class:   ResolveComReference_Tests
-     *
-     * Test the ResolveComReference task in various ways.
-     *
-     */
     sealed public class ResolveComReference_Tests
     {
-        /*
-         * Method:  SetupTaskItem
-         * 
-         * Creates a valid task item that's modified later
-         */
+        /// <summary>
+        /// Creates a valid task item that's modified later
+        /// </summary>
         private TaskItem SetupTaskItem()
         {
-            TaskItem item = new TaskItem();
+            var item = new TaskItem();
 
             item.SetMetadata(ComReferenceItemMetadataNames.guid, "{5C6D0C4D-D530-4B08-B22F-307CA6BFCB65}");
             item.SetMetadata(ComReferenceItemMetadataNames.versionMajor, "1");
@@ -192,7 +180,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         private TaskItem CreateComReferenceTaskItem(string itemSpec, string guid, string vMajor, string vMinor, string lcid, string wrapperType, string embedInteropTypes)
         {
-            TaskItem item = new TaskItem(itemSpec);
+            var item = new TaskItem(itemSpec);
 
             item.SetMetadata(ComReferenceItemMetadataNames.guid, guid);
             item.SetMetadata(ComReferenceItemMetadataNames.versionMajor, vMajor);
@@ -236,7 +224,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         private ComReferenceInfo CreateComReferenceInfo(ITaskItem taskItem, string typeLibName, string typeLibPath)
         {
-            ComReferenceInfo referenceInfo = new ComReferenceInfo();
+            var referenceInfo = new ComReferenceInfo();
 
             referenceInfo.taskItem = taskItem;
             referenceInfo.attr = ResolveComReference.TaskItemToTypeLibAttr(taskItem);
@@ -295,7 +283,7 @@ namespace Microsoft.Build.UnitTests
             CreateTestReferences(out axRefInfo, out tlbRefInfo, out piaRefInfo,
                 out axAttr, out tlbAttr, out piaAttr, out notInProjectAttr);
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
 
             // populate the ResolveComReference's list of project references
             rcr.allProjectRefs = new List<ComReferenceInfo>();
@@ -303,10 +291,8 @@ namespace Microsoft.Build.UnitTests
             rcr.allProjectRefs.Add(tlbRefInfo);
             rcr.allProjectRefs.Add(piaRefInfo);
 
-            ComReferenceInfo referenceInfo;
-
             // find the Ax ref, matching with any type of reference - should NOT find it
-            bool retValue = rcr.IsExistingProjectReference(axAttr, null, out referenceInfo);
+            bool retValue = rcr.IsExistingProjectReference(axAttr, null, out ComReferenceInfo referenceInfo);
             Assert.True(retValue == false && referenceInfo == null); // "ActiveX ref should NOT be found for any type of ref"
 
             // find the Ax ref, matching with aximp types - should find it
@@ -343,7 +329,6 @@ namespace Microsoft.Build.UnitTests
             retValue = rcr.IsExistingProjectReference(piaAttr, ComReferenceTypes.aximp, out referenceInfo);
             Assert.True(retValue == false && referenceInfo == null); // "Pia ref should NOT be found for aximp ref types"
 
-
             // try to find a non existing reference
             retValue = rcr.IsExistingProjectReference(notInProjectAttr, null, out referenceInfo);
             Assert.True(retValue == false && referenceInfo == null); // "not in project ref should not be found"
@@ -361,7 +346,7 @@ namespace Microsoft.Build.UnitTests
             CreateTestReferences(out axRefInfo, out tlbRefInfo, out piaRefInfo,
                 out axAttr, out tlbAttr, out piaAttr, out notInProjectAttr);
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
 
             // populate the ResolveComReference's list of project references
             rcr.allDependencyRefs = new List<ComReferenceInfo>();
@@ -369,10 +354,8 @@ namespace Microsoft.Build.UnitTests
             rcr.allDependencyRefs.Add(tlbRefInfo);
             rcr.allDependencyRefs.Add(piaRefInfo);
 
-            ComReferenceInfo referenceInfo;
-
             // find the Ax ref - should find it
-            bool retValue = rcr.IsExistingDependencyReference(axAttr, out referenceInfo);
+            bool retValue = rcr.IsExistingDependencyReference(axAttr, out ComReferenceInfo referenceInfo);
             Assert.True(retValue == true && referenceInfo == axRefInfo); // "ActiveX ref should be found"
 
             // find the Tlb ref - should find it
@@ -407,7 +390,7 @@ namespace Microsoft.Build.UnitTests
             CreateTestReferences(out axRefInfo, out tlbRefInfo, out piaRefInfo,
                 out axAttr, out tlbAttr, out piaAttr, out notInProjectAttr);
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
             rcr.BuildEngine = new MockEngine();
 
             // populate the ResolveComReference's list of project references
@@ -436,8 +419,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void BothKeyFileAndKeyContainer()
         {
-            ResolveComReference rcr = new ResolveComReference();
-            MockEngine e = new MockEngine();
+            var rcr = new ResolveComReference();
+            var e = new MockEngine();
             rcr.BuildEngine = e;
 
             rcr.KeyFile = "foo";
@@ -451,8 +434,8 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void DelaySignWithoutEitherKeyFileOrKeyContainer()
         {
-            ResolveComReference rcr = new ResolveComReference();
-            MockEngine e = new MockEngine();
+            var rcr = new ResolveComReference();
+            var e = new MockEngine();
             rcr.BuildEngine = e;
 
             rcr.DelaySign = true;
@@ -486,27 +469,27 @@ namespace Microsoft.Build.UnitTests
             {
                 string fxVersion = fxVersions[i];
 
-                ArrayList taskItems = new ArrayList();
+                var taskItems = new List<ITaskItem>();
 
-                TaskItem nonGacNoPrivate = new TaskItem(@"C:\windows\gar\test1.dll");
+                var nonGacNoPrivate = new TaskItem(@"C:\windows\gar\test1.dll");
                 nonGacNoPrivate.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
-                TaskItem gacNoPrivate = new TaskItem(@"C:\windows\gac\assembly1.dll");
+                var gacNoPrivate = new TaskItem(@"C:\windows\gac\assembly1.dll");
                 gacNoPrivate.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
-                TaskItem nonGacPrivateFalse = new TaskItem(@"C:\windows\gar\test1.dll");
+                var nonGacPrivateFalse = new TaskItem(@"C:\windows\gar\test1.dll");
                 nonGacPrivateFalse.SetMetadata(ItemMetadataNames.privateMetadata, "false");
                 nonGacPrivateFalse.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
-                TaskItem gacPrivateFalse = new TaskItem(@"C:\windows\gac\assembly1.dll");
+                var gacPrivateFalse = new TaskItem(@"C:\windows\gac\assembly1.dll");
                 gacPrivateFalse.SetMetadata(ItemMetadataNames.privateMetadata, "false");
                 gacPrivateFalse.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
-                TaskItem nonGacPrivateTrue = new TaskItem(@"C:\windows\gar\test1.dll");
+                var nonGacPrivateTrue = new TaskItem(@"C:\windows\gar\test1.dll");
                 nonGacPrivateTrue.SetMetadata(ItemMetadataNames.privateMetadata, "true");
                 nonGacPrivateTrue.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
-                TaskItem gacPrivateTrue = new TaskItem(@"C:\windows\gac\assembly1.dll");
+                var gacPrivateTrue = new TaskItem(@"C:\windows\gac\assembly1.dll");
                 gacPrivateTrue.SetMetadata(ItemMetadataNames.privateMetadata, "true");
                 gacPrivateTrue.SetMetadata(ItemMetadataNames.embedInteropTypes, "true");
 
@@ -559,10 +542,10 @@ namespace Microsoft.Build.UnitTests
         {
             string gacPath = @"C:\windows\gac";
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
             rcr.BuildEngine = new MockEngine();
 
-            ArrayList taskItems = new ArrayList();
+            var taskItems = new List<ITaskItem>();
             TaskItem nonGacNoPrivate = new TaskItem(@"C:\windows\gar\test1.dll");
             TaskItem gacNoPrivate = new TaskItem(@"C:\windows\gac\assembly1.dll");
 
@@ -614,7 +597,7 @@ namespace Microsoft.Build.UnitTests
             CreateTestReferences(out axRefInfo, out tlbRefInfo, out piaRefInfo,
                 out axAttr, out tlbAttr, out piaAttr, out notInProjectAttr);
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
             rcr.BuildEngine = new MockEngine();
 
             // populate the ResolveComReference's list of project references
@@ -642,13 +625,13 @@ namespace Microsoft.Build.UnitTests
 
             // tlb and ax refs with same lib name but different attributes should be considered conflicting
             // We don't care about typelib name conflicts for PIA refs, because we don't have to create wrappers for them
-            ComReferenceInfo conflictTlb = new ComReferenceInfo(tlbRefInfo);
+            var conflictTlb = new ComReferenceInfo(tlbRefInfo);
             conflictTlb.attr = notInProjectAttr;
             rcr.allProjectRefs.Add(conflictTlb);
-            ComReferenceInfo conflictAx = new ComReferenceInfo(axRefInfo);
+            var conflictAx = new ComReferenceInfo(axRefInfo);
             conflictAx.attr = notInProjectAttr;
             rcr.allProjectRefs.Add(conflictAx);
-            ComReferenceInfo piaRef = new ComReferenceInfo(piaRefInfo);
+            var piaRef = new ComReferenceInfo(piaRefInfo);
             piaRef.attr = notInProjectAttr;
             rcr.allProjectRefs.Add(piaRef);
 
@@ -757,10 +740,9 @@ namespace Microsoft.Build.UnitTests
             Guid axGuid = Guid.NewGuid();
             ComReferenceInfo tlbRefInfo;
 
-            ResolveComReference rcr = new ResolveComReference();
+            var rcr = new ResolveComReference();
             rcr.BuildEngine = new MockEngine();
             rcr.IncludeVersionInInteropName = includeVersionInInteropName;
-
             rcr.allProjectRefs = new List<ComReferenceInfo>();
 
             TaskItem axTaskItem = CreateComReferenceTaskItem("ref", axGuid.ToString(), "1", "2", "1033", ComReferenceTypes.aximp);
@@ -790,7 +772,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.Equal(2, rcr.allProjectRefs.Count); // "Should be two references"
 
-            tlbRefInfo = (ComReferenceInfo)rcr.allProjectRefs[1];
+            tlbRefInfo = rcr.allProjectRefs[1];
             var embedInteropTypes = tlbRefInfo.taskItem.GetMetadata(ItemMetadataNames.embedInteropTypes);
             Assert.Equal("false", embedInteropTypes); // "The tlb wrapper for the activex control should have EmbedInteropTypes=false not " + embedInteropTypes);
             Assert.True(ComReference.AreTypeLibAttrEqual(tlbRefInfo.attr, axRefInfo.attr)); // "reference information should be the same"

--- a/src/Tasks/Dependencies.cs
+++ b/src/Tasks/Dependencies.cs
@@ -9,7 +9,8 @@ namespace Microsoft.Build.Tasks
     /// <remarks>
     /// Represents a cache of inputs to a compilation-style task.
     /// </remarks>
-    [Serializable()]
+    /// <remarks>On-disk serialization format, don't change field names or types or use readonly.</remarks>
+    [Serializable]
     internal class Dependencies
     {
         /// <summary>
@@ -32,8 +33,6 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Add a new dependency file.
         /// </summary>
-        /// <param name="filename"></param>
-        /// <returns></returns>
         internal void AddDependencyFile(string filename, DependencyFile file)
         {
             dependencies[filename] = file;

--- a/src/Tasks/Dependencies.cs
+++ b/src/Tasks/Dependencies.cs
@@ -6,9 +6,9 @@ using System.Collections;
 
 namespace Microsoft.Build.Tasks
 {
-    /// <remarks>
+    /// <summary>
     /// Represents a cache of inputs to a compilation-style task.
-    /// </remarks>
+    /// </summary>
     /// <remarks>On-disk serialization format, don't change field names or types or use readonly.</remarks>
     [Serializable]
     internal class Dependencies

--- a/src/Tasks/RCWForCurrentContext.cs
+++ b/src/Tasks/RCWForCurrentContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Tasks.InteropUtilities
         /// <summary>
         /// Indicates if we created the RCW and therefore need to release it's com reference.
         /// </summary>
-        private bool _shouldReleaseRCW;
+        private readonly bool _shouldReleaseRCW;
 
         /// <summary>
         /// Constructor creates the new RCW in the current context.
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Tasks.InteropUtilities
             // the caching behaviour of the marshaled pointer. 
             // See RCW::GetComIPForMethodTableFromCache in ndp\clr\src\VM\RuntimeCallableWrapper.cpp
             IntPtr iunknownPtr = Marshal.GetIUnknownForObject(rcw);
-            Object objInCurrentCtx = null;
+            Object objInCurrentCtx;
 
             try
             {

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Tasks
 
             // On dogfood build machines, v3.5 is not formally installed, so this returns null.
             // We don't use redist lists in this case.            
-            string[] redistListPaths = (referenceAssembliesPath == null) ? Array.Empty<string>(): GetRedistListPathsFromDisk(referenceAssembliesPath);
+            string[] redistListPaths = (referenceAssembliesPath == null) ? Array.Empty<string>() : GetRedistListPathsFromDisk(referenceAssembliesPath);
 
             var assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
             for (int i = 0; i < redistListPaths.Length; ++i)
@@ -349,6 +349,7 @@ namespace Microsoft.Build.Tasks
 
                 redistList = new RedistList(assemblyTables);
                 s_cachedRedistList.Add(key, redistList);
+
                 return redistList;
             }
         }
@@ -456,7 +457,7 @@ namespace Microsoft.Build.Tasks
         public string GetUnifiedAssemblyName(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            return entry != null ? entry.FullName : assemblyName;
+            return entry?.FullName ?? assemblyName;
         }
 
         /// <summary>

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -3,24 +3,20 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
-using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace Microsoft.Build.Tasks
 {
-    /*
-     * Class:   RedistList
-     *
-     */
     /// <summary>
     /// Defines list of redistributable assemblies for use in dependency analysis.
     /// The input is a set of XML files in a well known format consisting of
@@ -36,7 +32,8 @@ namespace Microsoft.Build.Tasks
     internal sealed class RedistList
     {
         // List of cached RedistList objects, the key is a semi-colon delimited list of data file paths
-        private readonly static Hashtable s_cachedRedistList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, RedistList> s_cachedRedistList = new Dictionary<string, RedistList>(StringComparer.OrdinalIgnoreCase);
+
         // Process wide cache of redist lists found on disk under fx directories.
         // K: target framework directory, V: redist lists found on disk underneath K
         private static Dictionary<string, string[]> s_redistListPathCache;
@@ -48,33 +45,32 @@ namespace Microsoft.Build.Tasks
         /// When we check to see if an assembly is in this redist list we want to cache it so that if we ask again we do not
         /// have to re-scan bits of the redist list and do the assemblynameExtension comparisons.
         /// </summary>
-        private ConcurrentDictionary<AssemblyNameExtension, NGen<bool>> _assemblyNameInRedist = new ConcurrentDictionary<AssemblyNameExtension, NGen<bool>>(AssemblyNameComparer.GenericComparer);
+        private readonly ConcurrentDictionary<AssemblyNameExtension, NGen<bool>> _assemblyNameInRedist = new ConcurrentDictionary<AssemblyNameExtension, NGen<bool>>(AssemblyNameComparer.GenericComparer);
 
         /// <summary>
         /// AssemblyName to unified assemblyName. We make this kind of call a lot and also will ask for the same name multiple times.
         /// </summary>
-        private ConcurrentDictionary<string, AssemblyEntry> _assemblyNameToUnifiedAssemblyName = new ConcurrentDictionary<string, AssemblyEntry>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, AssemblyEntry> _assemblyNameToUnifiedAssemblyName = new ConcurrentDictionary<string, AssemblyEntry>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// AssemblyName to AssemblyNameExtension object. We make this kind of call a lot and also will ask for the same name multiple times.
         /// </summary>
-        private ConcurrentDictionary<string, AssemblyNameExtension> _assemblyNameToAssemblyNameExtension = new ConcurrentDictionary<string, AssemblyNameExtension>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, AssemblyNameExtension> _assemblyNameToAssemblyNameExtension = new ConcurrentDictionary<string, AssemblyNameExtension>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// When we check to see if an assembly is remapped we should cache the result because we may get asked the same question a number of times.
         /// Since the remapping list does not change between builds neither would the results of the remapping for a given fusion name.
         /// </summary>
-        private ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension> _remappingCache = new ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension>(AssemblyNameComparer.GenericComparerConsiderRetargetable);
+        private readonly ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension> _remappingCache = new ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension>(AssemblyNameComparer.GenericComparerConsiderRetargetable);
 
         // List of cached BlackList RedistList objects, the key is a semi-colon delimited list of data file paths
-        private ConcurrentDictionary<string, Hashtable> _cachedBlackList = new ConcurrentDictionary<string, Hashtable>(StringComparer.OrdinalIgnoreCase);
-
-
+        private readonly ConcurrentDictionary<string, Hashtable> _cachedBlackList = new ConcurrentDictionary<string, Hashtable>(StringComparer.OrdinalIgnoreCase);
+        
         /***************Fields which are only set in the constructor and should not be modified by the class. **********************/
         // Array of errors encountered while reading files.
-        private ReadOnlyCollection<Exception> _errors;
+        private readonly ReadOnlyCollection<Exception> _errors;
         // Array of files corresponding to the errors above.
-        private ReadOnlyCollection<String> _errorFilenames;
+        private readonly ReadOnlyCollection<String> _errorFilenames;
 
         // List of assembly entries loaded from the XML data files, one entry for each valid File element
         private readonly ReadOnlyCollection<AssemblyEntry> _assemblyList;
@@ -91,12 +87,12 @@ namespace Microsoft.Build.Tasks
 
         private RedistList(AssemblyTableInfo[] assemblyTableInfos)
         {
-            List<Exception> errors = new List<Exception>();
-            List<string> errorFilenames = new List<string>();
-            List<AssemblyEntry> assemblyList = new List<AssemblyEntry>();
-            List<AssemblyRemapping> remappingEntries = new List<AssemblyRemapping>();
+            var errors = new List<Exception>();
+            var errorFilenames = new List<string>();
+            var assemblyList = new List<AssemblyEntry>();
+            var remappingEntries = new List<AssemblyRemapping>();
 
-            if (assemblyTableInfos == null) throw new ArgumentNullException("assemblyTableInfos");
+            if (assemblyTableInfos == null) throw new ArgumentNullException(nameof(assemblyTableInfos));
             foreach (AssemblyTableInfo assemblyTableInfo in assemblyTableInfos)
             {
                 ReadFile(assemblyTableInfo, assemblyList, errors, errorFilenames, remappingEntries);
@@ -110,12 +106,14 @@ namespace Microsoft.Build.Tasks
             assemblyList.Sort(s_sortByVersionDescending);
             _assemblyList = new ReadOnlyCollection<AssemblyEntry>(assemblyList);
 
-            Dictionary<string, int> simpleNameMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var simpleNameMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < assemblyList.Count; ++i)
             {
                 AssemblyEntry entry = assemblyList[i];
                 if (!simpleNameMap.ContainsKey(entry.SimpleName))
+                {
                     simpleNameMap.Add(entry.SimpleName, i);
+                }
             }
 
             _simpleNameMap = new ReadOnlyDictionary<string, int>(simpleNameMap);
@@ -124,36 +122,17 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Returns any exceptions encountered while reading\parsing the XML.
         /// </summary>
-        internal Exception[] Errors
-        {
-            get
-            {
-                return _errors.ToArray();
-            }
-        }
+        internal Exception[] Errors => _errors.ToArray();
 
         /// <summary>
         /// Returns any exceptions encountered while reading\parsing the XML.
         /// </summary>
-        internal string[] ErrorFileNames
-        {
-            get
-            {
-                return _errorFilenames.ToArray();
-            }
-        }
-
+        internal string[] ErrorFileNames => _errorFilenames.ToArray();
 
         /// <summary>
         /// Returns the number of entries in the redist list
         /// </summary>
-        internal int Count
-        {
-            get
-            {
-                return _assemblyList.Count;
-            }
-        }
+        internal int Count => _assemblyList.Count;
 
         /// <summary>
         /// Determines whether or not the specified assembly is part of the Framework.
@@ -163,17 +142,18 @@ namespace Microsoft.Build.Tasks
         public bool IsFrameworkAssembly(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null && !String.IsNullOrEmpty(entry.RedistName)){
+            if (!String.IsNullOrEmpty(entry?.RedistName))
+            {
                 AssemblyNameExtension assembly = GetAssemblyNameExtension(assemblyName);
 
                 // The version of the checking assembly should be lower than the one of the unified assembly
-                if(assembly.Version <= entry.AssemblyNameExtension.Version)
+                if (assembly.Version <= entry.AssemblyNameExtension.Version)
+                {
                     return entry.RedistName.StartsWith("Microsoft-Windows-CLRCoreComp", StringComparison.OrdinalIgnoreCase);
-                else
-                    return false;
-            }
-            else
+                }
                 return false;
+            }
+            return false;
         }
 
         /// <summary>
@@ -184,10 +164,7 @@ namespace Microsoft.Build.Tasks
         public bool IsPrerequisiteAssembly(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null)
-                return entry.InGAC;
-            else
-                return false;
+            return entry != null && entry.InGAC;
         }
 
         /// <summary>
@@ -196,9 +173,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public AssemblyNameExtension RemapAssembly(AssemblyNameExtension extensionToRemap)
         {
-            AssemblyNameExtension remappedExtension = null;
-
-            if (!_remappingCache.TryGetValue(extensionToRemap, out remappedExtension))
+            if (!_remappingCache.TryGetValue(extensionToRemap, out AssemblyNameExtension remappedExtension))
             {
                 // We do not expect there to be more than a handfull of entries
                 foreach (AssemblyRemapping remapEntry in _remapEntries)
@@ -213,9 +188,8 @@ namespace Microsoft.Build.Tasks
             }
 
             // Important to clone since we tend to mutate assemblyNameExtensions in RAR
-            return remappedExtension != null ? remappedExtension.Clone() : null;
+            return remappedExtension?.Clone();
         }
-
 
         /// <summary>
         /// Determines whether or not the specified assembly is a redist root.
@@ -223,14 +197,7 @@ namespace Microsoft.Build.Tasks
         internal bool? IsRedistRoot(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null)
-            {
-                return entry.IsRedistRoot;
-            }
-            else
-            {
-                return null;
-            }
+            return entry?.IsRedistRoot;
         }
 
         /// <summary>
@@ -247,8 +214,7 @@ namespace Microsoft.Build.Tasks
                 redistListPaths = RedistList.GetRedistListPathsFromDisk(frameworkVersion20Path);
             }
 
-            AssemblyTableInfo[] assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
-
+            var assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
             for (int i = 0; i < redistListPaths.Length; ++i)
             {
                 assemblyTableInfos[i] = new AssemblyTableInfo(redistListPaths[i], frameworkVersion20Path);
@@ -256,7 +222,6 @@ namespace Microsoft.Build.Tasks
 
             return GetRedistList(assemblyTableInfos);
         }
-
 
         /// <summary>
         /// Returns an instance of RedistList initialized from the framework folder for v3.0
@@ -281,14 +246,11 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// This is owned by chris mann
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
         public static RedistList GetRedistListFromPath(string path)
         {
-            string[] redistListPaths = (path == null) ? Array.Empty<string>(): RedistList.GetRedistListPathsFromDisk(path);
+            string[] redistListPaths = (path == null) ? Array.Empty<string>(): GetRedistListPathsFromDisk(path);
 
-            AssemblyTableInfo[] assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
-
+            var assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
             for (int i = 0; i < redistListPaths.Length; ++i)
             {
                 assemblyTableInfos[i] = new AssemblyTableInfo(redistListPaths[i], path);
@@ -303,10 +265,9 @@ namespace Microsoft.Build.Tasks
 
             // On dogfood build machines, v3.5 is not formally installed, so this returns null.
             // We don't use redist lists in this case.            
-            string[] redistListPaths = (referenceAssembliesPath == null) ? Array.Empty<string>(): RedistList.GetRedistListPathsFromDisk(referenceAssembliesPath);
+            string[] redistListPaths = (referenceAssembliesPath == null) ? Array.Empty<string>(): GetRedistListPathsFromDisk(referenceAssembliesPath);
 
-            AssemblyTableInfo[] assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
-
+            var assemblyTableInfos = new AssemblyTableInfo[redistListPaths.Length];
             for (int i = 0; i < redistListPaths.Length; ++i)
             {
                 assemblyTableInfos[i] = new AssemblyTableInfo(redistListPaths[i], referenceAssembliesPath);
@@ -320,11 +281,10 @@ namespace Microsoft.Build.Tasks
         /// redist list files underneath that path.  A process-wide cache is used to
         /// avoid hitting the disk multiple times for the same framework directory.
         /// </summary>
-        /// <param name="frameworkDirectory"></param>
         /// <returns>Array of paths to redist lists under given framework directory.</returns>
         public static string[] GetRedistListPathsFromDisk(string frameworkDirectory)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, "frameworkDirectory");
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, nameof(frameworkDirectory));
 
             lock (s_locker)
             {
@@ -333,21 +293,20 @@ namespace Microsoft.Build.Tasks
                     s_redistListPathCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
                 }
 
-                if (!s_redistListPathCache.ContainsKey(frameworkDirectory))
+                if (!s_redistListPathCache.TryGetValue(frameworkDirectory, out string[] results))
                 {
                     string redistDirectory = Path.Combine(frameworkDirectory, RedistListFolder);
 
                     if (Directory.Exists(redistDirectory))
                     {
-                        string[] results = Directory.GetFiles(redistDirectory, MatchPattern);
+                        results = Directory.GetFiles(redistDirectory, MatchPattern);
                         s_redistListPathCache.Add(frameworkDirectory, results);
-
-                        return s_redistListPathCache[frameworkDirectory];
+                        return results;
                     }
                 }
                 else
                 {
-                    return s_redistListPathCache[frameworkDirectory];
+                    return results;
                 }
             }
 
@@ -357,19 +316,10 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The name of this redist.
         /// </summary>
-        /// <param name="assemblyName"></param>
-        /// <returns></returns>
         internal string RedistName(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null)
-            {
-                return entry.RedistName;
-            }
-            else
-            {
-                return null;
-            }
+            return entry?.RedistName;
         }
 
         /// <summary>
@@ -379,10 +329,10 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public static RedistList GetRedistList(AssemblyTableInfo[] assemblyTables)
         {
-            if (assemblyTables == null) throw new ArgumentNullException("assemblyTables");
+            if (assemblyTables == null) throw new ArgumentNullException(nameof(assemblyTables));
             Array.Sort(assemblyTables);
 
-            StringBuilder keyBuilder = assemblyTables.Length > 0 ? new StringBuilder(assemblyTables[0].Descriptor) : new StringBuilder();
+            var keyBuilder = assemblyTables.Length > 0 ? new StringBuilder(assemblyTables[0].Descriptor) : new StringBuilder();
             for (int i = 1; i < assemblyTables.Length; ++i)
             {
                 keyBuilder.Append(';');
@@ -392,40 +342,41 @@ namespace Microsoft.Build.Tasks
             string key = keyBuilder.ToString();
             lock (s_locker)
             {
-                if (s_cachedRedistList.ContainsKey(key))
-                    return (RedistList)s_cachedRedistList[key];
+                if (s_cachedRedistList.TryGetValue(key, out RedistList redistList))
+                {
+                    return redistList;
+                }
 
-                RedistList redistList = new RedistList(assemblyTables);
+                redistList = new RedistList(assemblyTables);
                 s_cachedRedistList.Add(key, redistList);
-
                 return redistList;
             }
         }
 
         private static string GetSimpleName(string assemblyName)
         {
-            if (assemblyName == null) throw new ArgumentNullException("assemblyName");
+            if (assemblyName == null) throw new ArgumentNullException(nameof(assemblyName));
             int i = assemblyName.IndexOf(",", StringComparison.Ordinal);
             return i > 0 ? assemblyName.Substring(0, i) : assemblyName;
         }
 
         private AssemblyEntry GetUnifiedAssemblyEntry(string assemblyName)
         {
-            if (assemblyName == null) throw new ArgumentNullException("assemblyName");
-            AssemblyEntry unifiedEntry = null;
-            if (!_assemblyNameToUnifiedAssemblyName.TryGetValue(assemblyName, out unifiedEntry))
+            if (assemblyName == null) throw new ArgumentNullException(nameof(assemblyName));
+            if (!_assemblyNameToUnifiedAssemblyName.TryGetValue(assemblyName, out AssemblyEntry unifiedEntry))
             {
                 string simpleName = GetSimpleName(assemblyName);
-                if (_simpleNameMap.ContainsKey(simpleName))
+                if (_simpleNameMap.TryGetValue(simpleName, out int index))
                 {
                     // Provides the starting index into assemblyList of the simpleName
-                    int index = (int)_simpleNameMap[simpleName];
-                    AssemblyNameExtension highestVersionInRedist = new AssemblyNameExtension(_assemblyList[index].FullName);
+                    var highestVersionInRedist = new AssemblyNameExtension(_assemblyList[index].FullName);
                     for (int i = index; i < _assemblyList.Count; ++i)
                     {
                         AssemblyEntry entry = _assemblyList[i];
                         if (!string.Equals(simpleName, entry.SimpleName, StringComparison.OrdinalIgnoreCase))
+                        {
                             break;
+                        }
 
                         AssemblyNameExtension firstAssembly = GetAssemblyNameExtension(assemblyName);
                         AssemblyNameExtension secondAssembly = entry.AssemblyNameExtension;
@@ -450,7 +401,7 @@ namespace Microsoft.Build.Tasks
 
         private AssemblyNameExtension GetAssemblyNameExtension(string assemblyName)
         {
-            return _assemblyNameToAssemblyNameExtension.GetOrAdd(assemblyName, (key) => new AssemblyNameExtension(key));
+            return _assemblyNameToAssemblyNameExtension.GetOrAdd(assemblyName, key => new AssemblyNameExtension(key));
         }
 
         /// <summary>
@@ -458,16 +409,14 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public bool FrameworkAssemblyEntryInRedist(AssemblyNameExtension assemblyName)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(assemblyName, "assemblyName");
+            ErrorUtilities.VerifyThrowArgumentNull(assemblyName, nameof(assemblyName));
 
-            NGen<bool> isAssemblyNameInRedist = false;
-            if (!_assemblyNameInRedist.TryGetValue(assemblyName, out isAssemblyNameInRedist))
+            if (!_assemblyNameInRedist.TryGetValue(assemblyName, out NGen<bool> isAssemblyNameInRedist))
             {
                 string simpleName = GetSimpleName(assemblyName.Name);
-                if (_simpleNameMap.ContainsKey(simpleName))
+                if (_simpleNameMap.TryGetValue(simpleName, out int index))
                 {
                     // Provides the starting index into assemblyList of the simpleName
-                    int index = (int)_simpleNameMap[simpleName];
                     for (int i = index; i < _assemblyList.Count; ++i)
                     {
                         AssemblyEntry entry = _assemblyList[i];
@@ -507,10 +456,7 @@ namespace Microsoft.Build.Tasks
         public string GetUnifiedAssemblyName(string assemblyName)
         {
             AssemblyEntry entry = GetUnifiedAssemblyEntry(assemblyName);
-            if (entry != null)
-                return entry.FullName;
-            else
-                return assemblyName;
+            return entry != null ? entry.FullName : assemblyName;
         }
 
         /// <summary>
@@ -523,11 +469,10 @@ namespace Microsoft.Build.Tasks
             string simpleName
         )
         {
-            List<AssemblyEntry> candidateNames = new List<AssemblyEntry>();
+            var candidateNames = new List<AssemblyEntry>();
 
-            if (_simpleNameMap.ContainsKey(simpleName))
+            if (_simpleNameMap.TryGetValue(simpleName, out int index))
             {
-                int index = (int)_simpleNameMap[simpleName];
                 for (int i = index; i < _assemblyList.Count; ++i)
                 {
                     AssemblyEntry entry = _assemblyList[i];
@@ -572,7 +517,7 @@ namespace Microsoft.Build.Tasks
             // Sort so that the same set of whiteListAssemblyTableInfo will generate the same key for the cache
             Array.Sort(whiteListAssemblyTableInfo);
 
-            StringBuilder keyBuilder = whiteListAssemblyTableInfo.Length > 0 ? new StringBuilder(whiteListAssemblyTableInfo[0].Descriptor) : new StringBuilder();
+            var keyBuilder = whiteListAssemblyTableInfo.Length > 0 ? new StringBuilder(whiteListAssemblyTableInfo[0].Descriptor) : new StringBuilder();
 
             // Concatenate the paths to the whitelist xml files together to get the key into the blacklist cache.
             for (int i = 1; i < whiteListAssemblyTableInfo.Length; ++i)
@@ -583,19 +528,17 @@ namespace Microsoft.Build.Tasks
 
             string key = keyBuilder.ToString();
 
-            Hashtable returnTable = null;
-
-            if (!_cachedBlackList.TryGetValue(key, out returnTable))
+            if (!_cachedBlackList.TryGetValue(key, out Hashtable returnTable))
             {
-                List<AssemblyEntry> whiteListAssemblies = new List<AssemblyEntry>();
+                var whiteListAssemblies = new List<AssemblyEntry>();
 
                 // Unique list of redist names in the subset files read in. We use this to make sure we are subtracting from the correct framework list.
-                Hashtable uniqueClientListNames = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                var uniqueClientListNames = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
                 // Get the assembly entries for the white list
                 foreach (AssemblyTableInfo info in whiteListAssemblyTableInfo)
                 {
-                    List<AssemblyEntry> whiteListAssembliesReadIn = new List<AssemblyEntry>();
+                    var whiteListAssembliesReadIn = new List<AssemblyEntry>();
 
                     // Need to know how many errors are in the list before the read file call so that if the redist name is null due to an error
                     // we do not get a "redist name is null or empty" error when in actual fact it was a file not found error.
@@ -603,7 +546,6 @@ namespace Microsoft.Build.Tasks
 
                     // Read in the subset list file. 
                     string redistName = ReadFile(info, whiteListAssembliesReadIn, whiteListErrors, whiteListErrorFileNames, null);
-
 
                     // Get the client subset name which has been read in.
                     if (!String.IsNullOrEmpty(redistName))
@@ -631,7 +573,7 @@ namespace Microsoft.Build.Tasks
                 }
 
                 // Dont care about the case of the assembly name
-                Hashtable blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                var blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
                 // Do we have any subset names?
                 bool uniqueClientNamesExist = uniqueClientListNames.Count > 0;
@@ -659,15 +601,14 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 
-
                 // Go through each of the white list assemblies and remove it from the black list. Do this based on the assembly name and the redist name
                 foreach (AssemblyEntry whiteListEntry in whiteListAssemblies)
                 {
                     blackList.Remove(whiteListEntry.FullName + "," + whiteListEntry.RedistName);
                 }
 
-                //The output hashtable needs to be just the full names and not the names + redist name
-                Hashtable blackListOfAssemblyNames = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                // The output hashtable needs to be just the full names and not the names + redist name
+                var blackListOfAssemblyNames = new Hashtable(StringComparer.OrdinalIgnoreCase);
                 foreach (string name in blackList.Values)
                 {
                     blackListOfAssemblyNames[name] = null;
@@ -696,12 +637,11 @@ namespace Microsoft.Build.Tasks
             // Keep track of what assembly entries we have read in from the redist list, we want to track this because we need to know if there are duplicate entries
             // if there are duplicate entries one with ingac = true and one with InGac=false we want to choose the one with ingac true.
             // The reason we want to take the ingac True over ingac false is that this indicates the assembly IS in the gac.
-            Dictionary<string, AssemblyEntry> assemblyEntries = new Dictionary<string, AssemblyEntry>(StringComparer.OrdinalIgnoreCase);
+            var assemblyEntries = new Dictionary<string, AssemblyEntry>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
-                var readerSettings = new XmlReaderSettings();
-                readerSettings.DtdProcessing = DtdProcessing.Ignore;
+                var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
                 reader = XmlReader.Create(path, readerSettings);
 
                 while (reader.Read())
@@ -750,10 +690,7 @@ namespace Microsoft.Build.Tasks
             }
             finally
             {
-                if (reader != null)
-                {
-                    reader.Dispose();
-                }
+                reader?.Dispose();
             }
 
             foreach (AssemblyEntry entry in assemblyEntries.Values)
@@ -796,9 +733,9 @@ namespace Microsoft.Build.Tasks
 
                     if (fromEntry != null && toEntry != null)
                     {
-                        AssemblyRemapping pair = new AssemblyRemapping(fromEntry, toEntry);
+                        var pair = new AssemblyRemapping(fromEntry, toEntry);
 
-                        if (!mapping.Any<AssemblyRemapping>(x => x.From.Equals(pair.From)))
+                        if (!mapping.Any(x => x.From.Equals(pair.From)))
                         {
                             mapping.Add(pair);
                         }
@@ -839,10 +776,9 @@ namespace Microsoft.Build.Tasks
                             // We do not need to add the redistName and the framework directory because this will be the same for all entries in the current redist list being read.
                             string hashIndex = String.Format(CultureInfo.InvariantCulture, "{0},{1}", newEntry.FullName, newEntry.IsRedistRoot == null ? "null" : newEntry.IsRedistRoot.ToString());
 
-                            AssemblyEntry dictionaryEntry = null;
-                            assemblyEntries.TryGetValue(hashIndex, out dictionaryEntry);
+                            assemblyEntries.TryGetValue(hashIndex, out AssemblyEntry dictionaryEntry);
                             // If the entry is not in the hashtable or the entry is in the hashtable but the new entry has the ingac flag true, make sure the hashtable contains the entry with the ingac true.
-                            if (dictionaryEntry == null || (dictionaryEntry != null && newEntry.InGAC))
+                            if (dictionaryEntry == null || newEntry.InGAC)
                             {
                                 assemblyEntries[hashIndex] = newEntry;
                             }
@@ -871,7 +807,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private static AssemblyEntry ReadFileListEntry(AssemblyTableInfo assemblyTableInfo, string path, string redistName, XmlReader reader, bool fullFusionNameRequired)
         {
-            Dictionary<string, string> attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var attributes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             reader.MoveToFirstAttribute();
             do
@@ -881,39 +817,23 @@ namespace Microsoft.Build.Tasks
 
             reader.MoveToElement();
 
-            string name;
-            attributes.TryGetValue("AssemblyName", out name);
-
-            string version;
-            attributes.TryGetValue("Version", out version);
-
-            string publicKeyToken;
-            attributes.TryGetValue("PublicKeyToken", out publicKeyToken);
-
-            string culture;
-            attributes.TryGetValue("Culture", out culture);
-
-            string inGAC;
-            attributes.TryGetValue("InGAC", out inGAC);
-
-            string retargetable;
-            attributes.TryGetValue("Retargetable", out retargetable);
-
-            string isRedistRoot;
-            attributes.TryGetValue("IsRedistRoot", out isRedistRoot);
-
-            bool inGACFlag;
-            if (!bool.TryParse(inGAC, out inGACFlag))
+            attributes.TryGetValue("AssemblyName", out string name);
+            attributes.TryGetValue("Version", out string version);
+            attributes.TryGetValue("PublicKeyToken", out string publicKeyToken);
+            attributes.TryGetValue("Culture", out string culture);
+            attributes.TryGetValue("InGAC", out string inGAC);
+            attributes.TryGetValue("Retargetable", out string retargetable);
+            attributes.TryGetValue("IsRedistRoot", out string isRedistRoot);
+            if (!bool.TryParse(inGAC, out bool inGACFlag))
             {
                 inGACFlag = true;                           // true by default 
             }
-            bool retargetableFlag;
-            // The retargetable flag is Yes or No for some reason
-            retargetableFlag = "Yes".Equals(retargetable, StringComparison.OrdinalIgnoreCase);
 
-            bool isRedistRootAsBoolean;
+            // The retargetable flag is Yes or No for some reason
+            bool retargetableFlag = "Yes".Equals(retargetable, StringComparison.OrdinalIgnoreCase);
+
             bool? isRedistRootFlag = null;                  // null by default.
-            if (bool.TryParse(isRedistRoot, out isRedistRootAsBoolean))
+            if (bool.TryParse(isRedistRoot, out bool isRedistRootAsBoolean))
             {
                 isRedistRootFlag = isRedistRootAsBoolean;
             }
@@ -932,7 +852,7 @@ namespace Microsoft.Build.Tasks
         }
 
         #region Comparers
-        private readonly static IComparer<AssemblyEntry> s_sortByVersionDescending = new SortByVersionDescending();
+        private static readonly IComparer<AssemblyEntry> s_sortByVersionDescending = new SortByVersionDescending();
 
         /// <summary>
         /// The redist list is a collection of AssemblyEntry. We would like to have the redist list sorted on two keys.
@@ -992,41 +912,23 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     internal class AssemblyTableInfo : IComparable
     {
-        private readonly string _path;
-        private readonly string _frameworkDirectory;
         private string _descriptor;
 
         internal AssemblyTableInfo(string path, string frameworkDirectory)
         {
-            _path = path;
-            _frameworkDirectory = frameworkDirectory;
+            Path = path;
+            FrameworkDirectory = frameworkDirectory;
         }
 
-        internal string Path
-        {
-            get { return _path; }
-        }
+        internal string Path { get; }
 
-        internal string FrameworkDirectory
-        {
-            get { return _frameworkDirectory; }
-        }
+        internal string FrameworkDirectory { get; }
 
-        internal string Descriptor
-        {
-            get
-            {
-                if (null == _descriptor)
-                {
-                    _descriptor = _path + _frameworkDirectory;
-                }
-                return _descriptor;
-            }
-        }
+        internal string Descriptor => _descriptor ?? (_descriptor = Path + FrameworkDirectory);
 
         public int CompareTo(object obj)
         {
-            AssemblyTableInfo that = (AssemblyTableInfo)obj;
+            var that = (AssemblyTableInfo)obj;
             return String.Compare(Descriptor, that.Descriptor, StringComparison.OrdinalIgnoreCase);
         }
     }
@@ -1044,7 +946,7 @@ namespace Microsoft.Build.Tasks
         private static Dictionary<string, string[]> s_subsetListPathCache;
 
         // Locl for subsetListPathCache
-        private static Object s_subsetListPathCacheLock = new Object();
+        private static readonly Object s_subsetListPathCacheLock = new Object();
 
         // Folder to look for the subset lists in under the target framework directories
         private const string subsetListFolder = "SubsetList";
@@ -1052,7 +954,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// The subset names to search for.
         /// </summary>
-        private string[] _subsetToSearchFor;
+        private readonly string[] _subsetToSearchFor;
 
         #endregion
 
@@ -1066,7 +968,7 @@ namespace Microsoft.Build.Tasks
         /// found in the target framework directories. This can happen if the the subsets are instead passed in as InstalledDefaultSubsetTables</param>
         internal SubsetListFinder(string[] subsetToSearchFor)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(subsetToSearchFor, "subsetToSearchFor");
+            ErrorUtilities.VerifyThrowArgumentNull(subsetToSearchFor, nameof(subsetToSearchFor));
             _subsetToSearchFor = subsetToSearchFor;
         }
 
@@ -1076,13 +978,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         ///  Folder to look for the subset lists under the target framework directories
         /// </summary>
-        public static string SubsetListFolder
-        {
-            get
-            {
-                return subsetListFolder;
-            }
-        }
+        public static string SubsetListFolder => subsetListFolder;
 
         #endregion
 
@@ -1096,7 +992,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>Array of paths locations to subset lists under the given framework directory.</returns>
         public string[] GetSubsetListPathsFromDisk(string frameworkDirectory)
         {
-            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, "frameworkDirectory");
+            ErrorUtilities.VerifyThrowArgumentNull(frameworkDirectory, nameof(frameworkDirectory));
 
             // Make sure we have some subset names to search for it is possible that no subsets are asked for
             // so we should return as quickly as possible in that case.
@@ -1111,22 +1007,19 @@ namespace Microsoft.Build.Tasks
                         s_subsetListPathCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
                     }
 
-
                     // TargetFrameworkDirectory is not unique enough because a different invocation could ask for a different 
                     // set of subset files from the same TargetFrameworkDirectory
                     string concatenatedSubsetListNames = String.Join(";", _subsetToSearchFor);
 
                     string key = frameworkDirectory + ":" + concatenatedSubsetListNames;
 
-
-                    string[] subsetLists = null;
-                    s_subsetListPathCache.TryGetValue(key, out subsetLists);
+                    s_subsetListPathCache.TryGetValue(key, out string[] subsetLists);
                     if (subsetLists == null)
                     {
                         // Get the path to the subset folder under the target framework directory
                         string subsetDirectory = Path.Combine(frameworkDirectory, subsetListFolder);
 
-                        List<string> subsetFilesForFrameworkDirectory = new List<string>();
+                        var subsetFilesForFrameworkDirectory = new List<string>();
 
                         // Go through each of the subsets and see if it is in the target framework subset directory 
                         foreach (string subsetName in _subsetToSearchFor)
@@ -1161,72 +1054,68 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     internal class AssemblyEntry
     {
-        private readonly string _fullName;
-        private readonly bool _inGAC;
-        private readonly bool? _isRedistRoot;
-        private readonly string _redistName;
-        private readonly string _simpleName;
-        private readonly string _frameworkDirectory;
-        private readonly bool _retargetable;
         private AssemblyNameExtension _assemblyName;
+
         public AssemblyEntry(string name, string version, string publicKeyToken, string culture, bool inGAC, bool? isRedistRoot, string redistName, string frameworkDirectory, bool retargetable)
         {
             Debug.Assert(name != null && frameworkDirectory != null);
-            _simpleName = name;
+            SimpleName = name;
             if (name != null && version != null && publicKeyToken != null && culture != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}", name, version, culture, publicKeyToken);
+                FullName = $"{name}, Version={version}, Culture={culture}, PublicKeyToken={publicKeyToken}";
             }
             else if (name != null && version != null && publicKeyToken != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, PublicKeyToken={2}", name, version, publicKeyToken);
+                FullName = $"{name}, Version={version}, PublicKeyToken={publicKeyToken}";
             }
             else if (name != null && version != null && culture != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}", name, version, culture);
+                FullName = $"{name}, Version={version}, Culture={culture}";
             }
             else if (name != null && version != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}", name, version);
+                FullName = $"{name}, Version={version}";
             }
             else if (name != null && publicKeyToken != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, PublicKeyToken={1}", name, version);
+                FullName = $"{name}, PublicKeyToken={version}";
             }
             else if (name != null && culture != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}, Culture={1}", name, culture);
+                FullName = $"{name}, Culture={culture}";
             }
             else if (name != null)
             {
-                _fullName = string.Format(CultureInfo.InvariantCulture, "{0}", name);
+                FullName = $"{name}";
             }
 
             if (retargetable)
             {
-                _fullName += ", Retargetable=Yes";
+                FullName += ", Retargetable=Yes";
             }
 
-            _inGAC = inGAC;
-            _isRedistRoot = isRedistRoot;
-            _redistName = redistName;
-            _frameworkDirectory = frameworkDirectory;
-            _retargetable = retargetable;
+            InGAC = inGAC;
+            IsRedistRoot = isRedistRoot;
+            RedistName = redistName;
+            FrameworkDirectory = frameworkDirectory;
+            Retargetable = retargetable;
         }
-        public string FullName { get { return _fullName; } }
-        public bool InGAC { get { return _inGAC; } }
-        public bool? IsRedistRoot { get { return _isRedistRoot; } }
-        public string RedistName { get { return _redistName; } }
-        public string SimpleName { get { return _simpleName; } }
-        public string FrameworkDirectory { get { return _frameworkDirectory; } }
-        public bool Retargetable { get { return _retargetable; } }
+
+        public string FullName { get; }
+        public bool InGAC { get; }
+        public bool? IsRedistRoot { get;  }
+        public string RedistName { get; }
+        public string SimpleName { get; }
+        public string FrameworkDirectory { get; }
+        public bool Retargetable { get; }
+
         public AssemblyNameExtension AssemblyNameExtension
         {
             get
             {
                 if (_assemblyName == null)
                 {
-                    _assemblyName = new AssemblyNameExtension(_fullName, true);
+                    _assemblyName = new AssemblyNameExtension(FullName, true);
                     _assemblyName.MarkImmutable();
                 }
 

--- a/src/Tasks/RequiresFramework35SP1Assembly.cs
+++ b/src/Tasks/RequiresFramework35SP1Assembly.cs
@@ -13,27 +13,15 @@ namespace Microsoft.Build.Tasks
     public sealed class RequiresFramework35SP1Assembly : TaskExtension
     {
         #region Fields
-        private string _errorReportUrl;
+
         private string _targetFrameworkVersion = Constants.TargetFrameworkVersion20;
         private bool? _createDesktopShortcut;
-        private bool _signingManifests;
-        private bool _outputRequiresMinimumFramework35SP1;
 
-        private ITaskItem[] _referencedAssemblies;
-        private ITaskItem[] _assemblies;
-        private ITaskItem _deploymentManifestEntryPoint;
-        private ITaskItem _entryPoint;
-        private ITaskItem[] _files;
-        private string _suiteName;
         #endregion
 
         #region Properties
 
-        public string ErrorReportUrl
-        {
-            get { return _errorReportUrl; }
-            set { _errorReportUrl = value; }
-        }
+        public string ErrorReportUrl { get; set; }
 
         public string TargetFrameworkVersion
         {
@@ -45,7 +33,7 @@ namespace Microsoft.Build.Tasks
                 }
                 return _targetFrameworkVersion;
             }
-            set { _targetFrameworkVersion = value; }
+            set => _targetFrameworkVersion = value;
         }
 
         public bool CreateDesktopShortcut
@@ -62,57 +50,25 @@ namespace Microsoft.Build.Tasks
                 }
                 return (bool)_createDesktopShortcut;
             }
-            set { _createDesktopShortcut = value; }
+            set => _createDesktopShortcut = value;
         }
 
-        public bool SigningManifests
-        {
-            get { return _signingManifests; }
-            set { _signingManifests = value; }
-        }
+        public bool SigningManifests { get; set; }
 
-        public ITaskItem[] ReferencedAssemblies
-        {
-            get { return _referencedAssemblies; }
-            set { _referencedAssemblies = value; }
-        }
+        public ITaskItem[] ReferencedAssemblies { get; set; }
 
-        public ITaskItem[] Assemblies
-        {
-            get { return _assemblies; }
-            set { _assemblies = value; }
-        }
+        public ITaskItem[] Assemblies { get; set; }
 
-        public ITaskItem DeploymentManifestEntryPoint
-        {
-            get { return _deploymentManifestEntryPoint; }
-            set { _deploymentManifestEntryPoint = value; }
-        }
+        public ITaskItem DeploymentManifestEntryPoint { get; set; }
 
-        public ITaskItem EntryPoint
-        {
-            get { return _entryPoint; }
-            set { _entryPoint = value; }
-        }
+        public ITaskItem EntryPoint { get; set; }
 
-        public ITaskItem[] Files
-        {
-            get { return _files; }
-            set { _files = value; }
-        }
+        public ITaskItem[] Files { get; set; }
 
-        public string SuiteName
-        {
-            get { return _suiteName; }
-            set { _suiteName = value; }
-        }
+        public string SuiteName { get; set; }
 
         [Output]
-        public bool RequiresMinimumFramework35SP1
-        {
-            get { return _outputRequiresMinimumFramework35SP1; }
-            set { _outputRequiresMinimumFramework35SP1 = value; }
-        }
+        public bool RequiresMinimumFramework35SP1 { get; set; }
 
         #endregion
 
@@ -157,11 +113,11 @@ namespace Microsoft.Build.Tasks
 
         private bool ExcludeReferenceFromHashing()
         {
-            if (HasExcludedFileOrSP1File(_referencedAssemblies) ||
-                HasExcludedFileOrSP1File(_assemblies) ||
-                HasExcludedFileOrSP1File(_files) ||
-                IsExcludedFileOrSP1File(_deploymentManifestEntryPoint) ||
-                IsExcludedFileOrSP1File(_entryPoint))
+            if (HasExcludedFileOrSP1File(ReferencedAssemblies) ||
+                HasExcludedFileOrSP1File(Assemblies) ||
+                HasExcludedFileOrSP1File(Files) ||
+                IsExcludedFileOrSP1File(DeploymentManifestEntryPoint) ||
+                IsExcludedFileOrSP1File(EntryPoint))
             {
                 return true;
             }
@@ -189,8 +145,6 @@ namespace Microsoft.Build.Tasks
         /// Is this file System.Data.Entity.dll?
         /// Is this file Client Sentinel Assembly? 
         /// </summary>
-        /// <param name="file"></param>
-        /// <returns></returns>
         private static bool IsExcludedFileOrSP1File(ITaskItem candidateFile)
         {
             if (candidateFile != null &&
@@ -211,18 +165,9 @@ namespace Microsoft.Build.Tasks
 
         #endregion
 
-        public RequiresFramework35SP1Assembly()
-        {
-        }
-
         public override bool Execute()
         {
-            _outputRequiresMinimumFramework35SP1 = false;
-
-            if (HasErrorUrl() || HasCreatedShortcut() || UncheckedSigning() || ExcludeReferenceFromHashing() || HasSuiteName())
-            {
-                _outputRequiresMinimumFramework35SP1 = true;
-            }
+            RequiresMinimumFramework35SP1 = HasErrorUrl() || HasCreatedShortcut() || UncheckedSigning() || ExcludeReferenceFromHashing() || HasSuiteName();
 
             return true;
         }

--- a/src/Tasks/ResGen.cs
+++ b/src/Tasks/ResGen.cs
@@ -99,8 +99,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public ITaskItem[] InputFiles
             {
-                get { return (ITaskItem[])Bag["InputFiles"]; }
-                set { Bag["InputFiles"] = value; }
+                get => (ITaskItem[])Bag[nameof(InputFiles)];
+                set => Bag[nameof(InputFiles)] = value;
             }
 
             /// <summary>
@@ -111,8 +111,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public ITaskItem[] OutputFiles
             {
-                get { return (ITaskItem[])Bag["OutputFiles"]; }
-                set { Bag["OutputFiles"] = value; }
+                get => (ITaskItem[])Bag[nameof(OutputFiles)];
+                set => Bag[nameof(OutputFiles)] = value;
             }
 
             /// <summary>
@@ -121,8 +121,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public bool PublicClass
             {
-                get { return GetBoolParameterWithDefault("PublicClass", false); }
-                set { Bag["PublicClass"] = value; }
+                get => GetBoolParameterWithDefault(nameof(PublicClass), false);
+                set => Bag[nameof(PublicClass)] = value;
             }
 
             /// <summary>
@@ -130,8 +130,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public ITaskItem[] References
             {
-                get { return (ITaskItem[])Bag["References"]; }
-                set { Bag["References"] = value; }
+                get => (ITaskItem[])Bag[nameof(References)];
+                set => Bag[nameof(References)] = value;
             }
 
             /// <summary>
@@ -139,8 +139,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public string SdkToolsPath
             {
-                get { return (string)Bag["SdkToolsPath"]; }
-                set { Bag["SdkToolsPath"] = value; }
+                get => (string)Bag[nameof(SdkToolsPath)];
+                set => Bag[nameof(SdkToolsPath)] = value;
             }
 
             /// <summary>
@@ -149,8 +149,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public string StronglyTypedLanguage
             {
-                get { return (string)Bag["StronglyTypedLanguage"]; }
-                set { Bag["StronglyTypedLanguage"] = value; }
+                get => (string)Bag[nameof(StronglyTypedLanguage)];
+                set => Bag[nameof(StronglyTypedLanguage)] = value;
             }
 
             /// <summary>
@@ -159,8 +159,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public string StronglyTypedNamespace
             {
-                get { return (string)Bag["StronglyTypedNamespace"]; }
-                set { Bag["StronglyTypedNamespace"] = value; }
+                get => (string)Bag[nameof(StronglyTypedNamespace)];
+                set => Bag[nameof(StronglyTypedNamespace)] = value;
             }
 
             /// <summary>
@@ -169,8 +169,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public string StronglyTypedClassName
             {
-                get { return (string)Bag["StronglyTypedClassName"]; }
-                set { Bag["StronglyTypedClassName"] = value; }
+                get => (string)Bag[nameof(StronglyTypedClassName)];
+                set => Bag[nameof(StronglyTypedClassName)] = value;
             }
 
             /// <summary>
@@ -179,8 +179,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public string StronglyTypedFileName
             {
-                get { return (string)Bag["StronglyTypedFileName"]; }
-                set { Bag["StronglyTypedFileName"] = value; }
+                get => (string)Bag[nameof(StronglyTypedFileName)];
+                set => Bag[nameof(StronglyTypedFileName)] = value;
             }
 
             /// <summary>
@@ -189,8 +189,8 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public bool UseSourcePath
             {
-                get { return GetBoolParameterWithDefault("UseSourcePath", false); }
-                set { Bag["UseSourcePath"] = value; }
+                get => GetBoolParameterWithDefault(nameof(UseSourcePath), false);
+                set => Bag[nameof(UseSourcePath)] = value;
             }
 
             #endregion // Properties
@@ -200,13 +200,7 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// Returns the name of the tool to execute
             /// </summary>
-            protected override string ToolName
-            {
-                get
-                {
-                    return "resgen.exe";
-                }
-            }
+            protected override string ToolName => "resgen.exe";
 
             /// <summary>
             /// Tracker.exe wants Unicode response files, and ResGen.exe doesn't care, 
@@ -216,10 +210,7 @@ namespace Microsoft.Build.Tasks
             /// We no longer use Tracker.exe in ResGen, but given that as ResGen doesn't care, 
             /// there doesn't really seem to be a particular reason to change it back, either...
             /// </comment>
-            protected override Encoding ResponseFileEncoding
-            {
-                get { return Encoding.Unicode; }
-            }
+            protected override Encoding ResponseFileEncoding => Encoding.Unicode;
 
             /// <summary>
             /// Invokes the ToolTask with the given parameters
@@ -228,18 +219,18 @@ namespace Microsoft.Build.Tasks
             public override bool Execute()
             {
                 // If there aren't any input resources, well, we've already succeeded!
-                if (ResGen.IsNullOrEmpty(InputFiles))
+                if (IsNullOrEmpty(InputFiles))
                 {
                     Log.LogMessageFromResources(MessageImportance.Low, "ResGen.NoInputFiles");
                     return !Log.HasLoggedErrors;
                 }
 
-                if (ResGen.IsNullOrEmpty(OutputFiles))
+                if (IsNullOrEmpty(OutputFiles))
                 {
                     GenerateOutputFileNames();
                 }
 
-                bool success = false;
+                bool success;
 
                 // if command line is too long, fail
                 string commandLineCommands = GenerateCommandLineCommands();
@@ -262,8 +253,8 @@ namespace Microsoft.Build.Tasks
                     {
                         // One or more of the generated resources was not, in fact generated --
                         // only keep in OutputFiles the ones that actually exist.
-                        ITaskItem[] outputFiles = this.OutputFiles;
-                        List<ITaskItem> successfullyGenerated = new List<ITaskItem>();
+                        ITaskItem[] outputFiles = OutputFiles;
+                        var successfullyGenerated = new List<ITaskItem>();
 
                         for (int i = 0; i < outputFiles.Length; i++)
                         {
@@ -273,7 +264,7 @@ namespace Microsoft.Build.Tasks
                             }
                         }
 
-                        this.OutputFiles = successfullyGenerated.ToArray();
+                        OutputFiles = successfullyGenerated.ToArray();
                     }
                 }
                 else
@@ -286,7 +277,7 @@ namespace Microsoft.Build.Tasks
                     {
                         if (!File.Exists(outputFile.ItemSpec))
                         {
-                            this.OutputFiles = Array.Empty<ITaskItem>();
+                            OutputFiles = Array.Empty<ITaskItem>();
                         }
                     }
 
@@ -299,7 +290,7 @@ namespace Microsoft.Build.Tasks
                     // Default the filename if we need to - regardless of whether the STR was successfully generated
                     if (StronglyTypedFileName == null)
                     {
-                        CodeDomProvider provider = null;
+                        CodeDomProvider provider;
                         try
                         {
                             provider = CodeDomProvider.CreateProvider(StronglyTypedLanguage);
@@ -343,10 +334,11 @@ namespace Microsoft.Build.Tasks
                         ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(
                             "resgen.exe",
                             TargetDotNetFrameworkVersion.Version35),
-                        StringComparison.OrdinalIgnoreCase) && String.IsNullOrEmpty(StronglyTypedLanguage))
+                        StringComparison.OrdinalIgnoreCase)
+                    && String.IsNullOrEmpty(StronglyTypedLanguage))
                 {
                     // 4.0 resgen.exe does support response files, so we can return the resgen arguments here!
-                    CommandLineBuilderExtension resGenArguments = new CommandLineBuilderExtension();
+                    var resGenArguments = new CommandLineBuilderExtension();
                     GenerateResGenCommands(resGenArguments, true /* arguments must be line-delimited */);
 
                     commandLine.AppendTextUnquoted(resGenArguments.ToString());
@@ -369,19 +361,17 @@ namespace Microsoft.Build.Tasks
             /// <param name="commandLine">Gets filled with command line options</param>
             protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
             {
-                ErrorUtilities.VerifyThrow(!ResGen.IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
+                ErrorUtilities.VerifyThrow(!IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
 
-                CommandLineBuilderExtension resGenArguments = new CommandLineBuilderExtension();
+                var resGenArguments = new CommandLineBuilderExtension();
                 GenerateResGenCommands(resGenArguments, false /* don't line-delimit arguments; spaces are just fine */);
 
                 string pathToResGen = GenerateResGenFullPath();
 
-                if (
-                        pathToResGen != null &&
-                        NativeMethodsShared.IsWindows &&
-                        !pathToResGen.Equals(NativeMethodsShared.GetLongFilePath(ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("resgen.exe", TargetDotNetFrameworkVersion.Version35)), StringComparison.OrdinalIgnoreCase) &&
-                        String.IsNullOrEmpty(StronglyTypedLanguage)
-                   )
+                if (pathToResGen != null &&
+                    NativeMethodsShared.IsWindows &&
+                    !pathToResGen.Equals(NativeMethodsShared.GetLongFilePath(ToolLocationHelper.GetPathToDotNetFrameworkSdkFile("resgen.exe", TargetDotNetFrameworkVersion.Version35)), StringComparison.OrdinalIgnoreCase) &&
+                    String.IsNullOrEmpty(StronglyTypedLanguage))
                 {
                     // 4.0 resgen.exe does support response files (at least as long as you're not building an STR), so we can 
                     // make use of them here by returning nothing!
@@ -399,10 +389,8 @@ namespace Microsoft.Build.Tasks
             /// <returns>A string containing the full path of this tool, or null if the tool was not found</returns>
             protected override string GenerateFullPathToTool()
             {
-                string pathToTool = null;
-
                 // Use ToolPath if it exists.
-                pathToTool = GenerateResGenFullPath();
+                string pathToTool = GenerateResGenFullPath();
                 return pathToTool;
             }
 
@@ -412,10 +400,10 @@ namespace Microsoft.Build.Tasks
             /// <returns>True if parameters are valid</returns>
             protected override bool ValidateParameters()
             {
-                ErrorUtilities.VerifyThrow(!ResGen.IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
+                ErrorUtilities.VerifyThrow(!IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
 
                 // make sure that if the output resources were set, they exactly match the number of input sources
-                if (!ResGen.IsNullOrEmpty(OutputFiles) && (OutputFiles.Length != InputFiles.Length))
+                if (!IsNullOrEmpty(OutputFiles) && (OutputFiles.Length != InputFiles.Length))
                 {
                     Log.LogErrorWithCodeFromResources("General.TwoVectorsMustHaveSameLength", InputFiles.Length, OutputFiles.Length, "InputFiles", "OutputFiles");
                     return false;
@@ -482,7 +470,7 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             private void GenerateOutputFileNames()
             {
-                ErrorUtilities.VerifyThrow(!ResGen.IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
+                ErrorUtilities.VerifyThrow(!IsNullOrEmpty(InputFiles), "If InputFiles is empty, the task should have returned before reaching this point");
 
                 ITaskItem[] inputFiles = InputFiles;
                 ITaskItem[] outputFiles = new ITaskItem[inputFiles.Length];
@@ -490,9 +478,7 @@ namespace Microsoft.Build.Tasks
                 // Set the default OutputFiles values
                 for (int i = 0; i < inputFiles.Length; i++)
                 {
-                    ITaskItem2 inputFileAsITaskItem2 = inputFiles[i] as ITaskItem2;
-
-                    if (inputFileAsITaskItem2 != null)
+                    if (inputFiles[i] is ITaskItem2 inputFileAsITaskItem2)
                     {
                         outputFiles[i] = new TaskItem(Path.ChangeExtension(inputFileAsITaskItem2.EvaluatedIncludeEscaped, ".resources"));
                     }
@@ -502,7 +488,7 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 
-                Bag["OutputFiles"] = outputFiles;
+                Bag[nameof(OutputFiles)] = outputFiles;
             }
 
             /// <summary>
@@ -511,11 +497,8 @@ namespace Microsoft.Build.Tasks
             /// <returns>The path to ResGen.exe, or null.</returns>
             private string GenerateResGenFullPath()
             {
-                string pathToTool = null;
-
                 // Use ToolPath if it exists.
-                pathToTool = (string)Bag["ToolPathWithFile"];
-
+                var pathToTool = (string)Bag["ToolPathWithFile"];
                 if (pathToTool == null)
                 {
                     // First see if the user has set ToolPath
@@ -560,7 +543,7 @@ namespace Microsoft.Build.Tasks
             {
                 resGenArguments = resGenArguments ?? new CommandLineBuilderExtension();
 
-                if (ResGen.IsNullOrEmpty(OutputFiles))
+                if (IsNullOrEmpty(OutputFiles))
                 {
                     GenerateOutputFileNames();
                 }
@@ -620,7 +603,7 @@ namespace Microsoft.Build.Tasks
                             {
                                 resGenArguments.AppendFileNamesIfNotNull
                                 (
-                                    new ITaskItem[] { inputFiles[i], outputFiles[i] },
+                                    new[] { inputFiles[i], outputFiles[i] },
                                     ","
                                 );
                             }
@@ -637,7 +620,7 @@ namespace Microsoft.Build.Tasks
                     resGenArguments.AppendSwitchIfNotNull
                     (
                         "/str:",
-                        new string[] { StronglyTypedLanguage, StronglyTypedNamespace, StronglyTypedClassName, StronglyTypedFileName },
+                        new[] { StronglyTypedLanguage, StronglyTypedNamespace, StronglyTypedClassName, StronglyTypedFileName },
                         ","
                     );
                 }

--- a/src/Tasks/ResGen.cs
+++ b/src/Tasks/ResGen.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Build.Tasks
                         ToolLocationHelper.GetPathToDotNetFrameworkSdkFile(
                             "resgen.exe",
                             TargetDotNetFrameworkVersion.Version35),
-                        StringComparison.OrdinalIgnoreCase)
+                            StringComparison.OrdinalIgnoreCase)
                     && String.IsNullOrEmpty(StronglyTypedLanguage))
                 {
                     // 4.0 resgen.exe does support response files, so we can return the resgen arguments here!

--- a/src/Tasks/ResolveCodeAnalysisRuleSet.cs
+++ b/src/Tasks/ResolveCodeAnalysisRuleSet.cs
@@ -16,66 +16,30 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public sealed class ResolveCodeAnalysisRuleSet : TaskExtension
     {
-        /// <summary>
-        /// The desired code analysis rule set file.
-        /// </summary>
-        private string _codeAnalysisRuleSet;
-
-        /// <summary>
-        /// The location of the project currently being built.
-        /// </summary>
-        private string _projectDirectory;
-
-        /// <summary>
-        /// The set of additional directories to search for code analysis rule set files.
-        /// </summary>
-        private string[] _codeAnalysisRuleSetDirectories;
-
-        /// <summary>
-        /// The location of the resolved rule set file. May be null if the file
-        /// does not exist on disk.
-        /// </summary>
-        private string _resolvedCodeAnalysisRuleSet;
-
         #region Properties
 
         /// <summary>
         /// The desired code analysis rule set file. May be a simple name, relative
         /// path, or full path.
         /// </summary>
-        public string CodeAnalysisRuleSet
-        {
-            get { return _codeAnalysisRuleSet; }
-            set { _codeAnalysisRuleSet = value; }
-        }
+        public string CodeAnalysisRuleSet { get; set; }
 
         /// <summary>
         /// The set of additional directories to search for code analysis rule set files.
         /// </summary>
-        public string[] CodeAnalysisRuleSetDirectories
-        {
-            get { return _codeAnalysisRuleSetDirectories; }
-            set { _codeAnalysisRuleSetDirectories = value; }
-        }
+        public string[] CodeAnalysisRuleSetDirectories { get; set; }
 
         /// <summary>
         /// The location of the project currently being built.
         /// </summary>
-        public string MSBuildProjectDirectory
-        {
-            get { return _projectDirectory; }
-            set { _projectDirectory = value; }
-        }
+        public string MSBuildProjectDirectory { get; set; }
 
         /// <summary>
         /// The location of the resolved rule set file. May be null if the file
         /// does not exist on disk.
         /// </summary>
         [Output]
-        public string ResolvedCodeAnalysisRuleSet
-        {
-            get { return _resolvedCodeAnalysisRuleSet; }
-        }
+        public string ResolvedCodeAnalysisRuleSet { get; private set; }
 
         /// <summary>
         /// Runs the task.
@@ -83,7 +47,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>True if the task succeeds without errors; false otherwise.</returns>
         public override bool Execute()
         {
-            _resolvedCodeAnalysisRuleSet = GetResolvedRuleSetPath();
+            ResolvedCodeAnalysisRuleSet = GetResolvedRuleSetPath();
 
             return !Log.HasLoggedErrors;
         }
@@ -109,30 +73,30 @@ namespace Microsoft.Build.Tasks
         /// <returns>The full or relative path to the rule set, or null if the file does not exist.</returns>
         private string GetResolvedRuleSetPath()
         {
-            if (string.IsNullOrEmpty(_codeAnalysisRuleSet))
+            if (string.IsNullOrEmpty(CodeAnalysisRuleSet))
             {
                 return null;
             }
 
-            if (_codeAnalysisRuleSet == Path.GetFileName(_codeAnalysisRuleSet))
+            if (CodeAnalysisRuleSet == Path.GetFileName(CodeAnalysisRuleSet))
             {
                 // This is a simple file name.
                 // Check if the file exists in the MSBuild project directory.
-                if (!string.IsNullOrEmpty(_projectDirectory))
+                if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
-                    string fullName = Path.Combine(_projectDirectory, _codeAnalysisRuleSet);
+                    string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
                     if (File.Exists(fullName))
                     {
-                        return _codeAnalysisRuleSet;
+                        return CodeAnalysisRuleSet;
                     }
                 }
 
                 // Try the rule set directories if we have some.
-                if (_codeAnalysisRuleSetDirectories != null)
+                if (CodeAnalysisRuleSetDirectories != null)
                 {
-                    foreach (string directory in _codeAnalysisRuleSetDirectories)
+                    foreach (string directory in CodeAnalysisRuleSetDirectories)
                     {
-                        string fullName = Path.Combine(directory, _codeAnalysisRuleSet);
+                        string fullName = Path.Combine(directory, CodeAnalysisRuleSet);
                         if (File.Exists(fullName))
                         {
                             return fullName;
@@ -140,26 +104,26 @@ namespace Microsoft.Build.Tasks
                     }
                 }
             }
-            else if (!Path.IsPathRooted(_codeAnalysisRuleSet))
+            else if (!Path.IsPathRooted(CodeAnalysisRuleSet))
             {
                 // This is a path relative to the project.
-                if (!string.IsNullOrEmpty(_projectDirectory))
+                if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
-                    string fullName = Path.Combine(_projectDirectory, _codeAnalysisRuleSet);
+                    string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
                     if (File.Exists(fullName))
                     {
-                        return _codeAnalysisRuleSet;
+                        return CodeAnalysisRuleSet;
                     }
                 }
             }
-            else if (File.Exists(_codeAnalysisRuleSet))
+            else if (File.Exists(CodeAnalysisRuleSet))
             {
                 // This is a full path.
-                return _codeAnalysisRuleSet;
+                return CodeAnalysisRuleSet;
             }
 
             // We can't resolve the rule set to any existing file.
-            Log.LogWarningWithCodeFromResources("Compiler.UnableToFindRuleSet", _codeAnalysisRuleSet);
+            Log.LogWarningWithCodeFromResources("Compiler.UnableToFindRuleSet", CodeAnalysisRuleSet);
             return null;
         }
 

--- a/src/Tasks/ResolveNativeReference.cs
+++ b/src/Tasks/ResolveNativeReference.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.IO;
-using System.Diagnostics;
-using System.Resources;
-using System.Reflection;
 using System.Collections;
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
-using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
@@ -36,13 +33,10 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                ErrorUtilities.VerifyThrowArgumentNull(_nativeReferences, "nativeReferences");
+                ErrorUtilities.VerifyThrowArgumentNull(_nativeReferences, nameof(NativeReferences));
                 return _nativeReferences;
             }
-            set
-            {
-                _nativeReferences = value;
-            }
+            set => _nativeReferences = value;
         }
 
         [Required]
@@ -50,100 +44,31 @@ namespace Microsoft.Build.Tasks
         {
             get
             {
-                ErrorUtilities.VerifyThrowArgumentNull(_additionalSearchPaths, "additionalSearchPaths");
+                ErrorUtilities.VerifyThrowArgumentNull(_additionalSearchPaths, nameof(AdditionalSearchPaths));
                 return _additionalSearchPaths;
             }
-            set
-            {
-                _additionalSearchPaths = value;
-            }
+            set => _additionalSearchPaths = value;
         }
 
         [Output]
-        public ITaskItem[] ContainingReferenceFiles
-        {
-            get
-            {
-                return _containingReferenceFiles;
-            }
-            set
-            {
-                _containingReferenceFiles = value;
-            }
-        }
+        public ITaskItem[] ContainingReferenceFiles { get; set; }
 
         [Output]
-        public ITaskItem[] ContainedPrerequisiteAssemblies
-        {
-            get
-            {
-                return _containedPrerequisiteAssemblies;
-            }
-            set
-            {
-                _containedPrerequisiteAssemblies = value;
-            }
-        }
+        public ITaskItem[] ContainedPrerequisiteAssemblies { get; set; }
 
         [Output]
-        public ITaskItem[] ContainedComComponents
-        {
-            get
-            {
-                return _containedComComponents;
-            }
-            set
-            {
-                _containedComComponents = value;
-            }
-        }
+        public ITaskItem[] ContainedComComponents { get; set; }
 
         [Output]
-        public ITaskItem[] ContainedTypeLibraries
-        {
-            get
-            {
-                return _containedTypeLibraries;
-            }
-            set
-            {
-                _containedTypeLibraries = value;
-            }
-        }
+        public ITaskItem[] ContainedTypeLibraries { get; set; }
 
         [Output]
-        public ITaskItem[] ContainedLooseTlbFiles
-        {
-            get
-            {
-                return _containedLooseTlbFiles;
-            }
-            set
-            {
-                _containedLooseTlbFiles = value;
-            }
-        }
+        public ITaskItem[] ContainedLooseTlbFiles { get; set; }
 
         [Output]
-        public ITaskItem[] ContainedLooseEtcFiles
-        {
-            get
-            {
-                return _containedLooseEtcFiles;
-            }
-            set
-            {
-                _containedLooseEtcFiles = value;
-            }
-        }
+        public ITaskItem[] ContainedLooseEtcFiles { get; set; }
 
-        private ITaskItem[] _nativeReferences = null;
-        private ITaskItem[] _containingReferenceFiles = null;
-        private ITaskItem[] _containedPrerequisiteAssemblies = null;
-        private ITaskItem[] _containedComComponents = null;
-        private ITaskItem[] _containedTypeLibraries = null;
-        private ITaskItem[] _containedLooseTlbFiles = null;
-        private ITaskItem[] _containedLooseEtcFiles = null;
+        private ITaskItem[] _nativeReferences;
         private string[] _additionalSearchPaths = Array.Empty<string>();
         #endregion
 
@@ -163,20 +88,19 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Task entry point.
         /// </summary>
-        /// <returns></returns>
         public override bool Execute()
         {
             // Process each task item. If one of them fails we still process the
             // rest of them, but remember that the task should return failure.
             bool retValue = true;
-            int reference = 0;
+            int reference;
 
-            Hashtable containingReferenceFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable containedPrerequisiteAssembliesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable containedComComponentsTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable containedTypeLibrariesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable containedLooseTlbFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-            Hashtable containedLooseEtcFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containingReferenceFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containedPrerequisiteAssembliesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containedComComponentsTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containedTypeLibrariesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containedLooseTlbFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var containedLooseEtcFilesTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
             for (reference = 0; reference < NativeReferences.GetLength(0); reference++)
             {
@@ -230,29 +154,29 @@ namespace Microsoft.Build.Tasks
 
             IComparer itemSpecComparer = new ItemSpecComparerClass();
 
-            _containingReferenceFiles = new ITaskItem[containingReferenceFilesTable.Count];
-            containingReferenceFilesTable.Values.CopyTo(_containingReferenceFiles, 0);
-            Array.Sort(_containingReferenceFiles, itemSpecComparer);
+            ContainingReferenceFiles = new ITaskItem[containingReferenceFilesTable.Count];
+            containingReferenceFilesTable.Values.CopyTo(ContainingReferenceFiles, 0);
+            Array.Sort(ContainingReferenceFiles, itemSpecComparer);
 
-            _containedPrerequisiteAssemblies = new ITaskItem[containedPrerequisiteAssembliesTable.Count];
-            containedPrerequisiteAssembliesTable.Values.CopyTo(_containedPrerequisiteAssemblies, 0);
-            Array.Sort(_containedPrerequisiteAssemblies, itemSpecComparer);
+            ContainedPrerequisiteAssemblies = new ITaskItem[containedPrerequisiteAssembliesTable.Count];
+            containedPrerequisiteAssembliesTable.Values.CopyTo(ContainedPrerequisiteAssemblies, 0);
+            Array.Sort(ContainedPrerequisiteAssemblies, itemSpecComparer);
 
-            _containedComComponents = new ITaskItem[containedComComponentsTable.Count];
-            containedComComponentsTable.Values.CopyTo(_containedComComponents, 0);
-            Array.Sort(_containedComComponents, itemSpecComparer);
+            ContainedComComponents = new ITaskItem[containedComComponentsTable.Count];
+            containedComComponentsTable.Values.CopyTo(ContainedComComponents, 0);
+            Array.Sort(ContainedComComponents, itemSpecComparer);
 
-            _containedTypeLibraries = new ITaskItem[containedTypeLibrariesTable.Count];
-            containedTypeLibrariesTable.Values.CopyTo(_containedTypeLibraries, 0);
-            Array.Sort(_containedTypeLibraries, itemSpecComparer);
+            ContainedTypeLibraries = new ITaskItem[containedTypeLibrariesTable.Count];
+            containedTypeLibrariesTable.Values.CopyTo(ContainedTypeLibraries, 0);
+            Array.Sort(ContainedTypeLibraries, itemSpecComparer);
 
-            _containedLooseTlbFiles = new ITaskItem[containedLooseTlbFilesTable.Count];
-            containedLooseTlbFilesTable.Values.CopyTo(_containedLooseTlbFiles, 0);
-            Array.Sort(_containedLooseTlbFiles, itemSpecComparer);
+            ContainedLooseTlbFiles = new ITaskItem[containedLooseTlbFilesTable.Count];
+            containedLooseTlbFilesTable.Values.CopyTo(ContainedLooseTlbFiles, 0);
+            Array.Sort(ContainedLooseTlbFiles, itemSpecComparer);
 
-            _containedLooseEtcFiles = new ITaskItem[containedLooseEtcFilesTable.Count];
-            containedLooseEtcFilesTable.Values.CopyTo(_containedLooseEtcFiles, 0);
-            Array.Sort(_containedLooseEtcFiles, itemSpecComparer);
+            ContainedLooseEtcFiles = new ITaskItem[containedLooseEtcFilesTable.Count];
+            containedLooseEtcFilesTable.Values.CopyTo(ContainedLooseEtcFiles, 0);
+            Array.Sort(ContainedLooseEtcFiles, itemSpecComparer);
 
             return retValue;
         }
@@ -267,7 +191,7 @@ namespace Microsoft.Build.Tasks
         {
             Log.LogMessageFromResources(MessageImportance.Low, "ResolveNativeReference.Comment", path);
 
-            Manifest manifest = null;
+            Manifest manifest;
 
             try
             {
@@ -285,19 +209,21 @@ namespace Microsoft.Build.Tasks
                 manifest.ReadOnly = true; // only reading a manifest, set flag so we get GenerateManifest.ResolveFailedInReadOnlyMode instead of GenerateManifest.ResolveFailedInReadWriteMode messages
                 manifest.ResolveFiles();
                 if (!manifest.OutputMessages.LogTaskMessages(this))
+                {
                     return false;
+                }
 
-                ApplicationManifest applicationManifest = manifest as ApplicationManifest;
-                bool isClickOnceApp = applicationManifest != null && applicationManifest.IsClickOnceManifest;
+                bool isClickOnceApp = manifest is ApplicationManifest applicationManifest && applicationManifest.IsClickOnceManifest;
                 // ClickOnce application manifest should not be added as native reference, but we should open and process it.        
                 if (containingReferenceFilesTable.ContainsKey(path) == false && !isClickOnceApp)
                 {
                     ITaskItem itemNativeReferenceFile = new TaskItem();
                     itemNativeReferenceFile.ItemSpec = path;
                     if (manifest.AssemblyIdentity.Name != null)
+                    {
                         itemNativeReferenceFile.SetMetadata(ItemMetadataNames.fusionName, manifest.AssemblyIdentity.Name);
-                    if (taskItem != null)
-                        taskItem.CopyMetadataTo(itemNativeReferenceFile);
+                    }
+                    taskItem?.CopyMetadataTo(itemNativeReferenceFile);
                     containingReferenceFilesTable.Add(path, itemNativeReferenceFile);
                 }
 
@@ -336,7 +262,9 @@ namespace Microsoft.Build.Tasks
                     foreach (FileReference fileref in manifest.FileReferences)
                     {
                         if (fileref.ResolvedPath == null)
+                        {
                             continue;
+                        }
 
                         // add the loose file to the outputs list, if it's not already there
                         if (containedLooseEtcFilesTable.ContainsKey(fileref.ResolvedPath) == false)
@@ -377,10 +305,7 @@ namespace Microsoft.Build.Tasks
                                     itemTypeLib.SetMetadata(ComReferenceItemMetadataNames.wrapperTool, ComReferenceTypes.tlbimp);
                                     itemTypeLib.SetMetadata(ComReferenceItemMetadataNames.guid, typelib.TlbId);
                                     itemTypeLib.SetMetadata(ComReferenceItemMetadataNames.lcid, "0");
-                                    string delimStr = ".";
-                                    char[] delimiter = delimStr.ToCharArray();
-                                    string[] verMajorAndMinor = null;
-                                    verMajorAndMinor = typelib.Version.Split(delimiter);
+                                    string[] verMajorAndMinor = typelib.Version.Split('.');
                                     // UNDONE: are major and minor version numbers in base 10 or 16?
                                     itemTypeLib.SetMetadata(ComReferenceItemMetadataNames.versionMajor, verMajorAndMinor[0]);
                                     itemTypeLib.SetMetadata(ComReferenceItemMetadataNames.versionMinor, verMajorAndMinor[1]);

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -7,14 +7,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Linq;
-using System.Globalization;
-using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -39,12 +38,12 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// SimpleName group
         /// </summary>
-        private static readonly string s_SDKsimpleNameGroup = "SDKSIMPLENAME";
+        private const string SDKsimpleNameGroup = "SDKSIMPLENAME";
 
         /// <summary>
         /// Version group
         /// </summary>
-        private static readonly string s_SDKVersionGroup = "SDKVERSION";
+        private const string SDKVersionGroup = "SDKVERSION";
 
         /// <summary>
         /// Delimiter used to delimit the dependent sdk's in the warning message
@@ -54,7 +53,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Split char for the appx attribute
         /// </summary>
-        private static readonly char[] s_appxSplitChar = new char[] { '-' };
+        private static readonly char[] s_appxSplitChar = { '-' };
 
         /// <summary>
         /// SDKName
@@ -74,7 +73,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Default target platform version
         /// </summary>
-        private static Version s_defaultTargetPlatformVersion = new Version("7.0");
+        private static readonly Version s_defaultTargetPlatformVersion = new Version("7.0");
 
         /// <summary>
         ///  Set of sdk references to resolve to paths on disk.
@@ -87,39 +86,24 @@ namespace Microsoft.Build.Tasks
         private ITaskItem[] _installedSDKs = Array.Empty<ITaskItem>();
 
         /// <summary>
-        /// Should resolution errors be logged as warnings or errors.
-        /// </summary>
-        private bool _logResolutionErrorsAsWarnings = false;
-
-        /// <summary>
-        /// The value of the prefer32bit flag used in the build
-        /// </summary>
-        private bool _prefer32Bit = false;
-
-        /// <summary>
         /// stores value of TargetPlatformVersion property
         /// </summary>
-        private Version _targetPlatformVersion = null;
+        private Version _targetPlatformVersion;
 
         /// <summary>
         /// Stores TargetPlatform property
         /// </summary>
-        private string _targetPlatformIdentifier = null;
+        private string _targetPlatformIdentifier;
 
         /// <summary>
         /// Stores ProjectName property
         /// </summary>
-        private string _projectName = null;
+        private string _projectName;
 
         /// <summary>
         /// Stores dictionary with runtime only reference dependencies
         /// </summary>
         private Dictionary<string, string> _runtimeReferenceOnlyDependenciesByName;
-
-        /// <summary>
-        /// Stores flag to enable warning if SDK's max platform version is not specified in the manifest
-        /// </summary>
-        private bool _enableMaxPlatformVersionEmptyWarning = false;
 
         #endregion
 
@@ -132,14 +116,11 @@ namespace Microsoft.Build.Tasks
         [Required]
         public ITaskItem[] SDKReferences
         {
-            get
-            {
-                return _sdkReferences;
-            }
+            get => _sdkReferences;
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentNull(value, "SDKReferences");
+                ErrorUtilities.VerifyThrowArgumentNull(value, nameof(SDKReferences));
                 _sdkReferences = value;
             }
         }
@@ -151,14 +132,11 @@ namespace Microsoft.Build.Tasks
         [Required]
         public ITaskItem[] InstalledSDKs
         {
-            get
-            {
-                return _installedSDKs;
-            }
+            get => _installedSDKs;
 
             set
             {
-                ErrorUtilities.VerifyThrowArgumentNull(value, "InstalledSDKs");
+                ErrorUtilities.VerifyThrowArgumentNull(value, nameof(InstalledSDKs));
                 _installedSDKs = value;
             }
         }
@@ -175,10 +153,7 @@ namespace Microsoft.Build.Tasks
                 return _targetPlatformIdentifier;
             }
 
-            set
-            {
-                _targetPlatformIdentifier = value;
-            }
+            set => _targetPlatformIdentifier = value;
         }
 
         /// <summary>
@@ -193,10 +168,7 @@ namespace Microsoft.Build.Tasks
                 return _projectName;
             }
 
-            set
-            {
-                _projectName = value;
-            }
+            set => _projectName = value;
         }
 
         /// <summary>
@@ -205,15 +177,11 @@ namespace Microsoft.Build.Tasks
         [Required]
         public string TargetPlatformVersion
         {
-            get
-            {
-                return TargetPlatformAsVersion.ToString();
-            }
+            get => TargetPlatformAsVersion.ToString();
 
             set
             {
-                Version versionValue;
-                if (Version.TryParse(value, out versionValue))
+                if (Version.TryParse(value, out Version versionValue))
                 {
                     TargetPlatformAsVersion = versionValue;
                 }
@@ -224,113 +192,56 @@ namespace Microsoft.Build.Tasks
         /// Reference may be passed in so their SDKNames can be resolved and then sdkroot paths can be tacked onto the reference
         /// so RAR can find the assembly correctly in the sdk location.
         /// </summary>
-        public ITaskItem[] References
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] References { get; set; }
 
         /// <summary>
         /// List of disallowed dependencies passed from the targets file (deprecated)
         /// For instance "VCLibs 11" should be disallowed in projects targeting Win 8.1 or higher.
         /// </summary>
-        public ITaskItem[] DisallowedSDKDependencies
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] DisallowedSDKDependencies { get; set; }
 
         /// <summary>
         /// List of dependencies passed from the targets file that will have the metadata RuntimeReferenceOnly set as true. 
         /// For instance "VCLibs 11" should have such a metadata set to true in projects targeting Win 8.1 or higher.
         /// </summary>
-        public ITaskItem[] RuntimeReferenceOnlySDKDependencies
-        {
-            get;
-            set;
-        }
+        public ITaskItem[] RuntimeReferenceOnlySDKDependencies { get; set; }
 
         /// <summary>
         /// Configuration for SDK's which are resolved
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
-        public string TargetedSDKConfiguration
-        {
-            get;
-            set;
-        }
+        public string TargetedSDKConfiguration { get; set; }
 
         /// <summary>
         /// Architecture of the SDK's we are targeting
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
-        public string TargetedSDKArchitecture
-        {
-            get;
-            set;
-        }
+        public string TargetedSDKArchitecture { get; set; }
 
         /// <summary>
         /// Enables warning when MaxPlatformVersion is not present in the manifest and the ESDK platform version (from its path) 
         /// is different than the target platform version (from the project)
         /// </summary>
-        public bool WarnOnMissingPlatformVersion
-        {
-            get
-            {
-                return _enableMaxPlatformVersionEmptyWarning;
-            }
-
-            set
-            {
-                _enableMaxPlatformVersionEmptyWarning = value;
-            }
-        }
+        public bool WarnOnMissingPlatformVersion { get; set; }
 
         /// <summary>
         /// Should problems resolving SDKs be logged as a warning or an error.
         /// If the resolution problem is logged as an error the build will fail.
         /// If the resolution problem is logged as a warning we will warn and continue.
         /// </summary>
-        public bool LogResolutionErrorsAsWarnings
-        {
-            get
-            {
-                return _logResolutionErrorsAsWarnings;
-            }
-
-            set
-            {
-                _logResolutionErrorsAsWarnings = value;
-            }
-        }
+        public bool LogResolutionErrorsAsWarnings { get; set; }
 
         /// <summary>
         /// The prefer32bit flag used during the build
         /// </summary>
-        public bool Prefer32Bit
-        {
-            get
-            {
-                return _prefer32Bit;
-            }
-
-            set
-            {
-                _prefer32Bit = value;
-            }
-        }
+        public bool Prefer32Bit { get; set; }
 
         /// <summary>
         /// Resolved SDK References
         /// </summary>
         [Output]
         [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SDK", Justification = "Shipped this way in Dev11 Beta (go-live)")]
-        public ITaskItem[] ResolvedSDKReferences
-        {
-            get;
-            private set;
-        }
+        public ITaskItem[] ResolvedSDKReferences { get; private set; }
 
         /// <summary>
         /// Version object containing target platform version
@@ -343,10 +254,7 @@ namespace Microsoft.Build.Tasks
                 return _targetPlatformVersion;
             }
 
-            set
-            {
-                _targetPlatformVersion = value;
-            }
+            set => _targetPlatformVersion = value;
         }
 
         #endregion
@@ -356,7 +264,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
-            ResolvedSDKReferences = Array.Empty<TaskItem>();
+            ResolvedSDKReferences = Array.Empty<ITaskItem>();
 
             if (InstalledSDKs.Length == 0)
             {
@@ -370,10 +278,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem runtimeDependencyOnlyItem in RuntimeReferenceOnlySDKDependencies)
                 {
-                    string dependencyName;
-                    string dependencyVersion;
-
-                    if (ParseSDKReference(runtimeDependencyOnlyItem.ItemSpec, out dependencyName, out dependencyVersion))
+                    if (ParseSDKReference(runtimeDependencyOnlyItem.ItemSpec, out string dependencyName, out string dependencyVersion))
                     {
                         _runtimeReferenceOnlyDependenciesByName[dependencyName] = dependencyVersion;
                     }
@@ -381,30 +286,22 @@ namespace Microsoft.Build.Tasks
             }
 
             // Convert the list of installed SDK's to a dictionary for faster lookup
-            Dictionary<string, ITaskItem> sdkItems = new Dictionary<string, ITaskItem>(StringComparer.OrdinalIgnoreCase);
+            var sdkItems = new Dictionary<string, ITaskItem>(InstalledSDKs.Length, StringComparer.OrdinalIgnoreCase);
 
             foreach (ITaskItem installedsdk in InstalledSDKs)
             {
                 string installLocation = installedsdk.ItemSpec;
                 string sdkName = installedsdk.GetMetadata(SDKName);
-                string sdkPlatformVersion = installedsdk.GetMetadata(SDKPlatformVersion);
 
                 if (installLocation.Length > 0 && sdkName.Length > 0)
                 {
-                    if (!sdkItems.ContainsKey(sdkName))
-                    {
-                        sdkItems.Add(sdkName, installedsdk);
-                    }
-                    else
-                    {
-                        sdkItems[sdkName] = installedsdk;
-                    }
+                    sdkItems[sdkName] = installedsdk;
                 }
             }
 
             // We need to check to see if there are any SDKNames on any of the reference items in the project. If there are 
             // then we do not want those SDKs to expand their reference assemblies by default because we are going to use RAR to look inside of them for certain reference assemblies only.
-            HashSet<string> sdkNamesOnReferenceItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var sdkNamesOnReferenceItems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             if (References != null)
             {
                 foreach (ITaskItem referenceItem in References)
@@ -418,16 +315,16 @@ namespace Microsoft.Build.Tasks
             }
 
             // The set of reference items declared in the project file, without duplicate entries.
-            HashSet<SDKReference> sdkReferenceItems = new HashSet<SDKReference>();
+            var sdkReferenceItems = new HashSet<SDKReference>();
 
             // Maps a product family name to a set of SDKs with that product family name
-            Dictionary<string, HashSet<SDKReference>> productFamilyNameToSDK = new Dictionary<string, HashSet<SDKReference>>(StringComparer.OrdinalIgnoreCase);
+            var productFamilyNameToSDK = new Dictionary<string, HashSet<SDKReference>>(StringComparer.OrdinalIgnoreCase);
 
             // Maps a sdk name (no version) to a set of SDKReferences with the same name
-            Dictionary<string, HashSet<SDKReference>> sdkNameToSDK = new Dictionary<string, HashSet<SDKReference>>(StringComparer.OrdinalIgnoreCase);
+            var sdkNameToSDK = new Dictionary<string, HashSet<SDKReference>>(StringComparer.OrdinalIgnoreCase);
 
             // Set of sdks which are not compatible with other sdks of the same product famuily or with the same sdk name
-            HashSet<SDKReference> sdksNotCompatibleWithOtherSDKs = new HashSet<SDKReference>();
+            var sdksNotCompatibleWithOtherSDKs = new HashSet<SDKReference>();
 
             // Go through each reference passed in and determine if it is in the set of installed SDKs. 
             // Also create new output items if the item is in an installed SDK and set the metadata correctly.
@@ -447,13 +344,12 @@ namespace Microsoft.Build.Tasks
                 if (!sdkReferenceItems.Contains(reference) /* filter out duplicate sdk reference entries*/)
                 {
                     sdkReferenceItems.Add(reference);
-                    reference.Resolve(sdkItems, TargetedSDKConfiguration, TargetedSDKArchitecture, sdkNamesOnReferenceItems, _logResolutionErrorsAsWarnings, _prefer32Bit, TargetPlatformIdentifier, TargetPlatformAsVersion, ProjectName, _enableMaxPlatformVersionEmptyWarning);
+                    reference.Resolve(sdkItems, TargetedSDKConfiguration, TargetedSDKArchitecture, sdkNamesOnReferenceItems, LogResolutionErrorsAsWarnings, Prefer32Bit, TargetPlatformIdentifier, TargetPlatformAsVersion, ProjectName, WarnOnMissingPlatformVersion);
                     if (reference.Resolved)
                     {
                         if (!String.IsNullOrEmpty(reference.ProductFamilyName))
                         {
-                            HashSet<SDKReference> sdksWithProductFamilyName = null;
-                            if (!productFamilyNameToSDK.TryGetValue(reference.ProductFamilyName, out sdksWithProductFamilyName))
+                            if (!productFamilyNameToSDK.TryGetValue(reference.ProductFamilyName, out HashSet<SDKReference> sdksWithProductFamilyName))
                             {
                                 productFamilyNameToSDK.Add(reference.ProductFamilyName, new HashSet<SDKReference> { reference });
                             }
@@ -468,8 +364,7 @@ namespace Microsoft.Build.Tasks
                             sdksNotCompatibleWithOtherSDKs.Add(reference);
                         }
 
-                        HashSet<SDKReference> sdksWithSimpleName = null;
-                        if (!sdkNameToSDK.TryGetValue(reference.SimpleName, out sdksWithSimpleName))
+                        if (!sdkNameToSDK.TryGetValue(reference.SimpleName, out HashSet<SDKReference> sdksWithSimpleName))
                         {
                             sdkNameToSDK.Add(reference.SimpleName, new HashSet<SDKReference> { reference });
                         }
@@ -494,16 +389,15 @@ namespace Microsoft.Build.Tasks
                 // If we have already error or warned about an sdk not being compatible with one of the notCompatibleReferences then do not log it again
                 // an sdk could be incompatible because the productfamily is the same but also be incompatible at the same time due to the sdk name
                 // we only want to log one of those cases so we do not get 2 warings or errors for the same sdks.
-                HashSet<SDKReference> sdksAlreadyErrorOrWarnedFor = new HashSet<SDKReference>();
+                var sdksAlreadyErrorOrWarnedFor = new HashSet<SDKReference>();
 
                 // Check to see if a productfamily was set, we want to emit this warning or error first.
                 if (!String.IsNullOrEmpty(notCompatibleReference.ProductFamilyName))
                 {
-                    HashSet<SDKReference> referenceInProductFamily = null;
-                    if (productFamilyNameToSDK.TryGetValue(notCompatibleReference.ProductFamilyName, out referenceInProductFamily))
+                    if (productFamilyNameToSDK.TryGetValue(notCompatibleReference.ProductFamilyName, out HashSet<SDKReference> referenceInProductFamily))
                     {
                         // We want to build a list of incompatible reference names so we can emit them in the error or warnings.
-                        List<string> listOfIncompatibleReferences = new List<string>();
+                        var listOfIncompatibleReferences = new List<string>();
                         foreach (SDKReference incompatibleReference in referenceInProductFamily)
                         {
                             if (!sdksAlreadyErrorOrWarnedFor.Contains(incompatibleReference) && incompatibleReference != notCompatibleReference /*cannot be incompatible with self*/)
@@ -529,11 +423,10 @@ namespace Microsoft.Build.Tasks
                     }
                 }
 
-                HashSet<SDKReference> referenceWithSameName = null;
-                if (sdkNameToSDK.TryGetValue(notCompatibleReference.SimpleName, out referenceWithSameName))
+                if (sdkNameToSDK.TryGetValue(notCompatibleReference.SimpleName, out HashSet<SDKReference> referenceWithSameName))
                 {
                     // We want to build a list of incompatible reference names so we can emit them in the error or warnings.
-                    List<string> listOfIncompatibleReferences = new List<string>();
+                    var listOfIncompatibleReferences = new List<string>();
                     foreach (SDKReference incompatibleReference in referenceWithSameName)
                     {
                         if (!sdksAlreadyErrorOrWarnedFor.Contains(incompatibleReference) && incompatibleReference != notCompatibleReference /*cannot be incompatible with self*/)
@@ -576,7 +469,7 @@ namespace Microsoft.Build.Tasks
         {
             if (referencesToAddMetadata != null)
             {
-                foreach (var referenceItem in sdkReferenceItems)
+                foreach (SDKReference referenceItem in sdkReferenceItems)
                 {
                     string sdkSimpleName = referenceItem.SimpleName;
                     string rawSdkVersion = referenceItem.Version;
@@ -594,7 +487,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal static void VerifySDKDependsOn(TaskLoggingHelper log, HashSet<SDKReference> sdkReferenceItems)
         {
-            foreach (var reference in sdkReferenceItems)
+            foreach (SDKReference reference in sdkReferenceItems)
             {
                 List<string> dependentSDKs = ParseDependsOnSDK(reference.DependsOnSDK);
                 if (dependentSDKs.Count > 0)
@@ -620,9 +513,7 @@ namespace Microsoft.Build.Tasks
         {
             string[] unresolvedDependencyIdentities = dependentSDKs.Where(x =>
             {
-                string simpleName;
-                string sdkVersion;
-                bool parseSuccessful = ParseSDKReference(x, out simpleName, out sdkVersion);
+                bool parseSuccessful = ParseSDKReference(x, out string simpleName, out string sdkVersion);
                 if (!parseSuccessful)
                 {
                     // If a dependency could not be parsed as an SDK identity then ignore it from the list of unresolved dependencies
@@ -636,13 +527,13 @@ namespace Microsoft.Build.Tasks
                 return resolvedReference == null;
             })
             .Select(y => String.Format(CultureInfo.CurrentCulture, "\"{0}\"", y))
-            .ToArray<string>();
+            .ToArray();
 
             return unresolvedDependencyIdentities;
         }
 
         /// <summary>
-        ///  Parse out the sdk identities
+        /// Parse out the sdk identities
         /// </summary>
         internal static List<string> ParseDependsOnSDK(string dependsOnSDK)
         {
@@ -659,9 +550,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal SDKReference ParseSDKReference(ITaskItem referenceItem)
         {
-            string sdkSimpleName;
-            string rawSdkVersion;
-            bool splitSuccessful = ParseSDKReference(referenceItem.ItemSpec, out sdkSimpleName, out rawSdkVersion);
+            bool splitSuccessful = ParseSDKReference(referenceItem.ItemSpec, out string sdkSimpleName, out string rawSdkVersion);
 
             if (!splitSuccessful)
             {
@@ -669,7 +558,7 @@ namespace Microsoft.Build.Tasks
                 return null;
             }
 
-            SDKReference reference = new SDKReference(referenceItem, sdkSimpleName, rawSdkVersion);
+            var reference = new SDKReference(referenceItem, sdkSimpleName, rawSdkVersion);
             return reference;
         }
 
@@ -686,11 +575,10 @@ namespace Microsoft.Build.Tasks
 
             if (match.Success)
             {
-                sdkSimpleName = match.Groups[s_SDKsimpleNameGroup].Value.Trim();
+                sdkSimpleName = match.Groups[SDKsimpleNameGroup].Value.Trim();
 
-                rawSdkVersion = match.Groups[s_SDKVersionGroup].Value.Trim();
-                Version sdkVersion = null;
-                parsedVersion = Version.TryParse(rawSdkVersion, out sdkVersion);
+                rawSdkVersion = match.Groups[SDKVersionGroup].Value.Trim();
+                parsedVersion = Version.TryParse(rawSdkVersion, out _);
             }
 
             return sdkSimpleName.Length > 0 && parsedVersion;
@@ -745,7 +633,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void LogErrorOrWarning(Tuple<string, object[]> errorOrWarning)
         {
-            if (_logResolutionErrorsAsWarnings)
+            if (LogResolutionErrorsAsWarnings)
             {
                 Log.LogWarningWithCodeFromResources(errorOrWarning.Item1, errorOrWarning.Item2);
             }
@@ -763,7 +651,7 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// Delimiter for supported architectures
             /// </summary>
-            private static readonly char[] s_supportedArchitecturesSplitChars = new Char[] { ';' };
+            private static readonly char[] s_supportedArchitecturesSplitChars = { ';' };
 
             /// <summary>
             /// Delimiter used to delimit the supported architectures in the error message
@@ -823,7 +711,7 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// SDKManifest object encapsulating all the information contained in the manifest xml file
             /// </summary>
-            private SDKManifest _sdkManifest = null;
+            private SDKManifest _sdkManifest;
 
             /// <summary>
             /// What should happen if this sdk is resolved with other sdks of the same productfamily or same sdk name.
@@ -833,7 +721,7 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// Value of the prefer32Bit property from the project.
             /// </summary>
-            private bool _prefer32BitFromProject = false;
+            private bool _prefer32BitFromProject;
 
             #region Constructor
             /// <summary>
@@ -841,9 +729,9 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public SDKReference(ITaskItem taskItem, string sdkName, string sdkVersion)
             {
-                ErrorUtilities.VerifyThrowArgumentNull(taskItem, "taskItem");
-                ErrorUtilities.VerifyThrowArgumentLength(sdkName, "sdkName");
-                ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, "sdkVersion");
+                ErrorUtilities.VerifyThrowArgumentNull(taskItem, nameof(taskItem));
+                ErrorUtilities.VerifyThrowArgumentLength(sdkName, nameof(sdkName));
+                ErrorUtilities.VerifyThrowArgumentLength(sdkVersion, nameof(sdkVersion));
 
                 ReferenceItem = taskItem;
                 SimpleName = sdkName;
@@ -862,281 +750,156 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             ///  Sdk reference item passed in from the build
             /// </summary>
-            public ITaskItem ReferenceItem
-            {
-                get;
-                private set;
-            }
+            public ITaskItem ReferenceItem { get; }
 
             /// <summary>
             /// Parsed simple name
             /// </summary>
-            public string SimpleName
-            {
-                get;
-                private set;
-            }
+            public string SimpleName { get; }
 
             /// <summary>
             /// Parsed version.
             /// </summary>
-            public string Version
-            {
-                get;
-                private set;
-            }
+            public string Version { get; }
 
             /// <summary>
             /// Resolved full path to the root of the sdk.
             /// </summary>
-            public string ResolvedPath
-            {
-                get;
-                private set;
-            }
+            public string ResolvedPath { get; private set; }
 
             /// <summary>
             /// Has the reference been resolved
             /// </summary>
-            public bool Resolved
-            {
-                get
-                {
-                    return !String.IsNullOrEmpty(ResolvedPath);
-                }
-            }
+            public bool Resolved => !String.IsNullOrEmpty(ResolvedPath);
 
             /// <summary>
             /// Messages which may be warnings or errors depending on the logging setting.
             /// </summary>
-            public List<Tuple<string, object[]>> ResolutionErrors
-            {
-                get;
-                private set;
-            }
+            public List<Tuple<string, object[]>> ResolutionErrors { get; }
 
             /// <summary>
             /// Warning messages only
             /// </summary>
-            public List<Tuple<string, object[]>> ResolutionWarnings
-            {
-                get;
-                private set;
-            }
+            public List<Tuple<string, object[]>> ResolutionWarnings { get; }
 
             /// <summary>
             /// Messages generated during resolution
             /// </summary>
-            public List<Tuple<string, object[]>> StatusMessages
-            {
-                get;
-                private set;
-            }
+            public List<Tuple<string, object[]>> StatusMessages { get; }
 
             /// <summary>
             /// SDKName, this is a formatted name based on the SimpleName and the Version
             /// </summary>
-            public string SDKName
-            {
-                get;
-                private set;
-            }
+            public string SDKName { get; }
 
             /// <summary>
             /// Resolved item which will be output by the task.
             /// </summary>
-            public ITaskItem ResolvedItem
-            {
-                get;
-                set;
-            }
+            public ITaskItem ResolvedItem { get; set; }
 
             /// <summary>
             /// SDKType found in the sdk manifest
             /// </summary>
-            public SDKType SDKType
-            {
-                get;
-                set;
-            }
+            public SDKType SDKType { get; set; }
 
             /// <summary>
             /// The target platform in the sdk manifest
             /// </summary>
-            public string TargetPlatform
-            {
-                get;
-                set;
-            }
+            public string TargetPlatform { get; set; }
 
             /// <summary>
             /// The target platform min version in the sdk manifest
             /// </summary>
-            public string TargetPlatformMinVersion
-            {
-                get;
-                set;
-            }
+            public string TargetPlatformMinVersion { get; set; }
 
             /// <summary>
             /// The target platform max version in the sdk manifest
             /// </summary>
-            public string TargetPlatformVersion
-            {
-                get;
-                set;
-            }
+            public string TargetPlatformVersion { get; set; }
 
             /// <summary>
             /// DisplayName found in the sdk manifest
             /// </summary>
-            public string DisplayName
-            {
-                get;
-                set;
-            }
+            public string DisplayName { get; set; }
 
             /// <summary>
             /// Support Prefer32bit found in the sdk manifest
             /// </summary>
-            public string SupportPrefer32Bit
-            {
-                get;
-                set;
-            }
+            public string SupportPrefer32Bit { get; set; }
 
             /// <summary>
             /// CopyRedistToSubDirectory specifies where the redist files should be copied to relative to the root of the package.
             /// </summary>
-            public string CopyRedistToSubDirectory
-            {
-                get;
-                set;
-            }
+            public string CopyRedistToSubDirectory { get; set; }
 
             /// <summary>
             /// ProductFamilyName specifies the product family for the SDK. This is offered up as metadata on the resolved sdkreference and is used to detect sdk conflicts.
             /// </summary>
-            public string ProductFamilyName
-            {
-                get;
-                set;
-            }
+            public string ProductFamilyName { get; set; }
 
             /// <summary>
             /// SupportsMultipleVersions specifies what should happen if multiple versions of the product family or sdk name are detected
             /// </summary>
             public MultipleVersionSupport SupportsMultipleVersions
             {
-                get
-                {
-                    return _supportsMultipleVersions;
-                }
-
-                set
-                {
-                    _supportsMultipleVersions = value;
-                }
+                get => _supportsMultipleVersions;
+                set => _supportsMultipleVersions = value;
             }
 
             /// <summary>
             /// Supported Architectures is a semicolon delimited list of architectures that the SDK supports.
             /// </summary>
-            public string SupportedArchitectures
-            {
-                get;
-                set;
-            }
+            public string SupportedArchitectures { get; set; }
 
             /// <summary>
             /// DependsOnSDK is a semicolon delimited list of SDK identities that the SDK requires be resolved in order to function.
             /// </summary>
-            public string DependsOnSDK
-            {
-                get;
-                set;
-            }
+            public string DependsOnSDK { get; set; }
 
             /// <summary>
             /// MaxPlatformVersion as in the manifest
             /// </summary>
-            public string MaxPlatformVersion
-            {
-                get;
-                set;
-            }
+            public string MaxPlatformVersion { get; set; }
 
             /// <summary>
             /// MinOSVersion as in the manifest
             /// </summary>
-            public string MinOSVersion
-            {
-                get;
-                set;
-            }
+            public string MinOSVersion { get; set; }
 
             /// <summary>
             /// MaxOSVersionTested as in the manifest
             /// </summary>
-            public string MaxOSVersionTested
-            {
-                get;
-                set;
-            }
+            public string MaxOSVersionTested { get; set; }
 
             /// <summary>
             /// MoreInfo as in the manifest
             /// </summary>
-            public string MoreInfo
-            {
-                get;
-                set;
-            }
+            public string MoreInfo { get; set; }
 
             /// <summary>
             /// What ever framework identities we found in the manifest.
             /// </summary>
-            private Dictionary<string, string> FrameworkIdentitiesFromManifest
-            {
-                get;
-                set;
-            }
+            private Dictionary<string, string> FrameworkIdentitiesFromManifest { get; }
 
             /// <summary>
             /// The frameworkIdentity for the sdk, this may be a single name or a | delimited name
             /// </summary>
-            private string FrameworkIdentity
-            {
-                get;
-                set;
-            }
+            private string FrameworkIdentity { get; set; }
 
             /// <summary>
             /// PlatformIdentity if it exists in the appx manifest for this sdk.
             /// </summary>
-            private string PlatformIdentity
-            {
-                get;
-                set;
-            }
+            private string PlatformIdentity { get; set; }
 
             /// <summary>
             /// Whatever appx locations we found in the manifest
             /// </summary>
-            private Dictionary<string, string> AppxLocationsFromManifest
-            {
-                get;
-                set;
-            }
+            private Dictionary<string, string> AppxLocationsFromManifest { get; }
 
             /// <summary>
             /// The appxlocation for the sdk can be a single name or a | delimited list
             /// </summary>
-            private string AppxLocation
-            {
-                get;
-                set;
-            }
+            private string AppxLocation { get; set; }
 
             #endregion
 
@@ -1154,8 +917,7 @@ namespace Microsoft.Build.Tasks
                     // There must be a trailing slash or else the ExpandSDKReferenceAssemblies will not work.
                     ResolvedPath = FileUtilities.EnsureTrailingSlash(sdks[SDKName].ItemSpec);
 
-                    Version targetPlatformVersionFromItem;
-                    System.Version.TryParse(sdks[SDKName].GetMetadata(SDKPlatformVersion), out targetPlatformVersionFromItem);
+                    System.Version.TryParse(sdks[SDKName].GetMetadata(SDKPlatformVersion), out Version targetPlatformVersionFromItem);
 
                     GetSDKManifestAttributes();
 
@@ -1178,8 +940,7 @@ namespace Microsoft.Build.Tasks
             /// </summary>
             public override bool Equals(object obj)
             {
-                SDKReference reference = obj as SDKReference;
-                if (reference == null)
+                if (!(obj is SDKReference reference))
                 {
                     return false;
                 }
@@ -1210,7 +971,7 @@ namespace Microsoft.Build.Tasks
                     return true;
                 }
 
-                bool simpleNameMatches = String.Equals(this.SimpleName, other.SimpleName, StringComparison.OrdinalIgnoreCase);
+                bool simpleNameMatches = String.Equals(SimpleName, other.SimpleName, StringComparison.OrdinalIgnoreCase);
                 bool versionMatches = Version.Equals(other.Version, StringComparison.OrdinalIgnoreCase);
 
                 return simpleNameMatches && versionMatches;
@@ -1235,10 +996,10 @@ namespace Microsoft.Build.Tasks
             /// <summary>
             /// Get a piece of metadata off an item and make sureit is trimmed
             /// </summary>
-            private string GetItemMetadataTrimmed(ITaskItem item, string metadataName)
+            private static string GetItemMetadataTrimmed(ITaskItem item, string metadataName)
             {
                 string metadataValue = item.GetMetadata(metadataName);
-                return metadataValue = metadataValue != null ? metadataValue.Trim() : metadataValue;
+                return metadataValue != null ? metadataValue.Trim() : metadataValue;
             }
 
             /// <summary>
@@ -1361,8 +1122,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    SDKType sdkType = SDKType.Unspecified;
-                    Enum.TryParse<SDKType>(sdkTypeFromMetadata, out sdkType);
+                    Enum.TryParse<SDKType>(sdkTypeFromMetadata, out SDKType sdkType);
                     SDKType = sdkType;
                 }
 
@@ -1449,7 +1209,7 @@ namespace Microsoft.Build.Tasks
                 AddStatusMessage("ResolveSDKReference.TargetedConfigAndArchitecture", sdkConfiguration, sdkArchitecture);
 
                 string[] supportedArchitectures = null;
-                if (SupportedArchitectures != null && SupportedArchitectures.Length > 0)
+                if (!string.IsNullOrEmpty(SupportedArchitectures))
                 {
                     supportedArchitectures = SupportedArchitectures.Split(s_supportedArchitecturesSplitChars, StringSplitOptions.RemoveEmptyEntries);
                 }
@@ -1490,9 +1250,7 @@ namespace Microsoft.Build.Tasks
 
                 if (!String.IsNullOrEmpty(MaxPlatformVersion))
                 {
-                    Version maxPlatformVersionAsVersion;
-
-                    if (System.Version.TryParse(MaxPlatformVersion, out maxPlatformVersionAsVersion) && (maxPlatformVersionAsVersion < targetPlatformVersion))
+                    if (System.Version.TryParse(MaxPlatformVersion, out Version maxPlatformVersionAsVersion) && (maxPlatformVersionAsVersion < targetPlatformVersion))
                     {
                         AddResolutionWarning("ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion", projectName, DisplayName, Version, targetPlatformIdentifier, MaxPlatformVersion, targetPlatformIdentifier, targetPlatformVersion.ToString());
                     }
@@ -1509,9 +1267,7 @@ namespace Microsoft.Build.Tasks
 
                 if (!String.IsNullOrEmpty(TargetPlatformMinVersion))
                 {
-                    Version targetPlatformMinVersionAsVersion;
-
-                    if (System.Version.TryParse(TargetPlatformMinVersion, out targetPlatformMinVersionAsVersion) && (targetPlatformVersion < targetPlatformMinVersionAsVersion))
+                    if (System.Version.TryParse(TargetPlatformMinVersion, out Version targetPlatformMinVersionAsVersion) && (targetPlatformVersion < targetPlatformMinVersionAsVersion))
                     {
                         AddResolutionErrorOrWarning("ResolveSDKReference.PlatformVersionIsLessThanMinVersion", projectName, DisplayName, Version, targetPlatformVersion.ToString(), targetPlatformMinVersionAsVersion.ToString());
                     }
@@ -1519,8 +1275,7 @@ namespace Microsoft.Build.Tasks
 
                 if (String.Equals(NeutralArch, sdkArchitecture, StringComparison.OrdinalIgnoreCase) && !String.IsNullOrEmpty(SupportPrefer32Bit) && _prefer32BitFromProject)
                 {
-                    bool supportPrefer32Bit = true;
-                    bool.TryParse(SupportPrefer32Bit, out supportPrefer32Bit);
+                    bool.TryParse(SupportPrefer32Bit, out bool supportPrefer32Bit);
 
                     if (!supportPrefer32Bit)
                     {
@@ -1588,7 +1343,7 @@ namespace Microsoft.Build.Tasks
                         AppxLocation = null;
 
                         // For testing especially it's nice to have a set order of what the generated appxlocation string will be at the end
-                        SortedDictionary<string, string> architectureLocations = new SortedDictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+                        var architectureLocations = new SortedDictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
                         List<string> appxLocationComponents = new List<string>();
 
                         foreach (var appxLocation in AppxLocationsFromManifest)
@@ -1604,7 +1359,7 @@ namespace Microsoft.Build.Tasks
                                 }
 
                                 string configurationComponent = null;
-                                string architectureComponent = null;
+                                string architectureComponent;
                                 switch (appxComponents.Length)
                                 {
                                     case 1:
@@ -1706,14 +1461,9 @@ namespace Microsoft.Build.Tasks
 
                 if (!hasExpandReferenceAssemblies)
                 {
-                    if (referenceItemHasSDKName)
-                    {
-                        ResolvedItem.SetMetadata(SDKManifest.Attributes.ExpandReferenceAssemblies, "false");
-                    }
-                    else
-                    {
-                        ResolvedItem.SetMetadata(SDKManifest.Attributes.ExpandReferenceAssemblies, "true");
-                    }
+                    ResolvedItem.SetMetadata(
+                        SDKManifest.Attributes.ExpandReferenceAssemblies,
+                        referenceItemHasSDKName ? "false" : "true");
                 }
 
                 if (!hasCopyRedist)

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Build.Tasks
             private static string GetItemMetadataTrimmed(ITaskItem item, string metadataName)
             {
                 string metadataValue = item.GetMetadata(metadataName);
-                return metadataValue != null ? metadataValue.Trim() : metadataValue;
+                return metadataValue?.Trim() ?? metadataValue;
             }
 
             /// <summary>
@@ -1461,9 +1461,14 @@ namespace Microsoft.Build.Tasks
 
                 if (!hasExpandReferenceAssemblies)
                 {
-                    ResolvedItem.SetMetadata(
-                        SDKManifest.Attributes.ExpandReferenceAssemblies,
-                        referenceItemHasSDKName ? "false" : "true");
+                    if (referenceItemHasSDKName)
+                    {
+                        ResolvedItem.SetMetadata(SDKManifest.Attributes.ExpandReferenceAssemblies, "false");
+                    }
+                    else
+                    {
+                        ResolvedItem.SetMetadata(SDKManifest.Attributes.ExpandReferenceAssemblies, "true");
+                    }
                 }
 
                 if (!hasCopyRedist)

--- a/src/Tasks/ResolveSDKReference.cs
+++ b/src/Tasks/ResolveSDKReference.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Build.Tasks
             private static string GetItemMetadataTrimmed(ITaskItem item, string metadataName)
             {
                 string metadataValue = item.GetMetadata(metadataName);
-                return metadataValue?.Trim() ?? metadataValue;
+                return metadataValue?.Trim();
             }
 
             /// <summary>

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Build.Tasks
                 }
                 else
                 {
-                    List<Type> types = new List<Type>();
+                    var types = new List<Type>();
                     foreach (Type type in loadedAssembly.GetTypes())
                     {
                         if (!type.Name.StartsWith("$", StringComparison.Ordinal))


### PR DESCRIPTION
For #3320
- ReSharper, nameof()
- Converted some .NET 1.1 data structures to generics to avoid up and down casts
- Sized some allocations
