### PR TITLE
Project does not remember last context and caches cannot be reset

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -604,19 +604,26 @@ namespace Microsoft.Build.Evaluation
         public bool Build(string[] targets) { throw null; }
         public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
         public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance() { throw null; }
         public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings) { throw null; }
+        public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public string ExpandString(string unexpandedValue) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromFile(string file, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromProjectRootElement(Microsoft.Build.Construction.ProjectRootElement rootElement, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromXmlReader(System.Xml.XmlReader reader, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs() { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
         public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItemDefinition item) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItems(string itemType) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsByEvaluatedInclude(string evaluatedInclude) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsIgnoringCondition(string itemType) { throw null; }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -882,7 +882,6 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
-        public void ResetCaches() { }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -604,19 +604,26 @@ namespace Microsoft.Build.Evaluation
         public bool Build(string[] targets) { throw null; }
         public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers) { throw null; }
         public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers) { throw null; }
+        public bool Build(string[] targets, System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> loggers, System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> remoteLoggers, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance() { throw null; }
         public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings) { throw null; }
+        public Microsoft.Build.Execution.ProjectInstance CreateProjectInstance(Microsoft.Build.Execution.ProjectInstanceSettings settings, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public string ExpandString(string unexpandedValue) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromFile(string file, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromProjectRootElement(Microsoft.Build.Construction.ProjectRootElement rootElement, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public static Microsoft.Build.Evaluation.Project FromXmlReader(System.Xml.XmlReader reader, Microsoft.Build.Definition.ProjectOptions options) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs() { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.GlobResult> GetAllGlobs(string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
         public static string GetEvaluatedItemIncludeEscaped(Microsoft.Build.Evaluation.ProjectItemDefinition item) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(Microsoft.Build.Evaluation.ProjectItem item, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType) { throw null; }
+        public System.Collections.Generic.List<Microsoft.Build.Evaluation.ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType, Microsoft.Build.Evaluation.Context.EvaluationContext evaluationContext) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItems(string itemType) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsByEvaluatedInclude(string evaluatedInclude) { throw null; }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.ProjectItem> GetItemsIgnoringCondition(string itemType) { throw null; }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -882,7 +882,6 @@ namespace Microsoft.Build.Evaluation.Context
     {
         internal EvaluationContext() { }
         public static Microsoft.Build.Evaluation.Context.EvaluationContext Create(Microsoft.Build.Evaluation.Context.EvaluationContext.SharingPolicy policy) { throw null; }
-        public void ResetCaches() { }
         public enum SharingPolicy
         {
             Isolated = 1,

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -1108,7 +1108,19 @@ namespace Microsoft.Build.Evaluation
         /// </returns>
         public List<GlobResult> GetAllGlobs()
         {
-            return GetAllGlobs(GetEvaluatedItemElements());
+            return GetAllGlobs(evaluationContext: null);
+        }
+
+        /// <summary>
+        /// See <see cref="GetAllGlobs()"/>
+        /// </summary>
+        /// <param name="evaluationContext">
+        ///     The evaluation context to use in case reevaluation is required.
+        ///     To avoid reevaluation use <see cref="ProjectLoadSettings.RecordEvaluatedItemElements"/>
+        /// </param>
+        public List<GlobResult> GetAllGlobs(EvaluationContext evaluationContext)
+        {
+            return GetAllGlobs(GetEvaluatedItemElements(evaluationContext));
         }
 
         /// <summary>
@@ -1117,12 +1129,24 @@ namespace Microsoft.Build.Evaluation
         /// <param name="itemType">Confine search to item elements of this type</param>
         public List<GlobResult> GetAllGlobs(string itemType)
         {
+            return GetAllGlobs(itemType, null);
+        }
+
+        /// <summary>
+        /// See <see cref="GetAllGlobs(string)"/>
+        /// </summary>
+        /// <param name="evaluationContext">
+        ///     The evaluation context to use in case reevaluation is required.
+        ///     To avoid reevaluation use <see cref="ProjectLoadSettings.RecordEvaluatedItemElements"/>
+        /// </param>
+        public List<GlobResult> GetAllGlobs(string itemType, EvaluationContext evaluationContext)
+        {
             if (string.IsNullOrEmpty(itemType))
             {
                 return new List<GlobResult>();
             }
 
-            return GetAllGlobs(GetItemElementsByType(GetEvaluatedItemElements(), itemType));
+            return GetAllGlobs(GetItemElementsByType(GetEvaluatedItemElements(evaluationContext), itemType));
         }
 
         // represents cumulated remove information for a particular item type
@@ -1334,7 +1358,19 @@ namespace Microsoft.Build.Evaluation
         /// </returns>
         public List<ProvenanceResult> GetItemProvenance(string itemToMatch)
         {
-            return GetItemProvenance(itemToMatch, GetEvaluatedItemElements());
+            return GetItemProvenance(itemToMatch, evaluationContext: null);
+        }
+
+        /// <summary>
+        /// See <see cref="GetItemProvenance(string)"/>
+        /// </summary>
+        /// <param name="evaluationContext">
+        ///     The evaluation context to use in case reevaluation is required.
+        ///     To avoid reevaluation use <see cref="ProjectLoadSettings.RecordEvaluatedItemElements"/>
+        /// </param>
+        public List<ProvenanceResult> GetItemProvenance(string itemToMatch, EvaluationContext evaluationContext)
+        {
+            return GetItemProvenance(itemToMatch, GetEvaluatedItemElements(evaluationContext));
         }
 
         /// <summary>
@@ -1344,7 +1380,19 @@ namespace Microsoft.Build.Evaluation
         /// <param name="itemType">The item type to constrain the search in</param>
         public List<ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType)
         {
-            return GetItemProvenance(itemToMatch, GetItemElementsByType(GetEvaluatedItemElements(), itemType));
+            return GetItemProvenance(itemToMatch, itemType, null);
+        }
+
+        /// <summary>
+        /// See <see cref="GetItemProvenance(string, string)"/>
+        /// </summary>
+        /// <param name="evaluationContext">
+        ///     The evaluation context to use in case reevaluation is required.
+        ///     To avoid reevaluation use <see cref="ProjectLoadSettings.RecordEvaluatedItemElements"/>
+        /// </param>
+        public List<ProvenanceResult> GetItemProvenance(string itemToMatch, string itemType, EvaluationContext evaluationContext)
+        {
+            return GetItemProvenance(itemToMatch, GetItemElementsByType(GetEvaluatedItemElements(evaluationContext), itemType));
         }
 
         /// <summary>
@@ -1357,12 +1405,24 @@ namespace Microsoft.Build.Evaluation
         /// </param>
         public List<ProvenanceResult> GetItemProvenance(ProjectItem item)
         {
+            return GetItemProvenance(item, null);
+        }
+
+        /// <summary>
+        /// See <see cref="GetItemProvenance(ProjectItem)"/>
+        /// </summary>
+        /// <param name="evaluationContext">
+        ///     The evaluation context to use in case reevaluation is required.
+        ///     To avoid reevaluation use <see cref="ProjectLoadSettings.RecordEvaluatedItemElements"/>
+        /// </param>
+        public List<ProvenanceResult> GetItemProvenance(ProjectItem item, EvaluationContext evaluationContext)
+        {
             if (item == null)
             {
                 return new List<ProvenanceResult>();
             }
 
-            IEnumerable<ProjectItemElement> itemElementsAbove = GetItemElementsThatMightAffectItem(GetEvaluatedItemElements(), item);
+            IEnumerable<ProjectItemElement> itemElementsAbove = GetItemElementsThatMightAffectItem(GetEvaluatedItemElements(evaluationContext), item);
 
             return GetItemProvenance(item.EvaluatedInclude, itemElementsAbove);
         }
@@ -1374,12 +1434,13 @@ namespace Microsoft.Build.Evaluation
         /// 
         /// Using this method avoids storing extra data in memory when its not needed.
         /// </summary>
-        private List<ProjectItemElement> GetEvaluatedItemElements()
+        /// <param name="evaluationContext"></param>
+        private List<ProjectItemElement> GetEvaluatedItemElements(EvaluationContext evaluationContext)
         {
             if (!_loadSettings.HasFlag(ProjectLoadSettings.RecordEvaluatedItemElements))
             {
                 _loadSettings = _loadSettings | ProjectLoadSettings.RecordEvaluatedItemElements;
-                Reevaluate(LoggingService, _loadSettings);
+                Reevaluate(LoggingService, _loadSettings, evaluationContext);
             }
 
             return _data.EvaluatedItemElements;
@@ -2017,7 +2078,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public ProjectInstance CreateProjectInstance()
         {
-            return CreateProjectInstance(LoggingService, ProjectInstanceSettings.None);
+            return CreateProjectInstance(LoggingService, ProjectInstanceSettings.None, null);
         }
 
         /// <summary>
@@ -2029,7 +2090,17 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public ProjectInstance CreateProjectInstance(ProjectInstanceSettings settings)
         {
-            return CreateProjectInstance(LoggingService, settings);
+            return CreateProjectInstance(LoggingService, settings, null);
+        }
+
+        /// <summary>
+        /// See <see cref="CreateProjectInstance(ProjectInstanceSettings)"/>
+        /// </summary>
+        /// <param name="evaluationContext">The evaluation context to use in case reevaluation is required</param>
+        /// <returns></returns>
+        public ProjectInstance CreateProjectInstance(ProjectInstanceSettings settings, EvaluationContext evaluationContext)
+        {
+            return CreateProjectInstance(LoggingService, settings, evaluationContext);
         }
 
         /// <summary>
@@ -2253,13 +2324,22 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         public bool Build(string[] targets, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers)
         {
+            return Build(targets, loggers, remoteLoggers, null);
+        }
+
+        /// <summary>
+        /// See <see cref="Build(string[], IEnumerable&lt;ILogger&gt;, IEnumerable&lt;ForwardingLoggerRecord&gt;)"/>
+        /// </summary>
+        /// <param name="evaluationContext">The evaluation context to use in case reevaluation is required</param>
+        public bool Build(string[] targets, IEnumerable<ILogger> loggers, IEnumerable<ForwardingLoggerRecord> remoteLoggers, EvaluationContext evaluationContext)
+        {
             if (!IsBuildEnabled)
             {
                 LoggingService.LogError(s_buildEventContext, new BuildEventFileInfo(FullPath), "SecurityProjectBuildDisabled");
                 return false;
             }
 
-            ProjectInstance instance = CreateProjectInstance(LoggingService, ProjectInstanceSettings.None);
+            ProjectInstance instance = CreateProjectInstance(LoggingService, ProjectInstanceSettings.None, evaluationContext);
 
             if (loggers == null && ProjectCollection.Loggers != null)
             {
@@ -2612,9 +2692,12 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Creates a project instance based on this project using the specified logging service.
         /// </summary>  
-        private ProjectInstance CreateProjectInstance(ILoggingService loggingServiceForEvaluation, ProjectInstanceSettings settings)
+        private ProjectInstance CreateProjectInstance(
+            ILoggingService loggingServiceForEvaluation,
+            ProjectInstanceSettings settings,
+            EvaluationContext evaluationContext)
         {
-            ReevaluateIfNecessary(loggingServiceForEvaluation);
+            ReevaluateIfNecessary(loggingServiceForEvaluation, evaluationContext);
 
             return new ProjectInstance(_data, DirectoryPath, FullPath, ProjectCollection.HostServices, ProjectCollection.EnvironmentProperties, settings);
         }

--- a/src/Build/Definition/ProjectOptions.cs
+++ b/src/Build/Definition/ProjectOptions.cs
@@ -36,9 +36,6 @@ namespace Microsoft.Build.Definition
 
         /// <summary>
         /// The <see cref="EvaluationContext"/> to use for evaluation.
-        /// The <see cref="Project"/> will keep the reference to the context because
-        /// some of its methods trigger hidden reevaluations, and those hidden reevaluations need the initial context.
-        /// The stored context can be overridden via <see cref="Project.ReevaluateIfNecessary(EvaluationContext)"/>
         /// </summary>
         public EvaluationContext EvaluationContext { get; set; }
     }

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Evaluation.Context
             Isolated
         }
 
-        internal static Action<EvaluationContext> TestOnlyAlterStateOnCreate { get; set; }
+        internal static Action<EvaluationContext> TestOnlyHookOnCreate { get; set; }
 
         private int _used;
 
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Evaluation.Context
         public static EvaluationContext Create(SharingPolicy policy)
         {
             var context = new EvaluationContext(policy);
-            TestOnlyAlterStateOnCreate?.Invoke(context);
+            TestOnlyHookOnCreate?.Invoke(context);
 
             return context;
         }

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -82,17 +82,5 @@ namespace Microsoft.Build.Evaluation.Context
                     return null;
             }
         }
-
-        /// <summary>
-        /// Ideally caches should be discarded by discarding this entire object.
-        /// However, there could be situations where API users have a <see cref="Project"/> object loaned to another entity, and cannot swap the context, but still need to reset it.
-        /// Caches are not cleared atomically, users should ensure no other threads are performing evaluations while the caches are cleared.
-        /// </summary>
-        public void ResetCaches()
-        {
-            SdkResolverService.ClearCaches();
-            FileSystem.ClearCaches();
-            FileEntryExpansionCache.Clear();
-        }
     }
 }

--- a/src/Shared/FileSystem/CachingFileSystemWrapper.cs
+++ b/src/Shared/FileSystem/CachingFileSystemWrapper.cs
@@ -18,12 +18,6 @@ namespace Microsoft.Build.Shared.FileSystem
             _fileSystem = fileSystem;
         }
 
-        public void ClearCaches()
-        {
-            _fileSystem.ClearCaches();
-            _existenceCache.Clear();
-        }
-
         public bool DirectoryEntryExists(string path)
         {
             return CachedExistenceCheck(path, p => _fileSystem.DirectoryEntryExists(p));

--- a/src/Shared/FileSystem/IFileSystem.cs
+++ b/src/Shared/FileSystem/IFileSystem.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Build.Shared.FileSystem
     /// <summary>
     /// Abstracts away some file system operations
     /// </summary>
-    /// TODO: This interface has only enumeration and existence related methods. Consider extending it to include other file system operations.
     internal interface IFileSystem
     {
         /// <summary>
@@ -41,7 +40,5 @@ namespace Microsoft.Build.Shared.FileSystem
         /// Determines whether the given path refers to an existing entry in the directory service.
         /// </summary>
         bool DirectoryEntryExists(string path);
-
-        void ClearCaches();
     }
 }

--- a/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
+++ b/src/Shared/FileSystem/MSBuildOnWindowsFileSystem.cs
@@ -54,9 +54,5 @@ namespace Microsoft.Build.Shared.FileSystem
         {
             return WindowsFileSystem.Singleton().DirectoryEntryExists(path);
         }
-
-        public void ClearCaches()
-        {
-        }
     }
 }

--- a/src/Shared/FileSystem/ManagedFileSystem.cs
+++ b/src/Shared/FileSystem/ManagedFileSystem.cs
@@ -54,9 +54,5 @@ namespace Microsoft.Build.Shared.FileSystem
         {
             return FileExists(path) || DirectoryExists(path);
         }
-
-        public void ClearCaches()
-        {
-        }
     }
 }

--- a/src/Shared/FileSystem/WindowsFileSystem.cs
+++ b/src/Shared/FileSystem/WindowsFileSystem.cs
@@ -70,9 +70,6 @@ namespace Microsoft.Build.Shared.FileSystem
             return NativeMethodsShared.FileOrDirectoryExistsWindows(path);
         }
 
-        public void ClearCaches()
-        {
-        }
         private static IEnumerable<string> EnumerateFileOrDirectories(
             string directoryPath,
             FileArtifactType fileArtifactType,

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -2287,11 +2287,6 @@ namespace Microsoft.Build.UnitTests
             {
                 return FileSystems.Default.DirectoryEntryExists(path);
             }
-
-            public void ClearCaches()
-            {
-                FileSystems.Default.ClearCaches();
-            }
         }
     }
 }


### PR DESCRIPTION
This greatly simplifies things. The only way users should "reset" caches by sending in a different / new context. Turned out it's quite hard to reset caches atomically and in a readers / writers fashion with respect to ongoing evaluations because the context does not keep a record of which evaluations use it.