### PR TITLE
Optimize and clean up ProjectParser

### DIFF
--- a/src/Build/Construction/ProjectItemElement.cs
+++ b/src/Build/Construction/ProjectItemElement.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Build.Construction
         internal static ProjectItemElement CreateDisconnected(string itemType, ProjectRootElement containingProject)
         {
             XmlUtilities.VerifyThrowArgumentValidElementName(itemType);
-            ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[itemType] == null, "CannotModifyReservedItem", itemType);
+            ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(itemType), "CannotModifyReservedItem", itemType);
 
             XmlElementWithLocation element = containingProject.CreateElement(itemType);
 
@@ -417,7 +417,7 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowArgumentLength(newItemType, "itemType");
             XmlUtilities.VerifyThrowArgumentValidElementName(newItemType);
-            ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[newItemType] == null, "CannotModifyReservedItem", newItemType);
+            ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newItemType), "CannotModifyReservedItem", newItemType);
 
             // Because the element was created from our special XmlDocument, we know it's
             // an XmlElementWithLocation.

--- a/src/Build/Construction/ProjectMetadataElement.cs
+++ b/src/Build/Construction/ProjectMetadataElement.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Build.Construction
         {
             XmlUtilities.VerifyThrowArgumentValidElementName(name);
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "ItemSpecModifierCannotBeCustomMetadata", name);
-            ErrorUtilities.VerifyThrowInvalidOperation(XMakeElements.IllegalItemPropertyNames[name] == null, "CannotModifyReservedItemMetadata", name);
+            ErrorUtilities.VerifyThrowInvalidOperation(!XMakeElements.ReservedItemNames.Contains(name), "CannotModifyReservedItemMetadata", name);
 
             XmlElementWithLocation element = containingProject.CreateElement(name);
 
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowArgumentLength(newName, "newName");
             XmlUtilities.VerifyThrowArgumentValidElementName(newName);
-            ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[newName] == null, "CannotModifyReservedItemMetadata", newName);
+            ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newName), "CannotModifyReservedItemMetadata", newName);
 
             if (ExpressedAsAttribute)
             {

--- a/src/Build/Construction/ProjectPropertyElement.cs
+++ b/src/Build/Construction/ProjectPropertyElement.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Build.Construction
         {
             XmlUtilities.VerifyThrowArgumentValidElementName(name);
 
-            ErrorUtilities.VerifyThrowInvalidOperation(XMakeElements.IllegalItemPropertyNames[name] == null && !ReservedPropertyNames.IsReservedProperty(name), "OM_CannotCreateReservedProperty", name);
+            ErrorUtilities.VerifyThrowInvalidOperation(!XMakeElements.ReservedItemNames.Contains(name) && !ReservedPropertyNames.IsReservedProperty(name), "OM_CannotCreateReservedProperty", name);
 
             XmlElementWithLocation element = containingProject.CreateElement(name);
 
@@ -102,7 +102,7 @@ namespace Microsoft.Build.Construction
         {
             ErrorUtilities.VerifyThrowArgumentLength(newName, "newName");
             XmlUtilities.VerifyThrowArgumentValidElementName(newName);
-            ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[newName] == null, "CannotModifyReservedProperty", newName);
+            ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(newName), "CannotModifyReservedProperty", newName);
 
             // Because the element was created from our special XmlDocument, we know it's
             // an XmlElementWithLocation.

--- a/src/Build/Construction/ProjectTargetElement.cs
+++ b/src/Build/Construction/ProjectTargetElement.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Build.Construction
 
                 string unescapedValue = EscapingUtilities.UnescapeAll(value);
 
-                int indexOfSpecialCharacter = unescapedValue.IndexOfAny(XMakeElements.illegalTargetNameCharacters);
+                int indexOfSpecialCharacter = unescapedValue.IndexOfAny(XMakeElements.InvalidTargetNameCharacters);
                 if (indexOfSpecialCharacter >= 0)
                 {
                     ErrorUtilities.ThrowArgument("OM_NameInvalid", unescapedValue, unescapedValue[indexOfSpecialCharacter]);

--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Build.Evaluation
 
             XmlUtilities.VerifyThrowArgumentValidElementName(name);
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "ItemSpecModifierCannotBeCustomMetadata", name);
-            ErrorUtilities.VerifyThrowInvalidOperation(XMakeElements.IllegalItemPropertyNames[name] == null, "CannotModifyReservedItemMetadata", name);
+            ErrorUtilities.VerifyThrowInvalidOperation(!XMakeElements.ReservedItemNames.Contains(name), "CannotModifyReservedItemMetadata", name);
             ErrorUtilities.VerifyThrowInvalidOperation(_xml.Parent != null && _xml.Parent.Parent != null, "OM_ObjectIsNoLongerActive");
 
             if (!propagateMetadataToSiblingItems)

--- a/src/Build/Definition/ProjectItemDefinition.cs
+++ b/src/Build/Definition/ProjectItemDefinition.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Build.Evaluation
         {
             XmlUtilities.VerifyThrowArgumentValidElementName(name);
             ErrorUtilities.VerifyThrowArgument(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "ItemSpecModifierCannotBeCustomMetadata", name);
-            ErrorUtilities.VerifyThrowInvalidOperation(XMakeElements.IllegalItemPropertyNames[name] == null, "CannotModifyReservedItemMetadata", name);
+            ErrorUtilities.VerifyThrowInvalidOperation(!XMakeElements.ReservedItemNames.Contains(name), "CannotModifyReservedItemMetadata", name);
 
             ProjectMetadata metadatum;
 

--- a/src/Build/Definition/ProjectProperty.cs
+++ b/src/Build/Definition/ProjectProperty.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Build.Evaluation
             {
                 ErrorUtilities.VerifyThrowArgumentLength(name, "name");
                 ErrorUtilities.VerifyThrowInvalidOperation(isGlobalProperty || !ProjectHasMatchingGlobalProperty(project, name), "OM_GlobalProperty", name);
-                ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[name] == null, "OM_ReservedName", name);
+                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);
                 ErrorUtilities.VerifyThrowArgument(mayBeReserved || !ReservedPropertyNames.IsReservedProperty(name), "OM_ReservedName", name);
 
                 _name = name;

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -7,10 +7,7 @@
 
 using Microsoft.Build.Shared;
 using System;
-using System.Xml;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using Microsoft.Build.Framework;
 #if (!STANDALONEBUILD)
 using Microsoft.Internal.Performance;
@@ -38,57 +35,62 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Valid attribute list when only Condition and Label are valid
         /// </summary>
-        private readonly static string[] s_validAttributesOnlyConditionAndLabel = new string[] { XMakeAttributes.condition, XMakeAttributes.label };
+        private static readonly HashSet<string> ValidAttributesOnlyConditionAndLabel = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label };
 
         /// <summary>
         /// Valid attribute list for item
         /// </summary>
-        private readonly static string[] s_knownAttributesOnItem = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.include, XMakeAttributes.exclude, XMakeAttributes.remove, XMakeAttributes.keepMetadata, XMakeAttributes.removeMetadata, XMakeAttributes.keepDuplicates, XMakeAttributes.update };
+        private static readonly HashSet<string> KnownAttributesOnItem = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.include, XMakeAttributes.exclude, XMakeAttributes.remove, XMakeAttributes.keepMetadata, XMakeAttributes.removeMetadata, XMakeAttributes.keepDuplicates, XMakeAttributes.update };
+
+        /// <summary>
+        /// Valid attributes list for item which is case-insensitive.
+        /// </summary>
+        private static readonly HashSet<string> KnownAttributesOnItemIgnoreCase = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.include, XMakeAttributes.exclude, XMakeAttributes.remove, XMakeAttributes.keepMetadata, XMakeAttributes.removeMetadata, XMakeAttributes.keepDuplicates, XMakeAttributes.update };
 
         /// <summary>
         /// Valid attributes on import element
         /// </summary>
-        private readonly static string[] s_validAttributesOnImport = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.project, XMakeAttributes.sdk, XMakeAttributes.sdkVersion, XMakeAttributes.sdkMinimumVersion };
+        private static readonly HashSet<string> ValidAttributesOnImport = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.project, XMakeAttributes.sdk, XMakeAttributes.sdkVersion, XMakeAttributes.sdkMinimumVersion };
 
         /// <summary>
         /// Valid attributes on usingtask element
         /// </summary>
-        private readonly static string[] s_validAttributesOnUsingTask = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskName, XMakeAttributes.assemblyFile, XMakeAttributes.assemblyName, XMakeAttributes.taskFactory, XMakeAttributes.architecture, XMakeAttributes.runtime, XMakeAttributes.requiredPlatform, XMakeAttributes.requiredRuntime };
+        private static readonly HashSet<string> ValidAttributesOnUsingTask = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskName, XMakeAttributes.assemblyFile, XMakeAttributes.assemblyName, XMakeAttributes.taskFactory, XMakeAttributes.architecture, XMakeAttributes.runtime, XMakeAttributes.requiredPlatform, XMakeAttributes.requiredRuntime };
 
         /// <summary>
         /// Valid attributes on target element
         /// </summary>
-        private readonly static string[] s_validAttributesOnTarget = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.name, XMakeAttributes.inputs, XMakeAttributes.outputs, XMakeAttributes.keepDuplicateOutputs, XMakeAttributes.dependsOnTargets, XMakeAttributes.beforeTargets, XMakeAttributes.afterTargets, XMakeAttributes.returns };
+        private static readonly HashSet<string> ValidAttributesOnTarget = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.name, XMakeAttributes.inputs, XMakeAttributes.outputs, XMakeAttributes.keepDuplicateOutputs, XMakeAttributes.dependsOnTargets, XMakeAttributes.beforeTargets, XMakeAttributes.afterTargets, XMakeAttributes.returns };
 
         /// <summary>
         /// Valid attributes on on error element
         /// </summary>
-        private readonly static string[] s_validAttributesOnOnError = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.executeTargets };
+        private static readonly HashSet<string> ValidAttributesOnOnError = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.executeTargets };
 
         /// <summary>
         /// Valid attributes on output element
         /// </summary>
-        private readonly static string[] s_validAttributesOnOutput = new string[] { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskParameter, XMakeAttributes.itemName, XMakeAttributes.propertyName };
+        private static readonly HashSet<string> ValidAttributesOnOutput = new HashSet<string> { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.taskParameter, XMakeAttributes.itemName, XMakeAttributes.propertyName };
 
         /// <summary>
         /// Valid attributes on UsingTaskParameter element
         /// </summary>
-        private readonly static string[] s_validAttributesOnUsingTaskParameter = new string[] { XMakeAttributes.parameterType, XMakeAttributes.output, XMakeAttributes.required };
+        private static readonly HashSet<string> ValidAttributesOnUsingTaskParameter = new HashSet<string> { XMakeAttributes.parameterType, XMakeAttributes.output, XMakeAttributes.required };
 
         /// <summary>
         /// Valid attributes on UsingTaskTask element
         /// </summary>
-        private readonly static string[] s_validAttributesOnUsingTaskBody = new string[] { XMakeAttributes.evaluate };
+        private static readonly HashSet<string> ValidAttributesOnUsingTaskBody = new HashSet<string> { XMakeAttributes.evaluate };
 
         /// <summary>
         /// The ProjectRootElement to parse into
         /// </summary>
-        private ProjectRootElement _project;
+        private readonly ProjectRootElement _project;
 
         /// <summary>
         /// The document to parse from
         /// </summary>
-        private XmlDocumentWithLocation _document;
+        private readonly XmlDocumentWithLocation _document;
 
         /// <summary>
         /// Whether a ProjectExtensions node has been encountered already.
@@ -149,15 +151,7 @@ namespace Microsoft.Build.Construction
         private void Parse()
         {
             // XML guarantees exactly one root element
-            XmlElementWithLocation element = null;
-            foreach (XmlNode childNode in _document.ChildNodes)
-            {
-                if (childNode.NodeType == XmlNodeType.Element)
-                {
-                    element = (XmlElementWithLocation)childNode;
-                    break;
-                }
-            }
+            XmlElementWithLocation element = _document.DocumentElement as XmlElementWithLocation;
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(element != null, ElementLocation.Create(_document.FullPath), "NoRootProjectElement", XMakeElements.project);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.Name != XMakeElements.visualStudioProject, element.Location, "ProjectUpgradeNeeded", _project.FullPath);
@@ -174,73 +168,55 @@ namespace Microsoft.Build.Construction
                 _project.XmlNamespace = element.NamespaceURI;
             }
 
-            ParseProjectElement(element);
-        }
-
-        /// <summary>
-        /// Parse a ProjectRootElement from an element
-        /// </summary>
-        private void ParseProjectElement(XmlElementWithLocation element)
-        {
             // Historically, we allow any attribute on the Project element
 
-            // The element wasn't available to the ProjectRootElement constructor,
-            // so we have to set it now
+            // The element wasn't available to the ProjectRootElement constructor so we have to set it now
             _project.SetProjectRootElementFromParser(element, _project);
 
-
-            ParseProjectRootElementChildren(element);
-        }
-
-        /// <summary>
-        /// Parse the child of a ProjectRootElement
-        /// </summary>
-        private void ParseProjectRootElementChildren(XmlElementWithLocation element)
-        {
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectElement child = null;
-
                 switch (childElement.Name)
                 {
                     case XMakeElements.propertyGroup:
-                        child = ParseProjectPropertyGroupElement(childElement, _project);
+                        _project.AppendParentedChildNoChecks(ParseProjectPropertyGroupElement(childElement, _project));
                         break;
 
                     case XMakeElements.itemGroup:
-                        child = ParseProjectItemGroupElement(childElement, _project);
+                        _project.AppendParentedChildNoChecks(ParseProjectItemGroupElement(childElement, _project));
                         break;
 
                     case XMakeElements.importGroup:
-                        child = ParseProjectImportGroupElement(childElement, _project);
+                        _project.AppendParentedChildNoChecks(ParseProjectImportGroupElement(childElement, _project));
                         break;
 
                     case XMakeElements.import:
-                        child = ParseProjectImportElement(childElement, _project);
+                        _project.AppendParentedChildNoChecks(ParseProjectImportElement(childElement, _project));
                         break;
 
                     case XMakeElements.usingTask:
-                        child = ParseProjectUsingTaskElement(childElement);
+                        _project.AppendParentedChildNoChecks(ParseProjectUsingTaskElement(childElement));
                         break;
 
                     case XMakeElements.target:
-                        child = ParseProjectTargetElement(childElement);
+                        _project.AppendParentedChildNoChecks(ParseProjectTargetElement(childElement));
                         break;
 
                     case XMakeElements.itemDefinitionGroup:
-                        child = ParseProjectItemDefinitionGroupElement(childElement);
+                        _project.AppendParentedChildNoChecks(ParseProjectItemDefinitionGroupElement(childElement));
                         break;
 
                     case XMakeElements.choose:
-                        child = ParseProjectChooseElement(childElement, _project, 0 /* nesting depth */);
+                        _project.AppendParentedChildNoChecks(ParseProjectChooseElement(childElement, _project, 0 /* nesting depth */));
                         break;
 
                     case XMakeElements.projectExtensions:
-                        child = ParseProjectExtensionsElement(childElement);
+                        _project.AppendParentedChildNoChecks(ParseProjectExtensionsElement(childElement));
                         break;
+
                     case XMakeElements.sdk:
-                        child = ParseProjectSdkElement(childElement);
+                        _project.AppendParentedChildNoChecks(ParseProjectSdkElement(childElement));
                         break;
+
                     // Obsolete
                     case XMakeElements.error:
                     case XMakeElements.warning:
@@ -252,8 +228,6 @@ namespace Microsoft.Build.Construction
                         ProjectXmlUtilities.ThrowProjectInvalidChildElement(childElement.Name, childElement.ParentNode.Name, childElement.Location);
                         break;
                 }
-
-                _project.AppendParentedChildNoChecks(child);
             }
         }
 
@@ -262,13 +236,18 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectPropertyGroupElement ParseProjectPropertyGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             ProjectPropertyGroupElement propertyGroup = new ProjectPropertyGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
-                ProjectPropertyElement property = ParseProjectPropertyElement(childElement, propertyGroup);
+                ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnlyConditionAndLabel);
+                XmlUtilities.VerifyThrowProjectValidElementName(childElement);
+                ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(childElement.Name) && !ReservedPropertyNames.IsReservedProperty(childElement.Name), childElement.Location, "CannotModifyReservedProperty", childElement.Name);
+
+                // All children inside a property are ignored, since they are only part of its value
+                ProjectPropertyElement property = new ProjectPropertyElement(childElement, propertyGroup, _project);
 
                 propertyGroup.AppendParentedChildNoChecks(property);
             }
@@ -276,26 +255,13 @@ namespace Microsoft.Build.Construction
             return propertyGroup;
         }
 
-        /// <summary>
-        /// Parse a ProjectPropertyElement from the element
-        /// </summary>
-        private ProjectPropertyElement ParseProjectPropertyElement(XmlElementWithLocation element, ProjectPropertyGroupElement parent)
-        {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
-
-            XmlUtilities.VerifyThrowProjectValidElementName(element);
-            ProjectErrorUtilities.VerifyThrowInvalidProject(XMakeElements.IllegalItemPropertyNames[element.Name] == null && !ReservedPropertyNames.IsReservedProperty(element.Name), element.Location, "CannotModifyReservedProperty", element.Name);
-
-            // All children inside a property are ignored, since they are only part of its value
-            return new ProjectPropertyElement(element, parent, _project);
-        }
 
         /// <summary>
         /// Parse a ProjectItemGroupElement
         /// </summary>
         private ProjectItemGroupElement ParseProjectItemGroupElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             ProjectItemGroupElement itemGroup = new ProjectItemGroupElement(element, parent, _project);
 
@@ -363,7 +329,7 @@ namespace Microsoft.Build.Construction
             ProjectErrorUtilities.VerifyThrowInvalidProject(update.Length > 0 || element.Attributes[XMakeAttributes.update] == null, element.Location, "MissingRequiredAttribute", XMakeAttributes.update, itemType);
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
-            ProjectErrorUtilities.VerifyThrowInvalidProject(XMakeElements.IllegalItemPropertyNames[itemType] == null, element.Location, "CannotModifyReservedItem", itemType);
+            ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(itemType), element.Location, "CannotModifyReservedItem", itemType);
 
             ProjectItemElement item = new ProjectItemElement(element, parent, _project);
 
@@ -407,22 +373,21 @@ namespace Microsoft.Build.Construction
                 return;
             }
 
-            for (int i = 0; i < s_knownAttributesOnItem.Length; i++)
+            if (KnownAttributesOnItem.Contains(name))
             {
-                //  Case insensitive comparison so that mis-capitalizing an attribute like Include or Exclude results in an easy to understand
-                //  error instead of unexpected behavior
-                if (name == s_knownAttributesOnItem[i])
-                {
-                    isReservedAttributeName = true;
-                    isValidMetadataNameInAttribute = false;
-                    return;
-                }
-                else if (name.Equals(s_knownAttributesOnItem[i], StringComparison.OrdinalIgnoreCase))
-                {
-                    isReservedAttributeName = false;
-                    isValidMetadataNameInAttribute = false;
-                    return;
-                }
+                isReservedAttributeName = true;
+                isValidMetadataNameInAttribute = false;
+
+                return;
+            }
+
+            //  Case insensitive comparison so that mis-capitalizing an attribute like Include or Exclude results in an easy to understand
+            //  error instead of unexpected behavior
+            if (KnownAttributesOnItemIgnoreCase.Contains(name))
+            {
+                isReservedAttributeName = false;
+                isValidMetadataNameInAttribute = false;
+                return;
             }
 
             //  Reserve attributes starting with underscores in case we need to add more built-in attributes later
@@ -433,8 +398,7 @@ namespace Microsoft.Build.Construction
                 return;
             }
 
-            if (FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name) ||
-                XMakeElements.IllegalItemPropertyNames[name] != null)
+            if (FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name) || XMakeElements.ReservedItemNames.Contains(name))
             {
                 isReservedAttributeName = false;
                 isValidMetadataNameInAttribute = false;
@@ -450,13 +414,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectMetadataElement ParseProjectMetadataElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             XmlUtilities.VerifyThrowProjectValidElementName(element);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!(parent is ProjectItemElement) || ((ProjectItemElement)parent).Remove.Length == 0, element.Location, "ChildElementsBelowRemoveNotAllowed", element.Name);
             ProjectErrorUtilities.VerifyThrowInvalidProject(!FileUtilities.ItemSpecModifiers.IsItemSpecModifier(element.Name), element.Location, "ItemSpecModifierCannotBeCustomMetadata", element.Name);
-            ProjectErrorUtilities.VerifyThrowInvalidProject(XMakeElements.IllegalItemPropertyNames[element.Name] == null, element.Location, "CannotModifyReservedItemMetadata", element.Name);
+            ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(element.Name), element.Location, "CannotModifyReservedItemMetadata", element.Name);
 
             ProjectMetadataElement metadatum = new ProjectMetadataElement(element, parent, _project);
 
@@ -478,20 +442,20 @@ namespace Microsoft.Build.Construction
         /// <returns>A ProjectImportGroupElement derived from the XML element passed in</returns>
         private ProjectImportGroupElement ParseProjectImportGroupElement(XmlElementWithLocation element, ProjectRootElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             ProjectImportGroupElement importGroup = new ProjectImportGroupElement(element, parent, _project);
 
             foreach (XmlElementWithLocation childElement in ProjectXmlUtilities.GetVerifyThrowProjectChildElements(element))
             {
                 ProjectErrorUtilities.VerifyThrowInvalidProject
-                    (
+                (
                     childElement.Name == XMakeElements.import,
                     childElement.Location,
                     "UnrecognizedChildElement",
                     childElement.Name,
                     element.Name
-                    );
+                );
 
                 ProjectImportElement item = ParseProjectImportElement(childElement, importGroup);
 
@@ -507,15 +471,15 @@ namespace Microsoft.Build.Construction
         private ProjectImportElement ParseProjectImportElement(XmlElementWithLocation element, ProjectElementContainer parent)
         {
             ProjectErrorUtilities.VerifyThrowInvalidProject
-                (
+            (
                 parent is ProjectRootElement || parent is ProjectImportGroupElement,
                 element.Location,
                 "UnrecognizedParentElement",
                 parent,
                 element
-                );
+            );
 
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnImport);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnImport);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.project);
             ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
 
@@ -551,7 +515,9 @@ namespace Microsoft.Build.Construction
                 }
                 else
                 {
-                    ProjectUsingTaskParameterElement parameter = ParseUsingTaskParameterElement(childElement, parameterGroup);
+                    ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskParameter);
+                    XmlUtilities.VerifyThrowProjectValidElementName(childElement);
+                    ProjectUsingTaskParameterElement parameter = new ProjectUsingTaskParameterElement(childElement, parameterGroup, _project);
                     parameterGroup.AppendParentedChildNoChecks(parameter);
 
                     // Add the name of the child element to the hashset so we can check for a duplicate child element
@@ -563,45 +529,25 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Parse a UsingTaskBodyElement from the element
-        /// </summary>
-        private ProjectUsingTaskBodyElement ParseUsingTaskBodyElement(XmlElementWithLocation element, ProjectUsingTaskElement parent)
-        {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnUsingTaskBody);
-            XmlUtilities.VerifyThrowProjectValidElementName(element);
-            return new ProjectUsingTaskBodyElement(element, parent, _project);
-        }
-
-        /// <summary>
-        /// Parse a UsingTaskParameterElement from the element
-        /// </summary>
-        private ProjectUsingTaskParameterElement ParseUsingTaskParameterElement(XmlElementWithLocation element, UsingTaskParameterGroupElement parent)
-        {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnUsingTaskParameter);
-            XmlUtilities.VerifyThrowProjectValidElementName(element);
-            return new ProjectUsingTaskParameterElement(element, parent, _project);
-        }
-
-        /// <summary>
         /// Parse a ProjectUsingTaskElement
         /// </summary>
         private ProjectUsingTaskElement ParseProjectUsingTaskElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnUsingTask);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnUsingTask);
             ProjectErrorUtilities.VerifyThrowInvalidProject(element.GetAttribute(XMakeAttributes.taskName).Length > 0, element.Location, "ProjectTaskNameEmpty");
 
             string assemblyName = element.GetAttribute(XMakeAttributes.assemblyName);
             string assemblyFile = element.GetAttribute(XMakeAttributes.assemblyFile);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject
-                (
-                ((assemblyName.Length > 0) ^ (assemblyFile.Length > 0)),
+            (
+                (assemblyName.Length > 0) ^ (assemblyFile.Length > 0),
                 element.Location,
                 "UsingTaskAssemblySpecification",
                 XMakeElements.usingTask,
                 XMakeAttributes.assemblyName,
                 XMakeAttributes.assemblyFile
-                );
+            );
 
             ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, XMakeAttributes.assemblyName);
             ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, XMakeAttributes.assemblyFile);
@@ -632,7 +578,9 @@ namespace Microsoft.Build.Construction
                             ProjectXmlUtilities.ThrowProjectInvalidChildElementDueToDuplicate(childElement);
                         }
 
-                        child = ParseUsingTaskBodyElement(childElement, usingTask);
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnUsingTaskBody);
+
+                        child = new ProjectUsingTaskBodyElement(childElement, usingTask, _project);
                         foundTaskElement = true;
                         break;
                     default:
@@ -651,15 +599,13 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectTargetElement ParseProjectTargetElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnTarget);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnTarget);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.name);
 
-            string targetName = ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.name);
-
             // Orcas compat: all target names are automatically unescaped
-            targetName = EscapingUtilities.UnescapeAll(targetName);
+            string targetName = EscapingUtilities.UnescapeAll(ProjectXmlUtilities.GetAttributeValue(element, XMakeAttributes.name));
 
-            int indexOfSpecialCharacter = targetName.IndexOfAny(XMakeElements.illegalTargetNameCharacters);
+            int indexOfSpecialCharacter = targetName.IndexOfAny(XMakeElements.InvalidTargetNameCharacters);
             if (indexOfSpecialCharacter >= 0)
             {
                 ProjectErrorUtilities.ThrowInvalidProject(element.GetAttributeLocation(XMakeAttributes.name), "NameInvalid", targetName, targetName[indexOfSpecialCharacter]);
@@ -693,8 +639,13 @@ namespace Microsoft.Build.Construction
                         break;
 
                     case XMakeElements.onError:
-                        onError = ParseProjectOnErrorElement(childElement, target);
-                        child = onError;
+                        // Previous OM accidentally didn't verify ExecuteTargets on parse,
+                        // but we do, as it makes no sense 
+                        ProjectXmlUtilities.VerifyThrowProjectAttributes(childElement, ValidAttributesOnOnError);
+                        ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(childElement, XMakeAttributes.executeTargets);
+                        ProjectXmlUtilities.VerifyThrowProjectNoChildElements(childElement);
+
+                        child = onError = new ProjectOnErrorElement(childElement, target, _project);
                         break;
 
                     case XMakeElements.itemDefinitionGroup:
@@ -726,12 +677,12 @@ namespace Microsoft.Build.Construction
             {
                 ProjectErrorUtilities.VerifyThrowInvalidProject
                 (
-                !XMakeAttributes.IsBadlyCasedSpecialTaskAttribute(attribute.Name),
-                attribute.Location,
-                "BadlyCasedSpecialTaskAttribute",
-                attribute.Name,
-                element.Name,
-                element.Name
+                    !XMakeAttributes.IsBadlyCasedSpecialTaskAttribute(attribute.Name),
+                    attribute.Location,
+                    "BadlyCasedSpecialTaskAttribute",
+                    attribute.Name,
+                    element.Name,
+                    element.Name
                 );
             }
 
@@ -754,42 +705,27 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectOutputElement ParseProjectOutputElement(XmlElementWithLocation element, ProjectTaskElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnOutput);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnOutput);
             ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.taskParameter);
             ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
 
-            string taskParameter = element.GetAttribute(XMakeAttributes.taskParameter);
-            string itemName = element.GetAttribute(XMakeAttributes.itemName);
-            string propertyName = element.GetAttribute(XMakeAttributes.propertyName);
+            XmlAttributeWithLocation itemNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.itemName);
+            XmlAttributeWithLocation propertyNameAttribute = element.GetAttributeWithLocation(XMakeAttributes.propertyName);
 
             ProjectErrorUtilities.VerifyThrowInvalidProject
-                (
-                (itemName.Length > 0 || propertyName.Length > 0) && (itemName.Length == 0 || propertyName.Length == 0),
+            (
+                String.IsNullOrWhiteSpace(itemNameAttribute?.Value) && !String.IsNullOrWhiteSpace(propertyNameAttribute?.Value) || !String.IsNullOrWhiteSpace(itemNameAttribute?.Value) && String.IsNullOrWhiteSpace(propertyNameAttribute?.Value),
                 element.Location,
                 "InvalidTaskOutputSpecification",
                 parent.Name
-                );
+            );
 
-            ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, XMakeAttributes.itemName);
-            ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, XMakeAttributes.propertyName);
+            ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, itemNameAttribute, XMakeAttributes.itemName);
+            ProjectXmlUtilities.VerifyThrowProjectAttributeEitherMissingOrNotEmpty(element, propertyNameAttribute, XMakeAttributes.propertyName);
 
-            ProjectErrorUtilities.VerifyThrowInvalidProject(!ReservedPropertyNames.IsReservedProperty(propertyName), element.Location, "CannotModifyReservedProperty", propertyName);
+            ProjectErrorUtilities.VerifyThrowInvalidProject(String.IsNullOrWhiteSpace(propertyNameAttribute?.Value) || !ReservedPropertyNames.IsReservedProperty(propertyNameAttribute.Value), element.Location, "CannotModifyReservedProperty", propertyNameAttribute?.Value);
 
             return new ProjectOutputElement(element, parent, _project);
-        }
-
-        /// <summary>
-        /// Parse a ProjectOnErrorElement
-        /// </summary>
-        private ProjectOnErrorElement ParseProjectOnErrorElement(XmlElementWithLocation element, ProjectTargetElement parent)
-        {
-            // Previous OM accidentally didn't verify ExecuteTargets on parse,
-            // but we do, as it makes no sense 
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnOnError);
-            ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(element, XMakeAttributes.executeTargets);
-            ProjectXmlUtilities.VerifyThrowProjectNoChildElements(element);
-
-            return new ProjectOnErrorElement(element, parent, _project);
         }
 
         /// <summary>
@@ -797,7 +733,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemDefinitionGroupElement ParseProjectItemDefinitionGroupElement(XmlElementWithLocation element)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             ProjectItemDefinitionGroupElement itemDefinitionGroup = new ProjectItemDefinitionGroupElement(element, _project, _project);
 
@@ -816,7 +752,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private ProjectItemDefinitionElement ParseProjectItemDefinitionXml(XmlElementWithLocation element, ProjectItemDefinitionGroupElement parent)
         {
-            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, s_validAttributesOnlyConditionAndLabel);
+            ProjectXmlUtilities.VerifyThrowProjectAttributes(element, ValidAttributesOnlyConditionAndLabel);
 
             // Orcas inadvertently did not check for reserved item types (like "Choose") in item definitions,
             // as we do for item types in item groups. So we do not have a check here.
@@ -875,7 +811,6 @@ namespace Microsoft.Build.Construction
                 choose.AppendParentedChildNoChecks(child);
             }
 
-            nestingDepth--;
             ProjectErrorUtilities.VerifyThrowInvalidProject(foundWhen, element.Location, "ChooseMustContainWhen");
 
             return choose;
@@ -958,7 +893,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Parse a ProjectExtensionsElement
+        /// Parse a ProjectSdkElement
         /// </summary>
         private ProjectSdkElement ParseProjectSdkElement(XmlElementWithLocation element)
         {

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Valid attributes list for item which is case-insensitive.
         /// </summary>
-        private static readonly HashSet<string> KnownAttributesOnItemIgnoreCase = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { XMakeAttributes.condition, XMakeAttributes.label, XMakeAttributes.include, XMakeAttributes.exclude, XMakeAttributes.remove, XMakeAttributes.keepMetadata, XMakeAttributes.removeMetadata, XMakeAttributes.keepDuplicates, XMakeAttributes.update };
+        private static readonly HashSet<string> KnownAttributesOnItemIgnoreCase = new HashSet<string>(KnownAttributesOnItem, StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Valid attributes on import element

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2390,7 +2390,7 @@ namespace Microsoft.Build.Execution
 
                     if (environmentVariableName != null &&
                         (!XmlUtilities.IsValidElementName(environmentVariableName)
-                        || XMakeElements.IllegalItemPropertyNames[environmentVariableName] != null
+                        || XMakeElements.ReservedItemNames.Contains(environmentVariableName)
                         || ReservedPropertyNames.IsReservedProperty(environmentVariableName))
                        )
                     {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -694,7 +694,7 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(projectToUse, "project");
             ErrorUtilities.VerifyThrowArgumentLength(itemTypeToUse, "itemType");
             XmlUtilities.VerifyThrowArgumentValidElementName(itemTypeToUse);
-            ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[itemTypeToUse] == null, "OM_ReservedName", itemTypeToUse);
+            ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(itemTypeToUse), "OM_ReservedName", itemTypeToUse);
 
             // TaskItems don't have an item type. So for their benefit, we have to lookup and add the regular item definition.
             List<ProjectItemDefinitionInstance> inheritedItemDefinitions = (itemDefinitions == null) ? null : new List<ProjectItemDefinitionInstance>(itemDefinitions);

--- a/src/Build/Instance/ProjectMetadataInstance.cs
+++ b/src/Build/Instance/ProjectMetadataInstance.cs
@@ -69,11 +69,11 @@ namespace Microsoft.Build.Execution
 
             if (allowItemSpecModifiers)
             {
-                ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[name] == null, "OM_ReservedName", name);
+                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);
             }
             else
             {
-                ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[name] == null && !FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "OM_ReservedName", name);
+                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name) && !FileUtilities.ItemSpecModifiers.IsItemSpecModifier(name), "OM_ReservedName", name);
             }
 
             _name = name;

--- a/src/Build/Instance/ProjectPropertyInstance.cs
+++ b/src/Build/Instance/ProjectPropertyInstance.cs
@@ -324,13 +324,13 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(escapedValue, "escapedValue");
             if (location == null)
             {
-                ErrorUtilities.VerifyThrowArgument(XMakeElements.IllegalItemPropertyNames[name] == null, "OM_ReservedName", name);
+                ErrorUtilities.VerifyThrowArgument(!XMakeElements.ReservedItemNames.Contains(name), "OM_ReservedName", name);
                 ErrorUtilities.VerifyThrowArgument(mayBeReserved || !ReservedPropertyNames.IsReservedProperty(name), "OM_CannotCreateReservedProperty", name);
                 XmlUtilities.VerifyThrowArgumentValidElementName(name);
             }
             else
             {
-                ProjectErrorUtilities.VerifyThrowInvalidProject(XMakeElements.IllegalItemPropertyNames[name] == null, location, "CannotModifyReservedProperty", name);
+                ProjectErrorUtilities.VerifyThrowInvalidProject(!XMakeElements.ReservedItemNames.Contains(name), location, "CannotModifyReservedProperty", name);
                 ProjectErrorUtilities.VerifyThrowInvalidProject(mayBeReserved || !ReservedPropertyNames.IsReservedProperty(name), location, "CannotModifyReservedProperty", name);
                 XmlUtilities.VerifyThrowProjectValidElementName(name, location);
             }

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -56,59 +56,36 @@ namespace Microsoft.Build.Internal
         internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";
 
         /// <summary>
-        /// Lookup for reserved property names
+        /// Lookup for reserved property names. Intentionally do not include MSBuildExtensionsPath* or MSBuildUserExtensionsPath in this list.  We need tasks to be able to override those.
         /// </summary>
-        private static HashSet<string> s_reservedProperties;
-
-        /// <summary>
-        /// Lock object, since this is a shared table, and concurrent evaluation must be safe
-        /// </summary>
-        private static Object s_locker = new Object();
-
-        /// <summary>
-        /// Intentionally do not include MSBuildExtensionsPath* or MSBuildUserExtensionsPath in this list.  We need tasks to be able to override those.
-        /// </summary>
-        private static HashSet<string> ReservedProperties
+        private static readonly HashSet<string> ReservedProperties = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default)
         {
-            get
-            {
-                lock (s_locker)
-                {
-                    if (s_reservedProperties == null)
-                    {
-                        s_reservedProperties = new HashSet<string>(MSBuildNameIgnoreCaseComparer.Default);
+            projectDirectory,
+            projectDirectoryNoRoot,
+            projectFile,
+            projectExtension,
+            projectFullPath,
+            projectName,
 
-                        s_reservedProperties.Add(projectDirectory);
-                        s_reservedProperties.Add(projectDirectoryNoRoot);
-                        s_reservedProperties.Add(projectFile);
-                        s_reservedProperties.Add(projectExtension);
-                        s_reservedProperties.Add(projectFullPath);
-                        s_reservedProperties.Add(projectName);
+            thisFileDirectory,
+            thisFileDirectoryNoRoot,
+            thisFile,
+            thisFileExtension,
+            thisFileFullPath,
+            thisFileName,
 
-                        s_reservedProperties.Add(thisFileDirectory);
-                        s_reservedProperties.Add(thisFileDirectoryNoRoot);
-                        s_reservedProperties.Add(thisFile);
-                        s_reservedProperties.Add(thisFileExtension);
-                        s_reservedProperties.Add(thisFileFullPath);
-                        s_reservedProperties.Add(thisFileName);
-
-                        s_reservedProperties.Add(binPath);
-                        s_reservedProperties.Add(projectDefaultTargets);
-                        s_reservedProperties.Add(toolsPath);
-                        s_reservedProperties.Add(toolsVersion);
-                        s_reservedProperties.Add(msbuildRuntimeType);
-                        s_reservedProperties.Add(startupDirectory);
-                        s_reservedProperties.Add(buildNodeCount);
-                        s_reservedProperties.Add(lastTaskResult);
-                        s_reservedProperties.Add(programFiles32);
-                        s_reservedProperties.Add(assemblyVersion);
-                        s_reservedProperties.Add(version);
-                    }
-                }
-
-                return s_reservedProperties;
-            }
-        }
+            binPath,
+            projectDefaultTargets,
+            toolsPath,
+            toolsVersion,
+            msbuildRuntimeType,
+            startupDirectory,
+            buildNodeCount,
+            lastTaskResult,
+            programFiles32,
+            assemblyVersion,
+            version
+        };
 
         /// <summary>
         /// Indicates if the given property is a reserved property.

--- a/src/Build/Utilities/Utilities.cs
+++ b/src/Build/Utilities/Utilities.cs
@@ -573,7 +573,7 @@ namespace Microsoft.Build.Internal
                     string environmentVariableName = environmentVariable.Key;
 
                     if (XmlUtilities.IsValidElementName(environmentVariableName) &&
-                        XMakeElements.IllegalItemPropertyNames[environmentVariableName] == null &&
+                        !XMakeElements.ReservedItemNames.Contains(environmentVariableName) &&
                         !ReservedPropertyNames.IsReservedProperty(environmentVariableName))
                     {
                         ProjectPropertyInstance environmentProperty = ProjectPropertyInstance.Create(environmentVariableName, environmentVariable.Value);

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Xml;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Construction;
 
@@ -82,17 +80,23 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static void VerifyThrowProjectAttributeEitherMissingOrNotEmpty(XmlElementWithLocation xmlElement, string attributeName)
         {
-            XmlAttributeWithLocation attribute = xmlElement.GetAttributeWithLocation(attributeName);
+            VerifyThrowProjectAttributeEitherMissingOrNotEmpty(xmlElement, xmlElement.GetAttributeWithLocation(attributeName), attributeName);
+        }
 
+        /// <summary>
+        /// Verifies that if the attribute is present on the element, its value is not empty
+        /// </summary>
+        internal static void VerifyThrowProjectAttributeEitherMissingOrNotEmpty(XmlElementWithLocation xmlElement, XmlAttributeWithLocation attribute, string attributeName)
+        {
             ProjectErrorUtilities.VerifyThrowInvalidProject
-                (
-                    attribute == null || attribute.Value.Length > 0,
-                    (attribute == null) ? null : attribute.Location,
-                    "InvalidAttributeValue",
-                    String.Empty,
-                    attributeName,
-                    xmlElement.Name
-                );
+            (
+                attribute == null || attribute.Value.Length > 0,
+                attribute?.Location,
+                "InvalidAttributeValue",
+                String.Empty,
+                attributeName,
+                xmlElement.Name
+            );
         }
 
         /// <summary>
@@ -132,22 +136,11 @@ namespace Microsoft.Build.Internal
         /// <summary>
         /// Verify  that all attributes on the element are on the list of legal attributes
         /// </summary>
-        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, string[] validAttributes)
+        internal static void VerifyThrowProjectAttributes(XmlElementWithLocation element, HashSet<string> validAttributes)
         {
             foreach (XmlAttributeWithLocation attribute in element.Attributes)
             {
-                bool valid = false;
-
-                for (int i = 0; i < validAttributes.Length; i++)
-                {
-                    if (String.Equals(attribute.Name, validAttributes[i], StringComparison.Ordinal))
-                    {
-                        valid = true;
-                        break;
-                    }
-                }
-
-                ProjectXmlUtilities.VerifyThrowProjectInvalidAttribute(valid, attribute);
+                ProjectXmlUtilities.VerifyThrowProjectInvalidAttribute(validAttributes.Contains(attribute.Name), attribute);
             }
         }
 

--- a/src/Shared/EscapingUtilities.cs
+++ b/src/Shared/EscapingUtilities.cs
@@ -35,8 +35,7 @@ namespace Microsoft.Build.Shared
             string escapedString
         )
         {
-            bool throwAwayBool;
-            return UnescapeAll(escapedString, out throwAwayBool);
+            return UnescapeAll(escapedString, out bool _);
         }
 
         private static bool IsHexDigit(char character)

--- a/src/Shared/XMakeAttributes.cs
+++ b/src/Shared/XMakeAttributes.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Xml;
-using System.Globalization;
 
 namespace Microsoft.Build.Shared
 {
@@ -94,26 +91,29 @@ namespace Microsoft.Build.Shared
         /////////////////////////////////////////////////////////////////////////////////////////////
         internal const string defaultXmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
 
+        private static readonly HashSet<string> KnownSpecialTaskAttributes = new HashSet<string> { condition, continueOnError, msbuildRuntime, msbuildArchitecture, xmlns };
+
+        private static readonly HashSet<string> KnownSpecialTaskAttributesIgnoreCase = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { condition, continueOnError, msbuildRuntime, msbuildArchitecture, xmlns };
+
+        private static readonly HashSet<string> KnownBatchingTargetAttributes = new HashSet<string> { name, condition, dependsOnTargets, beforeTargets, afterTargets };
+
+        private static readonly HashSet<string> ValidMSBuildRuntimeValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MSBuildRuntimeValues.clr2, MSBuildRuntimeValues.clr4, MSBuildRuntimeValues.currentRuntime, MSBuildRuntimeValues.any };
+
+        private static readonly HashSet<string> ValidMSBuildArchitectureValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MSBuildArchitectureValues.x86, MSBuildArchitectureValues.x64, MSBuildArchitectureValues.currentArchitecture, MSBuildArchitectureValues.any };
+
         /// <summary>
         /// Returns true if and only if the specified attribute is one of the attributes that the engine specifically recognizes
         /// on a task and treats in a special way.
         /// </summary>
         /// <param name="attribute"></param>
         /// <returns>true, if given attribute is a reserved task attribute</returns>
-        internal static bool IsSpecialTaskAttribute
-        (
-            string attribute
-        )
+        internal static bool IsSpecialTaskAttribute(string attribute)
         {
             // Currently the known "special" attributes for a task are:
             //  Condition, ContinueOnError
             //
             // We want to match case-sensitively on all of them
-            return ((attribute == condition) ||
-                    (attribute == continueOnError) ||
-                    (attribute == msbuildRuntime) ||
-                    (attribute == msbuildArchitecture) ||
-                    (attribute == xmlns));
+            return KnownSpecialTaskAttributes.Contains(attribute);
         }
 
         /// <summary>
@@ -123,11 +123,7 @@ namespace Microsoft.Build.Shared
         /// <returns>true, if the given attribute is reserved and badly cased</returns>
         internal static bool IsBadlyCasedSpecialTaskAttribute(string attribute)
         {
-            return (!IsSpecialTaskAttribute(attribute) &&
-                ((String.Compare(attribute, condition, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (String.Compare(attribute, continueOnError, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (String.Compare(attribute, msbuildRuntime, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (String.Compare(attribute, msbuildArchitecture, StringComparison.OrdinalIgnoreCase) == 0)));
+            return !IsSpecialTaskAttribute(attribute) && KnownSpecialTaskAttributesIgnoreCase.Contains(attribute);
         }
 
         /// <summary>
@@ -137,11 +133,7 @@ namespace Microsoft.Build.Shared
         /// <returns>true, if a target cannot batch on the given attribute</returns>
         internal static bool IsNonBatchingTargetAttribute(string attribute)
         {
-            return ((attribute == name) ||
-                    (attribute == condition) ||
-                    (attribute == dependsOnTargets) ||
-                    (attribute == beforeTargets) ||
-                    (attribute == afterTargets));
+            return KnownBatchingTargetAttributes.Contains(attribute);
         }
 
         /// <summary>
@@ -149,11 +141,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool IsValidMSBuildRuntimeValue(string runtime)
         {
-            return (runtime == null ||
-                    XMakeAttributes.MSBuildRuntimeValues.clr2.Equals(runtime, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildRuntimeValues.clr4.Equals(runtime, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildRuntimeValues.currentRuntime.Equals(runtime, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildRuntimeValues.any.Equals(runtime, StringComparison.OrdinalIgnoreCase));
+            return runtime == null || ValidMSBuildRuntimeValues.Contains(runtime);
         }
 
         /// <summary>
@@ -161,11 +149,7 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static bool IsValidMSBuildArchitectureValue(string architecture)
         {
-            return (architecture == null ||
-                    XMakeAttributes.MSBuildArchitectureValues.x86.Equals(architecture, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildArchitectureValues.x64.Equals(architecture, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildArchitectureValues.currentArchitecture.Equals(architecture, StringComparison.OrdinalIgnoreCase) ||
-                    XMakeAttributes.MSBuildArchitectureValues.any.Equals(architecture, StringComparison.OrdinalIgnoreCase));
+            return architecture == null || ValidMSBuildArchitectureValues.Contains(architecture);
         }
 
         /// <summary>

--- a/src/Shared/XMakeElements.cs
+++ b/src/Shared/XMakeElements.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Xml;
-using System.Globalization;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.Shared
 {
@@ -36,12 +33,12 @@ namespace Microsoft.Build.Shared
         internal const string usingTaskBody = "Task";
         internal const string sdk = "Sdk";
 
-        internal static readonly char[] illegalTargetNameCharacters = new char[] { '$', '@', '(', ')', '%', '*', '?', '.' };
+        internal static readonly char[] InvalidTargetNameCharacters = { '$', '@', '(', ')', '%', '*', '?', '.' };
 
         // Names that cannot be used as property or item names because they are reserved
-        internal static readonly string[] illegalPropertyOrItemNames = new string[] {
-            //            XMakeElements.project, // "Project" is not reserved, because unfortunately ProjectReference items 
-            // already use it as metadata name.
+        internal static readonly HashSet<string> ReservedItemNames = new HashSet<string>
+        {
+            // XMakeElements.project, "Project" is not reserved, because unfortunately ProjectReference items already use it as metadata name.
             XMakeElements.visualStudioProject,
             XMakeElements.target,
             XMakeElements.propertyGroup,
@@ -50,37 +47,11 @@ namespace Microsoft.Build.Shared
             XMakeElements.usingTask,
             XMakeElements.projectExtensions,
             XMakeElements.onError,
-            //            XMakeElements.import, // "Import" items are used by Visual Basic projects
+            // XMakeElements.import "Import" items are used by Visual Basic projects
             XMakeElements.importGroup,
             XMakeElements.choose,
             XMakeElements.when,
             XMakeElements.otherwise
         };
-
-        // The set of XMake reserved item/property names (e.g. Choose, Message etc.)
-        private static Lazy<Hashtable> s_illegalItemOrPropertyNamesHashtable = new Lazy<Hashtable>(
-            () =>
-            {
-                var table = new Hashtable(illegalPropertyOrItemNames.Length);
-                foreach (string reservedName in illegalPropertyOrItemNames)
-                {
-                    table.Add(reservedName, string.Empty);
-                }
-
-                return table;
-            },
-            true /* only one thread can initialize */);
-
-        /// <summary>
-        /// Read-only internal accessor for the hashtable containing
-        /// MSBuild reserved item/property names (like "Choose", for example).
-        /// </summary>
-        internal static Hashtable IllegalItemPropertyNames
-        {
-            get
-            {
-                return s_illegalItemOrPropertyNamesHashtable.Value;
-            }
-        }
     }
 }


### PR DESCRIPTION
* Use HashSet<string> instead of string[]
* Remove small single use methods
* Add ReservedItemNames