### PR TITLE
Change IO calls to IFileSystem / FileUtilities and other improvements

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 
 namespace Microsoft.Build.Execution
@@ -881,7 +882,7 @@ namespace Microsoft.Build.Execution
                 return true;
             }
 
-            if (File.Exists(path))
+            if (FileSystems.Default.FileExists(path))
             {
                 s_msbuildExeKnownToExistAt = path;
                 return true;

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Internal;
 
 using BackendNativeMethods = Microsoft.Build.BackEnd.NativeMethods;
 using System.Threading.Tasks;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd
@@ -450,7 +451,7 @@ namespace Microsoft.Build.BackEnd
             // Should always have been set already.
             ErrorUtilities.VerifyThrowInternalLength(msbuildLocation, "msbuildLocation");
 
-            if (!File.Exists(msbuildLocation))
+            if (!FileSystems.Default.FileExists(msbuildLocation))
             {
                 throw new BuildAbortedException(ResourceUtilities.FormatResourceString("CouldNotFindMSBuildExe", msbuildLocation));
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/MSBuild.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 // NOTE: This is nearly identical to the MSBuild task in Microsoft.Build.Tasks.  We are deprecating that task,
 // so this is the governing implementation.
@@ -322,7 +323,7 @@ namespace Microsoft.Build.BackEnd
                     break;
                 }
 
-                if (File.Exists(projectPath) || (_skipNonexistentProjects == SkipNonexistentProjectsBehavior.Build))
+                if (FileSystems.Default.FileExists(projectPath) || (_skipNonexistentProjects == SkipNonexistentProjectsBehavior.Build))
                 {
                     if (FileUtilities.IsVCProjFilename(projectPath))
                     {

--- a/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
+++ b/src/Build/BackEnd/Components/Scheduler/SchedulingPlan.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -144,7 +145,7 @@ namespace Microsoft.Build.BackEnd
                 return;
             }
 
-            if (!File.Exists(planName))
+            if (!FileSystems.Default.FileExists(planName))
             {
                 return;
             }

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Collections;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -840,7 +841,7 @@ namespace Microsoft.Build.BackEnd
         internal void ClearCacheFile()
         {
             string cacheFile = GetCacheFile();
-            if (File.Exists(cacheFile))
+            if (FileSystems.Default.FileExists(cacheFile))
             {
                 FileUtilities.DeleteNoThrow(cacheFile);
             }

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Execution
 {
@@ -590,7 +591,7 @@ namespace Microsoft.Build.Execution
         internal void ClearCachedFiles()
         {
             string resultsDirectory = TargetResult.GetCacheDirectory(_configurationId, "None" /*Does not matter because we just need the directory name not the file*/);
-            if (Directory.Exists(resultsDirectory))
+            if (FileSystems.Default.DirectoryExists(resultsDirectory))
             {
                 FileUtilities.DeleteDirectoryNoThrow(resultsDirectory, true /*recursive*/);
             }

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Execution
 {
@@ -274,7 +275,7 @@ namespace Microsoft.Build.Execution
             if (direction == TranslationDirection.WriteToStream)
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(cacheFile));
-                if (File.Exists(cacheFile))
+                if (FileSystems.Default.FileExists(cacheFile))
                 {
                     // If the file already exists, then we have cached this once before.  No need to cache it again since it cannot have changed.
                     return null;

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -17,6 +17,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 #if (!STANDALONEBUILD)
 using Microsoft.Internal.Performance;
 #if MSBUILDENABLEVSPROFILING 
@@ -1589,7 +1590,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public void ReloadFrom(string path, bool throwIfUnsavedChanges = true, bool? preserveFormatting = null)
         {
-            ErrorUtilities.VerifyThrowInvalidOperation(File.Exists(path), "FileToReloadFromDoesNotExist", path);
+            ErrorUtilities.VerifyThrowInvalidOperation(FileSystems.Default.FileExists(path), "FileToReloadFromDoesNotExist", path);
 
             XmlDocumentWithLocation DocumentProducer(bool shouldPreserveFormatting) => LoadDocument(path, shouldPreserveFormatting);
             ReloadFrom(DocumentProducer, throwIfUnsavedChanges, preserveFormatting);
@@ -1861,7 +1862,7 @@ namespace Microsoft.Build.Construction
             //
             const int maxSizeToConsiderEmpty = 100;
 
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 // Non-existent files are not treated as empty
                 //

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -1008,7 +1008,7 @@ namespace Microsoft.Build.Evaluation
                                 }
                                 else
                                 {
-                                    overrideDirectoryExists = Directory.Exists(_overrideTasksPath);
+                                    overrideDirectoryExists = FileSystems.Default.DirectoryExists(_overrideTasksPath);
                                 }
                             }
 

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
-
+using Microsoft.Build.Shared.FileSystem;
 using ErrorUtilities = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
 
@@ -257,7 +257,7 @@ namespace Microsoft.Build.Evaluation
             // When running from the command-line or from VS, use the msbuild.exe.config file.
             if (BuildEnvironmentHelper.Instance.Mode != BuildEnvironmentMode.None &&
                 !BuildEnvironmentHelper.Instance.RunningTests &&
-                File.Exists(BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile))
+                FileSystems.Default.FileExists(BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile))
             {
                 var configFile = new ExeConfigurationFileMap { ExeConfigFilename = BuildEnvironmentHelper.Instance.CurrentMSBuildConfigurationFile };
                 return ConfigurationManager.OpenMappedExeConfiguration(configFile, ConfigurationUserLevel.None);

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -11,6 +11,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 using error = Microsoft.Build.Shared.ErrorUtilities;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using InvalidToolsetDefinitionException = Microsoft.Build.Exceptions.InvalidToolsetDefinitionException;
@@ -192,7 +193,7 @@ namespace Microsoft.Build.Evaluation
 
                         // Other toolsets are installed in the xbuild directory
                         var xbuildToolsetsDir = Path.Combine(libraryPath, $"xbuild{Path.DirectorySeparatorChar}");
-                        if (Directory.Exists(xbuildToolsetsDir))
+                        if (FileSystems.Default.DirectoryExists(xbuildToolsetsDir))
                         {
                             var r = new Regex(Regex.Escape(xbuildToolsetsDir) + @"\d+\.\d+");
                             foreach (var d in Directory.GetDirectories(xbuildToolsetsDir).Where(d => r.IsMatch(d)))

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2379,7 +2379,7 @@ namespace Microsoft.Build.Evaluation
                         // Perhaps the import tag has a typo in, for example.
 
                         // There's a specific message for file not existing
-                        if (!File.Exists(importFileUnescaped))
+                        if (!FileSystems.Default.FileExists(importFileUnescaped))
                         {
                             bool ignoreMissingImportsFlagSet = (_loadSettings & ProjectLoadSettings.IgnoreMissingImports) != 0;
                             if (!throwOnFileNotExistsError || ignoreMissingImportsFlagSet)

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Logging
 {
@@ -152,7 +153,7 @@ namespace Microsoft.Build.Logging
 
                     // It is possible that the archive couldn't be created for some reason.
                     // Only embed it if it actually exists.
-                    if (File.Exists(archiveFilePath))
+                    if (FileSystems.Default.FileExists(archiveFilePath))
                     {
                         eventArgsWriter.WriteBlob(BinaryLogRecordKind.ProjectImportArchive, File.ReadAllBytes(archiveFilePath));
                         File.Delete(archiveFilePath);

--- a/src/MSBuild/ProjectSchemaValidationHandler.cs
+++ b/src/MSBuild/ProjectSchemaValidationHandler.cs
@@ -8,6 +8,7 @@ using System.Xml;
 using System.Xml.Schema;
 
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.CommandLine
 {
@@ -45,7 +46,7 @@ namespace Microsoft.Build.CommandLine
                 schemaFile = Path.Combine(binPath, "Microsoft.Build.xsd");
             }
 
-            if (File.Exists(schemaFile))
+            if (FileSystems.Default.FileExists(schemaFile))
             {
                 // Print the schema file we're using, particularly since it can vary 
                 // according to the toolset being used

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -23,7 +23,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
-
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 #if (!STANDALONEBUILD)
 using Microsoft.Internal.Performance;
@@ -252,7 +252,7 @@ namespace Microsoft.Build.CommandLine
         /// </comments>
         static private void AppendOutputFile(string path, Int64 elapsedTime)
         {
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 using (StreamWriter sw = File.CreateText(path))
                 {
@@ -1650,7 +1650,7 @@ namespace Microsoft.Build.CommandLine
                 {
                     commandLineSwitches.SetSwitchError("MissingResponseFileError", unquotedCommandLineArg);
                 }
-                else if (!File.Exists(responseFile))
+                else if (!FileSystems.Default.FileExists(responseFile))
                 {
                     commandLineSwitches.SetParameterError("ResponseFileNotFoundError", unquotedCommandLineArg);
                 }
@@ -1851,7 +1851,7 @@ namespace Microsoft.Build.CommandLine
             bool found = false;
 
             // if the auto-response file does not exist, only use the switches on the command line
-            if (File.Exists(autoResponseFile))
+            if (FileSystems.Default.FileExists(autoResponseFile))
             {
                 found = true;
                 GatherResponseFileSwitch("@" + autoResponseFile, switchesFromAutoResponseFile);
@@ -2479,7 +2479,7 @@ namespace Microsoft.Build.CommandLine
             {
                 projectFile = FileUtilities.FixFilePath(parameters[0]);
 
-                if (Directory.Exists(projectFile))
+                if (FileSystems.Default.DirectoryExists(projectFile))
                 {
                     // If the project file is actually a directory then change the directory to be searched
                     // and null out the project file
@@ -2488,7 +2488,7 @@ namespace Microsoft.Build.CommandLine
                 }
                 else
                 {
-                    InitializationException.VerifyThrow(File.Exists(projectFile), "ProjectNotFoundError", projectFile);
+                    InitializationException.VerifyThrow(FileSystems.Default.FileExists(projectFile), "ProjectNotFoundError", projectFile);
                 }
             }
 
@@ -3275,7 +3275,7 @@ namespace Microsoft.Build.CommandLine
 
             // figure out whether the assembly's identity (strong/weak name), or its filename/path is provided
             string testFile = FileUtilities.FixFilePath(loggerAssemblySpec);
-            if (File.Exists(testFile))
+            if (FileSystems.Default.FileExists(testFile))
             {
                 loggerAssemblyFile = testFile;
             }
@@ -3426,7 +3426,7 @@ namespace Microsoft.Build.CommandLine
             {
                 InitializationException.VerifyThrow(schemaFile == null, "MultipleSchemasError", parameter);
                 string fileName = FileUtilities.FixFilePath(parameter);
-                InitializationException.VerifyThrow(File.Exists(fileName), "SchemaNotFoundError", fileName);
+                InitializationException.VerifyThrow(FileSystems.Default.FileExists(fileName), "SchemaNotFoundError", fileName);
 
                 schemaFile = Path.Combine(Directory.GetCurrentDirectory(), fileName);
             }

--- a/src/MSBuildTaskHost/FileSystem/MSBuildTaskHostFileSystem.cs
+++ b/src/MSBuildTaskHost/FileSystem/MSBuildTaskHostFileSystem.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Shared.FileSystem
+{
+    /// <summary>
+    /// Legacy implementation for MSBuildTaskHost which is stuck on net20 APIs
+    /// </summary>
+    internal class MSBuildTaskHostFileSystem : IFileSystem
+    {
+        private static readonly MSBuildTaskHostFileSystem Instance = new MSBuildTaskHostFileSystem();
+
+        public static MSBuildTaskHostFileSystem Singleton() => Instance;
+
+        public bool DirectoryEntryExists(string path)
+        {
+            return NativeMethodsShared.FileOrDirectoryExists(path);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            return NativeMethodsShared.DirectoryExists(path);
+        }
+
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return Directory.GetDirectories(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return Directory.GetFiles(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            ErrorUtilities.VerifyThrow(searchOption == SearchOption.TopDirectoryOnly, $"In net20 {nameof(Directory.GetFileSystemEntries)} does not take a {nameof(SearchOption)} parameter");
+
+            return Directory.GetFileSystemEntries(path, searchPattern);
+        }
+
+        public bool FileExists(string path)
+        {
+            return NativeMethodsShared.FileExists(path);
+        }
+    }
+}

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -171,14 +171,16 @@
       <Link>OutOfProcTaskHostTaskResult.cs</Link>
     </Compile>
     <Compile Include="..\Shared\TaskLoader.cs" />
-    <Compile Include="..\Shared\LoadedType.cs">
-    </Compile>
-    <Compile Include="..\Shared\AssemblyLoadInfo.cs">
-    </Compile>
+    <Compile Include="..\Shared\LoadedType.cs" />
+    <Compile Include="..\Shared\AssemblyLoadInfo.cs" />
     <Compile Include="..\Shared\TaskHostTaskCancelled.cs" />
     <Compile Include="..\Shared\TaskParameter.cs" />
-    <Compile Include="..\Shared\AssemblyNameExtension.cs">
-    </Compile>
+    <Compile Include="..\Shared\AssemblyNameExtension.cs" />
+
+    <Compile Include="..\Shared\FileSystem\IFileSystem.cs" />
+    <Compile Include="..\Shared\FileSystem\FileSystems.cs" />
+    <Compile Include="FileSystem\MSBuildTaskHostFileSystem.cs" />
+
     <Compile Include="..\MSBuild\NodeEndpointOutOfProcTaskHost.cs" />
     <Compile Include="..\MSBuild\OutOfProcTaskHostNode.cs" />
     <Compile Include="..\MSBuild\OutOfProcTaskAppDomainWrapperBase.cs">

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -191,8 +192,8 @@ namespace Microsoft.Build.Shared
 
             // We're not in VS, check for MSBuild.exe / dll to consider this a standalone environment.
             string msBuildPath = null;
-            if (File.Exists(msBuildExe)) msBuildPath = msBuildExe;
-            else if (File.Exists(msBuildDll)) msBuildPath = msBuildDll;
+            if (FileSystems.Default.FileExists(msBuildExe)) msBuildPath = msBuildExe;
+            else if (FileSystems.Default.FileExists(msBuildDll)) msBuildPath = msBuildDll;
 
             if (!string.IsNullOrEmpty(msBuildPath))
             {
@@ -215,7 +216,7 @@ namespace Microsoft.Build.Shared
                 Regex.IsMatch(msbuildAssembly, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*", RegexOptions.IgnoreCase))
             {
                 // In a Visual Studio path we must have MSBuild.exe
-                if (File.Exists(msbuildExe))
+                if (FileSystems.Default.FileExists(msbuildExe))
                 {
                     return new BuildEnvironment(
                         BuildEnvironmentMode.VisualStudio,
@@ -243,7 +244,7 @@ namespace Microsoft.Build.Shared
             var vsVersion = s_getEnvironmentVariable("VisualStudioVersion");
 
             if (string.IsNullOrEmpty(vsInstallDir) || string.IsNullOrEmpty(vsVersion) ||
-                vsVersion != CurrentVisualStudioVersion || !Directory.Exists(vsInstallDir)) return null;
+                vsVersion != CurrentVisualStudioVersion || !FileSystems.Default.DirectoryExists(vsInstallDir)) return null;
 
             return new BuildEnvironment(
                 BuildEnvironmentMode.VisualStudio,
@@ -264,7 +265,7 @@ namespace Microsoft.Build.Shared
 
             Version v = new Version(CurrentVisualStudioVersion);
             var instances = s_getVisualStudioInstances()
-                .Where(i => i.Version.Major == v.Major && Directory.Exists(i.Path))
+                .Where(i => i.Version.Major == v.Major && FileSystems.Default.DirectoryExists(i.Path))
                 .ToList();
 
             if (instances.Count == 0) return null;
@@ -300,7 +301,7 @@ namespace Microsoft.Build.Shared
 
         private static BuildEnvironment TryFromStandaloneMSBuildExe(string msBuildExePath)
         {
-            if (!string.IsNullOrEmpty(msBuildExePath) && File.Exists(msBuildExePath))
+            if (!string.IsNullOrEmpty(msBuildExePath) && FileSystems.Default.FileExists(msBuildExePath))
             {
                 // MSBuild.exe was found outside of Visual Studio. Assume Standalone mode.
                 return new BuildEnvironment(

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -117,7 +118,7 @@ namespace Microsoft.Build.Shared
                                 cultureSubfolder,
                                 $"{assemblyName.Name}.{extension}");
                             if (IsAssemblyAlreadyLoaded(candidatePath) ||
-                                !File.Exists(candidatePath))
+                                !FileSystems.Default.FileExists(candidatePath))
                             {
                                 continue;
                             }

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Security;
 using System.Threading;
 using System.Xml;
+using Microsoft.Build.Shared.FileSystem;
 #if FEATURE_VARIOUS_EXCEPTIONS
 using System.Xml.Schema;
 using System.Runtime.Serialization;
@@ -324,7 +325,7 @@ namespace Microsoft.Build.Shared
 
                     // For some reason we get Watson buckets because GetTempPath gives us a folder here that doesn't exist.
                     // Either because %TMP% is misdefined, or because they deleted the temp folder during the build.
-                    if (!Directory.Exists(DebugDumpPath))
+                    if (!FileSystems.Default.DirectoryExists(DebugDumpPath))
                     {
                         // If this throws, no sense catching it, we can't log it now, and we're here
                         // because we're a child node with no console to log to, so die

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1751,20 +1751,20 @@ namespace Microsoft.Build.Shared
                     excludeSpecsUnescaped);
             }
 
-            var filesKey = ComputeFileEnumerationCacheKey(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
+            var enumerationKey = ComputeFileEnumerationCacheKey(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped);
 
             ImmutableArray<string> files;
-            if (!_cachedGlobExpansions.TryGetValue(filesKey, out files))
+            if (!_cachedGlobExpansions.TryGetValue(enumerationKey, out files))
             {
                 // avoid parallel evaluations of the same wildcard by using a unique lock for each wildcard
-                object locks = _cachedGlobExpansionsLock.Value.GetOrAdd(filesKey, _ => new object());
+                object locks = _cachedGlobExpansionsLock.Value.GetOrAdd(enumerationKey, _ => new object());
                 lock (locks)
                 {
-                    if (!_cachedGlobExpansions.TryGetValue(filesKey, out files))
+                    if (!_cachedGlobExpansions.TryGetValue(enumerationKey, out files))
                     {
                         files =
                             _cachedGlobExpansions.GetOrAdd(
-                                filesKey,
+                                enumerationKey,
                                 (_) =>
                                     GetFilesImplementation(
                                         projectDirectoryUnescaped,
@@ -1786,12 +1786,26 @@ namespace Microsoft.Build.Shared
             Debug.Assert(projectDirectoryUnescaped != null);
             Debug.Assert(filespecUnescaped != null);
 
-            var sb = new StringBuilder();
-
             if (filespecUnescaped.Contains(".."))
             {
                 filespecUnescaped = FileUtilities.GetFullPathNoThrow(filespecUnescaped);
             }
+
+            var excludeSize = 0;
+
+            if (excludes != null)
+            {
+                foreach (var exclude in excludes)
+                {
+                    excludeSize += exclude.Length;
+                }
+            }
+
+            var sb = new StringBuilder(
+                projectDirectoryUnescaped.Length + // OK to over allocate a bit, this is a short lived object
+                filespecUnescaped.Length +
+                excludeSize
+                );
 
             // Don't include the project directory when the glob is independent of it.
             // Otherwise, if the project-directory-independent glob is used in multiple projects we'll get cache misses

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1731,12 +1731,13 @@ namespace Microsoft.Build.Shared
         /// <param name="excludeSpecsUnescaped">Exclude files that match this file spec.</param>
         /// <returns>The array of files.</returns>
         internal string[] GetFiles
-        (
+            (
             string projectDirectoryUnescaped,
             string filespecUnescaped,
-            IEnumerable<string> excludeSpecsUnescaped = null
-        )
+            List<string> excludeSpecsUnescaped = null
+            )
         {
+
             // For performance. Short-circuit iff there is no wildcard.
             if (!HasWildcards(filespecUnescaped))
             {
@@ -1781,7 +1782,7 @@ namespace Microsoft.Build.Shared
             return filesToReturn;
         }
 
-        private static string ComputeFileEnumerationCacheKey(string projectDirectoryUnescaped, string filespecUnescaped, IEnumerable<string> excludes)
+        private static string ComputeFileEnumerationCacheKey(string projectDirectoryUnescaped, string filespecUnescaped, List<string> excludes)
         {
             Debug.Assert(projectDirectoryUnescaped != null);
             Debug.Assert(filespecUnescaped != null);
@@ -2039,7 +2040,7 @@ namespace Microsoft.Build.Shared
             return ((value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z'));
         }
 
-        static string[] CreateArrayWithSingleItemIfNotExcluded(string filespecUnescaped, IEnumerable<string> excludeSpecsUnescaped)
+        static string[] CreateArrayWithSingleItemIfNotExcluded(string filespecUnescaped, List<string> excludeSpecsUnescaped)
         {
             if (excludeSpecsUnescaped != null)
             {
@@ -2076,7 +2077,7 @@ namespace Microsoft.Build.Shared
         private string[] GetFilesImplementation(
             string projectDirectoryUnescaped,
             string filespecUnescaped,
-            IEnumerable<string> excludeSpecsUnescaped)
+            List<string> excludeSpecsUnescaped)
         {
             // UNDONE (perf): Short circuit the complex processing when we only have a path and a wildcarded filename
 

--- a/src/Shared/FileSystem/FileSystems.cs
+++ b/src/Shared/FileSystem/FileSystems.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Build.Shared.FileSystem
 
         private static IFileSystem GetFileSystem()
         {
+#if CLR2COMPATIBILITY
+            return MSBuildTaskHostFileSystem.Singleton();
+#else
             if (NativeMethodsShared.IsWindows)
             {
                 return MSBuildOnWindowsFileSystem.Singleton();
@@ -22,6 +25,7 @@ namespace Microsoft.Build.Shared.FileSystem
             {
                 return ManagedFileSystem.Singleton();
             }
+#endif
         }
     }
 }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -4,7 +4,6 @@
 using System;
 #if !CLR2COMPATIBILITY
 using System.Collections.Concurrent;
-using Microsoft.Build.Shared.FileSystem;
 #endif
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,6 +17,7 @@ using System.Text.RegularExpressions;
 using System.Text;
 using System.Threading;
 using Microsoft.Build.Utilities;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -87,10 +87,10 @@ namespace Microsoft.Build.Shared
 
 #if !CLR2COMPATIBILITY
         private static readonly ConcurrentDictionary<string, bool> FileExistenceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-
-        private static readonly IFileSystem DefaultFileSystem = FileSystems.Default;
+#else
+        private static readonly Microsoft.Build.Shared.Concurrent.ConcurrentDictionary<string, bool> FileExistenceCache = new Microsoft.Build.Shared.Concurrent.ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 #endif
-
+        private static readonly IFileSystem DefaultFileSystem = FileSystems.Default;
         private enum GetFileAttributesResult
         {
             Directory,
@@ -736,26 +736,19 @@ namespace Microsoft.Build.Shared
         /// Returns if the directory exists
         /// </summary>
         /// <param name="fullPath">Full path to the directory in the filesystem</param>
+        /// <param name="fileSystem">The file system</param>
         /// <returns></returns>
-        internal static bool DirectoryExistsNoThrow(string fullPath
-#if !CLR2COMPATIBILITY
-            ,IFileSystem fileSystem = null
-#endif
-            )
+        internal static bool DirectoryExistsNoThrow(string fullPath, IFileSystem fileSystem = null)
         {
             fullPath = AttemptToShortenPath(fullPath);
 
             try
             {
-#if CLR2COMPATIBILITY
-                return NativeMethodsShared.DirectoryExists(fullPath);
-#else
                 fileSystem = fileSystem ?? DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
                     ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.DirectoryExists)
                     : fileSystem.DirectoryExists(fullPath);
-#endif
 
             }
             catch
@@ -768,26 +761,19 @@ namespace Microsoft.Build.Shared
         /// Returns if the directory exists
         /// </summary>
         /// <param name="fullPath">Full path to the file in the filesystem</param>
+        /// <param name="fileSystem">The file system</param>
         /// <returns></returns>
-        internal static bool FileExistsNoThrow(string fullPath
-#if !CLR2COMPATIBILITY
-            ,IFileSystem fileSystem = null
-#endif
-        )
+        internal static bool FileExistsNoThrow(string fullPath, IFileSystem fileSystem = null)
         {
             fullPath = AttemptToShortenPath(fullPath);
 
             try
             {
-#if CLR2COMPATIBILITY
-                return NativeMethodsShared.FileExists(fullPath);
-#else
                 fileSystem = fileSystem ?? DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
                     ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.FileExists)
                     : fileSystem.FileExists(fullPath);
-#endif
 
             }
             catch
@@ -802,26 +788,17 @@ namespace Microsoft.Build.Shared
         /// Does not throw IO exceptions, to match Directory.Exists and File.Exists.
         /// Unlike calling each of those in turn it only accesses the disk once, which is faster.
         /// </summary>
-        internal static bool FileOrDirectoryExistsNoThrow(string fullPath
-#if !CLR2COMPATIBILITY
-        ,IFileSystem fileSystem = null
-#endif
-        )
+        internal static bool FileOrDirectoryExistsNoThrow(string fullPath, IFileSystem fileSystem = null)
         {
             fullPath = AttemptToShortenPath(fullPath);
 
             try
             {
-#if CLR2COMPATIBILITY
-                return NativeMethodsShared.FileOrDirectoryExists(fullPath);
-#else
                 fileSystem = fileSystem ?? DefaultFileSystem;
 
                 return Traits.Instance.CacheFileExistence
                     ? FileExistenceCache.GetOrAdd(fullPath, fileSystem.DirectoryEntryExists)
                     : fileSystem.DirectoryEntryExists(fullPath);
-#endif
-
             }
             catch
             {

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Shared
         {
             string cacheDirectory = GetCacheDirectory();
 
-            if (Directory.Exists(cacheDirectory))
+            if (DefaultFileSystem.DirectoryExists(cacheDirectory))
             {
                 DeleteDirectoryNoThrow(cacheDirectory, true);
             }
@@ -417,13 +417,13 @@ namespace Microsoft.Build.Shared
                 firstSlash = value.Substring(1).IndexOf('/') + 1;
             }
 
-            if (firstSlash > 0 && Directory.Exists(Path.Combine(baseDirectory, value.Substring(0, firstSlash))))
+            if (firstSlash > 0 && DefaultFileSystem.DirectoryExists(Path.Combine(baseDirectory, value.Substring(0, firstSlash))))
             {
                 return true;
             }
 
             // Check for actual files or directories under / that get missed by the above logic
-            if (firstSlash == 0 && value[0] == '/' && (Directory.Exists(value) || File.Exists(value)))
+            if (firstSlash == 0 && value[0] == '/' && DefaultFileSystem.DirectoryEntryExists(value))
             {
                 return true;
             }
@@ -640,7 +640,7 @@ namespace Microsoft.Build.Shared
             {
                 try
                 {
-                    if (Directory.Exists(path))
+                    if (DefaultFileSystem.DirectoryExists(path))
                     {
                         Directory.Delete(path, recursive);
                         break;
@@ -1150,7 +1150,7 @@ namespace Microsoft.Build.Shared
                 // If we successfully locate the file in the directory that we're
                 // looking in, simply return that location. Otherwise we'll
                 // keep moving up the tree.
-                if (File.Exists(possibleFileDirectory))
+                if (DefaultFileSystem.FileExists(possibleFileDirectory))
                 {
                     // We've found the file, return the directory we found it in
                     return lookInDirectory;

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -19,6 +19,7 @@ using PropertyElement = Microsoft.Build.Evaluation.ToolsetElement.PropertyElemen
 #endif
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -864,7 +865,7 @@ namespace Microsoft.Build.Shared
             if (!String.IsNullOrEmpty(combinedPath))
             {
                 combinedPath = Path.GetFullPath(combinedPath);
-                if (Directory.Exists(combinedPath))
+                if (FileSystems.Default.DirectoryExists(combinedPath))
                 {
                     return combinedPath;
                 }
@@ -1041,7 +1042,7 @@ namespace Microsoft.Build.Shared
             string programFilesReferenceAssemblyDirectory = Path.Combine(programFilesReferenceAssemblyLocation, versionPrefix);
             string referenceAssemblyDirectory = null;
 
-            if (Directory.Exists(programFilesReferenceAssemblyDirectory))
+            if (FileSystems.Default.DirectoryExists(programFilesReferenceAssemblyDirectory))
             {
                 referenceAssemblyDirectory = programFilesReferenceAssemblyDirectory;
             }
@@ -1339,7 +1340,7 @@ namespace Microsoft.Build.Shared
                 // .net was improperly uninstalled: msbuild.exe isn't there
                 if (this._hasMsBuild &&
                     generatedPathToDotNetFramework != null &&
-                    !File.Exists(Path.Combine(generatedPathToDotNetFramework, NativeMethodsShared.IsWindows ? "MSBuild.exe" : "mcs.exe")))
+                    !FileSystems.Default.FileExists(Path.Combine(generatedPathToDotNetFramework, NativeMethodsShared.IsWindows ? "MSBuild.exe" : "mcs.exe")))
                 {
                     return null;
                 }
@@ -1375,7 +1376,7 @@ namespace Microsoft.Build.Shared
                         frameworkPath = Path.Combine(frameworkPath, this.Version.ToString());
                     }
 
-                    if (!string.IsNullOrEmpty(frameworkPath) && Directory.Exists(frameworkPath))
+                    if (!string.IsNullOrEmpty(frameworkPath) && FileSystems.Default.DirectoryExists(frameworkPath))
                     {
                         generatedPathToDotNetFrameworkSdkTools = frameworkPath;
                     }
@@ -1477,7 +1478,7 @@ namespace Microsoft.Build.Shared
                     // when a user requests the 40 reference assembly path we don't need to read the redist list because we will not be chaining so we may as well just
                     // generate the path and save us some time.
                     string referencePath = GenerateReferenceAssemblyPath(FrameworkLocationHelper.programFilesReferenceAssemblyLocation, this.FrameworkName);
-                    if (Directory.Exists(referencePath))
+                    if (FileSystems.Default.DirectoryExists(referencePath))
                     {
                         this._pathToDotNetFrameworkReferenceAssemblies = FileUtilities.EnsureTrailingSlash(referencePath);
                     }

--- a/src/Shared/InprocTrackingNativeMethods.cs
+++ b/src/Shared/InprocTrackingNativeMethods.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
 #endif
 using System.Security;
+using Microsoft.Build.Shared.FileSystem;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.Permissions;
 #endif
@@ -207,7 +208,7 @@ namespace Microsoft.Build.Shared
                 string buildToolsPath = FrameworkLocationHelper.GeneratePathToBuildToolsForToolsVersion(MSBuildConstants.CurrentToolsVersion, DotNetFrameworkArchitecture.Current);
                 string fileTrackerPath = Path.Combine(buildToolsPath, fileTrackerDllName.Value);
 
-                if (!File.Exists(fileTrackerPath))
+                if (!FileSystems.Default.FileExists(fileTrackerPath))
                 {
                     throw new DllNotFoundException(fileTrackerDllName.Value);
                 }

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -529,7 +530,7 @@ namespace Microsoft.Build.Shared
                         // to unescape first.
                         string unescapedItemSpec = EscapingUtilities.UnescapeAll(itemSpec);
 
-                        if (File.Exists(unescapedItemSpec))
+                        if (FileSystems.Default.FileExists(unescapedItemSpec))
                         {
                             modifiedItemSpec = File.GetCreationTime(unescapedItemSpec).ToString(FileTimeFormat, null);
                         }
@@ -545,7 +546,7 @@ namespace Microsoft.Build.Shared
                         // to unescape first.
                         string unescapedItemSpec = EscapingUtilities.UnescapeAll(itemSpec);
 
-                        if (File.Exists(unescapedItemSpec))
+                        if (FileSystems.Default.FileExists(unescapedItemSpec))
                         {
                             modifiedItemSpec = File.GetLastAccessTime(unescapedItemSpec).ToString(FileTimeFormat, null);
                         }

--- a/src/Shared/TaskEngineAssemblyResolver.cs
+++ b/src/Shared/TaskEngineAssemblyResolver.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.Runtime.Loader;
 #endif
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.BackEnd.Logging
 {
@@ -101,7 +102,7 @@ namespace Microsoft.Build.BackEnd.Logging
             // Is this our task assembly?
             if (_taskAssemblyFile != null)
             {
-                if (File.Exists(_taskAssemblyFile))
+                if (FileSystems.Default.FileExists(_taskAssemblyFile))
                 {
                     try
                     {

--- a/src/Shared/TempFileUtilities.cs
+++ b/src/Shared/TempFileUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -91,7 +92,7 @@ namespace Microsoft.Build.Shared
 
                 string file = Path.Combine(directory, $"tmp{Guid.NewGuid():N}{extension}");
 
-                ErrorUtilities.VerifyThrow(!File.Exists(file), "Guid should be unique");
+                ErrorUtilities.VerifyThrow(!FileSystems.Default.FileExists(file), "Guid should be unique");
 
                 if (createFile)
                 {
@@ -133,7 +134,7 @@ namespace Microsoft.Build.Shared
                     ? GetTemporaryDirectory()
                     : System.IO.Path.Combine(System.IO.Path.GetTempPath(), name);
 
-                if (Directory.Exists(Path))
+                if (FileSystems.Default.DirectoryExists(Path))
                 {
                     Directory.Delete(Path, true);
                 }

--- a/src/Shared/TypeLoader.cs
+++ b/src/Shared/TypeLoader.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Threading;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Shared
 {
@@ -168,7 +169,7 @@ namespace Microsoft.Build.Shared
                     var assemblyNameInExecutableDirectory = Path.Combine(BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory,
                         Path.GetFileName(assemblyLoadInfo.AssemblyFile));
 
-                    if (File.Exists(assemblyNameInExecutableDirectory))
+                    if (FileSystems.Default.FileExists(assemblyNameInExecutableDirectory))
                     {
                         var simpleName = Path.GetFileNameWithoutExtension(assemblyLoadInfo.AssemblyFile);
                         loadedAssembly = Assembly.Load(new AssemblyName(simpleName));

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.UnitTests
 
             void Verify(string include, string[] excludes, bool shouldHaveNoMatches = false, string customMessage = null)
             {
-                string[] matchedFiles = FileMatcher.Default.GetFiles(testFolder.FolderPath, include, excludes);
+                string[] matchedFiles = FileMatcher.Default.GetFiles(testFolder.FolderPath, include, excludes?.ToList());
 
                 if (shouldHaveNoMatches)
                 {
@@ -1260,11 +1260,11 @@ namespace Microsoft.Build.UnitTests
                     Array.Sort(files);
                     Assert.Equal(new []{"a.cs", "b.cs", "c.cs"}, files);
 
-                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs"});
+                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new List<string>{"a.cs"});
                     Array.Sort(files);
                     Assert.Equal(new[] {"b.cs", "c.cs" }, files);
 
-                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new []{"a.cs", "c.cs"});
+                    files = FileMatcher.Default.GetFiles(testProject.TestRoot, "**/*.cs", new List<string>{"a.cs", "c.cs"});
                     Array.Sort(files);
                     Assert.Equal(new[] {"b.cs" }, files);
                 }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -17,6 +17,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.UnitTests;
 using Shouldly;
 using Xunit;
@@ -530,7 +531,7 @@ namespace Microsoft.Build.UnitTests
                 message = fileRelativePath + " doesn't exist, but it should.";
             }
 
-            Assert.True(File.Exists(Path.Combine(TempProjectDir, fileRelativePath)), message);
+            Assert.True(FileSystems.Default.FileExists(Path.Combine(TempProjectDir, fileRelativePath)), message);
         }
 
         /// <summary>
@@ -816,7 +817,7 @@ namespace Microsoft.Build.UnitTests
             {
                 try
                 {
-                    if (Directory.Exists(dir))
+                    if (FileSystems.Default.DirectoryExists(dir))
                     {
                         foreach (string directory in Directory.GetDirectories(dir))
                         {
@@ -1031,7 +1032,7 @@ namespace Microsoft.Build.UnitTests
         {
             for (int i = 0; i < files.Length; i++)
             {
-                if (File.Exists(files[i])) File.Delete(files[i]);
+                if (FileSystems.Default.FileExists(files[i])) File.Delete(files[i]);
             }
         }
 
@@ -1462,7 +1463,7 @@ namespace Microsoft.Build.UnitTests
                 return null;
             }
 
-            Assert.True(Directory.Exists(rootDirectory), $"Directory {rootDirectory} does not exist");
+            Assert.True(FileSystems.Default.DirectoryExists(rootDirectory), $"Directory {rootDirectory} does not exist");
 
             var result = new string[files.Length];
 
@@ -1479,10 +1480,10 @@ namespace Microsoft.Build.UnitTests
                 var directoryName = Path.GetDirectoryName(fullPath);
 
                 Directory.CreateDirectory(directoryName);
-                Assert.True(Directory.Exists(directoryName));
+                Assert.True(FileSystems.Default.DirectoryExists(directoryName));
 
                 File.WriteAllText(fullPath, string.Empty);
-                Assert.True(File.Exists(fullPath));
+                Assert.True(FileSystems.Default.FileExists(fullPath));
 
                 result[i] = fullPath;
             }
@@ -1514,13 +1515,13 @@ namespace Microsoft.Build.UnitTests
         {
             foreach (string path in paths)
             {
-                if (File.Exists(path))
+                if (FileSystems.Default.FileExists(path))
                 {
                     File.Delete(path);
                 }
 
                 string directory = Path.GetDirectoryName(path);
-                if (Directory.Exists(directory) && (Directory.GetFileSystemEntries(directory).Length == 0))
+                if (FileSystems.Default.DirectoryExists(directory) && (Directory.GetFileSystemEntries(directory).Length == 0))
                 {
                     Directory.Delete(directory);
                 }

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.UnitTests;
 using Xunit;
 
@@ -84,7 +85,7 @@ public class MSBuildTestAssemblyFixture : IDisposable
         while (currentFolder != null)
         {
             string potentialVersionsPropsPath = Path.Combine(currentFolder, "build", "Versions.props");
-            if (File.Exists(potentialVersionsPropsPath))
+            if (FileSystems.Default.FileExists(potentialVersionsPropsPath))
             {
                 var doc = XDocument.Load(potentialVersionsPropsPath);
                 var ns = doc.Root.Name.Namespace;

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -9,6 +9,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
@@ -266,7 +267,7 @@ namespace Microsoft.Build.UnitTests
         {
             var folder = WithTransientTestState(new TransientTestFolder(folderPath, createFolder));
 
-            Assert.True(!(createFolder ^ Directory.Exists(folder.FolderPath)));
+            Assert.True(!(createFolder ^ FileSystems.Default.DirectoryExists(folder.FolderPath)));
 
             return folder;
         }
@@ -534,7 +535,7 @@ namespace Microsoft.Build.UnitTests
             {
                 if (_expectedAsOutput)
                 {
-                    Assert.True(File.Exists(Path), $"A file expected as an output does not exist: {Path}");
+                    Assert.True(FileSystems.Default.FileExists(Path), $"A file expected as an output does not exist: {Path}");
                 }
             }
             finally

--- a/src/Tasks/Al.cs
+++ b/src/Tasks/Al.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -303,7 +304,7 @@ namespace Microsoft.Build.Tasks
                 pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }
 
-            if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))
+            if (String.IsNullOrEmpty(pathToTool) || !FileSystems.Default.FileExists(pathToTool))
             {
                 pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             }

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 using ProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 
@@ -128,7 +129,7 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
                     {
                         // This should never happen. Microsoft.Common.CurrentVersion.targets will not specify a AssemblyFoldersFromConfig search path
                         // if the specified (or default) file is not found.
-                        ErrorUtilities.VerifyThrow(File.Exists(_assemblyFolderConfigFile),
+                        ErrorUtilities.VerifyThrow(FileSystems.Default.FileExists(_assemblyFolderConfigFile),
                             $"The AssemblyFolders config file specified does not exist: {_assemblyFolderConfigFile}");
 
                         try

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text;
 
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 #if !FEATURE_ASSEMBLY_LOADFROM || MONO
 using System.Reflection.PortableExecutable;
 using System.Reflection.Metadata;
@@ -94,7 +95,7 @@ namespace Microsoft.Build.Tasks
 
                 try
                 {
-                    if (File.Exists(newLocation))
+                    if (FileSystems.Default.FileExists(newLocation))
                     {
                         assembly = Assembly.ReflectionOnlyLoadFrom(newLocation);
                     }
@@ -817,7 +818,7 @@ namespace Microsoft.Build.Tasks
         {
             using (var sr = new BinaryReader(File.OpenRead(path)))
             {
-                if (!File.Exists(path))
+                if (!FileSystems.Default.FileExists(path))
                 {
                     return string.Empty;
                 }

--- a/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
+++ b/src/Tasks/AssemblyDependency/GenerateBindingRedirects.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System.Reflection;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -103,7 +104,7 @@ namespace Microsoft.Build.Tasks
 
             var writeOutput = true;
 
-            if(File.Exists(OutputAppConfigFile.ItemSpec))
+            if(FileSystems.Default.FileExists(OutputAppConfigFile.ItemSpec))
             {
                 try
                 {

--- a/src/Tasks/AssemblyFolder.cs
+++ b/src/Tasks/AssemblyFolder.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Win32;
 
 namespace Microsoft.Build.Tasks
@@ -65,7 +66,7 @@ namespace Microsoft.Build.Tasks
                             if (product.ValueCount > 0)
                             {
                                 string folder = (string)product.GetValue("");
-                                if (Directory.Exists(folder))
+                                if (FileSystems.Default.DirectoryExists(folder))
                                 {
                                     string regkeyAlias = aliasKey + "\\" + productName;
                                     directories[regkeyAlias] = folder;

--- a/src/Tasks/AxTlbBaseReference.cs
+++ b/src/Tasks/AxTlbBaseReference.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -122,7 +123,7 @@ namespace Microsoft.Build.Tasks
             string wrapperPath = GetWrapperPath();
 
             // now see if the wrapper assembly actually exists
-            if (!File.Exists(wrapperPath))
+            if (!FileSystems.Default.FileExists(wrapperPath))
             {
                 return false;
             }
@@ -144,7 +145,7 @@ namespace Microsoft.Build.Tasks
             }
 
             // if wrapper doesn't exist, wrapper is obviously not up to date
-            if (!File.Exists(wrapperInfo.path))
+            if (!FileSystems.Default.FileExists(wrapperInfo.path))
             {
                 return false;
             }

--- a/src/Tasks/AxTlbBaseTask.cs
+++ b/src/Tasks/AxTlbBaseTask.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -127,8 +128,8 @@ namespace Microsoft.Build.Tasks
         {
             // Verify that a path for the tool exists -- if the tool doesn't exist in it 
             // we'll worry about that later
-            if ((String.IsNullOrEmpty(ToolPath) || !Directory.Exists(ToolPath)) &&
-                (String.IsNullOrEmpty(SdkToolsPath) || !Directory.Exists(SdkToolsPath)))
+            if ((String.IsNullOrEmpty(ToolPath) || !FileSystems.Default.DirectoryExists(ToolPath)) &&
+                (String.IsNullOrEmpty(SdkToolsPath) || !FileSystems.Default.DirectoryExists(SdkToolsPath)))
             {
                 Log.LogErrorWithCodeFromResources("AxTlbBaseTask.SdkOrToolPathNotSpecifiedOrInvalid", SdkToolsPath ?? "", ToolPath ?? "");
                 return false;
@@ -181,7 +182,7 @@ namespace Microsoft.Build.Tasks
             // Make sure that if KeyFile is defined, it's a real file.
             if (!String.IsNullOrEmpty(KeyFile))
             {
-                if (File.Exists(KeyFile))
+                if (FileSystems.Default.FileExists(KeyFile))
                 {
                     keyFileExists = true;
                 }

--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -16,6 +16,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.XPath;
 using System.Xml.Xsl;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 {
@@ -352,7 +353,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             string bootstrapperPath = BootstrapperPath;
             string setupSourceFile = System.IO.Path.Combine(bootstrapperPath, SETUP_BIN);
 
-            if (!File.Exists(setupSourceFile))
+            if (!FileSystems.Default.FileExists(setupSourceFile))
             {
                 _results.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.MissingSetupBin", SETUP_BIN, bootstrapperPath));
                 return false;
@@ -511,13 +512,13 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             string startDirectory = System.IO.Path.Combine(BootstrapperPath, RESOURCES_PATH);
             _cultures.Clear();
 
-            if (Directory.Exists(startDirectory))
+            if (FileSystems.Default.DirectoryExists(startDirectory))
             {
                 foreach (string subDirectory in Directory.GetDirectories(startDirectory))
                 {
                     string resourceDirectory = System.IO.Path.Combine(startDirectory, subDirectory);
                     string resourceFile = System.IO.Path.Combine(resourceDirectory, SETUP_RESOURCES_FILE);
-                    if (File.Exists(resourceFile))
+                    if (FileSystems.Default.FileExists(resourceFile))
                     {
                         var resourceDoc = new XmlDocument();
                         try
@@ -577,7 +578,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             XmlElement rootElement = _document.CreateElement("Products", BOOTSTRAPPER_NAMESPACE);
             string packagePath = PackagePath;
 
-            if (Directory.Exists(packagePath))
+            if (FileSystems.Default.DirectoryExists(packagePath))
             {
                 foreach (string strSubDirectory in Directory.GetDirectories(packagePath))
                 {
@@ -784,8 +785,8 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 // set up our validation logic by detecting the trace-switch enabled and whether or
                 //   not our files exist.
                 bool validate = true;
-                bool fileExists = File.Exists(filePath);
-                bool schemaExists = File.Exists(schemaPath);
+                bool fileExists = FileSystems.Default.FileExists(filePath);
+                bool schemaExists = FileSystems.Default.FileExists(schemaPath);
 
                 // if we're being asked to validate but we can't find the schema file, then
                 //   output something useful to tell user that we can't find the schema.
@@ -949,7 +950,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                                 string strLangManifestFilename = System.IO.Path.Combine(strLanguageDirectory, CHILD_MANIFEST_FILE);
                                 string strLangManifestSchemaFileName = System.IO.Path.Combine(SchemaPath, MANIFEST_FILE_SCHEMA);
 
-                                if (File.Exists(strLangManifestFilename))
+                                if (FileSystems.Default.FileExists(strLangManifestFilename))
                                 {
                                     // Load Package.xml
                                     XmlValidationResults packageValidationResults = new XmlValidationResults(strLangManifestFilename);
@@ -1458,7 +1459,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         {
                             if (resourceUpdater != null)
                             {
-                                if (!File.Exists(packageFileSource.Value))
+                                if (!FileSystems.Default.FileExists(packageFileSource.Value))
                                 {
                                     _results?.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.PackageResourceFileNotFound", packageFileSource.Value, builder.Name));
                                     fSucceeded = false;
@@ -1476,7 +1477,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                                     string strDestinationFileName = System.IO.Path.Combine(settings.OutputPath, packageFileDestination.Value);
                                     try
                                     {
-                                        if (!File.Exists(packageFileSource.Value))
+                                        if (!FileSystems.Default.FileExists(packageFileSource.Value))
                                         {
                                             _results?.AddMessage(BuildMessage.CreateMessage(BuildMessageSeverity.Error, "GenerateBootstrapper.PackageFileNotFound", packageFileDestination.Value, builder.Name));
                                             fSucceeded = false;
@@ -1529,7 +1530,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                 // Add the Eula attribute correctly
                 if (eulas != null && !String.IsNullOrEmpty(eulaAttribute?.Value))
                 {
-                    if (File.Exists(eulaAttribute.Value))
+                    if (FileSystems.Default.FileExists(eulaAttribute.Value))
                     {
                         string key = GetFileHash(eulaAttribute.Value);
                         if (eulas.TryGetValue(key, out KeyValuePair<string, string> eulaInfo))
@@ -1587,7 +1588,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
         private static void EnsureFolderExists(string strFolderPath)
         {
-            if (!Directory.Exists(strFolderPath))
+            if (!FileSystems.Default.DirectoryExists(strFolderPath))
             {
                 Directory.CreateDirectory(strFolderPath);
             }
@@ -2045,7 +2046,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             XmlAttribute hashAttribute = packageFileNode.Attributes[HASH_ATTRIBUTE];
             XmlAttribute publicKeyAttribute = packageFileNode.Attributes[PUBLICKEY_ATTRIBUTE];
 
-            if (File.Exists(fileSource))
+            if (FileSystems.Default.FileExists(fileSource))
             {
                 string publicKey = GetPublicKeyOfFile(fileSource);
                 if (hashAttribute == null && publicKeyAttribute == null)
@@ -2111,7 +2112,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
         private static string GetPublicKeyOfFile(string fileSource)
         {
-            if (File.Exists(fileSource))
+            if (FileSystems.Default.FileExists(fileSource))
             {
                 try
                 {

--- a/src/Tasks/CodeTaskFactory.cs
+++ b/src/Tasks/CodeTaskFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -637,7 +638,7 @@ namespace Microsoft.Build.Tasks
                 {
                     try
                     {
-                        bool fileExists = File.Exists(referenceAssembly);
+                        bool fileExists = FileSystems.Default.FileExists(referenceAssembly);
                         if (!fileExists)
                         {
                             if (!referenceAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || !referenceAssembly.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
@@ -657,10 +658,10 @@ namespace Microsoft.Build.Tasks
                                         NativeMethodsShared.FrameworkCurrentPath,
                                         "Facades",
                                         Path.GetFileName(referenceAssembly));
-                                    if (!File.Exists(path))
+                                    if (!FileSystems.Default.FileExists(path))
                                     {
                                         var newPath = path + ".dll";
-                                        path = !File.Exists(newPath) ? path + ".exe" : newPath;
+                                        path = !FileSystems.Default.FileExists(newPath) ? path + ".exe" : newPath;
                                     }
                                     candidateAssembly = Assembly.UnsafeLoadFrom(path);
                                     if (candidateAssembly != null)

--- a/src/Tasks/Copy.cs
+++ b/src/Tasks/Copy.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -225,7 +226,7 @@ namespace Microsoft.Build.Tasks
 
             if (!string.IsNullOrEmpty(destinationFolder) && !_directoriesKnownToExist.ContainsKey(destinationFolder))
             {
-                if (!Directory.Exists(destinationFolder))
+                if (!FileSystems.Default.DirectoryExists(destinationFolder))
                 {
                     Log.LogMessageFromResources(MessageImportance.Normal, "Copy.CreatesDirectory", destinationFolder);
                     Directory.CreateDirectory(destinationFolder);
@@ -761,7 +762,7 @@ namespace Microsoft.Build.Tasks
                         }
                     }
 
-                    if (e is IOException && DestinationFolder != null && File.Exists(DestinationFolder.ItemSpec))
+                    if (e is IOException && DestinationFolder != null && FileSystems.Default.FileExists(DestinationFolder.ItemSpec))
                     {
                         // We failed to create the DestinationFolder because it's an existing file. No sense retrying.
                         // We don't check for this case upstream because it'd be another hit to the filesystem.

--- a/src/Tasks/Delete.cs
+++ b/src/Tasks/Delete.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -72,7 +73,7 @@ namespace Microsoft.Build.Tasks
                     // For speed, eliminate duplicates caused by poor targets authoring
                     if (!deletedFilesSet.Contains(file.ItemSpec))
                     {
-                        if (File.Exists(file.ItemSpec))
+                        if (FileSystems.Default.FileExists(file.ItemSpec))
                         {
                             // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
                             Log.LogMessageFromResources(MessageImportance.Normal, "Delete.DeletingFile", file.ItemSpec);

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -58,7 +59,7 @@ namespace Microsoft.Build.Tasks
         {
             this.filename = FileUtilities.FixFilePath(filename);
 
-            if (File.Exists(FileName))
+            if (FileSystems.Default.FileExists(FileName))
             {
                 lastModified = File.GetLastWriteTime(FileName);
                 exists = true;

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -520,7 +521,7 @@ namespace Microsoft.Build.Tasks
                 // Work around https://github.com/Microsoft/msbuild/issues/2273 and
                 // https://github.com/dotnet/corefx/issues/19110, which result in
                 // a bad path being returned above on Nano Server SKUs of Windows.
-                if (!File.Exists(systemCmd))
+                if (!FileSystems.Default.FileExists(systemCmd))
                 {
                     return Environment.GetEnvironmentVariable("ComSpec");
                 }
@@ -545,7 +546,7 @@ namespace Microsoft.Build.Tasks
             // If the working directory is UNC, we're going to use "pushd" in the batch file to set it.
             // If it's invalid, pushd won't fail: it will just go ahead and use the system folder.
             // So verify it's valid here.
-            if (!Directory.Exists(_workingDirectory))
+            if (!FileSystems.Default.DirectoryExists(_workingDirectory))
             {
                 throw new DirectoryNotFoundException(ResourceUtilities.FormatResourceString("Exec.InvalidWorkingDirectory", _workingDirectory));
             }

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Security.Cryptography;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -68,7 +69,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (var file in Files)
             {
-                if (!File.Exists(file.ItemSpec))
+                if (!FileSystems.Default.FileExists(file.ItemSpec))
                 {
                     Log.LogErrorFromResources("FileHash.FileNotFound", file.ItemSpec);
                 }

--- a/src/Tasks/FileIO/ReadLinesFromFile.cs
+++ b/src/Tasks/FileIO/ReadLinesFromFile.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -35,7 +36,7 @@ namespace Microsoft.Build.Tasks
             bool success = true;
             if (File != null)
             {
-                if (System.IO.File.Exists(File.ItemSpec))
+                if (FileSystems.Default.FileExists(File.ItemSpec))
                 {
                     try
                     {

--- a/src/Tasks/FileIO/VerifyFileHash.cs
+++ b/src/Tasks/FileIO/VerifyFileHash.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -37,7 +38,7 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
-            if (!System.IO.File.Exists(File))
+            if (!FileSystems.Default.FileExists(File))
             {
                 Log.LogErrorFromResources("FileHash.FileNotFound", File);
                 return false;

--- a/src/Tasks/FileState.cs
+++ b/src/Tasks/FileState.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -139,13 +140,13 @@ namespace Microsoft.Build.Tasks
                     else
                     {
                         // Check if we have a directory
-                        IsDirectory = Directory.Exists(_filename);
+                        IsDirectory = FileSystems.Default.DirectoryExists(_filename);
                         Exists = IsDirectory;
 
                         // If not exists, see if this is a file
                         if (!Exists)
                         {
-                            Exists = File.Exists(_filename);
+                            Exists = FileSystems.Default.FileExists(_filename);
                         }
 
                         if (IsDirectory)

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -40,6 +40,7 @@ using System.Runtime.Versioning;
 
 using Microsoft.Build.Utilities;
 using System.Xml.Linq;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -1010,7 +1011,7 @@ namespace Microsoft.Build.Tasks
                 {
                     foreach (ITaskItem outputFile in outputFiles)
                     {
-                        if (!File.Exists(outputFile.ItemSpec))
+                        if (!FileSystems.Default.FileExists(outputFile.ItemSpec))
                         {
                             _unsuccessfullyCreatedOutFiles.Add(outputFile.ItemSpec);
                         }
@@ -1049,7 +1050,7 @@ namespace Microsoft.Build.Tasks
                     {
                         foreach (ITaskItem outputFile in outputFiles)
                         {
-                            if (!File.Exists(outputFile.ItemSpec))
+                            if (!FileSystems.Default.FileExists(outputFile.ItemSpec))
                             {
                                 _unsuccessfullyCreatedOutFiles.Add(outputFile.ItemSpec);
                             }
@@ -1260,7 +1261,7 @@ namespace Microsoft.Build.Tasks
                 Sources[i].CopyMetadataTo(OutputResources[i]);
                 Sources[i].SetMetadata("OutputResource", OutputResources[i].ItemSpec);
 
-                if (!File.Exists(Sources[i].ItemSpec))
+                if (!FileSystems.Default.FileExists(Sources[i].ItemSpec))
                 {
                     // Error but continue with the files that do exist
                     Log.LogErrorWithCodeFromResources("GenerateResource.ResourceNotFound", Sources[i].ItemSpec);
@@ -1285,7 +1286,7 @@ namespace Microsoft.Build.Tasks
             {
                 // We're generating a STR class file, so there must be exactly one input resource file.
                 // If that resource file itself is out of date, the STR class file is going to get generated anyway.
-                if (nothingOutOfDate && File.Exists(Sources[0].ItemSpec))
+                if (nothingOutOfDate && FileSystems.Default.FileExists(Sources[0].ItemSpec))
                 {
                     GetStronglyTypedResourceToProcess(ref inputsToProcess, ref outputsToProcess);
                 }
@@ -2383,7 +2384,7 @@ namespace Microsoft.Build.Tasks
                         ITaskItem assemblyFile = _assemblyFiles[i];
                         _assemblyNames[i] = null;
 
-                        if (assemblyFile.ItemSpec != null && File.Exists(assemblyFile.ItemSpec))
+                        if (assemblyFile.ItemSpec != null && FileSystems.Default.FileExists(assemblyFile.ItemSpec))
                         {
                             string fusionName = assemblyFile.GetMetadata(ItemMetadataNames.fusionName);
                             if (!String.IsNullOrEmpty(fusionName))
@@ -2563,7 +2564,7 @@ namespace Microsoft.Build.Tasks
                         currentOutputDirectory = Path.Combine(priDirectory,
                             reader.cultureName ?? String.Empty);
 
-                        if (!Directory.Exists(currentOutputDirectory))
+                        if (!FileSystems.Default.DirectoryExists(currentOutputDirectory))
                         {
                             currentOutputDirectoryAlreadyExisted = false;
                             Directory.CreateDirectory(currentOutputDirectory);
@@ -2633,7 +2634,7 @@ namespace Microsoft.Build.Tasks
                         _logger.LogErrorWithCodeFromResources("GenerateResource.CannotWriteSTRFile",
                             _stronglyTypedFilename, e.Message);
 
-                        if (File.Exists(outFileOrDir)
+                        if (FileSystems.Default.FileExists(outFileOrDir)
                             && GetFormat(inFile) != Format.Assembly
                             // outFileOrDir is a directory when the input file is an assembly
                             && GetFormat(outFileOrDir) != Format.Assembly)
@@ -2655,7 +2656,7 @@ namespace Microsoft.Build.Tasks
                 {
                     _logger.LogErrorWithCodeFromResources("GenerateResource.CannotWriteOutput",
                         FileUtilities.GetFullPathNoThrow(currentOutputFile), io.Message);
-                    if (File.Exists(currentOutputFile))
+                    if (FileSystems.Default.FileExists(currentOutputFile))
                     {
                         if (GetFormat(currentOutputFile) != Format.Assembly)
                             // Never delete an assembly since we don't ever actually write to assemblies.
@@ -2744,7 +2745,7 @@ namespace Microsoft.Build.Tasks
             if (!success)
             {
                 string shorterPath = Path.Combine(outputDirectory ?? String.Empty, cultureName ?? String.Empty);
-                if (!Directory.Exists(shorterPath))
+                if (!FileSystems.Default.DirectoryExists(shorterPath))
                 {
                     Directory.CreateDirectory(shorterPath);
                 }
@@ -2946,7 +2947,7 @@ namespace Microsoft.Build.Tasks
         internal void ReadAssemblyResources(String name, String outFileOrDir)
         {
             // If something else in the solution failed to build...
-            if (!File.Exists(name))
+            if (!FileSystems.Default.FileExists(name))
             {
                 _logger.LogErrorWithCodeFromResources("GenerateResource.MissingFile", name);
                 return;

--- a/src/Tasks/GenerateTrustInfo.cs
+++ b/src/Tasks/GenerateTrustInfo.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 
@@ -42,7 +43,7 @@ namespace Microsoft.Build.Tasks
             }
 
             // Read trust-info from app.manifest
-            if (BaseManifest != null && File.Exists(BaseManifest.ItemSpec))
+            if (BaseManifest != null && FileSystems.Default.FileExists(BaseManifest.ItemSpec))
             {
                 try
                 {

--- a/src/Tasks/GetSDKReferenceFiles.cs
+++ b/src/Tasks/GetSDKReferenceFiles.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -1100,7 +1101,7 @@ namespace Microsoft.Build.Tasks
                     currentAssembly = Assembly.GetExecutingAssembly().CodeBase;
                     var codeBase = new Uri(currentAssembly);
                     DateTime currentCodeLastWriteTime = File.GetLastWriteTimeUtc(codeBase.LocalPath);
-                    if (File.Exists(referencesCacheFile) && currentCodeLastWriteTime < referencesCacheFileLastWriteTimeUtc)
+                    if (FileSystems.Default.FileExists(referencesCacheFile) && currentCodeLastWriteTime < referencesCacheFileLastWriteTimeUtc)
                     {
                         return true;
                     }

--- a/src/Tasks/MSBuild.cs
+++ b/src/Tasks/MSBuild.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -286,7 +287,7 @@ namespace Microsoft.Build.Tasks
                     break;
                 }
 
-                if (File.Exists(projectPath) || (_skipNonexistentProjects == SkipNonexistentProjectsBehavior.Build))
+                if (FileSystems.Default.FileExists(projectPath) || (_skipNonexistentProjects == SkipNonexistentProjectsBehavior.Build))
                 {
                     if (FileUtilities.IsVCProjFilename(projectPath))
                     {

--- a/src/Tasks/ManifestUtil/AssemblyIdentity.cs
+++ b/src/Tasks/ManifestUtil/AssemblyIdentity.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Serialization;
+using Microsoft.Build.Shared.FileSystem;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
@@ -179,7 +180,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <returns>The assembly identity of the specified file.</returns>
         public static AssemblyIdentity FromManifest(string path)
         {
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 return null;
             }
@@ -252,7 +253,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <returns>The assembly identity of the specified file.</returns>
         public static AssemblyIdentity FromManagedAssembly(string path)
         {
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 return null;
             }
@@ -290,7 +291,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <returns>The assembly identity of the specified file.</returns>
         public static AssemblyIdentity FromNativeAssembly(string path)
         {
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 return null;
             }
@@ -316,7 +317,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         /// <returns>The assembly identity of the specified file.</returns>
         public static AssemblyIdentity FromFile(string path)
         {
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 return null;
             }
@@ -513,14 +514,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             {
                 string file = String.Format(CultureInfo.InvariantCulture, "{0}.dll", _name);
                 string path = Path.Combine(searchPath, file);
-                if (File.Exists(path) && IsEqual(this, FromFile(path), specificVersion))
+                if (FileSystems.Default.FileExists(path) && IsEqual(this, FromFile(path), specificVersion))
                 {
                     return path;
                 }
 
                 file = String.Format(CultureInfo.InvariantCulture, "{0}.manifest", _name);
                 path = Path.Combine(searchPath, file);
-                if (File.Exists(path) && IsEqual(this, FromManifest(path), specificVersion))
+                if (FileSystems.Default.FileExists(path) && IsEqual(this, FromManifest(path), specificVersion))
                 {
                     return path;
                 }

--- a/src/Tasks/ManifestUtil/DeployManifest.cs
+++ b/src/Tasks/ManifestUtil/DeployManifest.cs
@@ -11,6 +11,7 @@ using System.Xml.Serialization;
 using Microsoft.Build.Utilities;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using System.Collections.Generic;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 {
@@ -144,7 +145,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 // Get the redistlist file path
                 string redistListFilePath = GetRedistListFilePath(referenceAssemblyPath);
 
-                if (File.Exists(redistListFilePath))
+                if (FileSystems.Default.FileExists(redistListFilePath))
                 {
                     installableFramework = GetInstallableFramework(redistListFilePath);
                 }
@@ -579,7 +580,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 {
                     manifestPath = Path.Combine(Path.GetDirectoryName(SourcePath), _entryPoint.TargetPath);
                 }
-                if (File.Exists(manifestPath))
+                if (FileSystems.Default.FileExists(manifestPath))
                 {
                     ApplicationManifest entryPointManifest = ManifestReader.ReadManifest(manifestPath, false) as ApplicationManifest;
                     if (entryPointManifest != null)

--- a/src/Tasks/ManifestUtil/Manifest.cs
+++ b/src/Tasks/ManifestUtil/Manifest.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 {
@@ -293,7 +294,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
             if (Path.IsPathRooted(path))
             {
-                if (File.Exists(path))
+                if (FileSystems.Default.FileExists(path))
                 {
                     return path;
                 }
@@ -310,7 +311,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 {
                     string resolvedPath = Path.Combine(searchPath, path);
                     resolvedPath = Path.GetFullPath(resolvedPath);
-                    if (File.Exists(resolvedPath))
+                    if (FileSystems.Default.FileExists(resolvedPath))
                     {
                         return resolvedPath;
                     }

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -21,6 +21,7 @@ using System.Security.Permissions;
 using System.Security.Policy;
 using System.Text;
 using System.Xml;
+using Microsoft.Build.Shared.FileSystem;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
@@ -162,7 +163,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 string path = Path.Combine(paths[0], PermissionSetsFolder);
 
                 // PermissionSets folder doesn't exit
-                if (Directory.Exists(path))
+                if (FileSystems.Default.DirectoryExists(path))
                 {
                     string[] files = Directory.GetFiles(path, "*.xml");
                     var filesInfo = new FileInfo[files.Length];
@@ -581,7 +582,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 throw new ArgumentNullException(nameof(path));
             }
 
-            if (!File.Exists(path))
+            if (!FileSystems.Default.FileExists(path))
             {
                 throw new FileNotFoundException(String.Format(CultureInfo.InvariantCulture, resources.GetString("SecurityUtil.SignTargetNotFound"), path), path);
             }
@@ -709,12 +710,12 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
 #pragma warning disable 618 // Disabling warning on using internal ToolLocationHelper API. At some point we should migrate this.
             string toolPath = ToolLocationHelper.GetPathToWindowsSdkFile(ToolName, TargetDotNetFrameworkVersion.VersionLatest, VisualStudioVersion.VersionLatest);
-            if (toolPath == null || !File.Exists(toolPath))
+            if (toolPath == null || !FileSystems.Default.FileExists(toolPath))
             {
                 toolPath = ToolLocationHelper.GetPathToWindowsSdkFile(ToolName, TargetDotNetFrameworkVersion.Version45,
                     VisualStudioVersion.Version110);
             }
-            if (toolPath == null || !File.Exists(toolPath))
+            if (toolPath == null || !FileSystems.Default.FileExists(toolPath))
             {
                 var pathToDotNetFrameworkSdk = ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.Version40, VisualStudioVersion.Version100);
                 if (pathToDotNetFrameworkSdk != null)
@@ -722,15 +723,15 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     toolPath = Path.Combine(pathToDotNetFrameworkSdk, "bin", ToolName);
                 }
             }
-            if (toolPath == null || !File.Exists(toolPath))
+            if (toolPath == null || !FileSystems.Default.FileExists(toolPath))
             {
                 toolPath = GetVersionIndependentToolPath(ToolName);
             }
-            if (toolPath == null || !File.Exists(toolPath))
+            if (toolPath == null || !FileSystems.Default.FileExists(toolPath))
             {
                 toolPath = Path.Combine(Directory.GetCurrentDirectory(), ToolName);
             }
-            if (!File.Exists(toolPath))
+            if (!FileSystems.Default.FileExists(toolPath))
             {
                 throw new ApplicationException(String.Format(CultureInfo.CurrentCulture,
                     resources.GetString("SecurityUtil.SigntoolNotFound"), toolPath));

--- a/src/Tasks/ManifestUtil/TrustInfo.cs
+++ b/src/Tasks/ManifestUtil/TrustInfo.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;
 using System.Xml;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 {
@@ -597,7 +598,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             Stream s = null;
             try
             {
-                if (File.Exists(path))
+                if (FileSystems.Default.FileExists(path))
                 {
                     s = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
                 }

--- a/src/Tasks/ManifestUtil/Util.cs
+++ b/src/Tasks/ManifestUtil/Util.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Security;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
 {
@@ -215,7 +216,7 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
             if (!logging) return null;
             string logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"Microsoft\VisualStudio\8.0\VSPLOG");
-            if (!Directory.Exists(logPath))
+            if (!FileSystems.Default.DirectoryExists(logPath))
                 Directory.CreateDirectory(logPath);
             return logPath;
         }

--- a/src/Tasks/Move.cs
+++ b/src/Tasks/Move.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -193,13 +194,13 @@ namespace Microsoft.Build.Tasks
             string destinationFile
         )
         {
-            if (Directory.Exists(destinationFile))
+            if (FileSystems.Default.DirectoryExists(destinationFile))
             {
                 Log.LogErrorWithCodeFromResources("Move.DestinationIsDirectory", sourceFile, destinationFile);
                 return false;
             }
 
-            if (Directory.Exists(sourceFile))
+            if (FileSystems.Default.DirectoryExists(sourceFile))
             {
                 // If the source file passed in is actually a directory instead of a file, log a nice
                 // error telling the user so.  Otherwise, .NET Framework's File.Move method will throw
@@ -209,21 +210,21 @@ namespace Microsoft.Build.Tasks
             }
 
             // Check the source exists.
-            if (!File.Exists(sourceFile))
+            if (!FileSystems.Default.FileExists(sourceFile))
             {
                 Log.LogErrorWithCodeFromResources("Move.SourceDoesNotExist", sourceFile);
                 return false;
             }
 
             // We can't ovewrite a file unless it's writeable
-            if (OverwriteReadOnlyFiles && File.Exists(destinationFile))
+            if (OverwriteReadOnlyFiles && FileSystems.Default.FileExists(destinationFile))
             {
                 MakeWriteableIfReadOnly(destinationFile);
             }
 
             string destinationFolder = Path.GetDirectoryName(destinationFile);
 
-            if (!string.IsNullOrEmpty(destinationFolder) && !Directory.Exists(destinationFolder))
+            if (!string.IsNullOrEmpty(destinationFolder) && !FileSystems.Default.DirectoryExists(destinationFolder))
             {
                 Log.LogMessageFromResources(MessageImportance.Normal, "Move.CreatesDirectory", destinationFolder);
                 Directory.CreateDirectory(destinationFolder);
@@ -258,7 +259,7 @@ namespace Microsoft.Build.Tasks
             // If the destination file exists, then make sure it's read-write.
             // The File.Move command copies attributes, but our move needs to
             // leave the file writeable.
-            if (File.Exists(destinationFile))
+            if (FileSystems.Default.FileExists(destinationFile))
             {
                 // Make it writable
                 MakeWriteableIfReadOnly(destinationFile);

--- a/src/Tasks/NativeMethods.cs
+++ b/src/Tasks/NativeMethods.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -855,12 +856,12 @@ namespace Microsoft.Build.Tasks
                 return MoveFileExWindows(existingFileName, newFileName, flags);
             }
 
-            if (!File.Exists(existingFileName))
+            if (!FileSystems.Default.FileExists(existingFileName))
             {
                 return false;
             }
 
-            var targetExists = File.Exists(newFileName);
+            var targetExists = FileSystems.Default.FileExists(newFileName);
 
             if (targetExists
                 && ((flags & MoveFileFlags.MOVEFILE_REPLACE_EXISTING) != MoveFileFlags.MOVEFILE_REPLACE_EXISTING))
@@ -1532,7 +1533,7 @@ typedef enum _tagAssemblyComparisonResult
                 }
                 else
                 {
-                    if (Directory.Exists(s_gacPath))
+                    if (FileSystems.Default.DirectoryExists(s_gacPath))
                     {
                         if (!string.IsNullOrWhiteSpace(assemblyName))
                         {
@@ -1658,7 +1659,7 @@ typedef enum _tagAssemblyComparisonResult
                 var path = Path.Combine(s_gacPath, assemblyNameVersion.Name);
 
                 // See if we can find the name as a directory in the GAC
-                if (Directory.Exists(path))
+                if (FileSystems.Default.DirectoryExists(path))
                 {
                     // Since we have a strong name, create the path to the dll
                     path = Path.Combine(
@@ -1671,7 +1672,7 @@ typedef enum _tagAssemblyComparisonResult
                                 .Aggregate(new StringBuilder(), (builder, v) => builder.Append(v.ToString("x2")))),
                         assemblyNameVersion.Name + ".dll");
 
-                    if (File.Exists(path))
+                    if (FileSystems.Default.FileExists(path))
                     {
                         return path;
                     }

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Xml;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -297,7 +298,7 @@ namespace Microsoft.Build.Tasks
                 {
                     string redistDirectory = Path.Combine(frameworkDirectory, RedistListFolder);
 
-                    if (Directory.Exists(redistDirectory))
+                    if (FileSystems.Default.DirectoryExists(redistDirectory))
                     {
                         results = Directory.GetFiles(redistDirectory, MatchPattern);
                         s_redistListPathCache.Add(frameworkDirectory, results);
@@ -1018,7 +1019,7 @@ namespace Microsoft.Build.Tasks
                         foreach (string subsetName in _subsetToSearchFor)
                         {
                             string subsetFilePath = Path.Combine(subsetDirectory, subsetName + ".xml");
-                            if (File.Exists(subsetFilePath))
+                            if (FileSystems.Default.FileExists(subsetFilePath))
                             {
                                 subsetFilesForFrameworkDirectory.Add(subsetFilePath);
                             }

--- a/src/Tasks/RegisterAssembly.cs
+++ b/src/Tasks/RegisterAssembly.cs
@@ -13,6 +13,7 @@ using System.Security;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -204,7 +205,7 @@ namespace Microsoft.Build.Tasks
 
             Log.LogMessageFromResources(MessageImportance.Low, "RegisterAssembly.RegisteringAssembly", assemblyPath);
 
-            if (!File.Exists(assemblyPath))
+            if (!FileSystems.Default.FileExists(assemblyPath))
             {
                 Log.LogErrorWithCodeFromResources("RegisterAssembly.RegisterAsmFileDoesNotExist", assemblyPath);
                 return false;
@@ -232,7 +233,7 @@ namespace Microsoft.Build.Tasks
                 Log.LogMessageFromResources(MessageImportance.Low, "RegisterAssembly.RegisteringTypeLib", typeLibPath);
 
                 // only regenerate the type lib if necessary
-                if ((!File.Exists(typeLibPath)) ||
+                if ((!FileSystems.Default.FileExists(typeLibPath)) ||
                     (File.GetLastWriteTime(typeLibPath) < File.GetLastWriteTime(assemblyPath)))
                 {
                     // Regenerate the type library

--- a/src/Tasks/RemoveDir.cs
+++ b/src/Tasks/RemoveDir.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -50,7 +51,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (ITaskItem directory in Directories)
             {
-                if (Directory.Exists(directory.ItemSpec))
+                if (FileSystems.Default.DirectoryExists(directory.ItemSpec))
                 {
                     // Do not log a fake command line as well, as it's superfluous, and also potentially expensive
                     Log.LogMessageFromResources(MessageImportance.Normal, "RemoveDir.Removing", directory.ItemSpec);

--- a/src/Tasks/ResGen.cs
+++ b/src/Tasks/ResGen.cs
@@ -8,6 +8,7 @@ using System.Text;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 using CodeDomProvider = System.CodeDom.Compiler.CodeDomProvider;
@@ -254,7 +255,7 @@ namespace Microsoft.Build.Tasks
 
                         for (int i = 0; i < outputFiles.Length; i++)
                         {
-                            if (File.Exists(outputFiles[i].ItemSpec))
+                            if (FileSystems.Default.FileExists(outputFiles[i].ItemSpec))
                             {
                                 successfullyGenerated.Add(outputFiles[i]);
                             }
@@ -271,7 +272,7 @@ namespace Microsoft.Build.Tasks
                     // was in fact generated
                     if (!success)
                     {
-                        if (!File.Exists(outputFile.ItemSpec))
+                        if (!FileSystems.Default.FileExists(outputFile.ItemSpec))
                         {
                             OutputFiles = Array.Empty<ITaskItem>();
                         }
@@ -434,8 +435,8 @@ namespace Microsoft.Build.Tasks
 
                 // Verify that the ToolPath exists -- if the tool doesn't exist in it 
                 // we'll worry about that later
-                if ((String.IsNullOrEmpty(ToolPath) || !Directory.Exists(ToolPath)) &&
-                    (String.IsNullOrEmpty(SdkToolsPath) || !Directory.Exists(SdkToolsPath)))
+                if ((String.IsNullOrEmpty(ToolPath) || !FileSystems.Default.DirectoryExists(ToolPath)) &&
+                    (String.IsNullOrEmpty(SdkToolsPath) || !FileSystems.Default.DirectoryExists(SdkToolsPath)))
                 {
                     Log.LogErrorWithCodeFromResources("ResGen.SdkOrToolPathNotSpecifiedOrInvalid", SdkToolsPath ?? "", ToolPath ?? "");
                     return false;
@@ -502,7 +503,7 @@ namespace Microsoft.Build.Tasks
                     {
                         pathToTool = Path.Combine(ToolPath, ToolExe);
 
-                        if (!File.Exists(pathToTool))
+                        if (!FileSystems.Default.FileExists(pathToTool))
                         {
                             pathToTool = null;
                         }

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -10,6 +10,7 @@ using System.Resources;
 using System.Xml;
 
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -201,7 +202,7 @@ namespace Microsoft.Build.Tasks
                 //
                 // filename is the filename of the .resx file that is to be examined.
 
-                if (File.Exists(FileName))
+                if (FileSystems.Default.FileExists(FileName))
                 {
                     linkedFiles = GetLinkedFiles(filename, baseLinkedFileDirectory);
                 }

--- a/src/Tasks/ResolveCodeAnalysisRuleSet.cs
+++ b/src/Tasks/ResolveCodeAnalysisRuleSet.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -81,7 +82,7 @@ namespace Microsoft.Build.Tasks
                 if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
                     string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
-                    if (File.Exists(fullName))
+                    if (FileSystems.Default.FileExists(fullName))
                     {
                         return CodeAnalysisRuleSet;
                     }
@@ -93,7 +94,7 @@ namespace Microsoft.Build.Tasks
                     foreach (string directory in CodeAnalysisRuleSetDirectories)
                     {
                         string fullName = Path.Combine(directory, CodeAnalysisRuleSet);
-                        if (File.Exists(fullName))
+                        if (FileSystems.Default.FileExists(fullName))
                         {
                             return fullName;
                         }
@@ -106,13 +107,13 @@ namespace Microsoft.Build.Tasks
                 if (!string.IsNullOrEmpty(MSBuildProjectDirectory))
                 {
                     string fullName = Path.Combine(MSBuildProjectDirectory, CodeAnalysisRuleSet);
-                    if (File.Exists(fullName))
+                    if (FileSystems.Default.FileExists(fullName))
                     {
                         return CodeAnalysisRuleSet;
                     }
                 }
             }
-            else if (File.Exists(CodeAnalysisRuleSet))
+            else if (FileSystems.Default.FileExists(CodeAnalysisRuleSet))
             {
                 // This is a full path.
                 return CodeAnalysisRuleSet;

--- a/src/Tasks/ResolveKeySource.cs
+++ b/src/Tasks/ResolveKeySource.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 #if FEATURE_PFX_SIGNING
 using Microsoft.Runtime.Hosting;
 #endif
@@ -201,7 +202,7 @@ namespace Microsoft.Build.Tasks
             {
 #if FEATURE_PFX_SIGNING
                 // if the cert isn't on disk, we can't import it
-                if (!File.Exists(CertificateFile))
+                if (!FileSystems.Default.FileExists(CertificateFile))
                 {
                     Log.LogErrorWithCodeFromResources("ResolveKeySource.CertificateNotInStore");
                 }

--- a/src/Tasks/ResolveNativeReference.cs
+++ b/src/Tasks/ResolveNativeReference.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
 using Microsoft.Build.Utilities;
 
@@ -109,7 +110,7 @@ namespace Microsoft.Build.Tasks
                 ITaskItem item = NativeReferences[reference];
                 string path = item.GetMetadata("HintPath");
                 // If no HintPath then fallback to trying to resolve from the assembly identity...
-                if (String.IsNullOrEmpty(path) || !File.Exists(path))
+                if (String.IsNullOrEmpty(path) || !FileSystems.Default.FileExists(path))
                 {
                     AssemblyIdentity ai = AssemblyIdentity.FromAssemblyName(item.ItemSpec);
                     if (ai != null)

--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactory.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -526,7 +527,7 @@ namespace Microsoft.Build.Tasks
             foreach (string reference in references)
             {
                 // The user specified a full path to an assembly, so there is no need to resolve
-                if (File.Exists(reference))
+                if (FileSystems.Default.FileExists(reference))
                 {
                     // The path could be relative like ..\Assembly.dll so we need to get the full path
                     resolvedAssemblyReferences.Add(Path.GetFullPath(reference));
@@ -712,12 +713,12 @@ namespace Microsoft.Build.Tasks
             }
             finally
             {
-                if (File.Exists(assemblyPath))
+                if (FileSystems.Default.FileExists(assemblyPath))
                 {
                     File.Delete(assemblyPath);
                 }
 
-                if (deleteSourceCodeFile && File.Exists(sourceCodePath))
+                if (deleteSourceCodeFile && FileSystems.Default.FileExists(sourceCodePath))
                 {
                     File.Delete(sourceCodePath);
                 }

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
@@ -186,7 +187,7 @@ namespace Microsoft.Build.Tasks
                 pathToTool = ToolLocationHelper.GetPathToDotNetFrameworkFile(ToolExe, TargetDotNetFrameworkVersion.Latest);
             }
 
-            if (String.IsNullOrEmpty(pathToTool) || !File.Exists(pathToTool))
+            if (String.IsNullOrEmpty(pathToTool) || !FileSystems.Default.FileExists(pathToTool))
             {
                 pathToTool = SdkToolsPathUtility.GeneratePathToTool(SdkToolsPathUtility.FileInfoExists, ProcessorArchitecture.CurrentProcessArchitecture, SdkToolsPath, ToolExe, Log, true);
             }
@@ -204,7 +205,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (string reference in References)
                 {
-                    if (!File.Exists(reference))
+                    if (!FileSystems.Default.FileExists(reference))
                     {
                         Log.LogErrorWithCodeFromResources("SGen.ResourceNotFound", reference);
                         return false;
@@ -293,7 +294,7 @@ namespace Microsoft.Build.Tasks
                     commandLineBuilder.AppendNestedSwitch("/compiler:", "/platform:", Platform);
                 }
 
-                serializationAssemblyPathExists = File.Exists(SerializationAssemblyPath);
+                serializationAssemblyPathExists = FileSystems.Default.FileExists(SerializationAssemblyPath);
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
             {

--- a/src/Tasks/SdkToolsPathUtility.cs
+++ b/src/Tasks/SdkToolsPathUtility.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Provide a method which can be used with a delegate to provide a specific FileExists behavior.
         ///
-        /// Use FileInfo instead of File.Exists(...) because the latter fails silently (by design) if CAS
+        /// Use FileInfo instead of FileSystems.Default.FileExists(...) because the latter fails silently (by design) if CAS
         /// doesn't grant access. We want the security exception if there is going to be one.
         /// </summary>
         /// <returns>True if the file exists. False if it does not</returns>

--- a/src/Tasks/StateFileBase.cs
+++ b/src/Tasks/StateFileBase.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -35,7 +36,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(stateFile))
                 {
-                    if (File.Exists(stateFile))
+                    if (FileSystems.Default.FileExists(stateFile))
                     {
                         File.Delete(stateFile);
                     }
@@ -71,7 +72,7 @@ namespace Microsoft.Build.Tasks
             // then we create one.  
             try
             {
-                if (!string.IsNullOrEmpty(stateFile) && File.Exists(stateFile))
+                if (!string.IsNullOrEmpty(stateFile) && FileSystems.Default.FileExists(stateFile))
                 {
                     using (FileStream s = new FileStream(stateFile, FileMode.Open))
                     {
@@ -133,7 +134,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (!string.IsNullOrEmpty(stateFile))
                 {
-                    if (File.Exists(stateFile))
+                    if (FileSystems.Default.FileExists(stateFile))
                     {
                         File.Delete(stateFile);
                     }

--- a/src/Tasks/UnregisterAssembly.cs
+++ b/src/Tasks/UnregisterAssembly.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices.ComTypes;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -144,7 +145,7 @@ namespace Microsoft.Build.Tasks
 
             Log.LogMessageFromResources(MessageImportance.Low, "UnregisterAssembly.UnregisteringAssembly", assemblyPath);
 
-            if (File.Exists(assemblyPath))
+            if (FileSystems.Default.FileExists(assemblyPath))
             {
                 try
                 {
@@ -218,7 +219,7 @@ namespace Microsoft.Build.Tasks
 
             Log.LogMessageFromResources(MessageImportance.Low, "UnregisterAssembly.UnregisteringTypeLib", typeLibPath);
 
-            if (File.Exists(typeLibPath))
+            if (FileSystems.Default.FileExists(typeLibPath))
             {
                 try
                 {

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Tasks
 {
@@ -75,7 +76,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem sourceFile in SourceFiles.TakeWhile(i => !_cancellationToken.IsCancellationRequested))
                 {
-                    if (!File.Exists(sourceFile.ItemSpec))
+                    if (!FileSystems.Default.FileExists(sourceFile.ItemSpec))
                     {
                         Log.LogErrorFromResources("Unzip.ErrorFileDoesNotExist", sourceFile.ItemSpec);
                         continue;

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Xaml;
 using System.IO;
 using Microsoft.Build.Shared;
-
+using Microsoft.Build.Shared.FileSystem;
 using XamlTypes = Microsoft.Build.Framework.XamlTypes;
 
 namespace Microsoft.Build.Tasks.Xaml
@@ -145,7 +145,7 @@ namespace Microsoft.Build.Tasks.Xaml
             {
                 // valid *absolute* file path
 
-                if (!File.Exists(contentOrFile))
+                if (!FileSystems.Default.FileExists(contentOrFile))
                     throw new ArgumentException(ResourceUtilities.FormatResourceString("Xaml.RuleFileNotFound", contentOrFile));
 
                 return ParseXamlDocument(new StreamReader(contentOrFile), desiredRule);
@@ -157,7 +157,7 @@ namespace Microsoft.Build.Tasks.Xaml
                 // Unable to convert to a path, parse as XML
                 return ParseXamlDocument(new StringReader(contentOrFile), desiredRule);
 
-            if (File.Exists(maybeFullPath))
+            if (FileSystems.Default.FileExists(maybeFullPath))
                 // file found, parse as a file
                 return ParseXamlDocument(new StreamReader(maybeFullPath), desiredRule);
 

--- a/src/Utilities/PlatformManifest.cs
+++ b/src/Utilities/PlatformManifest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Xml;
 using System.Collections.Generic;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Utilities
 {
@@ -90,7 +91,7 @@ namespace Microsoft.Build.Utilities
             {
                 string platformManifestPath = Path.Combine(_pathToManifest, "Platform.xml");
 
-                if (File.Exists(platformManifestPath))
+                if (FileSystems.Default.FileExists(platformManifestPath))
                 {
                     XmlDocument doc = new XmlDocument();
                     XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };

--- a/src/Utilities/SDKManifest.cs
+++ b/src/Utilities/SDKManifest.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Utilities
 {
@@ -309,7 +310,7 @@ namespace Microsoft.Build.Utilities
 
             try
             {
-                if (File.Exists(sdkManifestPath))
+                if (FileSystems.Default.FileExists(sdkManifestPath))
                 {
                     XmlDocument doc = new XmlDocument();
                     XmlReaderSettings readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -18,6 +18,7 @@ using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using UtilitiesDotNetFrameworkArchitecture = Microsoft.Build.Utilities.DotNetFrameworkArchitecture;
 using SharedDotNetFrameworkArchitecture = Microsoft.Build.Shared.DotNetFrameworkArchitecture;
 using System.Collections.ObjectModel;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;
 
 namespace Microsoft.Build.Utilities
@@ -824,7 +825,7 @@ namespace Microsoft.Build.Utilities
                         propsFileLocation = Path.Combine(sdkRoot, designTimeFolderName, commonConfigurationFolderName, neutralArchitectureName, targetPlatformIdentifier, targetPlatformVersion);
                     }
 
-                    if (Directory.Exists(propsFileLocation))
+                    if (FileSystems.Default.DirectoryExists(propsFileLocation))
                     {
                         return propsFileLocation;
                     }
@@ -1016,7 +1017,7 @@ namespace Microsoft.Build.Utilities
                 {
                     winmdLocation = Path.Combine(sdkRoot, referencesFolderName, commonConfigurationFolderName, neutralArchitectureName);
 
-                    if (!Directory.Exists(winmdLocation))
+                    if (!FileSystems.Default.DirectoryExists(winmdLocation))
                     {
                         ErrorUtilities.DebugTraceMessage("GetLegacyTargetPlatformReferences", "Target platform location '{0}' did not exist", winmdLocation);
                         winmdLocation = null;
@@ -1116,7 +1117,7 @@ namespace Microsoft.Build.Utilities
                 ErrorUtilities.DebugTraceMessage("GetApiContractReferences", "Gathering contract references for contract with name '{0}' and version '{1}", contract.Name, contract.Version);
                 string contractPath = Path.Combine(referencesRoot, contract.Name, contract.Version);
 
-                if (Directory.Exists(contractPath))
+                if (FileSystems.Default.DirectoryExists(contractPath))
                 {
                     string[] winmdPaths = Directory.GetFiles(contractPath, "*.winmd");
 
@@ -1620,7 +1621,7 @@ namespace Microsoft.Build.Utilities
             // return that directory.
             foreach (string referenceAssemblyDirectory in referenceAssemblyDirectories)
             {
-                if (File.Exists(Path.Combine(referenceAssemblyDirectory, "mscorlib.dll")))
+                if (FileSystems.Default.FileExists(Path.Combine(referenceAssemblyDirectory, "mscorlib.dll")))
                 {
                     // We found the framework reference assembly directory with mscorlib in it
                     // that's our standard lib path, so return it, with no trailing slash.
@@ -1694,7 +1695,7 @@ namespace Microsoft.Build.Utilities
                 }
 
                 string legacyMsCorlib20Path = FrameworkLocationHelper.GetPathToDotNetFrameworkV20(targetedArchitecture);
-                if (legacyMsCorlib20Path != null && File.Exists(Path.Combine(legacyMsCorlib20Path, "mscorlib.dll")))
+                if (legacyMsCorlib20Path != null && FileSystems.Default.FileExists(Path.Combine(legacyMsCorlib20Path, "mscorlib.dll")))
                 {
                     // We found the framework reference assembly directory with mscorlib in it
                     // that's our standard lib path, so return it, with no trailing slash.
@@ -1711,7 +1712,7 @@ namespace Microsoft.Build.Utilities
             // return that directory.
             foreach (string referenceAssemblyDirectory in referenceAssemblyDirectories)
             {
-                if (File.Exists(Path.Combine(referenceAssemblyDirectory, "mscorlib.dll")))
+                if (FileSystems.Default.FileExists(Path.Combine(referenceAssemblyDirectory, "mscorlib.dll")))
                 {
                     // We found the framework reference assembly directory with mscorlib in it
                     // that's our standard lib path, so return it, with no trailing slash.
@@ -2191,7 +2192,7 @@ namespace Microsoft.Build.Utilities
             var referencePaths = new List<string>();
 
             string path = FrameworkLocationHelper.GenerateReferenceAssemblyPath(targetFrameworkRootPath, frameworkName);
-            if (Directory.Exists(path))
+            if (FileSystems.Default.DirectoryExists(path))
             {
                 referencePaths.Add(path);
 
@@ -2214,7 +2215,7 @@ namespace Microsoft.Build.Utilities
                             {
                                 // On Mono, some directories contain Facades subdirectory with valid assemblies
                                 var facades = Path.Combine(path, "Facades");
-                                if (Directory.Exists(Path.Combine(path, "Facades")))
+                                if (FileSystems.Default.DirectoryExists(Path.Combine(path, "Facades")))
                                 {
                                     referencePaths.Add(facades);
                                 }
@@ -2498,7 +2499,7 @@ namespace Microsoft.Build.Utilities
                             string platformSDKManifest = Path.Combine(platformSDKDirectory, "SDKManifest.xml");
 
                             // If we are gathering the sdk platform manifests then check to see if there is a sdk manifest in the directory if not then skip over it as a platform sdk
-                            bool platformSDKManifestExists = File.Exists(platformSDKManifest);
+                            bool platformSDKManifestExists = FileSystems.Default.FileExists(platformSDKManifest);
                             if (targetPlatformSDK == null && !platformSDKs.TryGetValue(platformSDKKey, out targetPlatformSDK))
                             {
                                 targetPlatformSDK = new TargetPlatformSDK(platformSDKKey.TargetPlatformIdentifier, platformSDKKey.TargetPlatformVersion, platformSDKManifestExists ? platformSDKDirectory : null);
@@ -2770,7 +2771,7 @@ namespace Microsoft.Build.Utilities
                 if (userLocalAppData.Length > 0)
                 {
                     string localAppdataFolder = Path.Combine(userLocalAppData, "Microsoft SDKs");
-                    if (Directory.Exists(localAppdataFolder))
+                    if (FileSystems.Default.DirectoryExists(localAppdataFolder))
                     {
                         diskRoots.Add(localAppdataFolder);
                     }
@@ -2986,7 +2987,7 @@ namespace Microsoft.Build.Utilities
             string redistFile = Path.Combine(redistListFolder, "FrameworkList.xml");
 
             // If the redist list does not exist then the entire chain is incorrect.
-            if (!File.Exists(redistFile))
+            if (!FileSystems.Default.FileExists(redistFile))
             {
                 // Under MONO a directory may chain to one that has no redist list
                 var chainReference = NativeMethodsShared.IsMono ? string.Empty : null;
@@ -3081,13 +3082,13 @@ namespace Microsoft.Build.Utilities
                     pathToReturn = Path.GetFullPath(pathToReturn);
 
                     // The directory which we are chaining to does not exist, return null indicating the chain is incorrect.
-                    if (!Directory.Exists(pathToReturn))
+                    if (!FileSystems.Default.DirectoryExists(pathToReturn))
                     {
                         pathToReturn = null;
                     }
                 }
                 // We may also have a redirect path
-                else if (!string.IsNullOrEmpty(redirectPath) && Directory.Exists(redirectPath))
+                else if (!string.IsNullOrEmpty(redirectPath) && FileSystems.Default.DirectoryExists(redirectPath))
                 {
                     pathToReturn = redirectPath;
                 }
@@ -3242,7 +3243,7 @@ namespace Microsoft.Build.Utilities
 
             string filePath = Path.Combine(pathToSdk, fileName);
 
-            // Use FileInfo instead of File.Exists(...) because the latter fails silently (by design) if CAS
+            // Use FileInfo instead of FileSystems.Default.FileExists(...) because the latter fails silently (by design) if CAS
             // doesn't grant access. We want the security exception if there is going to be one.
             bool exists = new FileInfo(filePath).Exists;
             if (!exists)
@@ -3415,7 +3416,7 @@ namespace Microsoft.Build.Utilities
 
             string filePath = Path.Combine(pathToSdk, fileName);
 
-            // Use FileInfo instead of File.Exists(...) because the latter fails silently (by design) if CAS
+            // Use FileInfo instead of FileSystems.Default.FileExists(...) because the latter fails silently (by design) if CAS
             // doesn't grant access. We want the security exception if there is going to be one.
             bool exists = new FileInfo(filePath).Exists;
             if (!exists)
@@ -3482,7 +3483,7 @@ namespace Microsoft.Build.Utilities
             {
                 toolPath = Path.Combine(toolPath, fileName);
 
-                if (!File.Exists(toolPath))
+                if (!FileSystems.Default.FileExists(toolPath))
                 {
                     toolPath = null;
                 }
@@ -3703,7 +3704,7 @@ namespace Microsoft.Build.Utilities
                     string dotNetFx20Path = GetPathToDotNetFramework(TargetDotNetFrameworkVersion.Version20);
                     if (dotNetFx20Path != null)
                     {
-                        if (Directory.Exists(dotNetFx20Path))
+                        if (FileSystems.Default.DirectoryExists(dotNetFx20Path))
                         {
                             frameworkIdentifiers.Add(FrameworkLocationHelper.dotNetFrameworkIdentifier);
                         }
@@ -3855,14 +3856,14 @@ namespace Microsoft.Build.Utilities
 
                 // check v30
                 string dotNextFx30RefPath = Path.Combine(frameworkReferenceRoot, FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV30);
-                if (Directory.Exists(dotNextFx30RefPath))
+                if (FileSystems.Default.DirectoryExists(dotNextFx30RefPath))
                 {
                     versions.Add(FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV30);
                 }
 
                 // check v35
                 string dotNextFx35RefPath = Path.Combine(frameworkReferenceRoot, FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV35);
-                if (Directory.Exists(dotNextFx35RefPath))
+                if (FileSystems.Default.DirectoryExists(dotNextFx35RefPath))
                 {
                     versions.Add(FrameworkLocationHelper.dotNetFrameworkVersionFolderPrefixV35);
                 }

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Utilities
 {
@@ -452,7 +453,7 @@ namespace Microsoft.Build.Utilities
                 pathToTool = Path.Combine(ToolPath, ToolExe);
             }
 
-            if (string.IsNullOrWhiteSpace(pathToTool) || ToolPath == null && !File.Exists(pathToTool))
+            if (string.IsNullOrWhiteSpace(pathToTool) || ToolPath == null && !FileSystems.Default.FileExists(pathToTool))
             {
                 // Otherwise, try to find the tool ourselves.
                 pathToTool = GenerateFullPathToTool();
@@ -473,7 +474,7 @@ namespace Microsoft.Build.Utilities
                 bool isOnlyFileName = Path.GetFileName(pathToTool).Length == pathToTool.Length;
                 if (!isOnlyFileName)
                 {
-                    bool isExistingFile = File.Exists(pathToTool);
+                    bool isExistingFile = FileSystems.Default.FileExists(pathToTool);
                     if (!isExistingFile)
                     {
                         LogPrivate.LogErrorWithCodeFromResources("ToolTask.ToolExecutableNotFound", pathToTool);
@@ -1257,7 +1258,7 @@ namespace Microsoft.Build.Utilities
                     try
                     {
                         // The PATH can contain anything, including bad characters
-                        return Directory.Exists(path);
+                        return FileSystems.Default.DirectoryExists(path);
                     }
                     catch (Exception)
                     {
@@ -1265,7 +1266,7 @@ namespace Microsoft.Build.Utilities
                     }
                 })
                 .Select(folderPath => Path.Combine(folderPath, filename))
-                .FirstOrDefault(fullPath => !string.IsNullOrEmpty(fullPath) && File.Exists(fullPath));
+                .FirstOrDefault(fullPath => !string.IsNullOrEmpty(fullPath) && FileSystems.Default.FileExists(fullPath));
         }
 
         #endregion
@@ -1525,7 +1526,7 @@ namespace Microsoft.Build.Utilities
             finally
             {
                 // Clean up after ourselves.
-                if (_temporaryBatchFile != null && File.Exists(_temporaryBatchFile))
+                if (_temporaryBatchFile != null && FileSystems.Default.FileExists(_temporaryBatchFile))
                 {
                     DeleteTempFile(_temporaryBatchFile);
                 }

--- a/src/Utilities/TrackedDependencies/FileTracker.cs
+++ b/src/Utilities/TrackedDependencies/FileTracker.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 #if FEATURE_FILE_TRACKER
 
@@ -381,7 +382,7 @@ namespace Microsoft.Build.Utilities
 
                     trackerPath = Path.Combine(trackerPath, s_TrackerFilename);
 
-                    if (File.Exists(trackerPath))
+                    if (FileSystems.Default.FileExists(trackerPath))
                     {
                         return trackerPath;
                     }
@@ -481,7 +482,7 @@ namespace Microsoft.Build.Utilities
             {
                 trackerPath = Path.Combine(rootPath, filename);
 
-                if (!File.Exists(trackerPath))
+                if (!FileSystems.Default.FileExists(trackerPath))
                 {
                     // if an override path was specified, that's it -- we don't want to fall back if the file
                     // is not found there.
@@ -529,7 +530,7 @@ namespace Microsoft.Build.Utilities
                 string progfilesPath = Path.Combine(FrameworkLocationHelper.GenerateProgramFiles32(),
                     "MSBuild", MSBuildConstants.CurrentProductVersion, "FileTracker", s_FileTrackerFilename);
 
-                if (File.Exists(progfilesPath))
+                if (FileSystems.Default.FileExists(progfilesPath))
                 {
                     return progfilesPath;
                 }

--- a/src/Utilities/TrackedDependencies/FlatTrackingData.cs
+++ b/src/Utilities/TrackedDependencies/FlatTrackingData.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 #if FEATURE_FILE_TRACKER
 
@@ -651,7 +652,7 @@ namespace Microsoft.Build.Utilities
             else if (_tlogMarker != string.Empty)
             {
                 string markerDirectory = Path.GetDirectoryName(_tlogMarker);
-                if (!Directory.Exists(markerDirectory))
+                if (!FileSystems.Default.DirectoryExists(markerDirectory))
                 {
                     Directory.CreateDirectory(markerDirectory);
                 }

--- a/src/Utilities/TrackedDependencies/TrackedDependencies.cs
+++ b/src/Utilities/TrackedDependencies/TrackedDependencies.cs
@@ -6,6 +6,7 @@ using System.IO;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Utilities
 {
@@ -39,7 +40,7 @@ namespace Microsoft.Build.Utilities
                     // Very often with TLog files we're talking about
                     // a directory and a simply wildcarded filename
                     // Optimize for that case here.
-                    if (!FileMatcher.HasWildcards(directoryName) && Directory.Exists(directoryName))
+                    if (!FileMatcher.HasWildcards(directoryName) && FileSystems.Default.DirectoryExists(directoryName))
                     {
                         files = Directory.GetFiles(directoryName, searchPattern);
                     }


### PR DESCRIPTION
Based on #3480

Split of this PR from other stuff I am doing, since it is getting fairly large. And apparently it's open season for large sweeping edits :).
Replacing IO operations with IFileSystem seems like the healthy thing to do, as we'll be able to control the implementation for the entire codebase. Also, it will allow us to easily replace these calls with native implementations on Linux as well. Or, for example, eventually, to easily allow API users to define their own file system implementation.
