### PR TITLE
Catch a possible exception when trying to resolve from HKLM (#4)

### DIFF
--- a/src/Tasks/AssemblyFolder.cs
+++ b/src/Tasks/AssemblyFolder.cs
@@ -128,18 +128,21 @@ namespace Microsoft.Build.Tasks
         {
             s_assemblyFolders = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
-            // Populate the table of assembly folders.
-            AddFoldersFromRegistryKey
-            (
-                @"SOFTWARE\Microsoft\.NETFramework\AssemblyFolders",
-                s_assemblyFolders
-            );
+            if (NativeMethodsShared.IsWindows)
+            {
+                // Populate the table of assembly folders.
+                AddFoldersFromRegistryKey
+                (
+                    @"SOFTWARE\Microsoft\.NETFramework\AssemblyFolders",
+                    s_assemblyFolders
+                );
 
-            AddFoldersFromRegistryKey
-            (
-                @"SOFTWARE\Microsoft\VisualStudio\8.0\AssemblyFolders",
-                s_assemblyFolders
-            );
+                AddFoldersFromRegistryKey
+                (
+                    @"SOFTWARE\Microsoft\VisualStudio\8.0\AssemblyFolders",
+                    s_assemblyFolders
+                );
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
On Mono, RegistryKey.OpenSubKey will attempt to create the registry hive's on-disk folder, if it doesn't exist. For HKLM, that folder is in /etc/mono/registry - but only root has write access to /etc, so the constructor throws an exception. Let's avoid looking in the registry at all, on non-Windows.