### PR TITLE
Revert incorrect ToString() on XAttribute usage

### DIFF
--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -1539,7 +1539,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         else
                         {
                             string configFileKey = string.Format(CultureInfo.InvariantCulture, "EULA{0}", eulas.Count);
-                            var de = new KeyValuePair<string ,string>(configFileKey, eulaAttribute.ToString());
+                            var de = new KeyValuePair<string ,string>(configFileKey, eulaAttribute.Value);
                             eulas[key] = de;
                             eulaAttribute.Value = configFileKey;
                         }


### PR DESCRIPTION
Reverts the portion of #3390 which changed `eulaAttribute.Value` to `eulaAttribute.ToString()`.