### PR TITLE
Fix 'PE image does not have metadata' exception

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -204,8 +204,16 @@ namespace Microsoft.Build.Shared
             using (var stream = File.OpenRead(path))
             using (var peFile = new PEReader(stream))
             {
+                // If the file does not contain PE metadata, throw BadImageFormatException to preserve
+                // behavior from AssemblyName.GetAssemblyName(). RAR will deal with this correctly.
+                if (!peFile.HasMetadata)
+                {
+                    throw new BadImageFormatException(string.Format(CultureInfo.CurrentCulture,
+                        AssemblyResources.GetString("ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata"),
+                        path));
+                }
+
                 var metadataReader = peFile.GetMetadataReader();
-                
                 var entry = metadataReader.GetAssemblyDefinition();
 
                 assemblyName = new AssemblyName();

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1681,6 +1681,10 @@
     <value>The AssemblyFolder config file ('{0}') specified in Microsoft.Common.CurrentVersion.targets was invalid. The error was: {1}</value>
     <comment></comment>
   </data>
+  <data name="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+    <value>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</value>
+    <comment></comment>
+  </data>
   <!--
         The ResolveComReference message bucket is: MSB3281 - MSB3320
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: Aplikaci ResGen.exe nelze spustit, protože délka příkazového řádku ({0} znaků) překračuje maximální délku příkazu. Tento problém můžete vyřešit tak, že (1) odeberete nepotřebné odkazy na sestavení nebo (2) zkrátíte cesty k těmto odkazům.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Umístění AssemblyFoldersEx: {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe kann möglicherweise nicht ausgeführt werden, da die Befehlszeile {0} Zeichen lang ist und die maximal zulässige Länge für den Befehl überschreitet. Entfernen Sie entweder nicht benötigte Assemblyverweise (1) oder kürzen Sie die Pfade zu diesen Verweisen (2).</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Speicherort von AssemblyFoldersEx: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -1487,6 +1487,11 @@
         <target state="new">MSB3455: ResGen.exe may not run because the command line is {0} characters long, which exceeds the maximum length of the command. To fix this problem, please either (1) remove unnecessary assembly references, or (2) make the paths to those references shorter.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="new">AssemblyFoldersEx location: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: Es posible que ResGen.exe no se ejecute porque la línea de comandos tiene {0} caracteres, lo que supera la longitud máxima del comando. Para corregir este problema, (1) quite las referencias de ensamblado innecesarias, o bien (2) acorte las rutas de acceso a las referencias.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Ubicación de AssemblyFoldersEx: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe peut ne pas s'exécuter, car la ligne de commande contient {0} caractères, ce qui dépasse la longueur maximale de la commande. Essayez de résoudre le problème de l'une des manières suivantes : (1) Supprimez les références d'assembly inutiles. (2) Raccourcissez les chemins à ces références.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Emplacement d'AssemblyFoldersEx : "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe non può essere eseguito perché la riga di comando è lunga {0} caratteri e supera la lunghezza massima del comando. Per risolvere il problema, (1) rimuovere i riferimenti ad assembly non necessari o (2) rendere più brevi i percorsi dei riferimenti.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Percorso AssemblyFoldersEx: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: コマンド ラインの文字数が {0} で、これはコマンドの最大長を超えているため、ResGen.exe を実行できない可能性があります。この問題を解決するには、次のいずれかを行ってください。(1) 不要なアセンブリ参照を削除する。(2) これらの参照へのパスを短くする。</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">AssemblyFoldersEx の場所:"{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: 명령줄이 명령의 최대 길이를 초과하는 {0}자이기 때문에 ResGen.exe를 실행할 수 없습니다. 이 문제를 해결하려면 (1) 불필요한 어셈블리 참조를 제거하거나 (2) 해당 참조의 경로를 더 짧게 만드세요.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">AssemblyFoldersEx 위치: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: Nie można uruchomić programu ResGen.exe, ponieważ liczba znaków w wierszu polecenia ({0}) przekracza maksymalną dozwoloną długość polecenia. W celu rozwiązania tego problemu (1) usuń niepotrzebne odwołania do zestawów lub (2) skróć ścieżki do tych odwołań.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Lokalizacja klucza rejestru AssemblyFoldersEx: „{0}”</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe pode não ser executado porque a linha de comando tem {0} caracteres, o que excede o comprimento máximo do comando. Para corrigir esse problema, (1) remova referências de assembly desnecessárias ou (2) reduza o caminho para essas referências.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Localização de AssemblyFoldersEx: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: программа ResGen.exe может не выполняться, поскольку длина команды составляет следующее число символов: {0}, что превышает максимальную длину команды. Для исправления этой неполадки (1) удалите ненужные ссылки на сборки или (2) сократите длину путей этих ссылок.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">Расположение AssemblyFoldersEx: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: Komut satırı {0} karakter uzunluğunda olduğundan ve komut uzunluğu üst sınırını aştığından ResGen.exe çalışamayabilir. Bu sorunu gidermek için, lütfen (1) gereksiz bütünleştirilmiş kod başvurularını kaldırın ya da (2) bu başvuruların yollarını kısaltın.</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">AssemblyFoldersEx konumu: "{0}"</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe 可能无法运行，因为命令行的长度为 {0} 个字符，超过了命令的最大长度。若要解决此问题，请 (1) 删除不需要的程序集引用，或者 (2) 缩短这些引用的路径。</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">AssemblyFoldersEx 位置:“{0}”</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -1442,6 +1442,11 @@
         <target state="translated">MSB3455: ResGen.exe 可能無法執行，因為命令列的長度為 {0} 個字元，超過命令的最大長度。若要修正這個問題，請 (1) 移除不必要的組件參考，或者 (2) 使那些參考的路徑變短。</target>
         <note>{StrBegin="MSB3455: "}</note>
       </trans-unit>
+      <trans-unit id="ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata">
+        <source>Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</source>
+        <target state="new">Assembly file '{0}' could not be opened -- PE image doesn't contain managed metadata.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResolveAssemblyReference.AssemblyFoldersExSearchLocations">
         <source>AssemblyFoldersEx location: "{0}"</source>
         <target state="translated">AssemblyFoldersEx 位置: "{0}"</target>


### PR DESCRIPTION
If RAR find a dependency without PE metadata an
InvalidOperationException is thrown. Detect this case and implement the
Full Framework behavior (BadImageFormatException) expected by RAR.

Fixes #3386