### PR TITLE
Use XmlTextReader everywhere

### DIFF
--- a/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
@@ -472,9 +472,7 @@ multi-line comment here
 
             VerifyAssertLineByLine(expected, actual);
 
-#if FEATURE_XMLTEXTREADER
             VerifyLineEndings(actual);
-#endif
         }
 
         private void VerifyAssertLineByLine(string expected, string actual)

--- a/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/Scheduler_Tests.cs
@@ -673,11 +673,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 ");
 
             _parameters.DetailedSummary = true;
-#if FEATURE_XMLTEXTREADER
             Project project = new Project(new XmlTextReader(new StringReader(contents)));
-#else
-            Project project = new Project(XmlReader.Create(new StringReader(contents)));
-#endif
             BuildRequestData data = new BuildRequestData(project.CreateProjectInstance(), new string[] { "test" });
             BuildResult result = _buildManager.Build(_parameters, data);
             Assert.Equal(BuildResultCode.Success, result.OverallResult);

--- a/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TargetBuilder_Tests.cs
@@ -1170,11 +1170,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 </Project>
       ";
             StringReader reader = new StringReader(projectContents);
-#if FEATURE_XMLTEXTREADER
             Project project = new Project(new XmlTextReader(reader), null, null);
-#else
-            Project project = new Project(XmlReader.Create(reader), null, null);
-#endif
             bool success = project.Build(_mockLogger);
             Assert.False(success);
         }

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -808,11 +808,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                         </None>
                     </ItemGroup>
                 </Project>";
-#if FEATURE_XMLTEXTREADER
             System.Xml.XmlReader reader = new System.Xml.XmlTextReader(new StringReader(projectString));
-#else
-            System.Xml.XmlReader reader = System.Xml.XmlReader.Create(new StringReader(projectString));
-#endif
             Project project = new Project(reader);
             ProjectItem item = project.GetItems("None").Single();
 
@@ -858,11 +854,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                     </ItemGroup>
                 </Project>";
 
-#if FEATURE_XMLTEXTREADER
             System.Xml.XmlReader reader = new System.Xml.XmlTextReader(new StringReader(projectString));
-#else
-            System.Xml.XmlReader reader = System.Xml.XmlReader.Create(new StringReader(projectString));
-#endif
             Project project = new Project(reader);
             IEnumerable<ProjectItem> items = project.GetItems("CrazyList");
 
@@ -894,11 +886,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                     </ItemGroup>
                 </Project>";
 
-#if FEATURE_XMLTEXTREADER
             System.Xml.XmlReader reader = new System.Xml.XmlTextReader(new StringReader(projectString));
-#else
-            System.Xml.XmlReader reader = System.Xml.XmlReader.Create(new StringReader(projectString));
-#endif
             Project project = new Project(reader);
             IEnumerable<ProjectItem> items = project.GetItems("CrazyList");
 

--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -360,11 +360,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
             Project project;
             using (StringReader sr = new StringReader(one))
             {
-#if FEATURE_XMLTEXTREADER
                 using (XmlReader xr = XmlTextReader.Create(sr))
-#else
-                using (XmlReader xr = XmlReader.Create(sr))
-#endif
                 {
                     project = new Project(xr);
                 }

--- a/src/Build.UnitTests/Instance/HostServices_Tests.cs
+++ b/src/Build.UnitTests/Instance/HostServices_Tests.cs
@@ -412,18 +412,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
 </Project>
 ");
 
-#if FEATURE_XMLTEXTREADER
             Project project = new Project(new XmlTextReader(new StringReader(contents)), new Dictionary<string, string>(), ObjectModelHelpers.MSBuildDefaultToolsVersion);
-#else
-            Project project;
-            using (StringReader sr = new StringReader(contents))
-            {
-                using (XmlReader xr = XmlReader.Create(sr))
-                {
-                    project = new Project(xr, new Dictionary<string, string>(), ObjectModelHelpers.MSBuildDefaultToolsVersion);
-                }
-            }
-#endif
             project.FullPath = fileName;
             ProjectInstance instance = project.CreateProjectInstance();
 
@@ -445,25 +434,11 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Dictionary<string, string> globals = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             globals["UniqueDummy"] = Guid.NewGuid().ToString();
 
-#if FEATURE_XMLTEXTREADER
             Project project =
                 ProjectCollection.GlobalProjectCollection.LoadProject(
                     new XmlTextReader(new StringReader(contents)),
                     globals,
                     ObjectModelHelpers.MSBuildDefaultToolsVersion);
-#else
-            Project project;
-            using (StringReader sr = new StringReader(contents))
-            {
-                using (XmlReader xr = XmlReader.Create(sr))
-                {
-                    project = ProjectCollection.GlobalProjectCollection.LoadProject(
-                        xr,
-                        globals,
-                        ObjectModelHelpers.MSBuildDefaultToolsVersion);
-                }
-            }
-#endif
             project.FullPath = fileName;
 
             return project;

--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -194,11 +194,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 </Project>
                 ");
 
-#if FEATURE_XMLTEXTREADER
             ProjectRootElement xml = ProjectRootElement.Create(XmlTextReader.Create(new StringReader(content)));
-#else
-            ProjectRootElement xml = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-#endif
 
             Project project = new Project(xml);
             MockLogger logger = new MockLogger();
@@ -255,11 +251,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 </Project>
                 ");
 
-#if FEATURE_XMLTEXTREADER
             ProjectRootElement xml = ProjectRootElement.Create(XmlTextReader.Create(new StringReader(content)));
-#else
-            ProjectRootElement xml = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-#endif
 
             Project project = new Project(xml);
             MockLogger logger = new MockLogger();
@@ -297,11 +289,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 </Project>
                 ");
 
-#if FEATURE_XMLTEXTREADER
             ProjectRootElement xml = ProjectRootElement.Create(XmlTextReader.Create(new StringReader(content)));
-#else
-            ProjectRootElement xml = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-#endif
 
             Project project = new Project(xml);
             MockLogger logger = new MockLogger();

--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -77,42 +77,12 @@ namespace Microsoft.Build.Internal
         private static XmlReader GetXmlReader(string file, StreamReader input, out Encoding encoding)
         {
             string uri = new UriBuilder(Uri.UriSchemeFile, string.Empty) { Path = file }.ToString();
-#if FEATURE_XMLTEXTREADER
             var reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
 
             reader.Read();
             encoding = input.CurrentEncoding;
 
             return reader;
-#else
-            var xr = XmlReader.Create(input, new XmlReaderSettings {DtdProcessing = DtdProcessing.Ignore}, uri);
-
-            // Set Normalization = false if possible. Without this, certain line endings will be normalized
-            // with \n (specifically in XML comments). Does not throw if if type or property is not found.
-            // This issue does not apply to XmlTextReader (above) which is not shipped with .NET Core yet.
-            
-            // NOTE: This doesn't work in .NET Core.
-            //var xmlReaderType = typeof(XmlReader).GetTypeInfo().Assembly.GetType("System.Xml.XmlTextReaderImpl");
-
-            //// Works in full framework, not in .NET Core
-            //var normalization = xmlReaderType?.GetProperty("Normalization", BindingFlags.Instance | BindingFlags.NonPublic);
-            //normalization?.SetValue(xr, false);
-
-            //// Set _normalize = false, and _ps.eolNormalized = true
-            //var normalizationMember = xmlReaderType?.GetField("_normalize", BindingFlags.Instance | BindingFlags.NonPublic);
-            //normalizationMember?.SetValue(xr, false);
-
-            //var psField = xmlReaderType.GetField("_ps", BindingFlags.Instance | BindingFlags.NonPublic);
-            //var ps = psField.GetValue(xr);
-            
-            //var eolField = ps.GetType().GetField("eolNormalized", BindingFlags.Instance | BindingFlags.NonPublic);
-            //eolField.SetValue(ps, true);
-
-            xr.Read();
-            encoding = input.CurrentEncoding;
-
-            return xr;
-#endif
         }
 
         /// <summary>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -96,7 +96,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_XML_SOURCE_URI</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XML_LOADPATH</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_XML_SCHEMA_VALIDATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_XMLTEXTREADER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DEBUGGER</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_DEBUG_LAUNCH</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_WIN32_REGISTRY</DefineConstants>


### PR DESCRIPTION
This API wasn't in .NET Core when we originally ported but is now available in
all of our .NET Core targets. Using it everywhere improves programmatic editing
of MSBuild files.

Closes #1401.