### PR TITLE
AssemblyFolder: Don't add all directories under framework base path ..

### DIFF
--- a/src/Tasks/AssemblyFolder.cs
+++ b/src/Tasks/AssemblyFolder.cs
@@ -40,21 +40,6 @@ namespace Microsoft.Build.Tasks
             Hashtable directories
         )
         {
-            if (!NativeMethodsShared.IsWindows && hive == Registry.LocalMachine)
-            {
-                string path = NativeMethodsShared.FrameworkBasePath;
-                if (Directory.Exists(path))
-                {
-                    foreach (var p in Directory.EnumerateDirectories(path))
-                    {
-                        directories[
-                            "hklm" + "\\" + p.Substring(p.LastIndexOf(Path.DirectorySeparatorChar) + 1)] = p;
-                    }
-                }
-
-                return;
-            }
-
             using (RegistryKey baseKey = hive.OpenSubKey(key))
             {
                 string aliasKey = String.Empty;


### PR DESCRIPTION
.. as assembly search folders mapped to registry keys. This breaks
projects like Xamarin.Android/iOS as sometimes common assemblies like
System.dll get incorrectly resolved to regular .net assemblies rather
than being resolved to the custom built assemblies for that particular
target framework.

This is incorrect anyway, since it adds unexpected sources for resolving
assemblies and breaks expectations.