### PR TITLE
Add infastructure for long path support

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -46,6 +46,7 @@
 
   <!-- Production Dependencies -->
   <PropertyGroup>
+    <MicrosoftWin32RegistryVersion>4.3.0</MicrosoftWin32RegistryVersion>
     <VisualStudioSetupInteropVersion>1.16.30</VisualStudioSetupInteropVersion>
 
     <!-- MSBuild custom overall switch -->

--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Shouldly" Version="$(ShouldlyVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Shared\Constants.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -52,6 +52,8 @@
     <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
   </ItemGroup>
 
   <!-- This item group is for classes that exist in .NET Framework but not in .NET Core.

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -48,6 +48,9 @@
     <DefineConstants>$(DefineConstants);FEATURE_HANDLEREF</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HTTP_LISTENER</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_INSTALLED_MSBUILD</DefineConstants>
+    <!-- Directory.GetCurrentDirectory The pre .Net 4.6.2 implementation of Directory.GetCurrentDirectory is slow and creates strings in its work. -->
+    <DefineConstants>$(DefineConstants);FEATURE_LEGACY_GETCURRENTDIRECTORY</DefineConstants>
+    <!-- Path.GetFullPath The pre .Net 4.6.2 implementation of Path.GetFullPath is slow and creates strings in its work. -->
     <DefineConstants>$(DefineConstants);FEATURE_LEGACY_GETFULLPATH</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPE_SECURITY_CONSTRUCTOR</DefineConstants>

--- a/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -19,6 +19,11 @@
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -229,6 +229,10 @@
     <Reference Include="System.Configuration" />
     <PackageReference Include="LargeAddressAware" Version="$(LargeAddressAwareVersion)" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Build\Microsoft.Build.csproj" />
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" PrivateAssets="All" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -205,4 +205,8 @@
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" />
     <PackageReference Include="LargeAddressAware" Version="$(LargeAddressAwareVersion)" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -38,10 +37,6 @@ namespace Microsoft.Build.Shared
         // have the impossible combination of runningTests = false and currentExecutableOverride = null.
 
         // This is the fake current executable we use in case we are running tests.
-
-        // MaxPath accounts for the null-terminating character, for example, the maximum path on the D drive is "D:\<256 chars>\0".
-        // See: ndp\clr\src\BCL\System\IO\Path.cs
-        internal const int MaxPath = 260;
 
         /// <summary>
         /// The directory where MSBuild stores cache information used during the build.
@@ -95,6 +90,13 @@ namespace Microsoft.Build.Shared
 
         private static readonly IFileSystem DefaultFileSystem = FileSystems.Default;
 #endif
+
+        private enum GetFileAttributesResult
+        {
+            Directory,
+            Error,
+            File,
+        }
 
         /// <summary>
         /// Retrieves the MSBuild runtime cache directory
@@ -255,34 +257,7 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Compare an unsafe char buffer with a <see cref="System.String"/> to see if their contents are identical.
-        /// </summary>
-        /// <param name="buffer">The beginning of the char buffer.</param>
-        /// <param name="len">The length of the buffer.</param>
-        /// <param name="s">The string.</param>
-        /// <returns>True only if the contents of <paramref name="s"/> and the first <paramref name="len"/> characters in <paramref name="buffer"/> are identical.</returns>
-        private unsafe static bool AreStringsEqual(char* buffer, int len, string s)
-        {
-            if (len != s.Length)
-            {
-                return false;
-            }
-
-            foreach (char ch in s)
-            {
-                if (ch != *buffer++)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
         /// Gets the canonicalized full path of the provided path.
-        /// Path.GetFullPath The pre .Net 4.6.2 implementation of Path.GetFullPath is slow and creates strings in its work.
-        /// Therefore MSBuild has its own implementation on full framework.
         /// Guidance for use: call this on all paths accepted through public entry
         /// points that need normalization. After that point, only verify the path
         /// is rooted, using ErrorUtilities.VerifyThrowPathRooted.
@@ -290,116 +265,10 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string NormalizePath(string path)
         {
+
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
-
-#if FEATURE_LEGACY_GETFULLPATH
-
-            if (NativeMethodsShared.IsWindows)
-            {
-                int errorCode = 0; // 0 == success in Win32
-
-#if _DEBUG
-                // Just to make sure and exercise the code that sets the correct buffer size
-                // we'll start out with it deliberately too small
-                int lenDir = 1;
-#else
-                int lenDir = MaxPath;
-#endif
-                unsafe
-                {
-                    char* finalBuffer = stackalloc char[lenDir + 1]; // One extra for the null terminator
-
-                    int length = NativeMethodsShared.GetFullPathName(path, lenDir + 1, finalBuffer, IntPtr.Zero);
-                    errorCode = Marshal.GetLastWin32Error();
-
-                    // If the length returned from GetFullPathName is greater than the length of the buffer we've
-                    // allocated, then reallocate the buffer with the correct size, and repeat the call
-                    if (length > lenDir)
-                    {
-                        lenDir = length;
-                        char* tempBuffer = stackalloc char[lenDir];
-                        finalBuffer = tempBuffer;
-                        length = NativeMethodsShared.GetFullPathName(path, lenDir, finalBuffer, IntPtr.Zero);
-                        errorCode = Marshal.GetLastWin32Error();
-                        // If we find that the length returned from GetFullPathName is longer than the buffer capacity, then
-                        // something very strange is going on!
-                        ErrorUtilities.VerifyThrow(
-                            length <= lenDir,
-                            "Final buffer capacity should be sufficient for full path name and null terminator.");
-                    }
-
-                    if (length > 0)
-                    {
-                        // In order to prevent people from taking advantage of our ability to extend beyond MaxPath
-                        // since it is unlikely that the CLR fix will be a complete removal of maxpath madness
-                        // we reluctantly have to restrict things here.
-                        if (length >= MaxPath)
-                        {
-                            throw new PathTooLongException();
-                        }
-
-                        // Avoid creating new strings unnecessarily
-                        string finalFullPath = AreStringsEqual(finalBuffer, length, path)
-                            ? path
-                            : new string(
-                                finalBuffer,
-                                startIndex: 0,
-                                length: length);
-
-                        // We really don't care about extensions here, but Path.HasExtension provides a great way to
-                        // invoke the CLR's invalid path checks (these are independent of path length)
-                        Path.HasExtension(finalFullPath);
-
-                        if (finalFullPath.StartsWith(@"\\", StringComparison.Ordinal))
-                        {
-                            // If we detect we are a UNC path then we need to use the regular get full path in order to do the correct checks for UNC formatting
-                            // and security checks for strings like \\?\GlobalRoot
-                            int startIndex = 2;
-                            while (startIndex < finalFullPath.Length)
-                            {
-                                if (finalFullPath[startIndex] == '\\')
-                                {
-                                    startIndex++;
-                                    break;
-                                }
-                                else
-                                {
-                                    startIndex++;
-                                }
-                            }
-
-                            /*
-                              From Path.cs in the CLR
-
-                              Throw an ArgumentException for paths like \\, \\server, \\server\
-                              This check can only be properly done after normalizing, so
-                              \\foo\.. will be properly rejected.  Also, reject \\?\GLOBALROOT\
-                              (an internal kernel path) because it provides aliases for drives.
-
-                              throw new ArgumentException(Environment.GetResourceString("Arg_PathIllegalUNC"));
-
-                               // Check for \\?\Globalroot, an internal mechanism to the kernel
-                               // that provides aliases for drives and other undocumented stuff.
-                               // The kernel team won't even describe the full set of what
-                               // is available here - we don't want managed apps mucking
-                               // with this for security reasons.
-                            */
-                    if (startIndex == finalFullPath.Length || finalFullPath.IndexOf(@"\\?\globalroot", PathComparison) != -1)
-                    {
-                        finalFullPath = Path.GetFullPath(finalFullPath);
-                    }
-                }
-
-                        return finalFullPath;
-                    }
-                }
-
-                NativeMethodsShared.ThrowExceptionForErrorCode(errorCode);
-                return null;
-            }
-#endif
-            return FixFilePath(Path.GetFullPath(path));
-
+            string fullPath = GetFullPath(path);
+            return FixFilePath(fullPath);
         }
 
         internal static string NormalizePath(string directory, string file)
@@ -413,6 +282,72 @@ namespace Microsoft.Build.Shared
             return NormalizePath(Path.Combine(paths));
         }
 #endif
+
+        private static string GetFullPath(string path)
+        {
+#if FEATURE_LEGACY_GETFULLPATH
+            if (NativeMethodsShared.IsWindows)
+            {
+                string uncheckedFullPath = NativeMethodsShared.GetFullPath(path);
+                AssertMaxPathLimits(uncheckedFullPath);
+
+                // We really don't care about extensions here, but Path.HasExtension provides a great way to
+                // invoke the CLR's invalid path checks (these are independent of path length)
+                Path.HasExtension(uncheckedFullPath);
+
+                // If we detect we are a UNC path then we need to use the regular get full path in order to do the correct checks for UNC formatting
+                // and security checks for strings like \\?\GlobalRoot
+                return IsUNCPath(uncheckedFullPath) ? Path.GetFullPath(uncheckedFullPath) : uncheckedFullPath;
+            }
+#endif
+            string fullPath = Path.GetFullPath(path);
+            AssertMaxPathLimits(fullPath);
+            return fullPath;
+        }
+
+        private static void AssertMaxPathLimits(string path)
+        {
+            if (IsPathTooLong(path))
+            {
+                throw new PathTooLongException($"Path: {path} exceeds the OS max path limit. " +
+                    $"The fully qualified file name must be less than {NativeMethodsShared.OSMaxPathLimit - 1} characters.");
+            }
+        }
+
+        private static bool IsUNCPath(string path)
+        {
+            if (!NativeMethodsShared.IsWindows || !path.StartsWith(@"\\", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            bool isUNC = true;
+            for (int i = 2; i < path.Length - 1; i++)
+            {
+                if (path[i] == '\\')
+                {
+                    isUNC = false;
+                    break;
+                }
+            }
+
+            /*
+              From Path.cs in the CLR
+
+              Throw an ArgumentException for paths like \\, \\server, \\server\
+              This check can only be properly done after normalizing, so
+              \\foo\.. will be properly rejected.  Also, reject \\?\GLOBALROOT\
+              (an internal kernel path) because it provides aliases for drives.
+
+              throw new ArgumentException(Environment.GetResourceString("Arg_PathIllegalUNC"));
+
+               // Check for \\?\Globalroot, an internal mechanism to the kernel
+               // that provides aliases for drives and other undocumented stuff.
+               // The kernel team won't even describe the full set of what
+               // is available here - we don't want managed apps mucking
+               // with this for security reasons.
+            */
+            return isUNC || path.IndexOf(@"\\?\globalroot", StringComparison.OrdinalIgnoreCase) != -1;
+        }
 
         internal static string FixFilePath(string path)
         {
@@ -428,7 +363,7 @@ namespace Microsoft.Build.Shared
         ///
         /// @baseDirectory is just passed to LooksLikeUnixFilePath, to help with the check
         /// </summary>
-        internal static string MaybeAdjustFilePath(string value, string baseDirectory="")
+        internal static string MaybeAdjustFilePath(string value, string baseDirectory = "")
         {
             // Don't bother with arrays or properties or network paths, or those that
             // have no slashes.
@@ -473,7 +408,7 @@ namespace Microsoft.Build.Shared
         /// If @baseDirectory is not null, then look for the first segment exists under
         /// that
         /// </summary>
-        internal static bool LooksLikeUnixFilePath(string value, string baseDirectory="")
+        internal static bool LooksLikeUnixFilePath(string value, string baseDirectory = "")
         {
             if (!NativeMethodsShared.IsUnixLike)
             {
@@ -766,25 +701,6 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// A variation of Path.IsRooted that not throw any IO exception.
-        /// </summary>
-        internal static bool IsRootedNoThrow(string path)
-        {
-            bool result;
-
-            try
-            {
-                result = Path.IsPathRooted(FixFilePath(path));
-            }
-            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
-            {
-                result = false;
-            }
-
-            return result;
-        }
-
-        /// <summary>
         /// Gets a file info object for the specified file path. If the file path
         /// is invalid, or is a directory, or cannot be accessed, or does not exist,
         /// it returns null rather than throwing or returning a FileInfo around a non-existent file.
@@ -1027,15 +943,41 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string AttemptToShortenPath(string path)
         {
-            // >= not > because MAX_PATH assumes a trailing null
-            if (path.Length >= NativeMethodsShared.MAX_PATH ||
-               (!IsRootedNoThrow(path) && ((Directory.GetCurrentDirectory().Length + path.Length + 1 /* slash */) >= NativeMethodsShared.MAX_PATH)))
+            if (IsPathTooLong(path) || IsPathTooLongIfRooted(path))
             {
                 // Attempt to make it shorter -- perhaps there are some \..\ elements
                 path = GetFullPathNoThrow(path);
             }
-
             return FixFilePath(path);
+        }
+
+        private static bool IsPathTooLong(string path)
+        {
+            // >= not > because MAX_PATH assumes a trailing null
+            return path.Length >= (int)NativeMethodsShared.OSMaxPathLimit;
+        }
+
+        private static bool IsPathTooLongIfRooted(string path)
+        {
+            bool hasMaxPath = NativeMethodsShared.OSMaxPathLimit != NativeMethodsShared.MaxPathLimits.None;
+            int maxPath = (int)NativeMethodsShared.OSMaxPathLimit;
+            // >= not > because MAX_PATH assumes a trailing null
+            return hasMaxPath && !IsRootedNoThrow(path) && NativeMethodsShared.GetCurrentDirectory().Length + path.Length + 1 /* slash */ >= maxPath;
+        }
+
+        /// <summary>
+        /// A variation of Path.IsRooted that not throw any IO exception.
+        /// </summary>
+        private static bool IsRootedNoThrow(string path)
+        {
+            try
+            {
+                return Path.IsPathRooted(FixFilePath(path));
+            }
+            catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -309,8 +309,8 @@ namespace Microsoft.Build.Shared
         {
             if (IsPathTooLong(path))
             {
-                throw new PathTooLongException($"Path: {path} exceeds the OS max path limit. " +
-                    $"The fully qualified file name must be less than {NativeMethodsShared.OSMaxPathLimit - 1} characters.");
+                throw new PathTooLongException(ResourceUtilities.FormatString(
+                    AssemblyResources.GetString("Shared.PathTooLong"), path, NativeMethodsShared.OSMaxPathLimit - 1));
             }
         }
 

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -13,6 +13,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Reflection;
+using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
@@ -44,8 +45,16 @@ namespace Microsoft.Build.Shared
         internal const int FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
         internal const int FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
 
+        /// <summary>
+        /// Default buffer size to use when dealing with the Windows API.
+        /// </summary>
+        internal const int MAX_PATH = 260;
+
         private const string kernel32Dll = "kernel32.dll";
         private const string mscoreeDLL = "mscoree.dll";
+
+        private const string WINDOWS_FILE_SYSTEM_REGISTRY_KEY = @"SYSTEM\CurrentControlSet\Control\FileSystem";
+        private const string WINDOWS_LONG_PATHS_ENABLED_VALUE_NAME = "LongPathsEnabled";
 
 #if FEATURE_HANDLEREF
         internal static HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
@@ -167,6 +176,13 @@ namespace Microsoft.Build.Shared
             // Who knows
             Unknown
         }
+
+        internal enum MaxPathLimits
+        {
+            Unknown = 0,
+            LegacyWindows = MAX_PATH,
+            None = int.MaxValue,
+        };
 
         #endregion
 
@@ -452,14 +468,62 @@ namespace Microsoft.Build.Shared
         #region Member data
 
         /// <summary>
-        /// Default buffer size to use when dealing with the Windows API.
+        /// Gets an enum for the max path limit of the current OS.
         /// </summary>
-        /// <remarks>
-        /// This member is intentionally not a constant because we want to allow
-        /// unit tests to change it.
-        /// </remarks>
-        internal static int MAX_PATH = 260;
+        internal static MaxPathLimits OSMaxPathLimit
+        {
+            get
+            {
+#if EXPERIMENTAL_LONGPATHS_ENABLED
+                if (osMaxPathLimit == MaxPathLimits.Unknown)
+                {
+                    SetOSMaxPathLimit();
+                }
+                return osMaxPathLimit;
+#else
+                return MaxPathLimits.LegacyWindows;
+#endif
+            }
+        }
 
+        /// <summary>
+        /// Cached value for OSMaxPathLimit.
+        /// </summary>
+        private static MaxPathLimits osMaxPathLimit = MaxPathLimits.Unknown;
+
+        private static readonly object osMaxPathLimitLock = new object();
+
+        private static void SetOSMaxPathLimit()
+        {
+            lock (osMaxPathLimitLock)
+            {
+                if (osMaxPathLimit == MaxPathLimits.Unknown)
+                {
+                    osMaxPathLimit = IsMaxPathLimitLegacyWindows() ? MaxPathLimits.LegacyWindows : MaxPathLimits.None;
+                }
+            }
+        }
+
+        private static bool IsMaxPathLimitLegacyWindows()
+        {
+            try
+            {
+                return IsWindows && !IsLongPathsEnabledRegistry();
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        private static bool IsLongPathsEnabledRegistry()
+        {
+            using (RegistryKey fileSystemKey = Registry.LocalMachine.OpenSubKey(WINDOWS_FILE_SYSTEM_REGISTRY_KEY))
+            {
+                object longPathsEnabledValue = fileSystemKey?.GetValue(WINDOWS_LONG_PATHS_ENABLED_VALUE_NAME, 0);
+                return fileSystemKey != null && Convert.ToInt32(longPathsEnabledValue) == 1;
+            }
+        }
 
         /// <summary>
         /// Cached value for IsUnixLike (this method is called frequently during evaluation).
@@ -542,7 +606,7 @@ namespace Microsoft.Build.Shared
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
 #endif
         }
-        
+
 #if MONO
         private static bool? _isOSX;
 #endif
@@ -1181,17 +1245,76 @@ namespace Microsoft.Build.Shared
         /// Internal, optimized GetCurrentDirectory implementation that simply delegates to the native method
         /// </summary>
         /// <returns></returns>
-        internal static string GetCurrentDirectory()
+        internal unsafe static string GetCurrentDirectory()
         {
+#if FEATURE_LEGACY_GETCURRENTDIRECTORY
             if (IsWindows)
             {
-                StringBuilder sb = new StringBuilder(MAX_PATH);
-                int pathLength = GetCurrentDirectory(MAX_PATH, sb);
+                int bufferSize = GetCurrentDirectoryWin32(0, null);
+                char* buffer = stackalloc char[bufferSize];
+                int pathLength = GetCurrentDirectoryWin32(bufferSize, buffer);
+                return new string(buffer, startIndex: 0, length: pathLength);
+            }
+#endif
+            return Directory.GetCurrentDirectory();
+        }
 
-                return pathLength > 0 ? sb.ToString() : null;
+        private unsafe static int GetCurrentDirectoryWin32(int nBufferLength, char* lpBuffer)
+        {
+            int pathLength = GetCurrentDirectory(nBufferLength, lpBuffer);
+            VerifyThrowWin32Result(pathLength);
+            return pathLength;
+        }
+
+        internal unsafe static string GetFullPath(string path)
+        {
+            int bufferSize = GetFullPathWin32(path, 0, null, IntPtr.Zero);
+            char* buffer = stackalloc char[bufferSize];
+            int fullPathLength = GetFullPathWin32(path, bufferSize, buffer, IntPtr.Zero);
+            // Avoid creating new strings unnecessarily
+            return AreStringsEqual(buffer, fullPathLength, path) ? path : new string(buffer, startIndex: 0, length: fullPathLength);
+        }
+
+        private unsafe static int GetFullPathWin32(string target, int bufferLength, char* buffer, IntPtr mustBeZero)
+        {
+            int pathLength = GetFullPathName(target, bufferLength, buffer, mustBeZero);
+            VerifyThrowWin32Result(pathLength);
+            return pathLength;
+        }
+
+        /// <summary>
+        /// Compare an unsafe char buffer with a <see cref="System.String"/> to see if their contents are identical.
+        /// </summary>
+        /// <param name="buffer">The beginning of the char buffer.</param>
+        /// <param name="len">The length of the buffer.</param>
+        /// <param name="s">The string.</param>
+        /// <returns>True only if the contents of <paramref name="s"/> and the first <paramref name="len"/> characters in <paramref name="buffer"/> are identical.</returns>
+        private unsafe static bool AreStringsEqual(char* buffer, int len, string s)
+        {
+            if (len != s.Length)
+            {
+                return false;
             }
 
-            return Directory.GetCurrentDirectory();
+            foreach (char ch in s)
+            {
+                if (ch != *buffer++)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static void VerifyThrowWin32Result(int result)
+        {
+            bool isError = result == 0;
+            if (isError)
+            {
+                int code = Marshal.GetLastWin32Error();
+                ThrowExceptionForErrorCode(code);
+            }
         }
 
 #endregion
@@ -1276,7 +1399,7 @@ namespace Microsoft.Build.Shared
         [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
         [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-        internal static extern int GetCurrentDirectory(int nBufferLength, [Out] StringBuilder lpBuffer);
+        internal unsafe static extern int GetCurrentDirectory(int nBufferLength, char* lpBuffer);
 
         [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
         [SuppressMessage("Microsoft.Usage", "CA2205:UseManagedEquivalentsOfWin32Api", Justification = "Using unmanaged equivalent for performance reasons")]

--- a/src/Shared/Resources/Strings.shared.resx
+++ b/src/Shared/Resources/Strings.shared.resx
@@ -258,6 +258,10 @@
     <value>MSB5024: Could not determine a valid location to MSBuild. Try running this process from the Developer Command Prompt for Visual Studio.</value>
     <comment>{StrBegin="MSB5021: "}</comment>
   </data>
+  <data name="Shared.PathTooLong">
+    <value>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</value>
+    <comment></comment>
+  </data>
   <!--
         The shared message bucket is: MSB5001 - MSB5999
 

--- a/src/Shared/Resources/xlf/Strings.shared.cs.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.cs.xlf
@@ -60,6 +60,11 @@
         <target state="translated">Nástroj MSBuild očekává platný objekt {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Verze nástrojů {0} je neznámá. Dostupné verze nástrojů jsou {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.de.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.de.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild erwartet ein gültiges {0}-Objekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Die Toolsversion "{0}" ist unbekannt. Verfügbare Toolversionen sind {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.en.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.en.xlf
@@ -65,6 +65,11 @@
         <target state="new">MSBuild is expecting a valid "{0}" object.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="new">MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.es.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.es.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild espera un objeto "{0}" válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: No se reconoce la versión de herramientas "{0}". Las versiones de herramientas disponibles son {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.fr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.fr.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild attend un objet "{0}" valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: La version des outils "{0}" n'est pas reconnue. Les versions disponibles sont {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.it.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.it.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild prevede un oggetto "{0}" valido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: versione degli strumenti "{0}" non riconosciuta. Le versioni disponibili sono {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ja.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ja.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild は有効な "{0}" オブジェクトを必要としています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: ツール バージョン "{0}" が認識されません。使用可能なツール バージョンは {1} です。</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ko.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ko.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild에 올바른 "{0}" 개체가 필요합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 도구 버전 "{0}"을(를) 인식할 수 없습니다. 사용할 수 있는 도구 버전은 {1}입니다.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.pl.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pl.xlf
@@ -60,6 +60,11 @@
         <target state="translated">Program MSBuild oczekuje prawidłowego obiektu „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Wersja narzędzi „{0}” nie została rozpoznana. Dostępne wersje narzędzi to {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.pt-BR.xlf
@@ -60,6 +60,11 @@
         <target state="translated">O MSBuild está esperando um objeto "{0}" válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: A versão das ferramentas "{0}" não é reconhecida. As versões das ferramentas disponíveis são {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.ru.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.ru.xlf
@@ -60,6 +60,11 @@
         <target state="translated">Для MSBuild требуется допустимый объект "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: версия инструментов "{0}" не распознана. Доступные версии инструментов: {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.tr.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.tr.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild, geçerli bir "{0}" nesnesi bekliyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: Araçlar sürümü "{0}" tanınmıyor. Kullanılabilir araç sürümleri şunlardır: {1}.</target>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hans.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild 需要有效的“{0}”对象。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 无法识别工具版本“{0}”。可用的工具版本为 {1}。</target>

--- a/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
+++ b/src/Shared/Resources/xlf/Strings.shared.zh-Hant.xlf
@@ -60,6 +60,11 @@
         <target state="translated">MSBuild 需要有效的 "{0}" 物件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Shared.PathTooLong">
+        <source>Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</source>
+        <target state="new">Path: {0} exceeds the OS max path limit. The fully qualified file name must be less than {1} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedToolsVersion">
         <source>MSB4132: The tools version "{0}" is unrecognized. Available tools versions are {1}.</source>
         <target state="translated">MSB4132: 工具版本 "{0}" 無法辨認。可用的工具版本為 {1}。</target>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -970,6 +970,9 @@
     <PackageReference Include="System.Resources.Writer" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.6.0" />
 
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" ExcludeAssets="All" />
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />

--- a/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
+++ b/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
@@ -24,6 +24,10 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\AssemblyUtilities.cs">
       <Link>AssemblyUtilities.cs</Link>

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -32,6 +32,11 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+  </ItemGroup>
+
   <ItemGroup Label="Shared Code">
     <Compile Include="..\Shared\AssemblyFolders\AssemblyFoldersEx.cs">
       <Link>Shared\AssemblyFolders\AssemblyFoldersEx.cs</Link>


### PR DESCRIPTION
Made the necessary changes to enable builds of long path projects if the OS supports it. A second PR will toggle on the necessary config switches so it's clearer if any regressions occur from turning the functionality on. #53 