### PR TITLE
shorten sgen reference parameter line

### DIFF
--- a/src/Tasks.UnitTests/SGen_Tests.cs
+++ b/src/Tasks.UnitTests/SGen_Tests.cs
@@ -238,8 +238,8 @@ namespace Microsoft.Build.UnitTests
 
             string commandLine = sgen.CommandLine();
             string targetCommandLine = "/assembly:\"" + sgen.BuildAssemblyPath + Path.DirectorySeparatorChar
-                                       + "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\" /reference:\"C:\\SomeFolder\\reference1.dll\",\"C:\\SomeFolder\\reference2.dll\"";
-
+                                       + "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\" /reference:\"C:\\SomeFolder\\reference1.dll,C:\\SomeFolder\\reference2.dll\"";
+            
             Assert.True(String.Equals(commandLine, targetCommandLine, StringComparison.OrdinalIgnoreCase));
         }
     }

--- a/src/Tasks.UnitTests/SGen_Tests.cs
+++ b/src/Tasks.UnitTests/SGen_Tests.cs
@@ -192,5 +192,55 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(String.Equals(commandLine, targetCommandLine, StringComparison.OrdinalIgnoreCase));
         }
+
+        [Fact]
+        public void TestNullReferences()
+        {
+            SGenExtension sgen = new SGenExtension();
+            sgen.BuildAssemblyName = "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+            sgen.BuildAssemblyPath = "C:\\SomeFolder\\MyAsm.dll";
+            sgen.ShouldGenerateSerializer = true;
+            sgen.UseProxyTypes = false;
+            sgen.UseKeep = false;
+            sgen.References = null;
+
+            string commandLine = sgen.CommandLine();
+
+            Assert.True(commandLine.IndexOf("/reference:", StringComparison.OrdinalIgnoreCase) < 0);
+        }
+
+        [Fact]
+        public void TestEmptyReferences()
+        {
+            SGenExtension sgen = new SGenExtension();
+            sgen.BuildAssemblyName = "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+            sgen.BuildAssemblyPath = "C:\\SomeFolder\\MyAsm.dll";
+            sgen.ShouldGenerateSerializer = true;
+            sgen.UseProxyTypes = false;
+            sgen.UseKeep = false;
+            sgen.References = new string[]{ };
+
+            string commandLine = sgen.CommandLine();
+
+            Assert.True(commandLine.IndexOf("/reference:", StringComparison.OrdinalIgnoreCase) < 0);
+        }
+
+        [Fact]
+        public void TestReferencesCommandLine()
+        {
+            SGenExtension sgen = new SGenExtension();
+            sgen.BuildAssemblyName = "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+            sgen.BuildAssemblyPath = "C:\\SomeFolder\\MyAsm.dll";
+            sgen.ShouldGenerateSerializer = true;
+            sgen.UseProxyTypes = false;
+            sgen.UseKeep = false;
+            sgen.References = new string[]{ "C:\\SomeFolder\\reference1.dll", "C:\\SomeFolder\\reference2.dll" };
+
+            string commandLine = sgen.CommandLine();
+            string targetCommandLine = "/assembly:\"" + sgen.BuildAssemblyPath + Path.DirectorySeparatorChar
+                                       + "MyAsm, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null\" /reference:\"C:\\SomeFolder\\reference1.dll\",\"C:\\SomeFolder\\reference2.dll\"";
+
+            Assert.True(String.Equals(commandLine, targetCommandLine, StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -253,9 +253,10 @@ namespace Microsoft.Build.Tasks
                 // Append the references, if any.
                 if (References != null)
                 {
-                    foreach (string reference in References)
+                    if (References.Length > 0)
                     {
-                        commandLineBuilder.AppendSwitchIfNotNull("/reference:", reference);
+                        //Appending references if 
+                        commandLineBuilder.AppendSwitchIfNotNull("/r:", string.Join(",", References));
                     }
                 }
 

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -255,7 +255,10 @@ namespace Microsoft.Build.Tasks
                 {
                     if (References.Length > 0)
                     {
-                        //Appending references spliting them by comma
+                        // Use a single comma-delimited argument rather than multiple /reference:file
+                        // arguments to save 11 characters per reference (" /reference:" versus ","),
+                        // which can help squeak under the command-line length limit in the
+                        // many-references case.
                         commandLineBuilder.AppendSwitchIfNotNull("/reference:", string.Join(",", References));
                     }
                 }

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -255,8 +255,8 @@ namespace Microsoft.Build.Tasks
                 {
                     if (References.Length > 0)
                     {
-                        //Appending references if 
-                        commandLineBuilder.AppendSwitchIfNotNull("/r:", string.Join(",", References));
+                        //Appending references spliting them by comma
+                        commandLineBuilder.AppendSwitchIfNotNull("/reference:", string.Join(",", References));
                     }
                 }
 


### PR DESCRIPTION
shorten sgen reference parameter line to avoid too long string on GenerateSerializationAssemblies