### PR TITLE
Traits: This caches values of various environment variables which act…

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -18,12 +18,10 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-#if DEBUG
-                if (BuildEnvironmentHelper.Instance.RunningTests && Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS") == "1")
+                if (BuildEnvironmentHelper.Instance.RunningTests)
                 {
                     return new Traits();
                 }
-#endif
                 return _instance;
             }
         }

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -47,8 +47,6 @@ namespace Microsoft.Build.UnitTests
                 env.WithInvariant(new BuildFailureLogInvariant());
             }
 
-            env.SetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS", "1");
-
             return env;
         }
 


### PR DESCRIPTION
… as (#42)

.. switches to control features like logging imports. For use with
tests, this caching can be disabled but that is enabled only for DEBUG
builds. Which means that any tests trying to toggle and test those
environment variable dependent features will work only for debug builds.

So, we remove that restriction. And because the condition first checks if we are
running tests and only then looks at

    Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS")

.. it shouldn't affect performance much (untested!).