### PR TITLE
Fix paths for sdk resolver assemblies constructed from manifest files.

### DIFF
--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverLoader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                     ProjectFileErrorUtilities.ThrowInvalidProjectFile(new BuildEventFileInfo(location), "SdkResolverDllInManifestMissing", pathToManifest, string.Empty);
                 }
 
-                path = manifest.Path;
+                path = FileUtilities.FixFilePath(manifest.Path);
             }
             catch (SerializationException e)
             {


### PR DESCRIPTION
.. since they contain relative paths with windows style path separators
and that breaks on non-windows platforms.

```
/Users/foo/.nuget/packages/roslyntools.repotoolset/1.0.0-beta2-62901-01/tools/Tools.proj : error MSB4247: Could not load SDK Resolver. A manifest file exists, but the path to the SDK Resolver DLL file could not be found. Manifest file path '/Users/foo/dev/msbuild/artifacts/Debug-MONO/bootstrap/net461/MSBuild/15.0/Bin/SdkResolvers/Microsoft.Build.NuGetSdkResolver/Microsoft.Build.NuGetSdkResolver.xml'. SDK resolver path: /Users/foo/dev/msbuild/artifacts/Debug-MONO/bootstrap/net461/MSBuild/15.0/Bin/SdkResolvers/Microsoft.Build.NuGetSdkResolver/..\..\Microsoft.Build.NuGetSdkResolver.dll
```