### PR TITLE
Specify ngenApplication and avoid ngening satellite assemblies

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -11,20 +11,20 @@ folder InstallDir:\MSBuild\15.0
   file source=$(ThirdPartyNotice)
 
 folder InstallDir:\MSBuild\15.0\Bin
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\msbuild.exe" vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
   file source=$(X86BinPath)MSBuild.exe.config
-  file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
+  file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86 vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuildTaskHost.exe"
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
-  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -61,106 +61,106 @@ folder InstallDir:\MSBuild\15.0\Bin\SdkResolvers\Microsoft.Build.NuGetSdkResolve
   file source=$(SourceDir)MSBuild\SdkResolvers\VS\Microsoft.Build.NuGetSdkResolver.xml
 
 folder InstallDir:\MSBuild\15.0\Bin\cs
-  file source=$(X86BinPath)cs\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)cs\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)cs\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)cs\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\de
-  file source=$(X86BinPath)de\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)de\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)de\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)de\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\en
-  file source=$(X86BinPath)en\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)en\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)en\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)en\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)en\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)en\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)en\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)en\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)en\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)en\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\es
-  file source=$(X86BinPath)es\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)es\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)es\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)es\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\fr
-  file source=$(X86BinPath)fr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)fr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)fr\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)fr\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\it
-  file source=$(X86BinPath)it\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)it\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)it\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)it\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\ja
-  file source=$(X86BinPath)ja\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ja\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ja\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ja\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\ko
-  file source=$(X86BinPath)ko\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ko\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ko\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ko\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\pl
-  file source=$(X86BinPath)pl\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pl\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)pl\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)pl\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\pt-BR
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)pt-BR\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)pt-BR\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\ru
-  file source=$(X86BinPath)ru\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)ru\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)ru\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)ru\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\tr
-  file source=$(X86BinPath)tr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)tr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)tr\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)tr\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\zh-Hans
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)zh-Hans\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\zh-Hant
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.resources.dll
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X86BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X86BinPath)zh-Hant\MSBuild.resources.dll
+  file source=$(TaskHostBinPath)zh-Hant\MSBuildTaskHost.resources.dll
 
 folder InstallDir:\MSBuild\15.0\Bin\amd64
-  file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64
-  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x64
+  file source=$(X64BinPath)MSBuild.exe vs.file.ngenArchitecture=x64 vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x64 vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuildTaskHost.exe"
   file source=$(X64BinPath)MSBuild.exe.config
   file source=$(TaskHostX64BinPath)MSBuildTaskHost.exe.config
 
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)System.IO.Compression.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
+  file source=$(X86BinPath)System.Runtime.InteropServices.RuntimeInformation.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\amd64\MSBuild.exe"
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -190,89 +190,89 @@ folder InstallDir:\MSBuild\15.0\Bin\amd64\MSBuild
   file source=$(X86BinPath)Microsoft.Build.CommonTypes.xsd
 
 folder InstallDir:\MSBuild\15.0\Bin\amd64\cs
-  file source=$(X64BinPath)cs\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)cs\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)cs\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)cs\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)cs\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)cs\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)cs\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)cs\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\de
-  file source=$(X64BinPath)de\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)de\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)de\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)de\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)de\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)de\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)de\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)de\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\en
-  file source=$(X64BinPath)en\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)en\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)en\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)en\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)en\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)en\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)en\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)en\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)en\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)en\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\es
-  file source=$(X64BinPath)es\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)es\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)es\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)es\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)es\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)es\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)es\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)es\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\fr
-  file source=$(X64BinPath)fr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)fr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)fr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)fr\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)fr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)fr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)fr\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)fr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\it
-  file source=$(X64BinPath)it\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)it\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)it\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)it\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)it\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)it\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)it\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)it\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ja
-  file source=$(X64BinPath)ja\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ja\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ja\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ja\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ja\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ja\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ja\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ja\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ko
-  file source=$(X64BinPath)ko\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ko\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ko\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ko\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ko\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ko\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ko\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ko\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\pl
-  file source=$(X64BinPath)pl\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pl\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)pl\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)pl\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)pl\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)pl\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)pl\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)pl\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\pt-BR
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)pt-BR\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)pt-BR\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)pt-BR\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)pt-BR\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)pt-BR\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\ru
-  file source=$(X64BinPath)ru\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)ru\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)ru\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)ru\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)ru\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)ru\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)ru\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)ru\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\tr
-  file source=$(X64BinPath)tr\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)tr\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)tr\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)tr\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)tr\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)tr\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)tr\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)tr\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\zh-Hans
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hans\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)zh-Hans\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)zh-Hans\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)zh-Hans\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)zh-Hans\MSBuildTaskHost.resources.dll
 folder InstallDir:\MSBuild\15.0\Bin\amd64\zh-Hant
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll vs.file.ngenArchitecture=all
-  file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll vs.file.ngenArchitecture=all
-  file source=$(TaskHostX64BinPath)zh-Hant\MSBuildTaskHost.resources.dll vs.file.ngenArchitecture=all
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.resources.dll
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Tasks.Core.resources.dll
+  file source=$(X64BinPath)zh-Hant\Microsoft.Build.Utilities.Core.resources.dll
+  file source=$(X64BinPath)zh-Hant\MSBuild.resources.dll
+  file source=$(TaskHostX64BinPath)zh-Hant\MSBuildTaskHost.resources.dll
 
 folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Framework\Microsoft.Build.Framework.pkgdef

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -11,7 +11,7 @@ folder InstallDir:\MSBuild\15.0
   file source=$(ThirdPartyNotice)
 
 folder InstallDir:\MSBuild\15.0\Bin
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\msbuild.exe" vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
   file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all vs.file.ngenApplication="[installDir]\MSBuild\15.0\Bin\MSBuild.exe"


### PR DESCRIPTION
Without `vs.file.ngenApplication` VS uses configuration of devenv process for NGEN, which might have different binding redirects than `msbuild.exe.config`.