### PR TITLE
use ReferenceCopyLocalPaths to resolve _DeploymentReferencePaths

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3958,7 +3958,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
-      <_DeploymentReferencePaths Include="@(ReferencePath)">
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
     </ItemGroup>


### PR DESCRIPTION
Fixes Clickonce part in issue #3069.

