### PR TITLE
Use Central Package Versioning SDK

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,5 @@
 <Project>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" PrivateAssets="All" />
-  </ItemGroup>
-
   <PropertyGroup>
     <ThirdPartyNotice Condition=" '$(ThirdPartyNotice)' == '' ">$(RepoRoot)THIRDPARTYNOTICES.txt</ThirdPartyNotice>
   </PropertyGroup>
@@ -12,4 +8,8 @@
     <None Include="$(ThirdPartyNotice)" Pack="true" PackagePath="notices" Visible="false" Condition=" '$(IsPackable)' == 'true' " />
   </ItemGroup>
 
+  <PropertyGroup>
+    <CentralPackagesFile>$(MSBuildThisFileDirectory)build/Packages.props</CentralPackagesFile>
+  </PropertyGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.Build.CentralPackageVersions" />
 </Project>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,5 +3,6 @@
   <packageSources>
     <clear />
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,0 +1,68 @@
+<Project>
+
+  <PropertyGroup>
+      <!-- Prodcon-overrideable, using repo-toolset naming convention
+      <MicrosoftNetCompilersVersion Condition="'$(MicrosoftNetCompilersVersion)' == ''">2.8.2</MicrosoftNetCompilersVersion>
+      <MicrosoftNETCoreCompilersVersion Condition="'$(MicrosoftNETCoreCompilersVersion)' == ''">2.8.0</MicrosoftNETCoreCompilersVersion>-->
+
+      <!--<NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">4.8.0-preview1.5185</NuGetPackageVersion>
+          <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
+          <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
+          <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>
+      -->
+      <NuGetPackageVersion>4.8.0-preview1.5185</NuGetPackageVersion>
+      <NuGetBuildTasksVersion>$(NuGetPackageVersion)</NuGetBuildTasksVersion>
+      <NuGetCommandsVersion>$(NuGetPackageVersion)</NuGetCommandsVersion>
+      <NuGetProtocolVersion>$(NuGetPackageVersion)</NuGetProtocolVersion>
+      
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Update="LargeAddressAware" Version="1.0.3" />
+    <PackageReference Update="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />
+    <PackageReference Update="Microsoft.DotNet.BuildTools.GenAPI" Version="2.1.0-prerelease-02404-02" />
+    <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Update="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
+    <PackageReference Update="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageReference Update="Microsoft.Win32.Registry" Version="4.3.0" />
+    <PackageReference Update="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
+    <PackageReference Update="PdbGit" Version="3.0.41" />
+    <PackageReference Update="Shouldly" Version="3.0.0" />
+    <PackageReference Update="SourceLink.Create.CommandLine" Version="2.1.2" />
+    <PackageReference Update="System.CodeDom" Version="4.4.0" />
+    <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
+    <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Update="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Update="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
+    <PackageReference Update="System.Net.Http" Version="4.3.0" />
+    <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
+    <PackageReference Update="System.Resources.Writer" Version="4.0.0" />
+    <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Update="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.1.1" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
+    <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
+    
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.5.24.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.6.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
+
+    <PackageReference Update="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Update="System.Xml.XPath" Version="4.3.0" />
+    <PackageReference Update="xunit.assert" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.console" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.core" Version="$(XUnitVersion)" />    
+  </ItemGroup>
+
+  <ItemGroup>
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" Condition="'$(DisableNerdbankVersioning)' != 'true'" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="All"/>
+    <GlobalPackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+  </ItemGroup>
+
+</Project>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,20 +1,10 @@
 <Project>
 
   <PropertyGroup>
-      <!-- Prodcon-overrideable, using repo-toolset naming convention -->
-      <MicrosoftNetCompilersVersion Condition="'$(MicrosoftNetCompilersVersion)' == ''">2.8.2</MicrosoftNetCompilersVersion>
-      <MicrosoftNETCoreCompilersVersion Condition="'$(MicrosoftNETCoreCompilersVersion)' == ''">2.8.0</MicrosoftNETCoreCompilersVersion>
-
-      <!--<NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">4.8.0-preview1.5185</NuGetPackageVersion>
-          <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
-          <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
-          <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>
-      -->
-      <NuGetPackageVersion>4.8.0-preview1.5185</NuGetPackageVersion>
-      <NuGetBuildTasksVersion>$(NuGetPackageVersion)</NuGetBuildTasksVersion>
-      <NuGetCommandsVersion>$(NuGetPackageVersion)</NuGetCommandsVersion>
-      <NuGetProtocolVersion>$(NuGetPackageVersion)</NuGetProtocolVersion>
-      
+      <NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">4.8.0-preview1.5185</NuGetPackageVersion>
+      <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
+      <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
+      <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -1,9 +1,9 @@
 <Project>
 
   <PropertyGroup>
-      <!-- Prodcon-overrideable, using repo-toolset naming convention
+      <!-- Prodcon-overrideable, using repo-toolset naming convention -->
       <MicrosoftNetCompilersVersion Condition="'$(MicrosoftNetCompilersVersion)' == ''">2.8.2</MicrosoftNetCompilersVersion>
-      <MicrosoftNETCoreCompilersVersion Condition="'$(MicrosoftNETCoreCompilersVersion)' == ''">2.8.0</MicrosoftNETCoreCompilersVersion>-->
+      <MicrosoftNETCoreCompilersVersion Condition="'$(MicrosoftNETCoreCompilersVersion)' == ''">2.8.0</MicrosoftNETCoreCompilersVersion>
 
       <!--<NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">4.8.0-preview1.5185</NuGetPackageVersion>
           <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -39,34 +39,6 @@
     <!-- We are pretty much always on a preview SDK. No need to warn about it. -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <VSWhereVersion>2.2.7</VSWhereVersion>
-
-    <GenApiVersion>2.1.0-prerelease-02404-02</GenApiVersion>
-    <GitVersioningVersion>2.1.23</GitVersioningVersion>
-    <LargeAddressAwareVersion>1.0.3</LargeAddressAwareVersion>
-  </PropertyGroup>
-
-  <!-- Production Dependencies -->
-  <PropertyGroup>
-    <MicrosoftWin32RegistryVersion>4.3.0</MicrosoftWin32RegistryVersion>
-    <VisualStudioSetupInteropVersion>1.16.30</VisualStudioSetupInteropVersion>
-
-    <!-- MSBuild custom overall switch -->
-    <NuGetPackageVersion>4.8.0-preview1.5185</NuGetPackageVersion>
-
-    <!-- Prodcon-overrideable, using repo-toolset naming convention -->
-    <NuGetBuildTasksVersion>$(NuGetPackageVersion)</NuGetBuildTasksVersion>
-    <NuGetCommandsVersion>$(NuGetPackageVersion)</NuGetCommandsVersion>
-    <NuGetProtocolVersion>$(NuGetPackageVersion)</NuGetProtocolVersion>
-
-    <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>
-    <SystemReflectionMetadataVersion>1.6.0</SystemReflectionMetadataVersion>
-</PropertyGroup>
-
-  <!-- Test Dependencies -->
-  <PropertyGroup>
-    <MicrosoftCodeAnalysisBuildTasksVersion>3.0.0-beta1-61516-01</MicrosoftCodeAnalysisBuildTasksVersion>
-    <MicrosoftExtensionsDependencyModelVersion>2.1.0</MicrosoftExtensionsDependencyModelVersion>
-    <ShouldlyVersion>3.0.0</ShouldlyVersion>
   </PropertyGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "msbuild-sdks": {
+    "Microsoft.Build.CentralPackageVersions": "2.0.1",
     "RoslynTools.RepoToolset": "1.0.0-beta2-62901-01"
   }
 }

--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
+++ b/src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftCodeAnalysisBuildTasksVersion)" />
+    <PackageReference Include="System.Collections.Concurrent" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
 
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -30,30 +30,28 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
 
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.IO.Compression" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" Condition="'$(MonoBuild)' == 'true'" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(MonoBuild)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24.0" />
-    
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <Reference Include="System.Configuration" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Reflection.TypeExtensions" />
+    <PackageReference Include="System.Runtime.Loader" />
+    <PackageReference Include="System.Security.Principal.Windows" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
+    <PackageReference Include="System.Text.Encoding.CodePages" />
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 
   <!-- This item group is for classes that exist in .NET Framework but not in .NET Core.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,10 @@
 ﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!-- Add IsImplicitlyDefined to any packages that were 'magically' referenced (RepoTools!). This
+         should be removed if RepoTools adds the metadata for their package references. -->
+    <PackageReference Update="@(PackageReference)" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
   <!-- Import the repo root props -->
   <Import Project="..\Directory.Build.props"/>
 
@@ -64,11 +70,6 @@
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=624683</PackageProjectUrl>
     <PackageIconUrl>https://go.microsoft.com/fwlink/?linkid=825694</PackageIconUrl>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Condition="'$(DisableNerdbankVersioning)' != 'true'" Include="Nerdbank.GitVersioning" Version="$(GitVersioningVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="all"/>
-  </ItemGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <!-- When targeting .NET Framework, Exe and unit test projects build with x86 architecture if Platform is AnyCPU,

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -45,8 +45,8 @@
     <!-- MSBuild isn't xunit analyzer clean, so remove the reference to the xunit package added by the repo toolset and
          replace it with references to xunit.core and xunit.assert. -->
     <PackageReference Remove="xunit" />
-    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.core" />
+    <PackageReference Include="xunit.assert" />
 
     <!-- Don't localize unit test projects -->
     <PackageReference Remove="XliffTasks" />
@@ -78,11 +78,11 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(GenerateReferenceAssemblySources)' == 'true' and '$(OsEnvironment)'=='windows'">
-    <PackageReference Include="Microsoft.DotNet.BuildTools.GenAPI" Version="$(GenApiVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.BuildTools.GenAPI" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true' And '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
-    <PackageReference Include="xunit.console" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.console" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OutputType)' == 'Exe'">

--- a/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
+    <PackageReference Include="System.Threading.Thread" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <Reference Include="System.Xaml" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -31,11 +31,11 @@
 
   <ItemGroup Condition="'$(MonoBuild)' != 'true'">
     <!-- Include NuGet build tasks -->
-    <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksVersion)" />
-    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetBuildTasksVersion)" />
+    <PackageReference Include="NuGet.Build.Tasks" />
+    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" />
 
     <!-- Include DependencyModel libraries. -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
   </ItemGroup>
 
   <!-- Use deps file from this project with additional dependencies listed instead of the one generated in the MSBuild project -->

--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -223,11 +223,11 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
-    <PackageReference Include="LargeAddressAware" Version="$(LargeAddressAwareVersion)" PrivateAssets="All" />
+    <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -202,13 +202,13 @@
     <Content Include="..\MSBuild.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" />
-    <PackageReference Include="PdbGit" Version="3.0.41" />
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" />
-    <PackageReference Include="LargeAddressAware" Version="$(LargeAddressAwareVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
+    <PackageReference Include="PdbGit" />
+    <PackageReference Include="SourceLink.Create.CommandLine" />
+    <PackageReference Include="LargeAddressAware" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 </Project>

--- a/src/Samples/Directory.Build.props
+++ b/src/Samples/Directory.Build.props
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <!-- Use Samples subdirectory for samples in output folder -->
     <OutDirName>Samples\$(MSBuildProjectName)</OutDirName>
+
+    <!-- Don't regulate package versions for samples -->
+    <EnableCentralPackageVersions>false</EnableCentralPackageVersions>
   </PropertyGroup>
 
   <!-- Import parent props -->

--- a/src/Samples/Directory.Build.targets
+++ b/src/Samples/Directory.Build.targets
@@ -1,5 +1,11 @@
 ﻿<Project>
-  
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" Condition="'$(DisableNerdbankVersioning)' != 'true'" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-003" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" PrivateAssets="All" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+  </ItemGroup>
+
   <!-- Import parent targets -->
   <Import Project="..\Directory.Build.targets"/>
 

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
+    <PackageReference Include="System.Security.Principal.Windows" />
+    <PackageReference Include="System.Xml.XPath" />
+    <PackageReference Include="Shouldly" />
 
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -954,14 +954,24 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Repotools will add a PackageReference for the compilers package based on the current runtime.
+         To bootstrap, we will need the compilers for both runtimes to copy the output. -->
+    <PackageReference
+      Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
+      Include="Microsoft.Net.Compilers" ExcludeAssets="all" />
+    <PackageReference
+      Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(TargetFrameworkIdentifier)' != '.NETFramework'"
+      Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
-
-    <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="All" />
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <PackageReference Include="System.CodeDom" />
     <PackageReference Include="System.Linq.Parallel" />
@@ -975,9 +985,9 @@
     <PackageReference Include="Microsoft.Win32.Registry" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="All" />
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">
     <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -952,34 +952,34 @@
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.5.24.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <PackageReference Include="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" ExcludeAssets="All" />
+    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="All" />
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageReference Include="System.CodeDom" Version="4.4.0" />
-    <PackageReference Include="System.Linq.Parallel" Version="4.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Include="System.Resources.Writer" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
+    <PackageReference Include="System.CodeDom" />
+    <PackageReference Include="System.Linq.Parallel" />
+    <PackageReference Include="System.Net.Http" />
+    <PackageReference Include="System.Reflection.Metadata" />
+    <PackageReference Include="System.Reflection.TypeExtensions" />
+    <PackageReference Include="System.Resources.Writer" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" ExcludeAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="All" />
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" />
   </ItemGroup>
   <ItemGroup>
     <!--

--- a/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
+++ b/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\AssemblyUtilities.cs">

--- a/src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
+++ b/src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
-    <PackageReference Include="System.IO.FileSystem.Primitives " Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(MicrosoftCodeAnalysisBuildTasksVersion)" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" />
 
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -18,23 +18,23 @@
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(VisualStudioSetupInteropVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
 
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 
   <ItemGroup Label="Shared Code">

--- a/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
+++ b/src/Xunit.NetCore.Extensions/Xunit.NetCore.Extensions.csproj
@@ -5,7 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.core" Version="$(XUnitVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <PackageReference Include="xunit.core" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Uses SDK from https://github.com/Microsoft/MSBuildSdks

Versions for `PackageReference` can only be specified in `build/Packages.props` file. If you add a `Version=` attribute to any other `PackageReference` in our tree you get an error that you must specify it in the Packages.props file (it gives the path to it in the error message).