### PR TITLE
Flip base call order in RoslynCodeTaskFactoryCompilers

### DIFF
--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -115,9 +115,9 @@ namespace Microsoft.Build.Tasks
 
         protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
-            commandLine.AppendPlusOrMinusSwitch("/nostdlib", NoStandardLib);
-
             base.AddCommandLineCommands(commandLine);
+
+            commandLine.AppendPlusOrMinusSwitch("/nostdlib", NoStandardLib);
         }
     }
 
@@ -131,11 +131,11 @@ namespace Microsoft.Build.Tasks
 
         protected internal override void AddCommandLineCommands(CommandLineBuilderExtension commandLine)
         {
+            base.AddCommandLineCommands(commandLine);
+
             commandLine.AppendSwitchIfTrue("/nostdlib", NoStandardLib);
             commandLine.AppendPlusOrMinusSwitch("/optionexplicit", OptionExplicit);
             commandLine.AppendSwitchIfNotNull("/rootnamespace:", RootNamespace);
-
-            base.AddCommandLineCommands(commandLine);
         }
     }
 }


### PR DESCRIPTION
When using RoslynCodeTaskFactory with the dotnet host and csc.dll, the order in which the command line is constructed means /nostdlib+ is appended before the path to csc.dll. This causes the executed command to look like 

```
C:\Program Files\dotnet\dotnet.exe /nostdlib+ "C:\Program Files\dotnet\sdk\2.2.100-preview1-009013\Roslyn\bincore\csc.dll" /noconfig ...
```

This fails, as dotnet.exe tries to execute a program call 'dotnet-/nostdlib+' rather that csc.dll


This fix flips the order in which the base.AddCommandLineCommands is called, ensuring the dll is passed as the first argument, and /nostdlib+ is appended to end of the arguments instead.

The same fix is applied for the VB version.


