### PR TITLE
Add GetFileHash and VerifyFileHash tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
-
 ###############################################################################
 # Set default behavior for command prompt diff.
 #
@@ -17,7 +16,7 @@
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
@@ -46,9 +45,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain
@@ -65,3 +64,6 @@
 # Force bash scripts to always use lf line endings so that if a repro is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf
+
+# Ensure .bin files are stored as binary
+*.bin binary

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -570,6 +570,22 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public sealed partial class GetFileHash : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetFileHash() { }
+        public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MetadataName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MetadataNameBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
     public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
     {
         public GetFrameworkPath() { }
@@ -1184,6 +1200,16 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem OutputManifest { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string TargetFrameworkVersion { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class VerifyFileHash : Microsoft.Build.Tasks.TaskExtension
+    {
+        public VerifyFileHash() { }
+        public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -578,12 +578,10 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashEncoding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string MetadataName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string MetadataNameBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
@@ -1208,8 +1206,9 @@ namespace Microsoft.Build.Tasks
         public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
         public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashEncoding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -364,6 +364,22 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] AssemblyFiles { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public sealed partial class GetFileHash : Microsoft.Build.Tasks.TaskExtension
+    {
+        public GetFileHash() { }
+        public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MetadataName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string MetadataNameBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public override bool Execute() { throw null; }
+    }
     public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
     {
         public GetFrameworkPath() { }
@@ -676,6 +692,16 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] SourceFiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public void Cancel() { }
+        public override bool Execute() { throw null; }
+    }
+    public sealed partial class VerifyFileHash : Microsoft.Build.Tasks.TaskExtension
+    {
+        public VerifyFileHash() { }
+        public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -372,12 +372,10 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem[] Files { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        [Microsoft.Build.Framework.OutputAttribute]
-        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashEncoding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] Items { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string MetadataName { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string MetadataNameBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public partial class GetFrameworkPath : Microsoft.Build.Tasks.TaskExtension
@@ -700,8 +698,9 @@ namespace Microsoft.Build.Tasks
         public string Algorithm { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public string File { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
         public string Hash { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
-        public string HashBase64 { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
+        public string HashEncoding { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public override bool Execute() { throw null; }
     }
     public sealed partial class Warning : Microsoft.Build.Tasks.TaskExtension

--- a/src/Shared/ConversionUtilities.cs
+++ b/src/Shared/ConversionUtilities.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Globalization;
-
+using System.Text;
 using error = Microsoft.Build.Shared.ErrorUtilities;
 
 namespace Microsoft.Build.Shared
@@ -36,6 +36,22 @@ namespace Microsoft.Build.Shared
                 error.VerifyThrowArgument(false, "Shared.CannotConvertStringToBool", parameterValue);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Returns a hex representation of a byte array.
+        /// </summary>
+        /// <param name="bytes">The bytes to convert</param>
+        /// <returns>A string byte types formated as X2.</returns>
+        internal static string ConvertByteArrayToHex(byte[] bytes)
+        {
+            var sb = new StringBuilder();
+            foreach (var b in bytes)
+            {
+                sb.AppendFormat("{0:X2}", b);
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/GetFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/GetFileHash_Tests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Tasks.UnitTests.TestResources;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class GetFileHash_Tests
+    {
+        private readonly MockEngine _mockEngine;
+
+        public GetFileHash_Tests(ITestOutputHelper output)
+        {
+            _mockEngine = new MockEngine(output);
+        }
+
+        [Fact]
+        public void GetFileHash_FailsForUnknownAlgorithmName()
+        {
+            GetFileHash task = new GetFileHash
+            {
+                Files = new[] { new TaskItem(TestBinary.LoremFilePath) },
+                BuildEngine = _mockEngine,
+                Algorithm = "BANANA",
+            };
+            task.Execute().ShouldBeFalse();
+            _mockEngine.Log.ShouldContain("MSB3953");
+        }
+
+        [Fact]
+        public void GetFileHash_FailsForMissingFile()
+        {
+            GetFileHash task = new GetFileHash
+            {
+                Files = new[] { new TaskItem(Path.Combine(AppContext.BaseDirectory, "this_does_not_exist.txt")) },
+                BuildEngine = _mockEngine,
+            };
+            task.Execute().ShouldBeFalse();
+            _mockEngine.Log.ShouldContain("MSB3954");
+        }
+
+        [Theory]
+        [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
+        public void GetFileHash_ComputesCorrectChecksumForOneFile(TestBinary testBinary)
+        {
+            GetFileHash task = new GetFileHash
+            {
+                Files = new[] { new TaskItem(testBinary.FilePath) },
+                BuildEngine = _mockEngine,
+                Algorithm = testBinary.HashAlgorithm,
+            };
+            task.Execute().ShouldBeTrue();
+            task.Hash.ShouldBe(testBinary.Base16FileHash);
+            task.HashBase64.ShouldBe(testBinary.Base64FileHash);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
+        public void GetFileHash_ComputesCorrectChecksumForManyFiles(TestBinary testBinary)
+        {
+            GetFileHash task = new GetFileHash
+            {
+                Files = new[]
+                {
+                    new TaskItem(testBinary.FilePath),
+                    new TaskItem(testBinary.FilePath),
+                },
+                BuildEngine = _mockEngine,
+                Algorithm = testBinary.HashAlgorithm,
+            };
+
+            task.Execute().ShouldBeTrue();
+            task.Items.Length.ShouldBe(2);
+            task.Items.ShouldAllBe(i => string.Equals(testBinary.Base16FileHash, i.GetMetadata("FileHash"), StringComparison.Ordinal));
+            task.Items.ShouldAllBe(i => string.Equals(testBinary.Base64FileHash, i.GetMetadata("FileHashBase64"), StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/Tasks.UnitTests/GetFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/GetFileHash_Tests.cs
@@ -35,6 +35,19 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void GetFileHash_FailsForUnknownHashEncoding()
+        {
+            GetFileHash task = new GetFileHash
+            {
+                Files = new[] { new TaskItem(TestBinary.LoremFilePath) },
+                BuildEngine = _mockEngine,
+                HashEncoding = "blue",
+            };
+            task.Execute().ShouldBeFalse();
+            _mockEngine.Log.ShouldContain("MSB3951");
+        }
+
+        [Fact]
         public void GetFileHash_FailsForMissingFile()
         {
             GetFileHash task = new GetFileHash
@@ -55,10 +68,10 @@ namespace Microsoft.Build.UnitTests
                 Files = new[] { new TaskItem(testBinary.FilePath) },
                 BuildEngine = _mockEngine,
                 Algorithm = testBinary.HashAlgorithm,
+                HashEncoding = testBinary.HashEncoding,
             };
             task.Execute().ShouldBeTrue();
-            task.Hash.ShouldBe(testBinary.Base16FileHash);
-            task.HashBase64.ShouldBe(testBinary.Base64FileHash);
+            task.Hash.ShouldBe(testBinary.FileHash);
         }
 
         [Theory]
@@ -74,12 +87,12 @@ namespace Microsoft.Build.UnitTests
                 },
                 BuildEngine = _mockEngine,
                 Algorithm = testBinary.HashAlgorithm,
+                HashEncoding = testBinary.HashEncoding,
             };
 
             task.Execute().ShouldBeTrue();
             task.Items.Length.ShouldBe(2);
-            task.Items.ShouldAllBe(i => string.Equals(testBinary.Base16FileHash, i.GetMetadata("FileHash"), StringComparison.Ordinal));
-            task.Items.ShouldAllBe(i => string.Equals(testBinary.Base64FileHash, i.GetMetadata("FileHashBase64"), StringComparison.Ordinal));
+            task.Items.ShouldAllBe(i => string.Equals(testBinary.FileHash, i.GetMetadata("FileHash"), StringComparison.Ordinal));
         }
     }
 }

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -137,4 +137,10 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="TestResources\lorem.bin">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Tasks.UnitTests/TestResources/TestBinary.cs
+++ b/src/Tasks.UnitTests/TestResources/TestBinary.cs
@@ -20,44 +20,65 @@ namespace Microsoft.Build.Tasks.UnitTests.TestResources
                 {
                     FilePath = LoremFilePath,
                     HashAlgorithm = "SHA256",
-                    Base16FileHash = "BCFAF334240356E1B97824A866F643B1ADA3C16AA0B5B2BFA8390D8BB54A244C",
-                    Base64FileHash = "vPrzNCQDVuG5eCSoZvZDsa2jwWqgtbK/qDkNi7VKJEw="
+                    HashEncoding = "hex",
+                    FileHash = "BCFAF334240356E1B97824A866F643B1ADA3C16AA0B5B2BFA8390D8BB54A244C",
                 },
                 new TestBinary
                 {
                     FilePath = LoremFilePath,
                     HashAlgorithm = "SHA384",
-                    Base16FileHash = "5520B01FDE8A8A7EA38DCADFBF3CFAB2818FA0D5A8A16CB11A2FC7F5C9F1497F7B3C528FDB8CE10AA293A4E5FF32297F",
-                    Base64FileHash = "VSCwH96Kin6jjcrfvzz6soGPoNWooWyxGi/H9cnxSX97PFKP24zhCqKTpOX/Mil/"
+                    HashEncoding = "hex",
+                    FileHash = "5520B01FDE8A8A7EA38DCADFBF3CFAB2818FA0D5A8A16CB11A2FC7F5C9F1497F7B3C528FDB8CE10AA293A4E5FF32297F",
                 },
                 new TestBinary
                 {
                     FilePath = LoremFilePath,
                     HashAlgorithm = "SHA512",
-                    Base16FileHash = "7774962C97EAC52B45291E1410F06AC6EFF6AF9ED38A57E2CEB720650282E46CFE512FAAD68AD9C45B74ED1B7E460198E0B00D5C9EF0404FF76B12F8AD2D329F",
-                    Base64FileHash = "d3SWLJfqxStFKR4UEPBqxu/2r57TilfizrcgZQKC5Gz+US+q1orZxFt07Rt+RgGY4LANXJ7wQE/3axL4rS0ynw=="
+                    HashEncoding = "hex",
+                    FileHash = "7774962C97EAC52B45291E1410F06AC6EFF6AF9ED38A57E2CEB720650282E46CFE512FAAD68AD9C45B74ED1B7E460198E0B00D5C9EF0404FF76B12F8AD2D329F",
+                },
+                 new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA256",
+                    HashEncoding = "base64",
+                    FileHash = "vPrzNCQDVuG5eCSoZvZDsa2jwWqgtbK/qDkNi7VKJEw="
+                },
+                new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA384",
+                    HashEncoding = "base64",
+                    FileHash = "VSCwH96Kin6jjcrfvzz6soGPoNWooWyxGi/H9cnxSX97PFKP24zhCqKTpOX/Mil/"
+                },
+                new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA512",
+                    HashEncoding = "base64",
+                    FileHash = "d3SWLJfqxStFKR4UEPBqxu/2r57TilfizrcgZQKC5Gz+US+q1orZxFt07Rt+RgGY4LANXJ7wQE/3axL4rS0ynw=="
                 },
             };
 
+        public string FileHash { get; private set; }
         public string FilePath { get; private set; }
         public string HashAlgorithm { get; private set; }
-        public string Base16FileHash { get; private set; }
-        public string Base64FileHash { get; private set; }
+        public string HashEncoding { get; private set; }
 
         void IXunitSerializable.Deserialize(IXunitSerializationInfo info)
         {
+            FileHash = info.GetValue<string>(nameof(FileHash));
             FilePath = info.GetValue<string>(nameof(FilePath));
             HashAlgorithm = info.GetValue<string>(nameof(HashAlgorithm));
-            Base16FileHash = info.GetValue<string>(nameof(Base16FileHash));
-            Base64FileHash = info.GetValue<string>(nameof(Base64FileHash));
+            HashEncoding = info.GetValue<string>(nameof(HashEncoding));
         }
 
         void IXunitSerializable.Serialize(IXunitSerializationInfo info)
         {
+            info.AddValue(nameof(FileHash), FileHash);
             info.AddValue(nameof(FilePath), FilePath);
             info.AddValue(nameof(HashAlgorithm), HashAlgorithm);
-            info.AddValue(nameof(Base16FileHash), Base16FileHash);
-            info.AddValue(nameof(Base64FileHash), Base64FileHash);
+            info.AddValue(nameof(HashEncoding), HashEncoding);
         }
     }
 }

--- a/src/Tasks.UnitTests/TestResources/TestBinary.cs
+++ b/src/Tasks.UnitTests/TestResources/TestBinary.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.Tasks.UnitTests.TestResources
+{
+    public class TestBinary : IXunitSerializable
+    {
+        public static string LoremFilePath { get; } =
+            Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin");
+
+        public static TheoryData<TestBinary> GetLorem()
+            => new TheoryData<TestBinary>
+            {
+                new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA256",
+                    Base16FileHash = "BCFAF334240356E1B97824A866F643B1ADA3C16AA0B5B2BFA8390D8BB54A244C",
+                    Base64FileHash = "vPrzNCQDVuG5eCSoZvZDsa2jwWqgtbK/qDkNi7VKJEw="
+                },
+                new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA384",
+                    Base16FileHash = "5520B01FDE8A8A7EA38DCADFBF3CFAB2818FA0D5A8A16CB11A2FC7F5C9F1497F7B3C528FDB8CE10AA293A4E5FF32297F",
+                    Base64FileHash = "VSCwH96Kin6jjcrfvzz6soGPoNWooWyxGi/H9cnxSX97PFKP24zhCqKTpOX/Mil/"
+                },
+                new TestBinary
+                {
+                    FilePath = LoremFilePath,
+                    HashAlgorithm = "SHA512",
+                    Base16FileHash = "7774962C97EAC52B45291E1410F06AC6EFF6AF9ED38A57E2CEB720650282E46CFE512FAAD68AD9C45B74ED1B7E460198E0B00D5C9EF0404FF76B12F8AD2D329F",
+                    Base64FileHash = "d3SWLJfqxStFKR4UEPBqxu/2r57TilfizrcgZQKC5Gz+US+q1orZxFt07Rt+RgGY4LANXJ7wQE/3axL4rS0ynw=="
+                },
+            };
+
+        public string FilePath { get; private set; }
+        public string HashAlgorithm { get; private set; }
+        public string Base16FileHash { get; private set; }
+        public string Base64FileHash { get; private set; }
+
+        void IXunitSerializable.Deserialize(IXunitSerializationInfo info)
+        {
+            FilePath = info.GetValue<string>(nameof(FilePath));
+            HashAlgorithm = info.GetValue<string>(nameof(HashAlgorithm));
+            Base16FileHash = info.GetValue<string>(nameof(Base16FileHash));
+            Base64FileHash = info.GetValue<string>(nameof(Base64FileHash));
+        }
+
+        void IXunitSerializable.Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue(nameof(FilePath), FilePath);
+            info.AddValue(nameof(HashAlgorithm), HashAlgorithm);
+            info.AddValue(nameof(Base16FileHash), Base16FileHash);
+            info.AddValue(nameof(Base64FileHash), Base64FileHash);
+        }
+    }
+}

--- a/src/Tasks.UnitTests/TestResources/lorem.bin
+++ b/src/Tasks.UnitTests/TestResources/lorem.bin
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et nulla laoreet ex pharetra congue. Sed gravida justo orci. Nunc nec est vitae purus accumsan consectetur et vel risus. Sed lobortis nulla eu feugiat ornare. Pellentesque ornare semper lorem at vestibulum. Aliquam molestie erat nunc. Curabitur suscipit aliquet quam quis fringilla.

--- a/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Tasks.UnitTests.TestResources;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.UnitTests
+{
+    public sealed class VerifyFileHash_Tests
+    {
+        private readonly MockEngine _mockEngine;
+
+        public VerifyFileHash_Tests(ITestOutputHelper output)
+        {
+            _mockEngine = new MockEngine(output);
+        }
+
+        [Fact]
+        public void VerifyFileChecksum_FailsForMissingInputs()
+        {
+            new VerifyFileHash
+            {
+                File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
+                BuildEngine = _mockEngine,
+                Algorithm = "SHA256",
+            }
+            .Execute()
+            .ShouldBeFalse();
+
+            _mockEngine.Log.ShouldContain("MSB3951");
+        }
+
+        [Fact]
+        public void VerifyFileChecksum_FailsForConflictingInputs()
+        {
+            new VerifyFileHash
+            {
+                File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
+                BuildEngine = _mockEngine,
+                Algorithm = "SHA256",
+                Hash ="xyz",
+                HashBase64 = "xyz",
+            }
+            .Execute()
+            .ShouldBeFalse();
+
+            _mockEngine.Log.ShouldContain("MSB3951");
+        }
+
+        [Fact]
+        public void VerifyFileChecksum_FailsForUnknownAlgorithmName()
+        {
+            new VerifyFileHash
+            {
+                File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
+                BuildEngine = _mockEngine,
+                Algorithm = "BANANA",
+                Hash = "xyz",
+            }
+            .Execute()
+            .ShouldBeFalse();
+
+            _mockEngine.Log.ShouldContain("MSB3953");
+        }
+
+        [Fact]
+        public void VerifyFileChecksum_FailsForFileNotFound()
+        {
+            new VerifyFileHash
+            {
+                File = Path.Combine(AppContext.BaseDirectory, "this_does_not_exist.txt"),
+                BuildEngine = _mockEngine,
+                Algorithm = "BANANA",
+                Hash = "xyz",
+            }
+            .Execute()
+            .ShouldBeFalse();
+
+            _mockEngine.Log.ShouldContain("MSB3954");
+        }
+
+        [Theory]
+        [InlineData("SHA256", "C442A45BB8D0938AFB2B5B0AA61C3ADA1B346F668A42879B1E653042433FAFCB")]
+        [InlineData("SHA384", "F79223FF5E4A392AA01EC8BDF825C3B7F7941F9C5F7CF2A11BC61A8A5D0AF8182BAFC3FBFDACD83AE7A8A8EDF10B0255")]
+        [InlineData("SHA512", "F923D2DA8F21B67FF4040FE9C5D00B0E891064E7B1DE47B54C9DA86DAAF215EFC64E282056027BEC2E75A83DE9FA6FFE6CA60F0141E19254B25CAE79C2694777")]
+        public void VerifyFileChecksum_FailsForMismatch(string algoritm, string hash)
+        {
+            VerifyFileHash task = new VerifyFileHash
+            {
+                File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
+                BuildEngine = _mockEngine,
+                Algorithm = algoritm,
+                Hash = hash,
+            };
+
+            task.Execute().ShouldBeFalse(() => _mockEngine.Log);
+
+            _mockEngine.Log.ShouldContain("MSB3952");
+        }
+
+        [Theory]
+        [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
+        public void VerifyFileChecksum_Hex_Pass(TestBinary testBinary)
+        {
+            VerifyFileHash task = new VerifyFileHash
+            {
+                File = testBinary.FilePath,
+                BuildEngine = _mockEngine,
+                Algorithm = testBinary.HashAlgorithm,
+                Hash = testBinary.Base16FileHash,
+            };
+
+            task.Execute().ShouldBeTrue();
+        }
+
+
+        [Theory]
+        [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
+        public void VerifyFileChecksum_Base64_Pass(TestBinary testBinary)
+        {
+            VerifyFileHash task = new VerifyFileHash
+            {
+                File = testBinary.FilePath,
+                BuildEngine = _mockEngine,
+                Algorithm = testBinary.HashAlgorithm,
+                HashBase64 = testBinary.Base64FileHash,
+            };
+
+            task.Execute().ShouldBeTrue();
+        }
+    }
+}

--- a/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
@@ -21,30 +21,14 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
-        public void VerifyFileChecksum_FailsForMissingInputs()
+        public void VerifyFileChecksum_FailsForUnknownHashEncoding()
         {
             new VerifyFileHash
             {
                 File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
                 BuildEngine = _mockEngine,
                 Algorithm = "SHA256",
-            }
-            .Execute()
-            .ShouldBeFalse();
-
-            _mockEngine.Log.ShouldContain("MSB3951");
-        }
-
-        [Fact]
-        public void VerifyFileChecksum_FailsForConflictingInputs()
-        {
-            new VerifyFileHash
-            {
-                File = Path.Combine(AppContext.BaseDirectory, "TestResources", "lorem.bin"),
-                BuildEngine = _mockEngine,
-                Algorithm = "SHA256",
-                Hash ="xyz",
-                HashBase64 = "xyz",
+                HashEncoding = "red",
             }
             .Execute()
             .ShouldBeFalse();
@@ -105,30 +89,15 @@ namespace Microsoft.Build.UnitTests
 
         [Theory]
         [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
-        public void VerifyFileChecksum_Hex_Pass(TestBinary testBinary)
+        public void VerifyFileChecksum_Pass(TestBinary testBinary)
         {
             VerifyFileHash task = new VerifyFileHash
             {
                 File = testBinary.FilePath,
                 BuildEngine = _mockEngine,
                 Algorithm = testBinary.HashAlgorithm,
-                Hash = testBinary.Base16FileHash,
-            };
-
-            task.Execute().ShouldBeTrue();
-        }
-
-
-        [Theory]
-        [MemberData(nameof(TestBinary.GetLorem), MemberType = typeof(TestBinary))]
-        public void VerifyFileChecksum_Base64_Pass(TestBinary testBinary)
-        {
-            VerifyFileHash task = new VerifyFileHash
-            {
-                File = testBinary.FilePath,
-                BuildEngine = _mockEngine,
-                Algorithm = testBinary.HashAlgorithm,
-                HashBase64 = testBinary.Base64FileHash,
+                Hash = testBinary.FileHash,
+                HashEncoding = testBinary.HashEncoding,
             };
 
             task.Execute().ShouldBeTrue();

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Tasks
+{
+    /// <summary>
+    /// Computes the checksum for a single file.
+    /// </summary>
+    public sealed class GetFileHash : TaskExtension
+    {
+        internal const string DefaultFileHashAlgorithm = "SHA256";
+
+        /// <summary>
+        /// The files to be hashed.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        /// <summary>
+        /// The algorithm. Allowed values: SHA256, SHA384, SHA512. Default = SHA256.
+        /// </summary>
+        public string Algorithm { get; set; } = DefaultFileHashAlgorithm;
+
+        /// <summary>
+        /// The metadata name where the hash is store in each item. File hash is in hex. Defaults to "FileHash".
+        /// </summary>
+        public string MetadataName { get; set; } = "FileHash";
+
+        /// <summary>
+        /// The metadata name where the base64 encoded hash is store in each item. File hash is in hex. Defaults to "FileHashBase64".
+        /// </summary>
+        public string MetadataNameBase64 { get; set; } = "FileHashBase64";
+
+        /// <summary>
+        /// The hash of the file in hex. This is only set if there was one item group passed in.
+        /// </summary>
+        [Output]
+        public string Hash { get; set; }
+
+        /// <summary>
+        /// The hash of the file base64 encoded. This is only set if there was one item group passed in.
+        /// </summary>
+        [Output]
+        public string HashBase64 { get; set; }
+
+        /// <summary>
+        /// The input files with additional metadata set to include the file hash.
+        /// </summary>
+        [Output]
+        public ITaskItem[] Items { get; set; }
+
+        public override bool Execute()
+        {
+            if (!SupportsAlgorithm(Algorithm))
+            {
+                Log.LogErrorFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
+                return false;
+            }
+
+            foreach (var file in Files)
+            {
+                if (!File.Exists(file.ItemSpec))
+                {
+                    Log.LogErrorFromResources("FileHash.FileNotFound", file.ItemSpec);
+                    continue;
+                }
+
+                var hash = ComputeHash(Algorithm, file.ItemSpec);
+                file.SetMetadata("FileHashAlgoritm", Algorithm);
+                file.SetMetadata(MetadataName, ConversionUtilities.ConvertByteArrayToHex(hash));
+                file.SetMetadata(MetadataNameBase64, Convert.ToBase64String(hash));
+            }
+
+            Items = Files;
+
+            if (Files.Length == 1)
+            {
+                Hash = Files[0].GetMetadata(MetadataName);
+                HashBase64 = Files[0].GetMetadata(MetadataNameBase64);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        internal static bool SupportsAlgorithm(string algorithmName) => _supportedAlgorithms.Contains(algorithmName);
+
+        internal static byte[] ComputeHash(string algorithmName, string filePath)
+        {
+            using (var stream = File.OpenRead(filePath))
+            using (var algorithm = CreateAlgorithm(algorithmName))
+            {
+                return algorithm.ComputeHash(stream);
+            }
+        }
+
+        private static readonly HashSet<string> _supportedAlgorithms
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "SHA256",
+                "SHA384",
+                "SHA512",
+            };
+
+        private static HashAlgorithm CreateAlgorithm(string algorithmName)
+        {
+            switch (algorithmName.ToUpperInvariant())
+            {
+                case "SHA256":
+                    return SHA256.Create();
+                case "SHA384":
+                    return SHA384.Create();
+                case "SHA512":
+                    return SHA512.Create();
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Tasks
             return !Log.HasLoggedErrors;
         }
 
-        internal string EncodeHash(HashEncoding encoding, byte[] hash)
+        internal static string EncodeHash(HashEncoding encoding, byte[] hash)
         {
             switch (encoding)
             {
@@ -110,28 +110,10 @@ namespace Microsoft.Build.Tasks
         }
 
         internal static bool TryParseHashEncoding(string value, out HashEncoding encoding)
-        {
-            encoding = default(HashEncoding);
+            => Enum.TryParse<HashEncoding>(value, /*ignoreCase:*/ true, out encoding);
 
-            if (string.IsNullOrEmpty(value))
-            {
-                return false;
-            }
-
-            switch (value.ToLowerInvariant())
-            {
-                case _hashEncodingHex:
-                    encoding = Tasks.HashEncoding.Hex;
-                    return true;
-                case _hashEncodingBase64:
-                    encoding = Tasks.HashEncoding.Base64;
-                    return true;
-            }
-
-            return false;
-        }
-
-        internal static bool SupportsAlgorithm(string algorithmName) => _supportedAlgorithms.Contains(algorithmName);
+        internal static bool SupportsAlgorithm(string algorithmName)
+            => _supportedAlgorithms.Contains(algorithmName);
 
         internal static byte[] ComputeHash(string algorithmName, string filePath)
         {

--- a/src/Tasks/FileIO/HashEncoding.cs
+++ b/src/Tasks/FileIO/HashEncoding.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Tasks
+{
+    internal enum HashEncoding
+    {
+        Hex,
+        Base64,
+    }
+}

--- a/src/Tasks/FileIO/VerifyFileHash.cs
+++ b/src/Tasks/FileIO/VerifyFileHash.cs
@@ -56,26 +56,12 @@ namespace Microsoft.Build.Tasks
             }
 
             byte[] hash = GetFileHash.ComputeHash(Algorithm, File);
-            bool hashesMatch;
-            switch (encoding)
+            string actualHash = GetFileHash.EncodeHash(encoding, hash);
+            var comparison = encoding == Tasks.HashEncoding.Hex
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            if (!string.Equals(actualHash, Hash, comparison))
             {
-                case Tasks.HashEncoding.Hex:
-                    var actualHash = ConversionUtilities.ConvertByteArrayToHex(hash);
-                    hashesMatch = string.Equals(actualHash, Hash, StringComparison.OrdinalIgnoreCase);
-                    break;
-                case Tasks.HashEncoding.Base64:
-                    byte[] expectedHash = Convert.FromBase64String(Hash);
-                    hashesMatch = expectedHash.SequenceEqual(hash);
-                    break;
-                default:
-                    throw new NotImplementedException();
-            }
-
-            if (!hashesMatch)
-            {
-                var actualHash = encoding == Tasks.HashEncoding.Hex
-                    ? ConversionUtilities.ConvertByteArrayToHex(hash)
-                    : Convert.ToBase64String(hash);
                 Log.LogErrorFromResources("VerifyFileHash.HashMismatch", File, Algorithm, Hash, actualHash);
                 return false;
             }

--- a/src/Tasks/FileIO/VerifyFileHash.cs
+++ b/src/Tasks/FileIO/VerifyFileHash.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Tasks
+{
+    /// <summary>
+    /// Verifies that a file matches the expected file hash.
+    /// </summary>
+    public sealed class VerifyFileHash : TaskExtension
+    {
+        /// <summary>
+        /// The file path.
+        /// </summary>
+        [Required]
+        public string File { get; set; }
+
+        /// <summary>
+        /// The hasing algorithm to use. Allowed values: SHA256, SHA384, SHA512. Default = SHA256
+        /// </summary>
+        public string Algorithm { get; set; } = GetFileHash.DefaultFileHashAlgorithm;
+
+        /// <summary>
+        /// The expected hash of the file in hex.
+        /// </summary>
+        public string Hash { get; set; }
+
+        /// <summary>
+        /// The expected hash of the file in base64.
+        /// </summary>
+        public string HashBase64 { get; set; }
+
+        public override bool Execute()
+        {
+            if (!(string.IsNullOrEmpty(Hash) ^ string.IsNullOrEmpty(HashBase64)))
+            {
+                Log.LogErrorFromResources("VerifyFileHash.InvalidInputParameters");
+                return false;
+            }
+
+            if (!System.IO.File.Exists(File))
+            {
+                Log.LogErrorFromResources("FileHash.FileNotFound", File);
+                return false;
+            }
+
+            if (!GetFileHash.SupportsAlgorithm(Algorithm))
+            {
+                Log.LogErrorFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
+                return false;
+            }
+
+            byte[] hash = GetFileHash.ComputeHash(Algorithm, File);
+            if (!string.IsNullOrEmpty(Hash))
+            {
+                var actualHash = ConversionUtilities.ConvertByteArrayToHex(hash);
+                if (!string.Equals(actualHash, Hash, StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.LogErrorFromResources("VerifyFileHash.HashMismatch", File, Algorithm, Hash, actualHash);
+                    return false;
+                }
+            }
+            else
+            {
+                byte[] expectedHash = Convert.FromBase64String(HashBase64);
+                if (!expectedHash.SequenceEqual(hash))
+                {
+                    var actualHash = Convert.ToBase64String(hash);
+                    Log.LogErrorFromResources("VerifyFileHash.HashMismatch", File, Algorithm, HashBase64, actualHash);
+                    return false;
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -336,6 +336,7 @@
     <Compile Include="BuildCacheDisposeWrapper.cs" />
     <Compile Include="DownloadFile.cs" />
     <Compile Include="FileIO\GetFileHash.cs" />
+    <Compile Include="FileIO\HashEncoding.cs" />
     <Compile Include="FileIO\VerifyFileHash.cs" />
     <Compile Include="FileState.cs" />
     <Compile Include="Copy.cs">

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -335,6 +335,8 @@
     </Compile>
     <Compile Include="BuildCacheDisposeWrapper.cs" />
     <Compile Include="DownloadFile.cs" />
+    <Compile Include="FileIO\GetFileHash.cs" />
+    <Compile Include="FileIO\VerifyFileHash.cs" />
     <Compile Include="FileState.cs" />
     <Compile Include="Copy.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -40,6 +40,7 @@
 
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateTrustInfo"                     AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetAssemblyIdentity"                   AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash"                           AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkPath"                      AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkSdkPath"                   AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetReferenceAssemblyPaths"             AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
@@ -76,6 +77,7 @@
 
     <UsingTask TaskName="Microsoft.Build.Tasks.UpdateManifest"                        AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Vbc"                                   AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash"                        AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Warning"                               AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"                     AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"                      AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' == ''" />

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-  
+
    See bottom of this file for information about message buckets.
 
    Please keep this file sorted.
-  
+
   -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -153,11 +153,11 @@
         The AxImp message bucket is: MSB3656 - MSB3660.
 
         If this bucket overflows, pls. contact 'vsppbdev'.
-  -->  
+  -->
   <data name="AxImp.NoInputFileSpecified">
     <value>MSB3656: No input file has been passed to the task, exiting.</value>
     <comment>{StrBegin="MSB3656: "}</comment>
-  </data>  
+  </data>
   <!--
         The AxTlbBaseTask message bucket is: MSB3646 - MSB3655.
 
@@ -178,7 +178,7 @@
   <data name="AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid">
     <value>MSB3650: Neither SDKToolsPath '{0}' nor ToolPath '{1}' is a valid directory.  One of these must be set.</value>
     <comment>{StrBegin="MSB3650: "}</comment>
-  </data>  
+  </data>
   <data name="AxTlbBaseTask.StrongNameUtils.NoKeyPairInContainer">
     <value>MSB3651: The key container '{0}' does not contain a public/private key pair.</value>
     <comment>{StrBegin="MSB3651: "}</comment>
@@ -241,11 +241,11 @@
   </data>
   <data name="Copy.FileComment">
     <value>Copying file from "{0}" to "{1}".</value>
-    <comment>LOCALIZATION: {0} and {1} are paths.</comment>      
+    <comment>LOCALIZATION: {0} and {1} are paths.</comment>
   </data>
   <data name="Copy.HardLinkComment">
     <value>Creating hard link to copy "{0}" to "{1}".</value>
-    <comment>LOCALIZATION: {0} and {1} are paths.</comment>      
+    <comment>LOCALIZATION: {0} and {1} are paths.</comment>
   </data>
   <data name="Copy.RetryingAsFileCopy">
     <value>Could not use a link to copy "{0}" to "{1}". Copying the file instead. {2}</value>
@@ -264,7 +264,7 @@
   </data>
   <data name="Copy.SymbolicLinkComment">
     <value>Creating symbolic link to copy "{0}" to "{1}".</value>
-    <comment>LOCALIZATION: {0} and {1} are paths.</comment>      
+    <comment>LOCALIZATION: {0} and {1} are paths.</comment>
   </data>
   <data name="Copy.Retrying">
     <value>MSB3026: Could not copy "{0}" to "{1}". Beginning retry {2} in {3}ms. {4} {5}</value>
@@ -299,7 +299,7 @@
     <value>MSB3031: Could not set additional metadata. "{0}" is a reserved metadata name and cannot be modified.</value>
     <comment>{StrBegin="MSB3031: "} UE: Tasks and OM users are not allowed to remove or change the value of the built-in meta-data on items e.g. the meta-data "FullPath", "RelativeDir", etc. are reserved.</comment>
   </data>
-  
+
   <!--
         The CreateManifestResourceName message bucket is: MSB3041 - MSB3050
 
@@ -423,7 +423,7 @@
     <comment>{StrBegin="MSB3541: "}</comment>
   </data>
   <!--
-        The General message bucket is: 
+        The General message bucket is:
         MSB3081 - MSB3109
         MSB3666 - MSB3675   Task: General
 
@@ -1856,7 +1856,7 @@
   <data name="ResolveKeySource.ResolvedThumbprintEmpty">
     <value>MSB3327: Unable to find code signing certificate in the current user’s Windows certificate store. To correct this, either disable signing of the ClickOnce manifest or install the certificate into the certificate store.</value>
     <comment>{StrBegin="MSB3327: "}</comment>
-  </data>  
+  </data>
   <!--
         The ResolveManifestFiles message bucket is: MSB3331 - MSB3340
 
@@ -1893,7 +1893,7 @@
   <data name="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
     <value>Project reference "{0}" has not been resolved.</value>
     <comment>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </comment>
@@ -1972,7 +1972,7 @@
         The TlbImp message bucket is: MSB3661 - MSB3665
 
         If this bucket overflows, pls. contact 'vsppbdev'.
-  -->  
+  -->
   <data name="TlbImp.InvalidTransformParameter">
     <value>MSB3661: Invalid value '{0}' passed to the Transform property.</value>
     <comment>{StrBegin="MSB3661: "}</comment>
@@ -2167,7 +2167,7 @@
       <value>MSB3694: Unable to create Xaml task.  The EnumValue "{1}" on EnumProperty "{0}" is missing the SwitchValue attribute.</value>
     <comment>{StrBegin="MSB3694: "}</comment>
   </data>
-  <!-- 3695 belongs to this task but was skipped so that the two "CommandFailed" error codes could be side-by-side.  Please consider 
+  <!-- 3695 belongs to this task but was skipped so that the two "CommandFailed" error codes could be side-by-side.  Please consider
        using this error code first before jumping to 3723. -->
   <data name="Xaml.CommandFailed">
     <value>MSB3721: The command "{0}" exited with code {1}.</value>
@@ -2226,7 +2226,7 @@
   <data name="XslTransform.UseTrustedSettings" xml:space="preserve">
     <value>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</value>
   </data>
-  
+
 
   <!--
         The XmlPoke message bucket is: MSB3731-3740.
@@ -2305,29 +2305,29 @@
     <data name="WriteCodeFragment.MustSpecifyLocation" xml:space="preserve">
       <value>MSB3711: At least one of OutputFile or OutputDirectory must be provided.</value>
       <comment>{StrBegin="MSB3711: "}</comment>
-    </data>    
+    </data>
     <data name="WriteCodeFragment.CouldNotCreateProvider" xml:space="preserve">
       <value>MSB3712: Code for the language "{0}" could not be generated. {1}</value>
       <comment>{StrBegin="MSB3712: "}</comment>
-    </data> 
+    </data>
     <data name="WriteCodeFragment.CouldNotWriteOutput" xml:space="preserve">
       <value>MSB3713: The file "{0}" could not be created. {1}</value>
       <comment>{StrBegin="MSB3713: "}</comment>
-    </data>  
+    </data>
     <data name="WriteCodeFragment.SkippedNumberedParameter" xml:space="preserve">
       <value>MSB3714: The parameter "{0}" was supplied, but not all previously numbered parameters.</value>
       <comment>{StrBegin="MSB3714: "}</comment>
-    </data>     
+    </data>
     <data name="WriteCodeFragment.NoWorkToDo" xml:space="preserve">
       <value>No output file was written because no code was specified to create.</value>
-    </data>    
+    </data>
     <data name="WriteCodeFragment.GeneratedFile" xml:space="preserve">
       <value>Emitted specified code into "{0}".</value>
-    </data>      
+    </data>
     <data name="WriteCodeFragment.Comment" xml:space="preserve">
       <value>Generated by the MSBuild WriteCodeFragment class.</value>
-    </data>      
-    
+    </data>
+
 
  <!--
         MSB3751 - MSB3761   Task: CodeTaskFactory
@@ -2338,7 +2338,7 @@
   <data name="CodeTaskFactory.CodeElementIsMissing" xml:space="preserve">
     <value>MSB3751: The &lt;Code&gt; element is missing for the "{0}" task. This element is required.</value>
     <comment>{StrBegin="MSB3751: "} &lt;Code&gt; should not be localized it is the name of an xml element</comment>
-  </data>  
+  </data>
   <data name="CodeTaskFactory.AttributeEmpty" xml:space="preserve">
     <value>MSB3752: The "{0}" attribute has been set but is empty. If the "{0}" attribute is set it must not be empty.</value>
     <comment>{StrBegin="MSB3752: "}</comment>
@@ -2405,7 +2405,7 @@
   </data>
   <!--
         MSB3773 - MSB3783   Task: ResolveSDKReference
-        MSB3841 - MSB3850   
+        MSB3841 - MSB3850
         ResolveSDKReference Exception messages
         If this bucket overflows, pls. contact 'vsppbdev'.
  -->
@@ -2488,15 +2488,15 @@
     <data name="ResolveSDKReference.Prefer32BitNotSupportedWithNeutralProject" xml:space="preserve">
     <value>MSB3782: The "{0}" SDK does not support targeting a neutral architecture with "Prefer 32-Bit" enabled for the project. Please go to the project properties (Build tab for C# and Compile tab for VB) and disable the "Prefer 32-bit" option, or change your project to target a non-neutral architecture.</value>
     <comment>{StrBegin="MSB3782: "} Also, please localize "Prefer 32-Bit" in the same way that it is localized in wizard\vbdesigner\designer\proppages\buildproppage.resx</comment>
-   </data>  
+   </data>
     <data name="ResolveSDKReference.MaxPlatformVersionLessThanTargetPlatformVersion" xml:space="preserve">
     <value>MSB3783: Project "{0}" depends upon SDK "{1} v{2}" which was released originally for apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</value>
     <comment>{StrBegin="MSB3783: "}</comment>
-   </data>  
+   </data>
    <data name="ResolveSDKReference.InvalidDependencyInPlatform" xml:space="preserve">
     <value>MSB3841: The SDK "{0}" depends on the SDK "{1}", which is not compatible with "{2} {3}". Please reference a version of SDK "{0}" which supports "{2} {3}".</value>
     <comment>{StrBegin="MSB3841: "}</comment>
-   </data>  
+   </data>
    <data name="ResolveSDKReference.MaxPlatformVersionNotSpecified" xml:space="preserve">
     <value>MSB3842: Project "{0}" depends upon SDK "{1} v{2}" which supports apps targeting "{3} {4}". To verify whether "{1} v{2}" is compatible with "{5} {6}", contact the SDK author or see http://go.microsoft.com/fwlink/?LinkID=309181.</value>
     <comment>{StrBegin="MSB3842: "}</comment>
@@ -2592,7 +2592,7 @@
   </data>
   <data name="GetSDKReferenceFiles.NoOriginalItemSpec" xml:space="preserve">
     <value>The "OriginalItemSpec" metadata for the resolved SDK with path "{0}" was empty. The "OriginalItemSpec" metadata must be set."</value>
-  </data>  
+  </data>
   <data name="GetSDKReferenceFiles.CouldNotGetSDKReferenceFiles" xml:space="preserve">
     <value>MSB3795: There was a problem in the GetSDKReferenceFiles task. {0}</value>
     <comment>{StrBegin="MSB3795: "}</comment>
@@ -2636,13 +2636,13 @@
     <value>MSB3871: Shared projects cannot be built on their own.  Please either build a project that references this project, or build the entire solution.</value>
     <comment>{StrBegin="MSB3871: "}</comment>
   </data>
-  
+
   <!--
         MSB3891 - MSB3900   Targets: Copy Overflow
         If this bucket overflows, pls. contact 'vsppbdev'.
   -->
   <data name="Copy.ExactlyOneTypeOfLink">
-    <value>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</value>    
+    <value>MSB3891: Both "{0}" and "{1}" were specified in the project file. Please choose one or the other.</value>
   </data>
 
   <!--
@@ -2745,6 +2745,27 @@
   <data name="ZipDirectory.Comment">
     <value>Zipping directory "{0}" to "{1}".</value>
   </data>
+
+  <!--
+        MSB3951 - MSB3960  Tasks: GetFileHash and VerifyFileHash
+        If this bucket overflows, pls. contact 'vsppbdev'.
+  -->
+  <data name="VerifyFileHash.InvalidInputParameters" xml:space="preserve">
+    <value>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</value>
+    <comment>{StrBegin="MSB3951: "}</comment>
+  </data>
+  <data name="VerifyFileHash.HashMismatch" xml:space="preserve">
+    <value>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</value>
+    <comment>{StrBegin="MSB3952: "}</comment>
+  </data>
+  <data name="FileHash.UnrecognizedHashAlgorithm" xml:space="preserve">
+    <value>MSB3953: Unrecognized hash algorithm name '{0}'.</value>
+    <comment>{StrBegin="MSB3953: "}</comment>
+  </data>
+  <data name="FileHash.FileNotFound" xml:space="preserve">
+    <value>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</value>
+    <comment>{StrBegin="MSB3954: "}</comment>
+  </data>
   <!--
         The tasks message bucket is: MSB3001 - MSB3999
 
@@ -2799,13 +2820,13 @@
             MSB3642 - MSB3646   Task: GetReferenceAssemblyPaths
             MSB3646 - MSB3655   Task: AxTlbBaseTask
             MSB3656 - MSB3660   Task: AxImp
-            MSB3661 - MSB3665   Task: TlbImp            
+            MSB3661 - MSB3665   Task: TlbImp
             MSB3666 - MSB3675   Task: General
             MSB3676 - MSB3685   Task: Move
             MSB3686 - MSB3695   Task: XamlTaskFactory
             MSB3696 - MSB3700   Task: GenerateBootstrapper overflow
             MSB3701 - MSB3710   Task: XslTransformation
-            MSB3711 - MSB3720   Task: WriteCodeFragment      
+            MSB3711 - MSB3720   Task: WriteCodeFragment
             MSB3721 - MSB3730   Task: XamlTaskFactory overflow
             MSB3731 - MSB3740   Task: XmlPoke
             MSB3741 - MSB3750   Task: XmlPeek
@@ -2827,14 +2848,15 @@
             MSB3921 - MSB3930   Task: DownloadFile
             MSB3931 - MSB3940   Task: Unzip
             MSB3941 - MSB3950   Task: ZipDirectory
+            MSB3951 - MSB3960   Task: VerifyFileHash
 
             MSB4000 - MSB4200   Portable targets & tasks (vsproject\flavors\portable\msbuild)
             MSB9000 - MSB9900   MSBuild targets files (C++)
 
         The following codes are not longer used but have shipped so should not be reused:
             MSB3109
-       
-        
+
+
         The message spec is here:
            http://msbuild/wiki/default.aspx/MSBuild.GenerateResourceTaskMessages
 

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2750,8 +2750,8 @@
         MSB3951 - MSB3960  Tasks: GetFileHash and VerifyFileHash
         If this bucket overflows, pls. contact 'vsppbdev'.
   -->
-  <data name="VerifyFileHash.InvalidInputParameters" xml:space="preserve">
-    <value>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</value>
+  <data name="FileHash.UnrecognizedHashEncoding" xml:space="preserve">
+    <value>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</value>
     <comment>{StrBegin="MSB3951: "}</comment>
   </data>
   <data name="VerifyFileHash.HashMismatch" xml:space="preserve">
@@ -2759,7 +2759,7 @@
     <comment>{StrBegin="MSB3952: "}</comment>
   </data>
   <data name="FileHash.UnrecognizedHashAlgorithm" xml:space="preserve">
-    <value>MSB3953: Unrecognized hash algorithm name '{0}'.</value>
+    <value>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</value>
     <comment>{StrBegin="MSB3953: "}</comment>
   </data>
   <data name="FileHash.FileNotFound" xml:space="preserve">

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -356,6 +356,16 @@
         <target state="translated">Pracovní adresář {0} neexistuje.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">Nalezeno: {0}.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">Odkaz na projekt {0} nebyl přeložen.</target>
+        <target state="needs-review-translation">Odkaz na projekt {0} nebyl přeložen.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">{1} je neplatná hodnota parametru {0}.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -356,6 +356,16 @@
         <target state="translated">Das Arbeitsverzeichnis "{0}" ist nicht vorhanden.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}" wurde gefunden.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">Der Projektverweis "{0}" wurde nicht aufgelöst.</target>
+        <target state="needs-review-translation">Der Projektverweis "{0}" wurde nicht aufgelöst.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" ist ein ungültiger Wert für den {0}-Parameter.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -401,6 +401,16 @@
         <target state="new">The working directory "{0}" does not exist.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="new">Found "{0}".</target>
@@ -2238,7 +2248,7 @@
         <source>Project reference "{0}" has not been resolved.</source>
         <target state="new">Project reference "{0}" has not been resolved.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2462,6 +2472,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="new">"{1}" is an invalid value for the "{0}" parameter.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -407,9 +407,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2477,11 +2482,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -356,6 +356,16 @@
         <target state="translated">El directorio de trabajo "{0}" no existe.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">Se encontró "{0}".</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">La referencia del proyecto "{0}" no se ha resuelto.</target>
+        <target state="needs-review-translation">La referencia del proyecto "{0}" no se ha resuelto.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" no es un valor válido para el parámetro "{0}".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -356,6 +356,16 @@
         <target state="translated">Le répertoire de travail "{0}" n'existe pas.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}" trouvé.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">La référence de projet "{0}" n'a pas été résolue.</target>
+        <target state="needs-review-translation">La référence de projet "{0}" n'a pas été résolue.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" n'est pas une valeur valide pour le paramètre "{0}".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -356,6 +356,16 @@
         <target state="translated">La directory di lavoro "{0}" non esiste.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">Trovato "{0}".</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">Il riferimento al progetto "{0}" non è stato risolto.</target>
+        <target state="needs-review-translation">Il riferimento al progetto "{0}" non è stato risolto.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" è un valore non valido per il parametro "{0}".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -356,6 +356,16 @@
         <target state="translated">作業ディレクトリ "{0}" が存在しません。</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}" が見つかりました。</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">プロジェクト参照 "{0}" は解決されませんでした。</target>
+        <target state="needs-review-translation">プロジェクト参照 "{0}" は解決されませんでした。</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" は "{0}" パラメーターに対して無効な値です。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -356,6 +356,16 @@
         <target state="translated">작업 디렉터리 "{0}"이(가) 없습니다.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}"을(를) 찾았습니다.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">프로젝트 참조 "{0}"이(가) 확인되지 않았습니다.</target>
+        <target state="needs-review-translation">프로젝트 참조 "{0}"이(가) 확인되지 않았습니다.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}"은(는) "{0}" 매개 변수에 사용할 수 없는 값입니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -356,6 +356,16 @@
         <target state="translated">Katalog roboczy „{0}” nie istnieje.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">Odnaleziono element „{0}”.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">Odwołanie do projektu „{0}” nie zostało rozpoznane.</target>
+        <target state="needs-review-translation">Odwołanie do projektu „{0}” nie zostało rozpoznane.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">„{1}” jest nieprawidłową wartością parametru „{0}”.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -356,6 +356,16 @@
         <target state="translated">O diretório de trabalho "{0}" não existe.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}" encontrado.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">A referência de projeto "{0}" não foi resolvida.</target>
+        <target state="needs-review-translation">A referência de projeto "{0}" não foi resolvida.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" é um valor inválido para o parâmetro "{0}".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -356,6 +356,16 @@
         <target state="translated">Рабочий каталог "{0}" не существует.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">Найдено "{0}".</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">Ссылка на проект "{0}" не была разрешена.</target>
+        <target state="needs-review-translation">Ссылка на проект "{0}" не была разрешена.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" — недопустимое значение для параметра "{0}".</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -356,6 +356,16 @@
         <target state="translated">"{0}" çalışma dizini yok.</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">"{0}" bulundu.</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">"{0}" proje başvurusu çözümlenmedi.</target>
+        <target state="needs-review-translation">"{0}" proje başvurusu çözümlenmedi.</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" değeri "{0}" parametresi için geçersiz bir değer.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -356,6 +356,16 @@
         <target state="translated">工作目录“{0}”不存在。</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">已找到“{0}”。</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">尚未解析项目引用“{0}”。</target>
+        <target state="needs-review-translation">尚未解析项目引用“{0}”。</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">“{1}”是无效的“{0}”参数值。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -356,6 +356,16 @@
         <target state="translated">工作目錄 "{0}" 不存在。</target>
         <note>No error code because an error will be prefixed.</note>
       </trans-unit>
+      <trans-unit id="FileHash.FileNotFound">
+        <source>MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</source>
+        <target state="new">MSB3954: Failed to compute hash for file '{0}' because it does not exist or is inaccessible.</target>
+        <note>{StrBegin="MSB3954: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
         <target state="translated">找到 "{0}"。</target>
@@ -2186,9 +2196,9 @@
       </trans-unit>
       <trans-unit id="ResolveNonMSBuildProjectOutput.ProjectReferenceUnresolved">
         <source>Project reference "{0}" has not been resolved.</source>
-        <target state="translated">尚未解析專案參考 "{0}"。</target>
+        <target state="needs-review-translation">尚未解析專案參考 "{0}"。</target>
         <note>
-      UE and LOCALIZATION: 
+      UE and LOCALIZATION:
       This is not an error - we pass unresolved references to UnresolvedProjectReferences for further
       processing in the .targets file.
     </note>
@@ -2412,6 +2422,16 @@
         <source>"{1}" is an invalid value for the "{0}" parameter.</source>
         <target state="translated">"{1}" 是 "{0}" 參數的無效值。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.HashMismatch">
+        <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
+        <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
+        <note>{StrBegin="MSB3952: "}</note>
+      </trans-unit>
+      <trans-unit id="VerifyFileHash.InvalidInputParameters">
+        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
+        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -362,9 +362,14 @@
         <note>{StrBegin="MSB3954: "}</note>
       </trans-unit>
       <trans-unit id="FileHash.UnrecognizedHashAlgorithm">
-        <source>MSB3953: Unrecognized hash algorithm name '{0}'.</source>
-        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'.</target>
+        <source>MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</source>
+        <target state="new">MSB3953: Unrecognized hash algorithm name '{0}'. Allowed algorithms are 'SHA256', 'SHA384', and 'SHA512'.</target>
         <note>{StrBegin="MSB3953: "}</note>
+      </trans-unit>
+      <trans-unit id="FileHash.UnrecognizedHashEncoding">
+        <source>MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</source>
+        <target state="new">MSB3951: Unrecognized hash encoding '{0}'. Allowed encodings are 'hex' and 'base64'.</target>
+        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="FindInList.Found">
         <source>Found "{0}".</source>
@@ -2427,11 +2432,6 @@
         <source>MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</source>
         <target state="new">MSB3952: File hash mismatch. Expected {0} to have a {1} file hash of {2}, but it was {3}.</target>
         <note>{StrBegin="MSB3952: "}</note>
-      </trans-unit>
-      <trans-unit id="VerifyFileHash.InvalidInputParameters">
-        <source>MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</source>
-        <target state="new">MSB3951: Invalid input parameters. Either Hash or HashBase64 must be specified, but not both.</target>
-        <note>{StrBegin="MSB3951: "}</note>
       </trans-unit>
       <trans-unit id="WriteLinesToFile.ErrorOrWarning">
         <source>MSB3491: Could not write lines to file "{0}". {1}</source>


### PR DESCRIPTION
Add tasks for computing the file hash and verifying an expected file hash using SHA256, SHA384, or SHA512. These tasks were originally part of aspnet/buildtools, then moved to dotnet/arcade. I've polished them up and added better tests/logging. I'm not set on the API names so let me know if there is a better MSBuild convention for the task and property names.

Resolves https://github.com/Microsoft/msbuild/issues/3369

cc @jeffkl 