### PR TITLE
Pin glob expansion cache to EvaluationContext

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -882,6 +882,7 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
+        public void ResetCaches() { }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -882,6 +882,7 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
+        public void ResetCaches() { }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
+++ b/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
         }
 
+        public void ClearCaches()
+        {
+        }
+
         public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {
             return null;

--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -51,54 +51,8 @@ namespace Microsoft.Build.UnitTests.Definition
 
             sdkService.InitializeForTests(null, new List<SdkResolver> {resolver});
         }
-
-        [Theory]
-        [InlineData(EvaluationContext.SharingPolicy.Shared, 1, 1)]
-        [InlineData(EvaluationContext.SharingPolicy.Isolated, 3, 3)]
-        public void ContextSdkResolverIsUsed(EvaluationContext.SharingPolicy policy, int sdkLookupsForFoo, int sdkLookupsForBar)
-        {
-            try
-            {
-                EvaluationContext.TestOnlyAlterStateOnCreate = c => SetResolverForContext(c, _resolver);
-
-                var context = EvaluationContext.Create(policy);
-                EvaluateProjects(context);
-
-                _resolver.ResolvedCalls["foo"].ShouldBe(sdkLookupsForFoo);
-                _resolver.ResolvedCalls["bar"].ShouldBe(sdkLookupsForBar);
-                _resolver.ResolvedCalls.Count.ShouldBe(2);
-            }
-            finally
-            {
-                EvaluationContext.TestOnlyAlterStateOnCreate = null;
-            }
-        }
-
-        [Fact]
-        public void DefaultContextIsIsolatedContext()
-        {
-            var contextHashcodesSeen = new HashSet<int>();
-
-            EvaluateProjects(
-                null,
-                p =>
-                {
-                    var fieldInfo = p.GetType().GetField("_lastEvaluationContext", BindingFlags.NonPublic | BindingFlags.Instance);
-                    var obj = fieldInfo.GetValue(p);
-
-                    obj.ShouldBeOfType<EvaluationContext>();
-
-                    var context = (EvaluationContext) obj;
-
-                    context.Policy.ShouldBe(EvaluationContext.SharingPolicy.Isolated);
-
-                    contextHashcodesSeen.ShouldNotContain(context.GetHashCode());
-
-                    contextHashcodesSeen.Add(context.GetHashCode());
-                });
-        }
-
-        [Theory]
+		
+		[Theory]
         [InlineData(EvaluationContext.SharingPolicy.Shared)]
         [InlineData(EvaluationContext.SharingPolicy.Isolated)]
         public void ReevaluationShouldRespectContextLifetime(EvaluationContext.SharingPolicy policy)
@@ -137,66 +91,167 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             var fieldInfo = p.GetType().GetField("_lastEvaluationContext", BindingFlags.NonPublic | BindingFlags.Instance);
             var value = fieldInfo.GetValue(p);
+
+            value.ShouldBeOfType<EvaluationContext>();
+
             return (EvaluationContext) value;
         }
 
-        private void EvaluateProjects(EvaluationContext context, Action<Project> projectAction = null)
+        private static string[] _sdkResolutionProjects =
+        {
+            "<Project Sdk=\"foo\"></Project>",
+            "<Project Sdk=\"bar\"></Project>",
+            "<Project Sdk=\"foo\"></Project>",
+            "<Project Sdk=\"bar\"></Project>"
+        };
+
+        [Theory]
+        [InlineData(EvaluationContext.SharingPolicy.Shared, 1, 1)]
+        [InlineData(EvaluationContext.SharingPolicy.Isolated, 4, 4)]
+        public void ContextPinsSdkResolverCache(EvaluationContext.SharingPolicy policy, int sdkLookupsForFoo, int sdkLookupsForBar)
+        {
+            try
+            {
+                EvaluationContext.TestOnlyAlterStateOnCreate = c => SetResolverForContext(c, _resolver);
+
+                var context = EvaluationContext.Create(policy);
+                EvaluateProjects(_sdkResolutionProjects, context, null);
+
+                _resolver.ResolvedCalls.Count.ShouldBe(2);
+                _resolver.ResolvedCalls["foo"].ShouldBe(sdkLookupsForFoo);
+                _resolver.ResolvedCalls["bar"].ShouldBe(sdkLookupsForBar);
+            }
+            finally
+            {
+                EvaluationContext.TestOnlyAlterStateOnCreate = null;
+            }
+        }
+
+        [Fact]
+        public void DefaultContextIsIsolatedContext()
+        {
+            var contextHashcodesSeen = new HashSet<int>();
+
+            EvaluateProjects(
+                _sdkResolutionProjects,
+                null,
+                p =>
+                {
+                    var context = GetEvaluationContext(p);
+
+                    context.Policy.ShouldBe(EvaluationContext.SharingPolicy.Isolated);
+
+                    contextHashcodesSeen.ShouldNotContain(context.GetHashCode());
+
+                    contextHashcodesSeen.Add(context.GetHashCode());
+                });
+        }
+        public static IEnumerable<object> ContextPinsGlobExpansionCacheData
+        {
+            get
+            {
+                yield return new object[]
+                {
+                    EvaluationContext.SharingPolicy.Shared,
+                    new[]
+                    {
+                        new[] {"0.cs"},
+                        new[] {"0.cs"},
+                        new[] {"0.cs"},
+                        new[] {"0.cs"}
+                    }
+                };
+
+                yield return new object[]
+                {
+                    EvaluationContext.SharingPolicy.Isolated,
+                    new[]
+                    {
+                        new[] {"0.cs"},
+                        new[] {"0.cs", "1.cs"},
+                        new[] {"0.cs", "1.cs", "2.cs"},
+                        new[] {"0.cs", "1.cs", "2.cs", "3.cs"},
+                    }
+                };
+            }
+        }
+
+        private static string[] _globProjects =
+        {
+            @"<Project>
+                <ItemGroup>
+                    <i Include=`**/*.cs` />
+                </ItemGroup>
+            </Project>",
+
+            @"<Project>
+                <ItemGroup>
+                    <i Include=`**/*.cs` />
+                </ItemGroup>
+            </Project>",
+        };
+
+        [Theory]
+        [MemberData(nameof(ContextPinsGlobExpansionCacheData))]
+        public void ContextPinsGlobExpansionCache(EvaluationContext.SharingPolicy policy, string[][] expectedGlobExpansions)
+        {
+            var projectDirectory = _env.DefaultTestDirectory.FolderPath;
+
+            _env.SetCurrentDirectory(projectDirectory);
+
+            var context = EvaluationContext.Create(policy);
+
+            var evaluationCount = 0;
+
+            File.WriteAllText(Path.Combine(projectDirectory, $"{evaluationCount}.cs"), "");
+
+            EvaluateProjects(
+                _globProjects,
+                context,
+                project =>
+                {
+                    var expectedGlobExpansion = expectedGlobExpansions[evaluationCount];
+                    evaluationCount++;
+
+                    File.WriteAllText(Path.Combine(projectDirectory, $"{evaluationCount}.cs"), "");
+
+                    ObjectModelHelpers.AssertItems(expectedGlobExpansion, project.GetItems("i"));
+                }
+                );
+        }
+
+        /// <summary>
+        /// Should be at least two test projects to test cache visibility between projects
+        /// </summary>
+        private void EvaluateProjects(string[] projectContents, EvaluationContext context, Action<Project> projectAction)
         {
             var collection = _env.CreateProjectCollection().Collection;
 
-            var project1 = Project.FromXmlReader(
-                XmlReader.Create(new StringReader("<Project Sdk=\"foo\"></Project>")),
-                new ProjectOptions
-                {
-                    ProjectCollection = collection,
-                    EvaluationContext = context,
-                    LoadSettings = ProjectLoadSettings.IgnoreMissingImports
-                });
+            var projects = new List<Project>(projectContents.Length);
 
-            projectAction?.Invoke(project1);
+            foreach (var projectContent in projectContents)
+            {
+                var project = Project.FromXmlReader(
+                    XmlReader.Create(new StringReader(projectContent.Cleanup())),
+                    new ProjectOptions
+                    {
+                        ProjectCollection = collection,
+                        EvaluationContext = context,
+                        LoadSettings = ProjectLoadSettings.IgnoreMissingImports
+                    });
 
-            var project2 = Project.FromXmlReader(
-                XmlReader.Create(new StringReader("<Project Sdk=\"bar\"></Project>")),
-                new ProjectOptions
-                {
-                    ProjectCollection = collection,
-                    EvaluationContext = context,
-                    LoadSettings = ProjectLoadSettings.IgnoreMissingImports
-                });
+                projectAction?.Invoke(project);
 
-            projectAction?.Invoke(project2);
+                projects.Add(project);
+            }
 
-            var project3 = Project.FromXmlReader(
-                XmlReader.Create(new StringReader("<Project Sdk=\"foo\"></Project>")),
-                new ProjectOptions
-                {
-                    ProjectCollection = collection,
-                    EvaluationContext = context,
-                    LoadSettings = ProjectLoadSettings.IgnoreMissingImports
-                });
+            foreach (var project in projects)
+            {
+                project.AddItem("a", "b");
+                project.ReevaluateIfNecessary(context);
 
-            projectAction?.Invoke(project3);
-
-            var project4 = Project.FromXmlReader(
-                XmlReader.Create(new StringReader("<Project Sdk=\"bar\"></Project>")),
-                new ProjectOptions
-                {
-                    ProjectCollection = collection,
-                    EvaluationContext = context,
-                    LoadSettings = ProjectLoadSettings.IgnoreMissingImports
-                });
-
-            projectAction?.Invoke(project4);
-
-            project3.AddItem("a", "b");
-            project3.ReevaluateIfNecessary(context);
-
-            projectAction?.Invoke(project3);
-
-            project4.AddItem("a", "b");
-            project4.ReevaluateIfNecessary(context);
-
-            projectAction?.Invoke(project4);
+                projectAction?.Invoke(project);
+            }
         }
-  }
+    }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Build.BackEnd
                     // The expression is not of the form "@(X)". Treat as string
 
                     // Pass the non wildcard expanded excludes here to fix https://github.com/Microsoft/msbuild/issues/2621
-                    string[] includeSplitFiles = EngineFileUtilities.GetFileListEscaped(
+                    string[] includeSplitFiles = EngineFileUtilities.Default.GetFileListEscaped(
                         Project.Directory,
                         includeSplit,
                         excludes,
@@ -427,7 +427,7 @@ namespace Microsoft.Build.BackEnd
 
             foreach (string excludeSplit in excludes)
             {
-                string[] excludeSplitFiles = EngineFileUtilities.GetFileListUnescaped(Project.Directory, excludeSplit);
+                string[] excludeSplitFiles = EngineFileUtilities.Default.GetFileListUnescaped(Project.Directory, excludeSplit);
 
                 foreach (string excludeSplitFile in excludeSplitFiles)
                 {
@@ -512,7 +512,7 @@ namespace Microsoft.Build.BackEnd
                 // Don't unescape wildcards just yet - if there were any escaped, the caller wants to treat them
                 // as literals. Everything else is safe to unescape at this point, since we're only matching
                 // against the file system.
-                string[] fileList = EngineFileUtilities.GetFileListEscaped(Project.Directory, piece);
+                string[] fileList = EngineFileUtilities.Default.GetFileListEscaped(Project.Directory, piece);
 
                 foreach (string file in fileList)
                 {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private ProjectItemGroupTaskInstance _taskInstance;
 
+        private EngineFileUtilities _engineFileUtilities;
+
         /// <summary>
         /// Instantiates an ItemGroup task
         /// </summary>
@@ -46,6 +48,7 @@ namespace Microsoft.Build.BackEnd
             : base(loggingContext, projectInstance, logTaskInputs)
         {
             _taskInstance = taskInstance;
+            _engineFileUtilities = EngineFileUtilities.Default;
         }
 
         /// <summary>
@@ -401,12 +404,10 @@ namespace Microsoft.Build.BackEnd
                     // The expression is not of the form "@(X)". Treat as string
 
                     // Pass the non wildcard expanded excludes here to fix https://github.com/Microsoft/msbuild/issues/2621
-                    string[] includeSplitFiles = EngineFileUtilities.Default.GetFileListEscaped(
+                    string[] includeSplitFiles = _engineFileUtilities.GetFileListEscaped(
                         Project.Directory,
                         includeSplit,
-                        excludes,
-                        false,
-                        new ConcurrentDictionary<string, ImmutableArray<string>>());
+                        excludes);
 
                     foreach (string includeSplitFile in includeSplitFiles)
                     {
@@ -427,7 +428,7 @@ namespace Microsoft.Build.BackEnd
 
             foreach (string excludeSplit in excludes)
             {
-                string[] excludeSplitFiles = EngineFileUtilities.Default.GetFileListUnescaped(Project.Directory, excludeSplit);
+                string[] excludeSplitFiles = _engineFileUtilities.GetFileListUnescaped(Project.Directory, excludeSplit);
 
                 foreach (string excludeSplitFile in excludeSplitFiles)
                 {
@@ -512,7 +513,7 @@ namespace Microsoft.Build.BackEnd
                 // Don't unescape wildcards just yet - if there were any escaped, the caller wants to treat them
                 // as literals. Everything else is safe to unescape at this point, since we're only matching
                 // against the file system.
-                string[] fileList = EngineFileUtilities.Default.GetFileListEscaped(Project.Directory, piece);
+                string[] fileList = _engineFileUtilities.GetFileListEscaped(Project.Directory, piece);
 
                 foreach (string file in fileList)
                 {

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -26,6 +26,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cache.TryRemove(submissionId, out _);
         }
 
+        public override void ClearCaches()
+        {
+            base.ClearCaches();
+
+            _cache.Clear();
+        }
+
         public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {
             SdkResult result;

--- a/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         {
         }
 
+        public virtual void ClearCaches()
+        {
+        }
+
         /// <inheritdoc cref="IBuildComponent.InitializeComponent"/>
         public virtual void InitializeComponent(IBuildComponentHost host)
         {

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         void ClearCache(int submissionId);
 
         /// <summary>
+        /// Clear the entire cache
+        /// </summary>
+        void ClearCaches();
+
+        /// <summary>
         ///  Resolves the full path to the specified SDK.
         /// </summary>
         /// <param name="submissionId">The build submission ID that the resolution request is for.</param>

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cachedSdkResolver.ClearCache(submissionId);
         }
 
+        public override void ClearCaches()
+        {
+            _cachedSdkResolver.ClearCaches();
+        }
+
         /// <inheritdoc cref="INodePacketHandler.PacketReceived"/>
         public override void PacketReceived(int node, INodePacket packet)
         {

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _resolverStateBySubmission.TryRemove(submissionId, out _);
         }
 
+        public virtual void ClearCaches()
+        {
+            _resolverStateBySubmission.Clear();
+        }
+
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
         public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath)
         {

--- a/src/Build/Definition/BuiltInMetadata.cs
+++ b/src/Build/Definition/BuiltInMetadata.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Evaluation
             string evaluatedIncludeBeforeWildcardExpansion = EscapingUtilities.UnescapeAll(evaluatedIncludeBeforeWildcardExpansionEscaped);
             string evaluatedInclude = EscapingUtilities.UnescapeAll(evaluatedIncludeEscaped);
 
-            FileMatcher.Result match = FileMatcher.FileMatch(evaluatedIncludeBeforeWildcardExpansion, evaluatedInclude);
+            FileMatcher.Result match = FileMatcher.Default.FileMatch(evaluatedIncludeBeforeWildcardExpansion, evaluatedInclude);
 
             if (match.isLegalFileSpec && match.isMatch)
             {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2494,7 +2494,7 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
-                FileMatcher.Result match = FileMatcher.FileMatch(existingIncludePiece, unevaluatedInclude);
+                FileMatcher.Result match = FileMatcher.Default.FileMatch(existingIncludePiece, unevaluatedInclude);
 
                 if (match.isLegalFileSpec && match.isMatch)
                 {

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -76,5 +76,16 @@ namespace Microsoft.Build.Evaluation.Context
                     return null;
             }
         }
+
+        /// <summary>
+        /// Ideally caches should be discarded by discarding this entire object.
+        /// However, there could be situations where API users have a <see cref="Project"/> object loaned to another entity, and cannot swap the context, but still need to reset it.
+        /// </summary>
+        public void ResetCaches()
+        {
+            SdkResolverService.ClearCaches();
+            FileSystem.ClearCaches();
+            FileEntryExpansionCache.Clear();
+        }
     }
 }

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Threading;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Shared;
@@ -34,6 +36,8 @@ namespace Microsoft.Build.Evaluation.Context
 
         internal virtual ISdkResolverService SdkResolverService { get; } = new CachingSdkResolverService();
         internal IFileSystemAbstraction FileSystem { get; } = ManagedFileSystem.Singleton();
+
+        internal ConcurrentDictionary<string, ImmutableArray<string>> FileMatcherCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
 
         internal EvaluationContext(SharingPolicy policy)
         {

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -37,7 +37,10 @@ namespace Microsoft.Build.Evaluation.Context
         internal virtual ISdkResolverService SdkResolverService { get; } = new CachingSdkResolverService();
         internal IFileSystemAbstraction FileSystem { get; } = ManagedFileSystem.Singleton();
 
-        internal ConcurrentDictionary<string, ImmutableArray<string>> FileMatcherCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
+        /// <summary>
+        /// Key to file entry list. Example usages: cache glob expansion and intermediary directory expansions during glob expansion.
+        /// </summary>
+        internal ConcurrentDictionary<string, ImmutableArray<string>> FileEntryExpansionCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
 
         internal EvaluationContext(SharingPolicy policy)
         {

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation.Context
 {
@@ -32,6 +33,7 @@ namespace Microsoft.Build.Evaluation.Context
         internal SharingPolicy Policy { get; }
 
         internal virtual ISdkResolverService SdkResolverService { get; } = new CachingSdkResolverService();
+        internal IFileSystemAbstraction FileSystem { get; } = ManagedFileSystem.Singleton();
 
         internal EvaluationContext(SharingPolicy policy)
         {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Build.Evaluation
                     else
                     {
                         // The expression is not of the form "@(X)". Treat as string
-                        string[] includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(rootDirectory, includeSplitEscaped);
+                        string[] includeSplitFilesEscaped = EngineFileUtilities.Default.GetFileListEscaped(rootDirectory, includeSplitEscaped);
 
                         if (includeSplitFilesEscaped.Length > 0)
                         {
@@ -1536,7 +1536,7 @@ namespace Microsoft.Build.Evaluation
                         (
                             _expander.ExpandIntoStringLeaveEscaped(itemElement.Update, ExpanderOptions.ExpandPropertiesAndItems, itemElement.Location)
                         )
-                        .SelectMany(i => EngineFileUtilities.GetFileListEscaped(_projectRootElement.DirectoryPath, i))
+                        .SelectMany(i => EngineFileUtilities.Default.GetFileListEscaped(_projectRootElement.DirectoryPath, i))
                         .Select(EscapingUtilities.UnescapeAll));
 
             var itemsToUpdate = _data.GetItems(itemElement.ItemType).Where(i => expandedItemSet.Contains(i.EvaluatedInclude)).ToList();
@@ -1567,7 +1567,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (string excludeSplit in excludeSplits)
                     {
-                        string[] excludeSplitFiles = EngineFileUtilities.GetFileListEscaped(_projectRootElement.DirectoryPath, excludeSplit);
+                        string[] excludeSplitFiles = EngineFileUtilities.Default.GetFileListEscaped(_projectRootElement.DirectoryPath, excludeSplit);
 
                         foreach (string excludeSplitFile in excludeSplitFiles)
                         {
@@ -2202,7 +2202,7 @@ namespace Microsoft.Build.Evaluation
                     }
 
                     // Expand the wildcards and provide an alphabetical order list of import statements.
-                    importFilesEscaped = EngineFileUtilities.GetFileListEscaped(directoryOfImportingFile, importExpressionEscapedItem, forceEvaluate: true);
+                    importFilesEscaped = EngineFileUtilities.Default.GetFileListEscaped(directoryOfImportingFile, importExpressionEscapedItem, forceEvaluate: true);
                 }
                 catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
                 {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -759,7 +759,7 @@ namespace Microsoft.Build.Evaluation
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Items))
                 {
                     // comment next line to turn off lazy Evaluation
-                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler, _fileSystem, _evaluationContext?.FileMatcherCache ?? new ConcurrentDictionary<string, ImmutableArray<string>>());
+                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler, _fileSystem, _evaluationContext?.FileMatcherCache ?? new ConcurrentDictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase));
 
                     // Pass3: evaluate project items
                     foreach (ProjectItemGroupElement itemGroup in _itemGroupElements)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -6,7 +6,9 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -757,7 +759,7 @@ namespace Microsoft.Build.Evaluation
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Items))
                 {
                     // comment next line to turn off lazy Evaluation
-                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler);
+                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler, _fileSystem, _evaluationContext?.FileMatcherCache ?? new ConcurrentDictionary<string, ImmutableArray<string>>());
 
                     // Pass3: evaluate project items
                     foreach (ProjectItemGroupElement itemGroup in _itemGroupElements)

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -35,6 +35,7 @@ using EngineFileUtilities = Microsoft.Build.Internal.EngineFileUtilities;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
@@ -199,6 +200,7 @@ namespace Microsoft.Build.Evaluation
         private static readonly EngineFileUtilities.IOCache _fallbackSearchPathsCache = new EngineFileUtilities.IOCache();
 
         private readonly EvaluationProfiler _evaluationProfiler;
+        private IFileSystemAbstraction _fileSystem;
 
         /// <summary>
         /// Private constructor called by the static Evaluate method.
@@ -245,6 +247,7 @@ namespace Microsoft.Build.Evaluation
             _submissionId = submissionId;
             _evaluationContext = evaluationContext;
             _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
+            _fileSystem = evaluationContext?.FileSystem ?? FileSystemFactory.GetFileSystem();
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -202,7 +202,6 @@ namespace Microsoft.Build.Evaluation
         private static readonly EngineFileUtilities.IOCache _fallbackSearchPathsCache = new EngineFileUtilities.IOCache();
 
         private readonly EvaluationProfiler _evaluationProfiler;
-        private IFileSystemAbstraction _fileSystem;
 
         /// <summary>
         /// Private constructor called by the static Evaluate method.
@@ -221,8 +220,8 @@ namespace Microsoft.Build.Evaluation
             EvaluationContext evaluationContext,
             bool profileEvaluation)
         {
-            ErrorUtilities.VerifyThrowInternalNull(data, "data");
-            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, "projectRootElementCache");
+            ErrorUtilities.VerifyThrowInternalNull(data, nameof(data));
+            ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
 
             // Create containers for the evaluation results
             data.InitializeForEvaluation(toolsetProvider);
@@ -247,9 +246,8 @@ namespace Microsoft.Build.Evaluation
             _projectRootElementCache = projectRootElementCache;
             _sdkResolverService = sdkResolverService;
             _submissionId = submissionId;
-            _evaluationContext = evaluationContext;
+            _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
             _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
-            _fileSystem = evaluationContext?.FileSystem ?? FileSystemFactory.GetFileSystem();
         }
 
         /// <summary>
@@ -759,7 +757,7 @@ namespace Microsoft.Build.Evaluation
                 using (_evaluationProfiler.TrackPass(EvaluationPass.Items))
                 {
                     // comment next line to turn off lazy Evaluation
-                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler, _fileSystem, _evaluationContext?.FileMatcherCache ?? new ConcurrentDictionary<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase));
+                    lazyEvaluator = new LazyItemEvaluator<P, I, M, D>(_data, _itemFactory, _evaluationLoggingContext, _evaluationProfiler, _evaluationContext);
 
                     // Pass3: evaluate project items
                     foreach (ProjectItemGroupElement itemGroup in _itemGroupElements)

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2062,7 +2062,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             foreach (
                                 var resultantItem in
-                                EngineFileUtilities.GetFileListEscaped(
+                                EngineFileUtilities.Default.GetFileListEscaped(
                                     item.ProjectDirectory,
                                     item.EvaluatedIncludeEscaped,
                                     forceEvaluate: true))

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Evaluation
                         using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob,
                             excludePatternsForGlobs))
                         {
-                            includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
+                            includeSplitFilesEscaped = EngineFileUtilities.Default.GetFileListEscaped(
                                 _rootDirectory,
                                 glob,
                                 excludePatternsForGlobs,

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -97,14 +97,12 @@ namespace Microsoft.Build.Evaluation
                         }
 
                         string[] includeSplitFilesEscaped;
-                        using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob,
-                            excludePatternsForGlobs))
+                        using (_lazyEvaluator._evaluationProfiler.TrackGlob(_rootDirectory, glob, excludePatternsForGlobs))
                         {
-                            includeSplitFilesEscaped = EngineFileUtilities.Default.GetFileListEscaped(
+                            includeSplitFilesEscaped = EngineFileUtilities.GetFileListEscaped(
                                 _rootDirectory,
                                 glob,
-                                excludePatternsForGlobs,
-                                entriesCache: EntriesCache
+                                excludePatternsForGlobs
                             );
                         }
 

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Evaluation
@@ -45,10 +46,7 @@ namespace Microsoft.Build.Evaluation
                 _itemSpec.Expander = _expander;
             }
 
-            /// <summary>
-            /// Cache used for caching IO operation results
-            /// </summary>
-            protected ConcurrentDictionary<string, ImmutableArray<string>> EntriesCache => _lazyEvaluator._entriesCache;
+            protected EngineFileUtilities EngineFileUtilities => _lazyEvaluator.EngineFileUtilities;
 
             public virtual void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -13,6 +13,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Evaluation
@@ -44,12 +46,9 @@ namespace Microsoft.Build.Evaluation
             new Dictionary<string, LazyItemList>() :
             new Dictionary<string, LazyItemList>(StringComparer.OrdinalIgnoreCase);
 
-        /// <summary>
-        /// Cache used for caching IO operation results
-        /// </summary>
-        private readonly ConcurrentDictionary<string, ImmutableArray<string>> _entriesCache = new ConcurrentDictionary<string, ImmutableArray<string>>();
+        protected EngineFileUtilities EngineFileUtilities { get; }
 
-        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext, EvaluationProfiler evaluationProfiler)
+        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext, EvaluationProfiler evaluationProfiler, IFileSystemAbstraction fileSystem, ConcurrentDictionary<string, ImmutableArray<string>> fileMatcherCache)
         {
             _outerEvaluatorData = data;
             _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);
@@ -58,6 +57,8 @@ namespace Microsoft.Build.Evaluation
             _itemFactory = itemFactory;
             _loggingContext = loggingContext;
             _evaluationProfiler = evaluationProfiler;
+
+            EngineFileUtilities = new EngineFileUtilities(new FileMatcher(fileSystem, fileMatcherCache));
         }
 
         private ImmutableList<I> GetItems(string itemType)

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -13,6 +13,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
@@ -48,7 +49,7 @@ namespace Microsoft.Build.Evaluation
 
         protected EngineFileUtilities EngineFileUtilities { get; }
 
-        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext, EvaluationProfiler evaluationProfiler, IFileSystemAbstraction fileSystem, ConcurrentDictionary<string, ImmutableArray<string>> fileMatcherCache)
+        public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext, EvaluationProfiler evaluationProfiler, EvaluationContext evaluationContext)
         {
             _outerEvaluatorData = data;
             _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);
@@ -58,7 +59,7 @@ namespace Microsoft.Build.Evaluation
             _loggingContext = loggingContext;
             _evaluationProfiler = evaluationProfiler;
 
-            EngineFileUtilities = new EngineFileUtilities(new FileMatcher(fileSystem, fileMatcherCache));
+            EngineFileUtilities = new EngineFileUtilities(new FileMatcher(evaluationContext.FileSystem, evaluationContext.FileEntryExpansionCache));
         }
 
         private ImmutableList<I> GetItems(string itemType)

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Build.Globbing
                 bool needsRecursion;
                 bool isLegalFileSpec;
 
-                FileMatcher.GetFileSpecInfo(
+                FileMatcher.Default.GetFileSpecInfo(
                     fileSpec,
                     out fixedDirectoryPart,
                     out wildcardDirectoryPart,
@@ -192,7 +192,6 @@ namespace Microsoft.Build.Globbing
                     out matchFileExpression,
                     out needsRecursion,
                     out isLegalFileSpec,
-                    FileMatcher.s_defaultGetFileSystemEntries,
                     (fixedDirPart, wildcardDirPart, filePart) =>
                     {
                         var normalizedFixedPart = NormalizeTheFixedDirectoryPartAgainstTheGlobRoot(fixedDirPart, globRoot);

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -703,6 +703,28 @@
       <Link>SharedUtilities\FileMatcher.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\FileSystem\FileSystemFactory.cs">
+    	<Link>FileSystem\FileSystemFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\IFileSystemAbstraction.cs">
+    	<Link>FileSystem\IFileSystemAbstraction.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\ManagedFileSystem.cs">
+    	<Link>FileSystem\ManagedFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\NativeWin32Exception.cs">
+    	<Link>FileSystem\NativeWin32Exception.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\SafeFileHandle.cs">
+    	<Link>FileSystem\SafeFileHandle.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsFileSystem.cs">
+    	<Link>FileSystem\WindowsFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsNative.cs">
+    	<Link>FileSystem\WindowsNative.cs</Link>
+    </Compile>
+
     <Compile Include="..\Shared\FileUtilities.cs">
       <Link>SharedUtilities\FileUtilities.cs</Link>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.Internal
                 // as a relative path, we will get back a bunch of relative paths.
                 // If the filespec started out as an absolute path, we will get
                 // back a bunch of absolute paths.
-                fileList = FileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, entriesCache);
+                fileList = FileMatcher.Default.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, entriesCache);
 
                 ErrorUtilities.VerifyThrow(fileList != null, "We must have a list of files here, even if it's empty.");
 

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -5,19 +5,18 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Text;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Shared;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Utilities;
-using Microsoft.Build.Shared.EscapingStringExtensions;
 
 namespace Microsoft.Build.Internal
 {
     internal class EngineFileUtilities
     {
+        private readonly FileMatcher _fileMatcher;
+
         // Regexes for wildcard filespecs that should not get expanded
         // By default all wildcards are expanded.
         private static List<Regex> s_lazyWildCardExpansionRegexes;
@@ -36,6 +35,13 @@ namespace Microsoft.Build.Internal
             s_lazyWildCardExpansionRegexes = PopulateRegexFromEnvironment();
         }
 
+        public static EngineFileUtilities Default = new EngineFileUtilities(FileMatcher.Default);
+
+        public EngineFileUtilities(FileMatcher fileMatcher)
+        {
+            _fileMatcher = fileMatcher;
+        }
+
 
     /// <summary>
         /// Used for the purposes of evaluating an item specification. Given a filespec that may include wildcard characters * and
@@ -51,7 +57,7 @@ namespace Microsoft.Build.Internal
         /// <param name="filespecEscaped">The filespec to evaluate, escaped.</param>
         /// <param name="forceEvaluate">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <returns>Array of file paths, unescaped.</returns>
-        internal static string[] GetFileListUnescaped
+        internal string[] GetFileListUnescaped
             (
             string directoryEscaped,
             string filespecEscaped,
@@ -78,7 +84,7 @@ namespace Microsoft.Build.Internal
         /// <param name="forceEvaluate">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <param name="entriesCache">Cache used for caching IO operation results</param>
         /// <returns>Array of file paths, escaped.</returns>
-        internal static string[] GetFileListEscaped
+        internal string[] GetFileListEscaped
             (
             string directoryEscaped,
             string filespecEscaped,
@@ -131,7 +137,7 @@ namespace Microsoft.Build.Internal
         /// <param name="excludeSpecsEscaped">The exclude specification, escaped.</param>
         /// <param name="entriesCache">Cache used for caching IO operation results</param>
         /// <returns>Array of file paths.</returns>
-        private static string[] GetFileList
+        private string[] GetFileList
             (
             string directoryEscaped,
             string filespecEscaped,
@@ -173,7 +179,7 @@ namespace Microsoft.Build.Internal
                 // as a relative path, we will get back a bunch of relative paths.
                 // If the filespec started out as an absolute path, we will get
                 // back a bunch of absolute paths.
-                fileList = FileMatcher.Default.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, entriesCache);
+                fileList = _fileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, entriesCache);
 
                 ErrorUtilities.VerifyThrow(fileList != null, "We must have a list of files here, even if it's empty.");
 

--- a/src/Build/Utilities/EngineFileUtilities.cs
+++ b/src/Build/Utilities/EngineFileUtilities.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Internal
         }
 
 
-    /// <summary>
+        /// <summary>
         /// Used for the purposes of evaluating an item specification. Given a filespec that may include wildcard characters * and
         /// ?, we translate it into an actual list of files. If the input filespec doesn't contain any wildcard characters, and it
         /// doesn't appear to point to an actual file on disk, then we just give back the input string as an array of length one,
@@ -82,18 +82,16 @@ namespace Microsoft.Build.Internal
         /// <param name="filespecEscaped">The filespec to evaluate, escaped.</param>
         /// <param name="excludeSpecsEscaped">Filespecs to exclude, escaped.</param>
         /// <param name="forceEvaluate">Whether to force file glob expansion when eager expansion is turned off</param>
-        /// <param name="entriesCache">Cache used for caching IO operation results</param>
         /// <returns>Array of file paths, escaped.</returns>
         internal string[] GetFileListEscaped
             (
             string directoryEscaped,
             string filespecEscaped,
             IEnumerable<string> excludeSpecsEscaped = null,
-            bool forceEvaluate = false,
-            ConcurrentDictionary<string, ImmutableArray<string>> entriesCache = null
+            bool forceEvaluate = false
             )
         {
-            return GetFileList(directoryEscaped, filespecEscaped, true /* returnEscaped */, forceEvaluate, excludeSpecsEscaped, entriesCache);
+            return GetFileList(directoryEscaped, filespecEscaped, true /* returnEscaped */, forceEvaluate, excludeSpecsEscaped);
         }
 
         internal static bool FilespecHasWildcards(string filespecEscaped)
@@ -135,7 +133,6 @@ namespace Microsoft.Build.Internal
         /// <param name="returnEscaped"><code>true</code> to return escaped specs.</param>
         /// <param name="forceEvaluateWildCards">Whether to force file glob expansion when eager expansion is turned off</param>
         /// <param name="excludeSpecsEscaped">The exclude specification, escaped.</param>
-        /// <param name="entriesCache">Cache used for caching IO operation results</param>
         /// <returns>Array of file paths.</returns>
         private string[] GetFileList
             (
@@ -143,8 +140,7 @@ namespace Microsoft.Build.Internal
             string filespecEscaped,
             bool returnEscaped,
             bool forceEvaluateWildCards,
-            IEnumerable<string> excludeSpecsEscaped = null,
-            ConcurrentDictionary<string, ImmutableArray<string>> entriesCache = null
+            IEnumerable<string> excludeSpecsEscaped = null
             )
         {
             ErrorUtilities.VerifyThrowInternalLength(filespecEscaped, "filespecEscaped");
@@ -179,7 +175,7 @@ namespace Microsoft.Build.Internal
                 // as a relative path, we will get back a bunch of relative paths.
                 // If the filespec started out as an absolute path, we will get
                 // back a bunch of absolute paths.
-                fileList = _fileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, entriesCache);
+                fileList = _fileMatcher.GetFiles(directoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
 
                 ErrorUtilities.VerifyThrow(fileList != null, "We must have a list of files here, even if it's empty.");
 

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -58,12 +58,11 @@ namespace Microsoft.Build.Internal
             string wildcardDirectoryPart = null;
             string filenamePart = null;
 
-            FileMatcher.SplitFileSpec(
+            FileMatcher.Default.SplitFileSpec(
                 unescapedFileSpec,
                 out fixedDirPart,
                 out wildcardDirectoryPart,
-                out filenamePart,
-                FileMatcher.s_defaultGetFileSystemEntries);
+                out filenamePart);
 
             if (FileUtilities.PathIsInvalid(fixedDirPart))
             {
@@ -83,12 +82,11 @@ namespace Microsoft.Build.Internal
             bool isRecursive;
             bool isLegal;
 
-            FileMatcher.GetFileSpecInfoWithRegexObject(
+            FileMatcher.Default.GetFileSpecInfoWithRegexObject(
                 recombinedFileSpec,
                 out regex,
                 out isRecursive,
-                out isLegal,
-                FileMatcher.s_defaultGetFileSystemEntries);
+                out isLegal);
 
             return isLegal ? regex : null;
         }

--- a/src/Deprecated/Engine/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Deprecated/Engine/Shared/UnitTests/FileMatcher_Tests.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Build.UnitTests
                 Directory.CreateDirectory(workingPath);
                 Directory.CreateDirectory(workingPathSubfolder);
 
-                files = FileMatcher.GetFiles(workingPath, offendingPattern);
+                files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
             }
             finally
             {
@@ -590,7 +590,7 @@ namespace Microsoft.Build.UnitTests
             {
                 Directory.CreateDirectory(workingPath);
                 File.WriteAllText(fileName, "Hello there.");
-                files = FileMatcher.GetFiles(workingPath, offendingPattern);
+                files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
             }
             finally
             {
@@ -620,7 +620,7 @@ namespace Microsoft.Build.UnitTests
                 Directory.CreateDirectory(workingPath);
                 Directory.CreateDirectory(workingPathSubdir);
                 File.AppendAllText(workingPathSubdirBing, "y");
-                files = FileMatcher.GetFiles(workingPath, offendingPattern);
+                files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
             }
             finally
             {
@@ -1298,7 +1298,7 @@ namespace Microsoft.Build.UnitTests
                 bool shouldBeRecursive
             )
             {
-                FileMatcher.Result match = FileMatcher.FileMatch(filespec, fileToMatch);
+                FileMatcher.Result match = FileMatcher.Default.FileMatch(filespec, fileToMatch);
 
                 if (!match.isLegalFileSpec)
                 {

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -18,6 +18,7 @@ using System.Globalization;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Shared
@@ -41,8 +42,13 @@ namespace Microsoft.Build.Shared
         internal static readonly char[] directorySeparatorCharacters = { '/', '\\' };
         internal static readonly string[] directorySeparatorStrings = directorySeparatorCharacters.Select(c => c.ToString()).ToArray();
 
-        internal static readonly GetFileSystemEntries s_defaultGetFileSystemEntries = new GetFileSystemEntries(GetAccessibleFileSystemEntries);
-        private static readonly DirectoryExists s_defaultDirectoryExists = new DirectoryExists(Directory.Exists);
+        // TODO: for now this abstraction is specific to FileMatcher, but we can consider plumbing it through the evaluator as a whole
+        internal static readonly IFileSystemAbstraction DefaultFileSystem = FileSystemFactory.GetFileSystem();
+
+        internal static readonly GetFileSystemEntries s_defaultGetFileSystemEntries =
+            new GetFileSystemEntries((entityType, path, pattern, projectDirectory, stripProjectDirectory) =>
+                GetAccessibleFileSystemEntries(DefaultFileSystem, entityType, path, pattern, projectDirectory, stripProjectDirectory));
+        private static readonly DirectoryExists s_defaultDirectoryExists = new DirectoryExists(DefaultFileSystem.DirectoryExists);
 
         private static readonly Lazy<ConcurrentDictionary<string, string[]>> s_cachedFileEnumerations = new Lazy<ConcurrentDictionary<string, string[]>>(() => new ConcurrentDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase));
         private static readonly Lazy<ConcurrentDictionary<string, object>> s_cachedFileEnumerationsLock = new Lazy<ConcurrentDictionary<string, object>>(() => new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase));
@@ -121,15 +127,16 @@ namespace Microsoft.Build.Shared
         /// <param name="pattern">The pattern to search.</param>
         /// <param name="projectDirectory">The directory for the project within which the call is made</param>
         /// <param name="stripProjectDirectory">If true the project directory should be stripped</param>
+        /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns></returns>
-        private static ImmutableArray<string> GetAccessibleFileSystemEntries(FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
+        private static ImmutableArray<string> GetAccessibleFileSystemEntries(IFileSystemAbstraction fileSystem, FileSystemEntity entityType, string path, string pattern, string projectDirectory, bool stripProjectDirectory)
         {
             path = FileUtilities.FixFilePath(path);
             switch (entityType)
             {
-                case FileSystemEntity.Files: return GetAccessibleFiles(path, pattern, projectDirectory, stripProjectDirectory);
-                case FileSystemEntity.Directories: return GetAccessibleDirectories(path, pattern);
-                case FileSystemEntity.FilesAndDirectories: return GetAccessibleFilesAndDirectories(path, pattern);
+                case FileSystemEntity.Files: return GetAccessibleFiles(fileSystem, path, pattern, projectDirectory, stripProjectDirectory);
+                case FileSystemEntity.Directories: return GetAccessibleDirectories(fileSystem, path, pattern);
+                case FileSystemEntity.FilesAndDirectories: return GetAccessibleFilesAndDirectories(fileSystem,path, pattern);
                 default:
                     ErrorUtilities.VerifyThrow(false, "Unexpected filesystem entity type.");
                     break;
@@ -143,17 +150,18 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="path"></param>
         /// <param name="pattern"></param>
+        /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>An immutable array of matching file system entries (can be empty).</returns>
-        private static ImmutableArray<string> GetAccessibleFilesAndDirectories(string path, string pattern)
+        private static ImmutableArray<string> GetAccessibleFilesAndDirectories(IFileSystemAbstraction fileSystem, string path, string pattern)
         {
             if (Directory.Exists(path))
             {
                 try
                 {
                     return (ShouldEnforceMatching(pattern)
-                        ? Directory.EnumerateFileSystemEntries(path, pattern)
+                        ? fileSystem.EnumerateFileSystemEntries(path, pattern)
                             .Where(o => IsMatch(Path.GetFileName(o), pattern, true))
-                        : Directory.EnumerateFileSystemEntries(path, pattern)
+                        : fileSystem.EnumerateFileSystemEntries(path, pattern)
                     ).ToImmutableArray();
                 }
                 // for OS security
@@ -207,9 +215,11 @@ namespace Microsoft.Build.Shared
         /// <param name="filespec">The pattern.</param>
         /// <param name="projectDirectory">The project directory</param>
         /// <param name="stripProjectDirectory"></param>
+        /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Files that can be accessed.</returns>
         private static ImmutableArray<string> GetAccessibleFiles
         (
+            IFileSystemAbstraction fileSystem,
             string path,
             string filespec,     // can be null
             string projectDirectory,
@@ -225,11 +235,11 @@ namespace Microsoft.Build.Shared
                 IEnumerable<string> files;
                 if (filespec == null)
                 {
-                    files = Directory.EnumerateFiles(dir);
+                    files = fileSystem.EnumerateFiles(dir);
                 }
                 else
                 {
-                    files = Directory.EnumerateFiles(dir, filespec);
+                    files = fileSystem.EnumerateFiles(dir, filespec);
                     if (ShouldEnforceMatching(filespec))
                     {
                         files = files.Where(o => IsMatch(Path.GetFileName(o), filespec, true));
@@ -273,9 +283,11 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="path">The path.</param>
         /// <param name="pattern">Pattern to match</param>
+        /// <param name="fileSystem">The file system abstraction to use that implements file system operations</param>
         /// <returns>Accessible directories.</returns>
         private static ImmutableArray<string> GetAccessibleDirectories
         (
+            IFileSystemAbstraction fileSystem,
             string path,
             string pattern
         )
@@ -286,11 +298,11 @@ namespace Microsoft.Build.Shared
 
                 if (pattern == null)
                 {
-                    directories = Directory.EnumerateDirectories((path.Length == 0) ? s_thisDirectory : path);
+                    directories = fileSystem.EnumerateDirectories((path.Length == 0) ? s_thisDirectory : path);
                 }
                 else
                 {
-                    directories = Directory.EnumerateDirectories((path.Length == 0) ? s_thisDirectory : path, pattern);
+                    directories = fileSystem.EnumerateDirectories((path.Length == 0) ? s_thisDirectory : path, pattern);
                     if (ShouldEnforceMatching(pattern))
                     {
                         directories = directories.Where(o => IsMatch(Path.GetFileName(o), pattern, true));

--- a/src/Shared/FileSystem/FileSystemFactory.cs
+++ b/src/Shared/FileSystem/FileSystemFactory.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Factory for <see cref="IFileSystemAbstraction"/>
+    /// </summary>
+    internal static class FileSystemFactory
+    {
+        /// <nodoc/>
+        public static IFileSystemAbstraction GetFileSystem()
+        {
+            // The windows-specific file system is only available on Windows Vista or higher
+            if (IsWinVistaOrHigher())
+            {
+                return WindowsFileSystem.Singleton();
+            }
+
+            // Otherwise we fall back into the standard managed file system API
+            return ManagedFileSystem.Singleton();
+        }
+
+        private static bool IsWinVistaOrHigher()
+        {
+            var os = Environment.OSVersion;
+            return os.Platform == PlatformID.Win32NT && os.Version.Major >= 6;
+        }
+    }
+}

--- a/src/Shared/FileSystem/FileSystemFactory.cs
+++ b/src/Shared/FileSystem/FileSystemFactory.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Build.Shared.FileSystem
         public static IFileSystemAbstraction GetFileSystem()
         {
             // The windows-specific file system is only available on Windows Vista or higher
-            if (IsWinVistaOrHigher())
-            {
-                return WindowsFileSystem.Singleton();
-            }
+            //if (IsWinVistaOrHigher())
+            //{
+            //    return WindowsFileSystem.Singleton();
+            //}
 
             // Otherwise we fall back into the standard managed file system API
             return ManagedFileSystem.Singleton();

--- a/src/Shared/FileSystem/IFileSystemAbstraction.cs
+++ b/src/Shared/FileSystem/IFileSystemAbstraction.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Abstracts away some file system operations
+    /// </summary>
+    /// TODO: This interface has only enumeration and existence related methods. Consider extending it to include other file system operations.
+    internal interface IFileSystemAbstraction
+    {
+        /// <summary>
+        /// Returns an enumerable collection of file names that match a search pattern in a specified path, and optionally searches subdirectories.
+        /// </summary>
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Returns an enumerable collection of directory names that match a search pattern in a specified path, and optionally searches subdirectories.
+        /// </summary>
+        IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Returns an enumerable collection of file names and directory names that match a search pattern in a specified path, and optionally searches subdirectories.
+        /// </summary>
+        IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing directory on disk.
+        /// </summary>
+        bool DirectoryExists(string path);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing file on disk.
+        /// </summary>
+        bool FileExists(string path);
+
+        /// <summary>
+        /// Determines whether the given path refers to an existing entry in the directory service.
+        /// </summary>
+        bool DirectoryEntryExists(string path);
+    }
+}

--- a/src/Shared/FileSystem/IFileSystemAbstraction.cs
+++ b/src/Shared/FileSystem/IFileSystemAbstraction.cs
@@ -41,5 +41,7 @@ namespace Microsoft.Build.Shared.FileSystem
         /// Determines whether the given path refers to an existing entry in the directory service.
         /// </summary>
         bool DirectoryEntryExists(string path);
+
+        void ClearCaches();
     }
 }

--- a/src/Shared/FileSystem/ManagedFileSystem.cs
+++ b/src/Shared/FileSystem/ManagedFileSystem.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Implementation of file system operations directly over the dot net managed layer
+    /// </summary>
+    internal sealed class ManagedFileSystem : IFileSystemAbstraction
+    {
+        private static readonly ManagedFileSystem Instance = new ManagedFileSystem();
+
+        /// <nodoc/>
+        public static ManagedFileSystem Singleton() => ManagedFileSystem.Instance;
+
+        private ManagedFileSystem()
+        { }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public bool DirectoryExists(string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        /// <inheritdoc/>
+        public bool FileExists(string path)
+        {
+            return File.Exists(path);
+        }
+
+        /// <inheritdoc/>
+        public bool DirectoryEntryExists(string path)
+        {
+            return FileExists(path) || DirectoryExists(path);
+        }
+    }
+}

--- a/src/Shared/FileSystem/ManagedFileSystem.cs
+++ b/src/Shared/FileSystem/ManagedFileSystem.cs
@@ -54,5 +54,9 @@ namespace Microsoft.Build.Shared.FileSystem
         {
             return FileExists(path) || DirectoryExists(path);
         }
+
+        public void ClearCaches()
+        {
+        }
     }
 }

--- a/src/Shared/FileSystem/NativeWin32Exception.cs
+++ b/src/Shared/FileSystem/NativeWin32Exception.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// A possibly-recoverable exception wrapping a failed native call. The <see cref="Win32Exception.NativeErrorCode" /> captures the
+    /// associated recent error code (<see cref="System.Runtime.InteropServices.Marshal.GetLastWin32Error" />). The <see cref="Exception.Message" />
+    /// accounts for the native code as well as a human readable portion.
+    /// </summary>
+    /// <remarks>
+    /// This is much like <see cref="Win32Exception"/>, but the message field contains the caller-provided part in addition
+    /// to the system-provided message (rather than replacing the system provided message).
+    /// </remarks>
+    [SuppressMessage("Microsoft.Design", "CA1032:ImplementStandardExceptionConstructors",
+        Justification = "We don't need exceptions to cross AppDomain boundaries.")]
+    [Serializable]
+    internal sealed class NativeWin32Exception : Win32Exception
+    {
+        /// <summary>
+        /// Creates an exception representing a native failure (with a corresponding Win32 error code).
+        /// The exception's <see cref="Exception.Message" /> includes the error code, a system-provided message describing it,
+        /// and the provided application-specific message prefix (e.g. "Unable to open log file").
+        /// </summary>
+        public NativeWin32Exception(int nativeErrorCode, [Localizable(false)] string messagePrefix)
+            : base(nativeErrorCode, GetFormattedMessageForNativeErrorCode(nativeErrorCode, messagePrefix))
+        {
+            // Win32Exception does not initialize HResult but many others like IOException do.
+            // In order to have a uniform error checking, initialize HResult using something similar to HRESULT_FROM_WIN32
+            HResult = HResultFromWin32(nativeErrorCode);
+        }
+
+        /// <summary>
+        /// Creates an exception representing a native failure (with a corresponding Win32 error code).
+        /// The exception's <see cref="Exception.Message" /> includes the error code and a system-provided message describing it.
+        /// </summary>
+        public NativeWin32Exception(int nativeErrorCode)
+            : this(nativeErrorCode, null)
+        {
+        }
+
+        /// <summary>
+        /// Returns a human readable error string for a native error code, like <c>Native: Can't access the log file (0x5: Access is denied)</c>.
+        /// The message prefix (e.g. "Can't access the log file") is optional.
+        /// </summary>
+        public static string GetFormattedMessageForNativeErrorCode(int nativeErrorCode, [Localizable(false)] string messagePrefix = null)
+        {
+            string systemMessage = new Win32Exception(nativeErrorCode).Message;
+            if (!string.IsNullOrEmpty(messagePrefix))
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Native: {0} (0x{1:X}: {2})", messagePrefix, nativeErrorCode, systemMessage);
+            }
+            else
+            {
+                return string.Format(CultureInfo.InvariantCulture, "Native: 0x{0:X}: {1}", nativeErrorCode, systemMessage);
+            }
+        }
+
+        /// <summary>
+        /// Converts a Win32 error code to HResult
+        /// </summary>
+        public static int HResultFromWin32(int nativeErrorCode)
+        {
+            if (nativeErrorCode < 0 || nativeErrorCode > 0xFFFF)
+            {
+                return nativeErrorCode;
+            }
+
+            return unchecked((int)0x80070000) | nativeErrorCode;
+        }
+    }
+}

--- a/src/Shared/FileSystem/SafeFileHandle.cs
+++ b/src/Shared/FileSystem/SafeFileHandle.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Handle for a volume iteration as returned by WindowsNative.FindFirstVolumeW />
+    /// </summary>
+    internal sealed class SafeFindFileHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        /// <summary>
+        /// Private constructor for the PInvoke marshaller.
+        /// </summary>
+        private SafeFindFileHandle()
+            : base(ownsHandle: true)
+        {
+        }
+
+        /// <nodoc/>
+        protected override bool ReleaseHandle()
+        {
+            return WindowsNative.FindClose(handle);
+        }
+    }
+}

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// The type of file artifact to search for
+    /// </summary>
+    internal enum FileArtifactType : byte
+    {
+        /// <nodoc/>
+        File,
+        /// <nodoc/>
+        Directory,
+        /// <nodoc/>
+        FileOrDirectory
+    }
+
+    /// <summary>
+    /// Windows-specific implementation of file system operations using Windows native invocations
+    /// </summary>
+    internal class WindowsFileSystem : IFileSystemAbstraction
+    {
+        private static readonly WindowsFileSystem Instance = new WindowsFileSystem();
+
+        /// <nodoc/>
+        public static WindowsFileSystem Singleton() => WindowsFileSystem.Instance;
+
+        private WindowsFileSystem()
+        { }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return EnumerateFileOrDirectories(path, FileArtifactType.File, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            return EnumerateFileOrDirectories(path, FileArtifactType.Directory, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            return EnumerateFileOrDirectories(path, FileArtifactType.FileOrDirectory, searchPattern, searchOption);
+        }
+
+        /// <inheritdoc/>
+        public bool DirectoryExists(string path)
+        {
+            return FileOrDirectoryExists(FileArtifactType.Directory, path);
+        }
+
+        /// <inheritdoc/>
+        public bool FileExists(string path)
+        {
+            return FileOrDirectoryExists(FileArtifactType.File, path);
+        }
+
+        /// <inheritdoc/>
+        public bool DirectoryEntryExists(string path)
+        {
+            return FileOrDirectoryExists(FileArtifactType.FileOrDirectory, path);
+        }
+
+        private static bool FileOrDirectoryExists(FileArtifactType fileArtifactType, string path)
+        {
+            // The path gets normalized so we always use backslashes
+            path = NormalizePathToWindowsStyle(path);
+
+            WindowsNative.Win32FindData findResult;
+            using (var findHandle = WindowsNative.FindFirstFileW(path.TrimEnd('\\'), out findResult))
+            {
+                // Any error is interpreted as a file not found. This matches the managed Directory.Exists and File.Exists behavior
+                if (findHandle.IsInvalid)
+                {
+                    return false;
+                }
+
+                if (fileArtifactType == FileArtifactType.FileOrDirectory)
+                {
+                    return true;
+                }
+
+                var isDirectory = (findResult.DwFileAttributes & FileAttributes.Directory) != 0;
+
+                return !(fileArtifactType == FileArtifactType.Directory ^ isDirectory);
+            }
+        }
+
+        private static IEnumerable<string> EnumerateFileOrDirectories(
+            string directoryPath,
+            FileArtifactType fileArtifactType,
+            string searchPattern,
+            SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            var enumeration = new List<string>();
+
+            // The search pattern and path gets normalized so we always use backslashes
+            searchPattern = NormalizePathToWindowsStyle(searchPattern);
+            directoryPath = NormalizePathToWindowsStyle(directoryPath);
+
+            var result = CustomEnumerateDirectoryEntries(
+                directoryPath,
+                fileArtifactType,
+                searchPattern,
+                searchOption,
+                enumeration);
+
+            // If the result indicates that the enumeration succeeded or the directory does not exist, then the result is considered success.
+            // In particular, if the globed directory does not exist, then we want to return the empty file, and track for the anti-dependency.
+            if (
+                !(result.Status == WindowsNative.EnumerateDirectoryStatus.Success ||
+                  result.Status == WindowsNative.EnumerateDirectoryStatus.SearchDirectoryNotFound))
+            {
+                throw result.CreateExceptionForError();
+            }
+
+            return enumeration;
+        }
+
+        private static WindowsNative.EnumerateDirectoryResult CustomEnumerateDirectoryEntries(
+            string directoryPath,
+            FileArtifactType fileArtifactType,
+            string pattern,
+            SearchOption searchOption,
+            ICollection<string> result)
+        {
+            var searchDirectoryPath = Path.Combine(directoryPath.TrimEnd('\\'), "*");
+
+            WindowsNative.Win32FindData findResult;
+            using (var findHandle = WindowsNative.FindFirstFileW(searchDirectoryPath, out findResult))
+            {
+                if (findHandle.IsInvalid)
+                {
+                    int hr = Marshal.GetLastWin32Error();
+                    Debug.Assert(hr != WindowsNative.ErrorFileNotFound);
+
+                    WindowsNative.EnumerateDirectoryStatus findHandleOpenStatus;
+                    switch (hr)
+                    {
+                        case WindowsNative.ErrorFileNotFound:
+                            findHandleOpenStatus = WindowsNative.EnumerateDirectoryStatus.SearchDirectoryNotFound;
+                            break;
+                        case WindowsNative.ErrorPathNotFound:
+                            findHandleOpenStatus = WindowsNative.EnumerateDirectoryStatus.SearchDirectoryNotFound;
+                            break;
+                        case WindowsNative.ErrorDirectory:
+                            findHandleOpenStatus = WindowsNative.EnumerateDirectoryStatus.CannotEnumerateFile;
+                            break;
+                        case WindowsNative.ErrorAccessDenied:
+                            findHandleOpenStatus = WindowsNative.EnumerateDirectoryStatus.AccessDenied;
+                            break;
+                        default:
+                            findHandleOpenStatus = WindowsNative.EnumerateDirectoryStatus.UnknownError;
+                            break;
+                    }
+
+                    return new WindowsNative.EnumerateDirectoryResult(directoryPath, findHandleOpenStatus, hr);
+                }
+
+                while (true)
+                {
+                    var isDirectory = (findResult.DwFileAttributes & FileAttributes.Directory) != 0;
+
+                    // There will be entries for the current and parent directories. Ignore those.
+                    if (!isDirectory || (findResult.CFileName != "." && findResult.CFileName != ".."))
+                    {
+                        // Make sure pattern and directory/file filters are honored
+                        // We special case the "*" pattern since it is the default when no pattern is specified
+                        // so we avoid calling the matching function
+                        if (pattern == "*" ||
+                            WindowsNative.PathMatchSpecExW(findResult.CFileName, pattern, WindowsNative.DwFlags.PmsfNormal) ==
+                            WindowsNative.ErrorSuccess)
+                        {
+                            if (fileArtifactType == FileArtifactType.FileOrDirectory ||
+                                !(fileArtifactType == FileArtifactType.Directory ^ isDirectory))
+                            {
+                                result.Add(Path.Combine(directoryPath, findResult.CFileName));
+                            }
+                        }
+
+                        // Recursively go into subfolders if specified
+                        if (searchOption == SearchOption.AllDirectories && isDirectory)
+                        {
+                            var recurs = CustomEnumerateDirectoryEntries(
+                                Path.Combine(directoryPath, findResult.CFileName),
+                                fileArtifactType,
+                                pattern,
+                                searchOption,
+                                result);
+
+                            if (!recurs.Succeeded)
+                            {
+                                return recurs;
+                            }
+                        }
+                    }
+
+                    if (!WindowsNative.FindNextFileW(findHandle, out findResult))
+                    {
+                        int hr = Marshal.GetLastWin32Error();
+                        if (hr == WindowsNative.ErrorNoMoreFiles)
+                        {
+                            // Graceful completion of enumeration.
+                            return new WindowsNative.EnumerateDirectoryResult(
+                                directoryPath,
+                                WindowsNative.EnumerateDirectoryStatus.Success,
+                                hr);
+                        }
+
+                        Debug.Assert(hr != WindowsNative.ErrorSuccess);
+                        return new WindowsNative.EnumerateDirectoryResult(
+                            directoryPath,
+                            WindowsNative.EnumerateDirectoryStatus.UnknownError,
+                            hr);
+                    }
+                }
+            }
+        }
+
+        private static string NormalizePathToWindowsStyle(string path)
+        {
+            // We make sure all paths are under max path, in some cases
+            // the native functions used are slightly more resilient to
+            // max path issues, but we want to mimic the managed implementation
+            // at this regard
+            if (path?.Length > WindowsNative.MaxPath)
+            {
+                throw new PathTooLongException(
+                    $"The path '${path}' exceeds the length limit of '${WindowsNative.MaxPath}' characters.");
+            }
+
+            return path?.Replace("/", "\\");
+        }
+    }
+}

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -70,6 +70,10 @@ namespace Microsoft.Build.Shared.FileSystem
             return FileOrDirectoryExists(FileArtifactType.FileOrDirectory, path);
         }
 
+        public void ClearCaches()
+        {
+        }
+
         private static bool FileOrDirectoryExists(FileArtifactType fileArtifactType, string path)
         {
             // The path gets normalized so we always use backslashes

--- a/src/Shared/FileSystem/WindowsNative.cs
+++ b/src/Shared/FileSystem/WindowsNative.cs
@@ -1,0 +1,278 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Native implementation of file system operations
+    /// </summary>
+    internal static class WindowsNative
+    {
+        /// <summary>
+        /// Maximum path length.
+        /// </summary>
+        public const int MaxPath = 260;
+
+        /// <summary>
+        /// ERROR_SUCCESS
+        /// </summary>
+        public const int ErrorSuccess = 0x0;
+
+        /// <summary>
+        /// ERROR_FILE_NOT_FOUND
+        /// </summary>
+        public const int ErrorFileNotFound = 0x2;
+
+        /// <summary>
+        /// ERROR_PATH_NOT_FOUND
+        /// </summary>
+        public const int ErrorPathNotFound = 0x3;
+
+        /// <summary>
+        /// ERROR_DIRECTORY
+        /// </summary>
+        public const int ErrorDirectory = 0x10b;
+
+        /// <summary>
+        /// ERROR_ACCESS_DENIED
+        /// </summary>
+        public const int ErrorAccessDenied = 0x5;
+
+        /// <summary>
+        /// ERROR_NO_MORE_FILES
+        /// </summary>
+        public const uint ErrorNoMoreFiles = 0x12;
+
+        /// <summary>
+        /// Modifies the search condition of PathMatchSpecEx
+        /// </summary>
+        /// <remarks>
+        /// <see ref="https://msdn.microsoft.com/en-us/library/windows/desktop/bb773728(v=vs.85).aspx"/>
+        /// </remarks>
+        public static class DwFlags
+        {
+            /// <summary>
+            /// The pszSpec parameter points to a single file name pattern to be matched.
+            /// </summary>
+            public const int PmsfNormal = 0x0;
+
+            /// <summary>
+            /// The pszSpec parameter points to a semicolon-delimited list of file name patterns to be matched.
+            /// </summary>
+            public const int PmsfMultiple = 0x1;
+
+            /// <summary>
+            /// If PMSF_NORMAL is used, ignore leading spaces in the string pointed to by pszSpec. If PMSF_MULTIPLE is used, 
+            /// ignore leading spaces in each file type contained in the string pointed to by pszSpec. This flag can be combined with PMSF_NORMAL and PMSF_MULTIPLE.
+            /// </summary>
+            public const int PmsfDontStripSpaces = 0x00010000;
+        }
+
+        /// <summary>
+        /// Status of attempting to enumerate a directory.
+        /// </summary>
+        public enum EnumerateDirectoryStatus
+        {
+            /// <summary>
+            /// Enumeration of an existent directory succeeded.
+            /// </summary>
+            Success,
+
+            /// <summary>
+            /// One or more path components did not exist, so the search directory could not be opened.
+            /// </summary>
+            SearchDirectoryNotFound,
+
+            /// <summary>
+            /// A path component in the search path refers to a file. Only directories can be enumerated.
+            /// </summary>
+            CannotEnumerateFile,
+
+            /// <summary>
+            /// Directory enumeration could not complete due to denied access to the search directory or a file inside.
+            /// </summary>
+            AccessDenied,
+
+            /// <summary>
+            /// Directory enumeration failed without a well-known status (see <see cref="EnumerateDirectoryResult.NativeErrorCode"/>).
+            /// </summary>
+            UnknownError,
+        }
+
+        /// <summary>
+        /// Represents the result of attempting to enumerate a directory.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance",
+            "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
+        public struct EnumerateDirectoryResult
+        {
+            /// <summary>
+            /// Enumerated directory.
+            /// </summary>
+            public readonly string Directory;
+
+            /// <summary>
+            /// Overall status indication.
+            /// </summary>
+            public readonly EnumerateDirectoryStatus Status;
+
+            /// <summary>
+            /// Native error code. Note that an error code other than <c>ERROR_SUCCESS</c> may be present even on success.
+            /// </summary>
+            public readonly int NativeErrorCode;
+
+            /// <nodoc />
+            public EnumerateDirectoryResult(string directory, EnumerateDirectoryStatus status, int nativeErrorCode)
+            {
+                Directory = directory;
+                Status = status;
+                NativeErrorCode = nativeErrorCode;
+            }
+
+            /// <summary>
+            /// Indicates if enumeration succeeded.
+            /// </summary>
+            public bool Succeeded
+            {
+                get { return Status == EnumerateDirectoryStatus.Success; }
+            }
+
+            /// <summary>
+            /// Throws an exception if the native error code could not be canonicalized (a fairly exceptional circumstance).
+            /// This is allowed when <see cref="Status"/> is <see cref="EnumerateDirectoryStatus.UnknownError"/>.
+            /// </summary>
+            /// <remarks>
+            /// This is a good <c>default:</c> case when switching on every possible <see cref="EnumerateDirectoryStatus"/>
+            /// </remarks>
+            public NativeWin32Exception ThrowForUnknownError()
+            {
+                Debug.Assert(Status == EnumerateDirectoryStatus.UnknownError);
+                throw CreateExceptionForError();
+            }
+
+            /// <summary>
+            /// Throws an exception if the native error code was corresponds to a known <see cref="EnumerateDirectoryStatus"/>
+            /// (and enumeration was not successful).
+            /// </summary>
+            public NativeWin32Exception ThrowForKnownError()
+            {
+                Debug.Assert(Status != EnumerateDirectoryStatus.UnknownError &&
+                             Status != EnumerateDirectoryStatus.Success);
+                throw CreateExceptionForError();
+            }
+
+            /// <summary>
+            /// Creates (but does not throw) an exception for this result. The result must not be successful.
+            /// </summary>
+            public NativeWin32Exception CreateExceptionForError()
+            {
+                Debug.Assert(Status != EnumerateDirectoryStatus.Success);
+                if (Status == EnumerateDirectoryStatus.UnknownError)
+                {
+                    return new NativeWin32Exception(
+                        NativeErrorCode,
+                        "Enumerating a directory failed");
+                }
+                else
+                {
+                    return new NativeWin32Exception(
+                        NativeErrorCode,
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Enumerating a directory failed: {0:G}", Status));
+                }
+            }
+        }
+
+        /// <summary>
+        /// <c>Win32FindData</c>
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]
+        public struct Win32FindData
+        {
+            /// <summary>
+            /// The file attributes of a file
+            /// </summary>
+            public FileAttributes DwFileAttributes;
+
+            /// <summary>
+            /// Specified when a file or directory was created
+            /// </summary>
+            public System.Runtime.InteropServices.ComTypes.FILETIME FtCreationTime;
+
+            /// <summary>
+            /// Specifies when the file was last read from, written to, or for executable files, run.
+            /// </summary>
+            public System.Runtime.InteropServices.ComTypes.FILETIME FtLastAccessTime;
+
+            /// <summary>
+            /// For a file, the structure specifies when the file was last written to, truncated, or overwritten.
+            /// For a directory, the structure specifies when the directory is created.
+            /// </summary>
+            public System.Runtime.InteropServices.ComTypes.FILETIME FtLastWriteTime;
+
+            /// <summary>
+            /// The high-order DWORD value of the file size, in bytes.
+            /// </summary>
+            public uint NFileSizeHigh;
+
+            /// <summary>
+            /// The low-order DWORD value of the file size, in bytes.
+            /// </summary>
+            public uint NFileSizeLow;
+
+            /// <summary>
+            /// If the dwFileAttributes member includes the FILE_ATTRIBUTE_REPARSE_POINT attribute, this member specifies the reparse point tag.
+            /// </summary>
+            public uint DwReserved0;
+
+            /// <summary>
+            /// Reserved for future use.
+            /// </summary>
+            public uint DwReserved1;
+
+            /// <summary>
+            /// The name of the file.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MaxPath)]
+            public string CFileName;
+
+            /// <summary>
+            /// An alternative name for the file.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
+            public string CAlternate;
+        }
+
+        /// <nodoc/>
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [SuppressMessage("Microsoft.Interoperability", "CA1401:PInvokesShouldNotBeVisible", Justification = "Needed for custom enumeration.")]
+        public static extern SafeFindFileHandle FindFirstFileW(
+            string lpFileName,
+            out Win32FindData lpFindFileData);
+
+        /// <nodoc/>
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [SuppressMessage("Microsoft.Interoperability", "CA1401:PInvokesShouldNotBeVisible", Justification = "Needed for custom enumeration.")]
+        public static extern bool FindNextFileW(SafeHandle hFindFile, out Win32FindData lpFindFileData);
+
+        /// <nodoc/>
+        [DllImport("shlwapi.dll", CharSet = CharSet.Unicode)]
+        [SuppressMessage("Microsoft.Interoperability", "CA1401:PInvokesShouldNotBeVisible", Justification = "Needed for creating symlinks.")]
+        public static extern int PathMatchSpecExW([In] string pszFileParam, [In] string pszSpec, [In] int flags);
+
+        /// <nodoc/>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool FindClose(IntPtr findFileHandle);
+    }
+}

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool UseLazyWildCardEvaluation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildSkipEagerWildCardEvaluationRegexes"));
         public readonly bool LogExpandedWildcards = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGEXPANDEDWILDCARDS"));
+
+        /// <summary>
+        /// Cache file existence for the entire process
+        /// </summary>
         public readonly bool CacheFileExistence = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileExistence"));
 
         /// <summary>
@@ -48,7 +52,7 @@ namespace Microsoft.Build.Utilities
         public readonly bool UseSimpleInternConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleInternConcurrency"));
 
         /// <summary>
-        /// Cache wildcard expansions
+        /// Cache wildcard expansions for the entire process
         /// </summary>
         public readonly bool MSBuildCacheFileEnumerations = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileEnumerations"));
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.UnitTests
                 File.WriteAllBytes(Path.Combine(testFolder.FolderPath, file), new byte[1]);
             }
 
-            string[] fileMatches = FileMatcher.GetFiles(testFolder.FolderPath, pattern);
+            string[] fileMatches = FileMatcher.Default.GetFiles(testFolder.FolderPath, pattern);
 
             fileMatches.Length.ShouldBe(expectedMatchCount, $"Matches: '{String.Join("', '", fileMatches)}'");
         }
@@ -79,7 +79,7 @@ namespace Microsoft.Build.UnitTests
 
             void Verify(string include, string[] excludes, bool shouldHaveNoMatches = false, string customMessage = null)
             {
-                string[] matchedFiles = FileMatcher.GetFiles(testFolder.FolderPath, include, excludes);
+                string[] matchedFiles = FileMatcher.Default.GetFiles(testFolder.FolderPath, include, excludes);
 
                 if (shouldHaveNoMatches)
                 {
@@ -1156,7 +1156,7 @@ namespace Microsoft.Build.UnitTests
         public void IllegalTooLongPath()
         {
             string longString = new string('X', 500) + "*"; // need a wildcard to do anything
-            string[] result = FileMatcher.GetFiles(@"c:\", longString);
+            string[] result = FileMatcher.Default.GetFiles(@"c:\", longString);
 
             Assert.Equal(longString, result[0]); // Does not throw
 
@@ -1198,7 +1198,7 @@ namespace Microsoft.Build.UnitTests
             Directory.CreateDirectory(workingPath);
             Directory.CreateDirectory(workingPathSubfolder);
 
-            files = FileMatcher.GetFiles(workingPath, offendingPattern);
+            files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
         }
 
         [Fact]
@@ -1210,7 +1210,7 @@ namespace Microsoft.Build.UnitTests
 
             Directory.CreateDirectory(workingPath);
             File.WriteAllText(fileName, "Hello there.");
-            var files = FileMatcher.GetFiles(workingPath, offendingPattern);
+            var files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
 
             string result = String.Join(", ", files);
             Console.WriteLine(result);
@@ -1230,7 +1230,7 @@ namespace Microsoft.Build.UnitTests
             Directory.CreateDirectory(workingPath);
             Directory.CreateDirectory(workingPathSubdir);
             File.AppendAllText(workingPathSubdirBing, "y");
-            var files = FileMatcher.GetFiles(workingPath, offendingPattern);
+            var files = FileMatcher.Default.GetFiles(workingPath, offendingPattern);
 
             string result = String.Join(", ", files);
             Console.WriteLine(result);
@@ -1255,15 +1255,15 @@ namespace Microsoft.Build.UnitTests
 
                     var testProject = env.CreateTestProjectWithFiles(string.Empty, new[] {"a.cs", "b.cs", "c.cs"});
 
-                    var files = FileMatcher.GetFiles(testProject.TestRoot, "**/*.cs");
+                    var files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs");
                     Array.Sort(files);
                     Assert.Equal(new []{"a.cs", "b.cs", "c.cs"}, files);
 
-                    files = FileMatcher.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs"});
+                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs"});
                     Array.Sort(files);
                     Assert.Equal(new[] {"b.cs", "c.cs" }, files);
 
-                    files = FileMatcher.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs", "c.cs"});
+                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs", "c.cs"});
                     Array.Sort(files);
                     Assert.Equal(new[] {"b.cs" }, files);
                 }
@@ -2000,13 +2000,14 @@ namespace Microsoft.Build.UnitTests
         private static void MatchDriver(string filespec, string[] excludeFilespecs, string[] matchingFiles, string[] nonmatchingFiles, string[] untouchableFiles, bool normalizeAllPaths = true, bool normalizeExpectedMatchingFiles = false)
         {
             MockFileSystem mockFileSystem = new MockFileSystem(matchingFiles, nonmatchingFiles, untouchableFiles);
-            string[] files = FileMatcher.GetFiles
+
+            var fileMatcher = new FileMatcher(mockFileSystem.GetAccessibleFileSystemEntries, mockFileSystem.DirectoryExists);
+
+            string[] files = fileMatcher.GetFiles
             (
                 String.Empty, /* we don't need project directory as we use mock filesystem */
                 filespec,
-                excludeFilespecs?.ToList(),
-                new FileMatcher.GetFileSystemEntries(mockFileSystem.GetAccessibleFileSystemEntries),
-                new DirectoryExists(mockFileSystem.DirectoryExists)
+                excludeFilespecs?.ToList()
             );
 
             Func<string[], string[]> normalizeAllFunc = (paths => normalizeAllPaths ? paths.Select(MockFileSystem.Normalize).ToArray() : paths);
@@ -2073,6 +2074,9 @@ namespace Microsoft.Build.UnitTests
          * Validate that SplitFileSpec(...) is returning the expected constituent values.
          *************************************************************************************/
 
+        private static FileMatcher loopBackFileMatcher = new FileMatcher(GetFileSystemEntriesLoopBack, null);
+
+
         private static void ValidateSplitFileSpec
             (
             string filespec,
@@ -2084,13 +2088,13 @@ namespace Microsoft.Build.UnitTests
             string fixedDirectoryPart;
             string wildcardDirectoryPart;
             string filenamePart;
-            FileMatcher.SplitFileSpec
+
+            loopBackFileMatcher.SplitFileSpec
             (
                 filespec,
                 out fixedDirectoryPart,
                 out wildcardDirectoryPart,
-                out filenamePart,
-                new FileMatcher.GetFileSystemEntries(GetFileSystemEntriesLoopBack)
+                out filenamePart
             );
 
             expectedFixedDirectoryPart = FileUtilities.FixFilePath(expectedFixedDirectoryPart);
@@ -2192,13 +2196,12 @@ namespace Microsoft.Build.UnitTests
             Regex regexFileMatch;
             bool needsRecursion;
             bool isLegalFileSpec;
-            FileMatcher.GetFileSpecInfoWithRegexObject
+            loopBackFileMatcher.GetFileSpecInfoWithRegexObject
             (
                 filespec,
                 out regexFileMatch,
                 out needsRecursion,
-                out isLegalFileSpec,
-                new FileMatcher.GetFileSystemEntries(GetFileSystemEntriesLoopBack)
+                out isLegalFileSpec
             );
 
             if (isLegalFileSpec)
@@ -2227,7 +2230,7 @@ namespace Microsoft.Build.UnitTests
             bool shouldBeRecursive
         )
         {
-            FileMatcher.Result match = FileMatcher.FileMatch(filespec, fileToMatch);
+            FileMatcher.Result match = FileMatcher.Default.FileMatch(filespec, fileToMatch);
 
             if (!match.isLegalFileSpec)
             {

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        internal static void AssertItems(string[] expectedItems, IList<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
+        internal static void AssertItems(string[] expectedItems, ICollection<ProjectItem> items, Dictionary<string, string> expectedDirectMetadata = null, bool normalizeSlashes = false)
         {
             var converteditems = items.Select(i => (TestItem) new ProjectItemTestItemAdapter(i)).ToList();
             AssertItems(expectedItems, converteditems, expectedDirectMetadata, normalizeSlashes);

--- a/src/Tasks/CreateItem.cs
+++ b/src/Tasks/CreateItem.cs
@@ -199,14 +199,14 @@ namespace Microsoft.Build.Tasks
                 {
                     if (FileMatcher.HasWildcards(i.ItemSpec))
                     {
-                        string[] files = FileMatcher.GetFiles(null /* use current directory */, i.ItemSpec);
+                        string[] files = FileMatcher.Default.GetFiles(null /* use current directory */, i.ItemSpec);
                         foreach (string file in files)
                         {
                             TaskItem newItem = new TaskItem((ITaskItem)i);
                             newItem.ItemSpec = file;
 
                             // Compute the RecursiveDir portion.
-                            FileMatcher.Result match = FileMatcher.FileMatch(i.ItemSpec, file);
+                            FileMatcher.Result match = FileMatcher.Default.FileMatch(i.ItemSpec, file);
                             if (match.isLegalFileSpec && match.isMatch)
                             {
                                 if (match.wildcardDirectoryPart != null && match.wildcardDirectoryPart.Length > 0)

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -209,6 +209,27 @@
     <Compile Include="..\Shared\LanguageParser\VisualBasictokenizer.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\FileSystem\FileSystemFactory.cs">
+      <Link>FileSystem\FileSystemFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\IFileSystemAbstraction.cs">
+      <Link>FileSystem\IFileSystemAbstraction.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\ManagedFileSystem.cs">
+      <Link>FileSystem\ManagedFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\NativeWin32Exception.cs">
+      <Link>FileSystem\NativeWin32Exception.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\SafeFileHandle.cs">
+      <Link>FileSystem\SafeFileHandle.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsFileSystem.cs">
+      <Link>FileSystem\WindowsFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsNative.cs">
+      <Link>FileSystem\WindowsNative.cs</Link>
+    </Compile>
     <Compile Include="AppConfig\*.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -168,6 +168,27 @@
     <Compile Include="..\Shared\Traits.cs">
       <Link>Shared\Traits.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\FileSystem\FileSystemFactory.cs">
+	<Link>FileSystem\FileSystemFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\IFileSystemAbstraction.cs">
+	<Link>FileSystem\IFileSystemAbstraction.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\ManagedFileSystem.cs">
+	<Link>FileSystem\ManagedFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\NativeWin32Exception.cs">
+	<Link>FileSystem\NativeWin32Exception.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\SafeFileHandle.cs">
+	<Link>FileSystem\SafeFileHandle.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsFileSystem.cs">
+	<Link>FileSystem\WindowsFileSystem.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\FileSystem\WindowsNative.cs">
+    	<Link>FileSystem\WindowsNative.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Utilities
                         }
                         else
                         {
-                            files = FileMatcher.GetFiles(null, i.ItemSpec);
+                            files = FileMatcher.Default.GetFiles(null, i.ItemSpec);
                         }
 
                         foreach (string file in files)


### PR DESCRIPTION
- Introduce an IFileSystemAbstraction. Not currently used.
- Pin glob expansion cache in EvaluationContext

Future work:
- Route all evaluation IO through the interface
- Add caching behind the interface
- Experiment with native vs managed implementations