### PR TITLE
Do not use `[fail]` in tests

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -836,14 +836,14 @@ namespace Microsoft.Build.UnitTests.BackEnd
             string contents = CleanupFileContents(@"
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test'>
-    <Error Text='[fail]'/>
+    <Error Text='[errormessage]'/>
  </Target>
 </Project>
 ");
             BuildRequestData data = GetBuildRequestData(contents);
             BuildResult result = _buildManager.Build(_parameters, data);
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
-            _logger.AssertLogContains("[fail]");
+            _logger.AssertLogContains("[errormessage]");
         }
 
         /// <summary>
@@ -858,7 +858,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                  <Target Name='test'>
                      <Message Text='[Message]' Importance='high'/>
                      <Warning Text='[warn]'/>	
-                     <Error Text='[fail]'/>
+                     <Error Text='[errormessage]'/>
                 </Target>
               </Project>
             ");
@@ -867,7 +867,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.OnlyLogCriticalEvents = true;
             BuildResult result = _buildManager.Build(_parameters, data);
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
-            _logger.AssertLogContains("[fail]");
+            _logger.AssertLogContains("[errormessage]");
             _logger.AssertLogContains("[warn]");
             _logger.AssertLogDoesntContain("[message]");
             Assert.Equal(1, _logger.BuildStartedEvents.Count);
@@ -892,7 +892,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                  <Target Name='test'>
                      <Message Text='[message]' Importance='high'/>
                      <Warning Text='[warn]'/>	
-                     <Error Text='[fail]'/>
+                     <Error Text='[errormessage]'/>
                 </Target>
               </Project>
             ");
@@ -901,7 +901,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _parameters.OnlyLogCriticalEvents = false;
             BuildResult result = _buildManager.Build(_parameters, data);
             Assert.Equal(BuildResultCode.Failure, result.OverallResult);
-            _logger.AssertLogContains("[fail]");
+            _logger.AssertLogContains("[errormessage]");
             _logger.AssertLogContains("[warn]");
             _logger.AssertLogContains("[message]");
             Assert.Equal(1, _logger.BuildStartedEvents.Count);
@@ -1287,7 +1287,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(20)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1307,7 +1307,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(20)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1329,7 +1329,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(60)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1344,7 +1344,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult); // "Build should have failed."
-            _logger.AssertLogDoesntContain("[fail]");
+            _logger.AssertLogDoesntContain("[errormessage]");
         }
 
         /// <summary>
@@ -1360,7 +1360,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 <Project xmlns='msbuildnamespace' ToolsVersion='2.0'>
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(5)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1376,7 +1376,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult); // "Build should have failed."
-            _logger.AssertLogDoesntContain("[fail]");
+            _logger.AssertLogDoesntContain("[errormessage]");
         }
 
 #if FEATURE_TASKHOST
@@ -1395,7 +1395,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
  <UsingTask TaskName='Microsoft.Build.Tasks.Exec' AssemblyName='Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' TaskFactory='TaskHostFactory' />
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(10)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1411,7 +1411,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult); // "Build should have failed."
-            _logger.AssertLogDoesntContain("[fail]");
+            _logger.AssertLogDoesntContain("[errormessage]");
 
             // Task host should not have exited prematurely
             _logger.AssertLogDoesntContain("MSB4217");
@@ -1430,7 +1430,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 <Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(10)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1446,7 +1446,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult); // "Build should have failed."
-            _logger.AssertLogDoesntContain("[fail]");
+            _logger.AssertLogDoesntContain("[errormessage]");
         }
 
 #if FEATURE_TASKHOST
@@ -1463,7 +1463,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
  <UsingTask TaskName='Microsoft.Build.Tasks.Exec' AssemblyName='Microsoft.Build.Tasks.Core, Version=msbuildassemblyversion, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' TaskFactory='TaskHostFactory' />
  <Target Name='test'>
     <Exec Command='" + Helpers.GetSleepCommand(TimeSpan.FromSeconds(10)) + @"'/>
-    <Message Text='[fail]'/>
+    <Message Text='[errormessage]'/>
  </Target>
 </Project>
 ");
@@ -1479,7 +1479,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _buildManager.EndBuild();
 
             Assert.Equal(BuildResultCode.Failure, result.OverallResult); // "Build should have failed."
-            _logger.AssertLogDoesntContain("[fail]");
+            _logger.AssertLogDoesntContain("[errormessage]");
 
             // Task host should not have exited prematurely
             _logger.AssertLogDoesntContain("MSB4217");


### PR DESCRIPTION
xunit logs `[FAIL]` for errors, so searching in our test `.log` files is made harder by these messages.
