### PR TITLE
Avoid allocations when deserializing build event args

### DIFF
--- a/src/Framework/BuildEventArgs.cs
+++ b/src/Framework/BuildEventArgs.cs
@@ -255,13 +255,7 @@ namespace Microsoft.Build.Framework
         {
             if (buildEventContext == null)
             {
-                buildEventContext = new BuildEventContext
-                                       (
-                                       BuildEventContext.InvalidNodeId,
-                                       BuildEventContext.InvalidTargetId,
-                                       BuildEventContext.InvalidProjectContextId,
-                                       BuildEventContext.InvalidTaskId
-                                       );
+                buildEventContext = BuildEventContext.Invalid;
             }
         }
 #endregion

--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -481,13 +481,7 @@ namespace Microsoft.Build.Framework
         {
             if (parentProjectBuildEventContext == null)
             {
-                parentProjectBuildEventContext = new BuildEventContext
-                                                (
-                                                    BuildEventContext.InvalidNodeId,
-                                                    BuildEventContext.InvalidTargetId,
-                                                    BuildEventContext.InvalidProjectContextId,
-                                                    BuildEventContext.InvalidTaskId
-                                                 );
+                parentProjectBuildEventContext = BuildEventContext.Invalid;
             }
         }
         #endregion


### PR DESCRIPTION
Use our singleton `BuildEventContext.Invalid` instead.