### PR TITLE
[WIP] Capture metaproj in binlog (#3402)

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Build.Framework
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public string metaProjectPath;
-        public MetaProjectGeneratedEventArgs(string metaProjectPath) { }
+        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -342,7 +342,8 @@ namespace Microsoft.Build.Framework
     }
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public MetaProjectGeneratedEventArgs() { }
+        public string metaProjectPath;
+        public MetaProjectGeneratedEventArgs(string metaProjectPath) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -342,8 +342,8 @@ namespace Microsoft.Build.Framework
     }
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public string metaProjectPath;
-        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message) { }
+        public string metaProjectXml;
+        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -340,10 +340,10 @@ namespace Microsoft.Build.Framework
         Low = 2,
         Normal = 1,
     }
-    public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class MetaprojectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public string metaProjectXml;
-        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message) { }
+        public string metaprojectXml;
+        public MetaprojectGeneratedEventArgs(string metaprojectXml, string metaprojectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IEventSource3 : Microsoft.Build.Framework.IEventSource, Microsoft.Build.Framework.IEventSource2
     {
+        void IncludeEvaluationMetaprojects();
         void IncludeEvaluationProfiles();
         void IncludeTaskInputs();
     }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -340,6 +340,10 @@ namespace Microsoft.Build.Framework
         Low = 2,
         Normal = 1,
     }
+    public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public MetaProjectGeneratedEventArgs() { }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -339,10 +339,10 @@ namespace Microsoft.Build.Framework
         Low = 2,
         Normal = 1,
     }
-    public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class MetaprojectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public string metaProjectXml;
-        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message) { }
+        public string metaprojectXml;
+        public MetaprojectGeneratedEventArgs(string metaprojectXml, string metaprojectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -341,8 +341,8 @@ namespace Microsoft.Build.Framework
     }
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public string metaProjectPath;
-        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message) { }
+        public string metaProjectXml;
+        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -339,6 +339,10 @@ namespace Microsoft.Build.Framework
         Low = 2,
         Normal = 1,
     }
+    public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public MetaProjectGeneratedEventArgs() { }
+    }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -341,7 +341,8 @@ namespace Microsoft.Build.Framework
     }
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
-        public MetaProjectGeneratedEventArgs() { }
+        public string metaProjectPath;
+        public MetaProjectGeneratedEventArgs(string metaProjectPath) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Build.Framework
     public partial class MetaProjectGeneratedEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public string metaProjectPath;
-        public MetaProjectGeneratedEventArgs(string metaProjectPath) { }
+        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message) { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(128), AllowMultiple=false, Inherited=false)]
     public sealed partial class OutputAttribute : System.Attribute

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IEventSource3 : Microsoft.Build.Framework.IEventSource, Microsoft.Build.Framework.IEventSource2
     {
+        void IncludeEvaluationMetaprojects();
         void IncludeEvaluationProfiles();
         void IncludeTaskInputs();
     }

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -224,6 +224,7 @@ namespace Microsoft.Build.Utilities
     public partial class MuxLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         public MuxLogger() { }
+        public bool IncludeEvaluationMetaprojects { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool IncludeEvaluationProfiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool IncludeTaskInputs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Build.Utilities
     public partial class MuxLogger : Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger
     {
         public MuxLogger() { }
+        public bool IncludeEvaluationMetaprojects { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool IncludeEvaluationProfiles { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public bool IncludeTaskInputs { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
         public string Parameters { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }

--- a/src/Build.UnitTests/BackEnd/MockLoggingService.cs
+++ b/src/Build.UnitTests/BackEnd/MockLoggingService.cs
@@ -187,6 +187,15 @@ namespace Microsoft.Build.UnitTests.BackEnd
         }
 
         /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        public bool IncludeEvaluationMetaprojects
+        {
+            get => false;
+            set { }
+        }
+
+        /// <summary>
         /// Should evaluation events include profiling information?
         /// </summary>
         public bool IncludeEvaluationProfile

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2031,7 +2031,7 @@ EndGlobal
                 ProjectCollection collection = new ProjectCollection();
                 collection.RegisterLogger(logger);
 
-                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
 
                 Version ver = new Version("4.34");
                 string message = ResourceUtilities.FormatResourceString("AspNetCompiler.TargetingHigherFrameworksDefaultsTo40", solution.ProjectsInOrder[0].ProjectName, ver.ToString());

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Build.UnitTests.Construction
 
         private string _originalVisualStudioVersion = null;
 
+        private static readonly BuildEventContext _buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
+
         public SolutionProjectGenerator_Tests(ITestOutputHelper output)
         {
             this.output = output;
@@ -147,9 +149,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", _buildEventContext, CreateMockLoggingService());
 
             Assert.Equal("3.5", instances[0].ToolsVersion);
         }
@@ -184,9 +185,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, "3.5", _buildEventContext, CreateMockLoggingService());
 
             Assert.Equal("3.5", instances[0].ToolsVersion);
         }
@@ -214,9 +214,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
             Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, instances[0].ToolsVersion);
 
@@ -257,9 +256,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
             Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, instances[0].ToolsVersion);
 
@@ -294,9 +292,8 @@ namespace Microsoft.Build.UnitTests.Construction
                 ";
 
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
             Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, instances[0].ToolsVersion);
             Assert.Equal("ABC", instances[0].SubToolsetVersion);
@@ -397,8 +394,6 @@ namespace Microsoft.Build.UnitTests.Construction
 
             string previousLegacyEnvironmentVariable = Environment.GetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION");
 
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
-
             try
             {
                 Environment.SetEnvironmentVariable("MSBUILDLEGACYDEFAULTTOOLSVERSION", "1");
@@ -412,7 +407,7 @@ namespace Microsoft.Build.UnitTests.Construction
 
                     sp.FullPath = solutionFile;
                     sp.ParseSolutionFile();
-                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, buildEventContext, CreateMockLoggingService());
+                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, _buildEventContext, CreateMockLoggingService());
 
                     MockLogger logger = new MockLogger(output);
                     List<ILogger> loggers = new List<ILogger>(1);
@@ -434,7 +429,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 sp1.FullPath = solutionFileMultipleProjects;
                 sp1.ParseSolutionFile();
 
-                ProjectInstance[] instances1 = SolutionProjectGenerator.Generate(sp1, null, null, buildEventContext, CreateMockLoggingService());
+                ProjectInstance[] instances1 = SolutionProjectGenerator.Generate(sp1, null, null, _buildEventContext, CreateMockLoggingService());
 
                 MockLogger logger1 = new MockLogger(output);
                 List<ILogger> loggers1 = new List<ILogger>(1);
@@ -498,9 +493,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 sp.FullPath = solutionFile;
                 sp.ParseSolutionFile();
 
-                var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
-
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, buildEventContext, CreateMockLoggingService());
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, _buildEventContext, CreateMockLoggingService());
 
                 Assert.Equal(ObjectModelHelpers.MSBuildDefaultToolsVersion, instances[0].ToolsVersion);
                 Assert.Equal("11.0", instances[0].SubToolsetVersion);
@@ -563,8 +556,7 @@ EndGlobal
 ".Replace("`", "\"");
 
                 SolutionFile sp = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-                var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, buildEventContext, CreateMockLoggingService());
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(sp, null, null, _buildEventContext, CreateMockLoggingService());
             }
            );
         }
@@ -798,9 +790,8 @@ EndGlobal
             ObjectModelHelpers.CreateFileInTempProjectDirectory("D.csproj", projectDeltaFileContents);
             var solution = new SolutionFile { FullPath = solutionFile };
             solution.ParseSolutionFile();
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            var instances = SolutionProjectGenerator.Generate(solution, null, null, buildEventContext, CreateMockLoggingService());
+            var instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, CreateMockLoggingService());
 
             var projectBravoMetaProject = instances[1];
             Assert.False(projectBravoMetaProject.Targets.Any(kvp => kvp.Value.Outputs.Equals("@()"))); // "The outputItem parameter can be null; the Target element should not have an Outputs attribute in that case."
@@ -1015,9 +1006,8 @@ EndGlobal
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
             var solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            var instance = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, buildEventContext, CreateMockLoggingService())[0];
+            var instance = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, _buildEventContext, CreateMockLoggingService())[0];
 
             foreach (ITaskItem item in instance.Items)
             {
@@ -1084,9 +1074,8 @@ EndGlobal
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
-            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, buildEventContext, CreateMockLoggingService());
+            ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, ObjectModelHelpers.MSBuildDefaultToolsVersion, _buildEventContext, CreateMockLoggingService());
 
             int i = 0;
             foreach (ProjectInstance instance in instances)
@@ -1159,13 +1148,12 @@ EndGlobal
 
             // We're not passing in a /tv:xx switch, so the solution project will have tools version 2.0
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
 
             string[] solutionToolsVersions = { "4.0", ObjectModelHelpers.MSBuildDefaultToolsVersion };
 
             foreach (string solutionToolsVersion in solutionToolsVersions)
             {
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, solutionToolsVersion, buildEventContext, CreateMockLoggingService());
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, solutionToolsVersion, _buildEventContext, CreateMockLoggingService());
 
                 Assert.Equal(2, instances.Length);
 
@@ -1221,14 +1209,13 @@ EndGlobal
 
             ProjectInstance[] instances = null;
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper(solutionFileContents);
-            var buildEventContext = new BuildEventContext(0, 0, BuildEventContext.InvalidProjectContextId, 0);
             bool caughtException = false;
 
             try
             {
                 // SolutionProjectGenerator.Generate() is used at build-time, and creates evaluation- and 
                 // execution-model projects; as such it will throw if fed an explicitly invalid toolsversion
-                instances = SolutionProjectGenerator.Generate(solution, null, "invalid", buildEventContext, CreateMockLoggingService());
+                instances = SolutionProjectGenerator.Generate(solution, null, "invalid", _buildEventContext, CreateMockLoggingService());
             }
             catch (InvalidProjectFileException)
             {
@@ -2044,7 +2031,7 @@ EndGlobal
                 ProjectCollection collection = new ProjectCollection();
                 collection.RegisterLogger(logger);
 
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
+                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
 
                 Version ver = new Version("4.34");
                 string message = ResourceUtilities.FormatResourceString("AspNetCompiler.TargetingHigherFrameworksDefaultsTo40", solution.ProjectsInOrder[0].ProjectName, ver.ToString());

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -1664,6 +1664,9 @@ EndGlobal
                 ";
 
             SolutionFile solution = null;
+            MockLogger logger = new MockLogger();
+            ProjectCollection collection = new ProjectCollection();
+            collection.RegisterLogger(logger);
 
             try
             {
@@ -1674,7 +1677,7 @@ EndGlobal
                 // Creating a ProjectRootElement shouldn't affect the ProjectCollection at all
                 Assert.Equal(0, ProjectCollection.GlobalProjectCollection.LoadedProjects.Count());
 
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, null);
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, BuildEventContext.Invalid, collection.LoggingService);
 
                 // Instantiating the
                 Assert.Equal(0, ProjectCollection.GlobalProjectCollection.LoadedProjects.Count());

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -1656,7 +1656,7 @@ namespace Microsoft.Build.Execution
 #if FEATURE_APPDOMAIN
                 , AppDomain.CurrentDomain.SetupInformation
 #endif
-                , new LoggingNodeConfiguration(loggingService.IncludeEvaluationProfile, loggingService.IncludeTaskInputs)
+                , new LoggingNodeConfiguration(loggingService.IncludeEvaluationMetaprojects, loggingService.IncludeEvaluationProfile, loggingService.IncludeTaskInputs)
                 );
             }
 

--- a/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
+++ b/src/Build/BackEnd/Components/Logging/EventSourceSink.cs
@@ -130,6 +130,15 @@ namespace Microsoft.Build.BackEnd.Logging
             set;
         }
 
+        /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        public bool IncludeEvaluationMetaprojects
+        {
+            get;
+            private set;
+        }
+
 
         /// <summary>
         /// Should evaluation events include profiling information?
@@ -154,6 +163,11 @@ namespace Microsoft.Build.BackEnd.Logging
         #region Methods
 
         #region IEventSource3 Methods
+
+        void IEventSource3.IncludeEvaluationMetaprojects()
+        {
+            IncludeEvaluationMetaprojects = true;
+        }
 
         void IEventSource3.IncludeEvaluationProfiles()
         {

--- a/src/Build/BackEnd/Components/Logging/ILoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/ILoggingService.cs
@@ -171,6 +171,15 @@ namespace Microsoft.Build.BackEnd.Logging
         }
 
         /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        bool IncludeEvaluationMetaprojects
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Should evaluation events include profiling information?
         /// </summary>
         bool IncludeEvaluationProfile

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -194,6 +194,11 @@ namespace Microsoft.Build.BackEnd.Logging
         private int _nodeId = 0;
 
         /// <summary>
+        /// Whether to include evaluation metaprojects in events.
+        /// </summary>
+        private bool? _includeEvaluationMetaprojects;
+
+        /// <summary>
         /// Whether to include evaluation profiles in events.
         /// </summary>
         private bool? _includeEvaluationProfile;
@@ -474,6 +479,15 @@ namespace Microsoft.Build.BackEnd.Logging
             get;
             set;
         } = null;
+
+        /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        public bool IncludeEvaluationMetaprojects
+        {
+            get => (_includeEvaluationMetaprojects = _includeEvaluationMetaprojects ?? _eventSinkDictionary.Values.OfType<EventSourceSink>().Any(sink => sink.IncludeEvaluationMetaprojects)).Value;
+            set => _includeEvaluationMetaprojects = value;
+        }
 
         /// <summary>
         /// Should evaluation events include profiling information?

--- a/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
+++ b/src/Build/BackEnd/Node/LoggingNodeConfiguration.cs
@@ -9,8 +9,11 @@ namespace Microsoft.Build.BackEnd
 {
     internal sealed class LoggingNodeConfiguration : INodePacketTranslatable
     {
+        private bool _includeEvaluationMetaprojects;
         private bool _includeEvaluationProfiles;
         private bool _includeTaskInputs;
+
+        public bool IncludeEvaluationMetaprojects => _includeEvaluationMetaprojects;
 
         public bool IncludeEvaluationProfiles => _includeEvaluationProfiles;
 
@@ -20,14 +23,16 @@ namespace Microsoft.Build.BackEnd
         {
         }
 
-        public LoggingNodeConfiguration(bool includeEvaluationProfiles, bool includeTaskInputs)
+        public LoggingNodeConfiguration(bool includeEvaluationMetaprojects, bool includeEvaluationProfiles, bool includeTaskInputs)
         {
+            _includeEvaluationMetaprojects = includeEvaluationMetaprojects;
             _includeEvaluationProfiles = includeEvaluationProfiles;
             _includeTaskInputs = includeTaskInputs;
         }
 
         void INodePacketTranslatable.Translate(INodePacketTranslator translator)
         {
+            translator.Translate(ref _includeEvaluationMetaprojects);
             translator.Translate(ref _includeEvaluationProfiles);
             translator.Translate(ref _includeTaskInputs);
         }

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -726,6 +726,10 @@ namespace Microsoft.Build.Execution
 
             _shutdownException = null;
 
+            if (configuration.LoggingNodeConfiguration.IncludeEvaluationMetaprojects)
+            {
+                _loggingService.IncludeEvaluationMetaprojects = true;
+            }
             if (configuration.LoggingNodeConfiguration.IncludeEvaluationProfiles)
             {
                 _loggingService.IncludeEvaluationProfile = true;

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -913,18 +913,21 @@ namespace Microsoft.Build.Construction
             {
                 metaproject.Save(path);
             }
+            if (_loggingService.IncludeEvaluationMetaprojects == true)
+            {
+                var xml = new StringBuilder();
+                using (var writer = new StringWriter(xml))
+                {
+                    metaproject.Save(writer);
+                }
 
-            var xml = new StringBuilder();
-            using (var writer = new StringWriter(xml))
-            {
-                metaproject.Save(writer);
+                string message = ResourceUtilities.GetResourceString("MetaprojectGenerated");
+                var eventArgs = new MetaprojectGeneratedEventArgs(xml.ToString(), path, message)
+                {
+                    BuildEventContext = _projectBuildEventContext,
+                };
+                _loggingService.LogBuildEvent(eventArgs);
             }
-            string message = ResourceUtilities.GetResourceString("MetaprojectGenerated");
-            var eventArgs = new MetaprojectGeneratedEventArgs(xml.ToString(), path, message)
-            {
-                BuildEventContext = _projectBuildEventContext,
-            };
-            _loggingService.LogBuildEvent(eventArgs);
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -911,7 +911,8 @@ namespace Microsoft.Build.Construction
         {
             string filePath = Environment.GetEnvironmentVariable("MSBuildEmitSolution") == null ? Path.GetTempFileName() : metaProjectPath;
             metaProject.Save(filePath);
-            var eventArgs = new MetaProjectGeneratedEventArgs(metaProjectPath)
+            string message = ResourceUtilities.GetResourceString("MetaprojectGenerated");
+            var eventArgs = new MetaProjectGeneratedEventArgs(metaProjectPath, message)
             {
                 BuildEventContext = _projectBuildEventContext,
                 ProjectFile = filePath,

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -745,6 +745,7 @@ namespace Microsoft.Build.Construction
                 foreach (ProjectInstance instance in projectInstances)
                 {
                     instance.ToProjectRootElement().Save(instance.FullPath);
+                    LogMetaProjectGeneratedEvent(instance.FullPath);
                 }
             }
 
@@ -885,7 +886,9 @@ namespace Microsoft.Build.Construction
             if (Environment.GetEnvironmentVariable("MSBUILDEMITSOLUTION") != null)
             {
                 string path = traversalProject.FullPath;
-                traversalProject.Save(_solutionFile.FullPath + ".metaproj.tmp");
+                string metaProjectPath = _solutionFile.FullPath + ".metaproj.tmp";
+                traversalProject.Save(metaProjectPath);
+                LogMetaProjectGeneratedEvent(metaProjectPath);
                 traversalProject.FullPath = path;
             }
 
@@ -910,6 +913,16 @@ namespace Microsoft.Build.Construction
             AddStandardTraversalTargets(traversalInstance, projectsInOrder);
 
             return traversalInstance;
+        }
+
+        private void LogMetaProjectGeneratedEvent(string fullPath)
+        {
+            var eventArgs = new MetaProjectGeneratedEventArgs()
+            {
+                BuildEventContext = _projectBuildEventContext,
+                ProjectFile = fullPath,
+            };
+            _loggingService.LogBuildEvent(eventArgs);
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Build.Construction
             // to represent the SLN.
             foreach (ProjectInstance instance in projectInstances)
             {
-                EmitMetaProject(instance.ToProjectRootElement(), instance.FullPath);
+                EmitMetaproject(instance.ToProjectRootElement(), instance.FullPath);
             }
 
             return projectInstances.ToArray();
@@ -785,8 +785,8 @@ namespace Microsoft.Build.Construction
                 // If we cannot build the project directly, then we need to generate a metaproject for it.
                 if (!canBuildDirectly)
                 {
-                    ProjectInstance metaProject = CreateMetaproject(traversalInstance, project, projectConfiguration);
-                    projectInstances.Add(metaProject);
+                    ProjectInstance metaproject = CreateMetaproject(traversalInstance, project, projectConfiguration);
+                    projectInstances.Add(metaproject);
                 }
             }
 
@@ -880,8 +880,8 @@ namespace Microsoft.Build.Construction
             // For debugging purposes: some information is lost when evaluating into a project instance,
             // so make it possible to see what we have at this point.
             string path = traversalProject.FullPath;
-            string metaProjectPath = _solutionFile.FullPath + ".metaproj.tmp";
-            EmitMetaProject(traversalProject, metaProjectPath);
+            string metaprojectPath = _solutionFile.FullPath + ".metaproj.tmp";
+            EmitMetaproject(traversalProject, metaprojectPath);
             traversalProject.FullPath = path;
 
             // Create the instance.  From this point forward we can evaluate conditions against the traversal project directly.
@@ -907,20 +907,20 @@ namespace Microsoft.Build.Construction
             return traversalInstance;
         }
 
-        private void EmitMetaProject(ProjectRootElement metaProject, string path)
+        private void EmitMetaproject(ProjectRootElement metaproject, string path)
         {
             if (Environment.GetEnvironmentVariable("MSBuildEmitSolution") != null)
             {
-                metaProject.Save(path);
+                metaproject.Save(path);
             }
 
             var xml = new StringBuilder();
             using (var writer = new StringWriter(xml))
             {
-                metaProject.Save(writer);
+                metaproject.Save(writer);
             }
             string message = ResourceUtilities.GetResourceString("MetaprojectGenerated");
-            var eventArgs = new MetaProjectGeneratedEventArgs(xml.ToString(), path, message)
+            var eventArgs = new MetaprojectGeneratedEventArgs(xml.ToString(), path, message)
             {
                 BuildEventContext = _projectBuildEventContext,
             };

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -907,15 +907,22 @@ namespace Microsoft.Build.Construction
             return traversalInstance;
         }
 
-        private void EmitMetaProject(ProjectRootElement metaProject, string metaProjectPath)
+        private void EmitMetaProject(ProjectRootElement metaProject, string path)
         {
-            string filePath = Environment.GetEnvironmentVariable("MSBuildEmitSolution") == null ? Path.GetTempFileName() : metaProjectPath;
-            metaProject.Save(filePath);
+            if (Environment.GetEnvironmentVariable("MSBuildEmitSolution") != null)
+            {
+                metaProject.Save(path);
+            }
+
+            var xml = new StringBuilder();
+            using (var writer = new StringWriter(xml))
+            {
+                metaProject.Save(writer);
+            }
             string message = ResourceUtilities.GetResourceString("MetaprojectGenerated");
-            var eventArgs = new MetaProjectGeneratedEventArgs(metaProjectPath, message)
+            var eventArgs = new MetaProjectGeneratedEventArgs(xml.ToString(), path, message)
             {
                 BuildEventContext = _projectBuildEventContext,
-                ProjectFile = filePath,
             };
             _loggingService.LogBuildEvent(eventArgs);
         }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1799,6 +1799,8 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             private TelemetryEventHandler _telemetryEventHandler;
 
+            private bool _includeEvaluationMetaprojects;
+
             private bool _includeEvaluationProfiles;
 
             private bool _includeTaskInputs;
@@ -1888,6 +1890,24 @@ namespace Microsoft.Build.Evaluation
             /// The telemetry sent event.
             /// </summary>
             public event TelemetryEventHandler TelemetryLogged;
+
+            /// <summary>
+            /// Should evaluation events include generated metaprojects?
+            /// </summary>
+            public void IncludeEvaluationMetaprojects()
+            {
+                if (_buildTimeEventSource is IEventSource3 buildEventSource3)
+                {
+                    buildEventSource3.IncludeEvaluationMetaprojects();
+                }
+
+                if (_designTimeEventSource is IEventSource3 designTimeEventSource3)
+                {
+                    designTimeEventSource3.IncludeEvaluationMetaprojects();
+                }
+
+                _includeEvaluationMetaprojects = true;
+            }
 
             /// <summary>
             /// Should evaluation events include profiling information?
@@ -2052,6 +2072,10 @@ namespace Microsoft.Build.Evaluation
 
                 if (eventSource is IEventSource3 eventSource3)
                 {
+                    if (_includeEvaluationMetaprojects)
+                    {
+                        eventSource3.IncludeEvaluationMetaprojects();
+                    }
                     if (_includeEvaluationProfiles)
                     {
                         eventSource3.IncludeEvaluationProfiles();

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -117,6 +117,11 @@ namespace Microsoft.Build.Logging
                 {
                     projectImportsCollector = new ProjectImportsCollector(FilePath);
                 }
+
+                if (eventSource is IEventSource3 eventSource3)
+                {
+                    eventSource3.IncludeEvaluationMetaprojects();
+                }
             }
             catch (Exception e)
             {

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Logging
             }
             else if (e is MetaProjectGeneratedEventArgs metaProjectArgs)
             {
-                projectImportsCollector.AddFile(metaProjectArgs.ProjectFile, metaProjectArgs.metaProjectPath);
+                projectImportsCollector.AddFileFromMemory(metaProjectArgs.ProjectFile, metaProjectArgs.metaProjectXml);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -198,17 +198,17 @@ namespace Microsoft.Build.Logging
 
         private void CollectImports(BuildEventArgs e)
         {
-            ProjectImportedEventArgs importArgs = e as ProjectImportedEventArgs;
-            if (importArgs != null && importArgs.ImportedProjectFile != null)
+            if (e is ProjectImportedEventArgs importArgs && importArgs.ImportedProjectFile != null)
             {
                 projectImportsCollector.AddFile(importArgs.ImportedProjectFile);
-                return;
             }
-
-            ProjectStartedEventArgs projectArgs = e as ProjectStartedEventArgs;
-            if (projectArgs != null)
+            else if (e is ProjectStartedEventArgs projectArgs)
             {
                 projectImportsCollector.AddFile(projectArgs.ProjectFile);
+            }
+            else if (e is MetaProjectGeneratedEventArgs metaProjectArgs)
+            {
+                projectImportsCollector.AddFile(metaProjectArgs.ProjectFile);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -206,9 +206,9 @@ namespace Microsoft.Build.Logging
             {
                 projectImportsCollector.AddFile(projectArgs.ProjectFile);
             }
-            else if (e is MetaProjectGeneratedEventArgs metaProjectArgs)
+            else if (e is MetaprojectGeneratedEventArgs metaprojectArgs)
             {
-                projectImportsCollector.AddFileFromMemory(metaProjectArgs.ProjectFile, metaProjectArgs.metaProjectXml);
+                projectImportsCollector.AddFileFromMemory(metaprojectArgs.ProjectFile, metaprojectArgs.metaprojectXml);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.Logging
             }
             else if (e is MetaProjectGeneratedEventArgs metaProjectArgs)
             {
-                projectImportsCollector.AddFile(metaProjectArgs.ProjectFile);
+                projectImportsCollector.AddFile(metaProjectArgs.ProjectFile, metaProjectArgs.metaProjectPath);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Build.Logging
@@ -47,12 +48,7 @@ namespace Microsoft.Build.Logging
 
         public void AddFile(string filePath)
         {
-            AddFile(filePath, filePath);
-        }
-
-        public void AddFile(string filePath, string archivePath)
-        {
-            if (filePath != null && archivePath != null && _fileStream != null)
+            if (filePath != null && _fileStream != null)
             {
                 lock (_fileStream)
                 {
@@ -62,7 +58,29 @@ namespace Microsoft.Build.Logging
                     {
                         try
                         {
-                            AddFileCore(filePath, archivePath);
+                            AddFileCore(filePath);
+                        }
+                        catch
+                        {
+                        }
+                    }, TaskScheduler.Default);
+                }
+            }
+        }
+
+        public void AddFileFromMemory(string filePath, string data)
+        {
+            if (filePath != null && data != null && _fileStream != null)
+            {
+                lock (_fileStream)
+                {
+                    // enqueue the task to add a file and return quickly
+                    // to avoid holding up the current thread
+                    _currentTask = _currentTask.ContinueWith(t =>
+                    {
+                        try
+                        {
+                            AddFileFromMemoryCore(filePath, data);
                         }
                         catch
                         {
@@ -76,7 +94,7 @@ namespace Microsoft.Build.Logging
         /// This method doesn't need locking/synchronization because it's only called
         /// from a task that is chained linearly
         /// </remarks>
-        private void AddFileCore(string filePath, string archivePath)
+        private void AddFileCore(string filePath)
         {
             // quick check to avoid repeated disk access for Exists etc.
             if (_processedFiles.Contains(filePath))
@@ -99,14 +117,46 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            ZipArchiveEntry archiveEntry = _zipArchive.CreateEntry(CalculateArchivePath(archivePath));
-            archiveEntry.LastWriteTime = fileInfo.LastWriteTime;
-
-            using (Stream entryStream = archiveEntry.Open())
+            using (Stream entryStream = OpenArchiveEntry(filePath, fileInfo.LastWriteTime))
             using (FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
             {
                 content.CopyTo(entryStream);
             }
+        }
+
+        /// <remarks>
+        /// This method doesn't need locking/synchronization because it's only called
+        /// from a task that is chained linearly
+        /// </remarks>
+        private void AddFileFromMemoryCore(string filePath, string data)
+        {
+            // quick check to avoid repeated disk access for Exists etc.
+            if (_processedFiles.Contains(filePath))
+            {
+                return;
+            }
+
+            filePath = Path.GetFullPath(filePath);
+
+            // if the file is already included, don't include it again
+            if (!_processedFiles.Add(filePath))
+            {
+                return;
+            }
+
+            using (Stream entryStream = OpenArchiveEntry(filePath, DateTime.UtcNow))
+            using (var content = new MemoryStream(Encoding.UTF8.GetBytes(data)))
+            {
+                content.CopyTo(entryStream);
+            }
+        }
+
+        private Stream OpenArchiveEntry(string filePath, DateTime lastWriteTime)
+        {
+            string archivePath = CalculateArchivePath(filePath);
+            var archiveEntry = _zipArchive.CreateEntry(archivePath);
+            archiveEntry.LastWriteTime = lastWriteTime;
+            return archiveEntry.Open();
         }
 
         private static string CalculateArchivePath(string filePath)

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1642,6 +1642,10 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>{StrBegin="MSB4231: "}</comment>
   </data>
 
+  <data name="MetaprojectGenerated">
+    <value>Metaproject &quot;{0}&quot; generated.</value>
+  </data>
+
   <data name="ProjectImportSkippedFalseCondition">
     <value>Project &quot;{0}&quot; was not imported by &quot;{1}&quot; at ({2},{3}), due to false condition; ({4}) was evaluated as ({5}).</value>
   </data>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Operaci nelze dokončit, protože funkce BeginBuild ještě nebyla zavolána.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Der Vorgang kann nicht abgeschlossen werden, da BeginBuild noch nicht aufgerufen wurde.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">La operación no se puede completar porque todavía no se llamó a BeginBuild.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Impossible d'effectuer l'opération car la méthode BeginBuild n'a pas encore été appelée.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Non è possibile completare l'operazione perché BeginBuild non è stato ancora chiamato.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">BeginBuild がまだ呼び出されていないため、操作を完了できません。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">BeginBuild가 아직 호출되지 않았으므로 작업을 완료할 수 없습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Nie można zakończyć operacji, ponieważ metoda BeginBuild nie została jeszcze wywołana.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">A operação não pode ser concluída porque BeginBuild ainda não foi chamado.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">Не удается завершить операцию, так как ещё не был вызван BeginBuild.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">BeginBuild henüz çağrılmadığı için işlem tamamlanamıyor.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">无法完成该操作，因为尚未调用 BeginBuild。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -33,6 +33,11 @@
     %(RootDir) to an item-spec that's not a valid path would result in this error.
     LOCALIZATION: "{1}" is a localized message explaining the problem.</note>
       </trans-unit>
+      <trans-unit id="MetaprojectGenerated">
+        <source>Metaproject "{0}" generated.</source>
+        <target state="new">Metaproject "{0}" generated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildInProgress">
         <source>The operation cannot be completed because BeginBuild has not yet been called.</source>
         <target state="translated">無法完成作業，因為尚未呼叫 BeginBuild。</target>

--- a/src/Framework/IEventSource3.cs
+++ b/src/Framework/IEventSource3.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Build.Framework
     public interface IEventSource3 : IEventSource2
     {
         /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        void IncludeEvaluationMetaprojects();
+
+        /// <summary>
         /// Should evaluation events include profiling information?
         /// </summary>
         void IncludeEvaluationProfiles();

--- a/src/Framework/MetaProjectGeneratedEventArgs.cs
+++ b/src/Framework/MetaProjectGeneratedEventArgs.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Microsoft.Build.Framework
+﻿namespace Microsoft.Build.Framework
 {
     public class MetaProjectGeneratedEventArgs : BuildMessageEventArgs
     {
+        public string metaProjectPath;
+
+        public MetaProjectGeneratedEventArgs(string metaProjectPath)
+        {
+            this.metaProjectPath = metaProjectPath;
+        }
     }
 }

--- a/src/Framework/MetaProjectGeneratedEventArgs.cs
+++ b/src/Framework/MetaProjectGeneratedEventArgs.cs
@@ -10,21 +10,21 @@ namespace Microsoft.Build.Framework
     /// Arguments for the metaproject generated event.
     /// </summary>
     [Serializable]
-    public class MetaProjectGeneratedEventArgs : BuildMessageEventArgs
+    public class MetaprojectGeneratedEventArgs : BuildMessageEventArgs
     {
         /// <summary>
         /// Raw xml representing the metaproject.
         /// </summary>
-        public string metaProjectXml;
+        public string metaprojectXml;
 
         /// <summary>
-        /// Initializes a new instance of the MetaProjectGeneratedEventArgs class.
+        /// Initializes a new instance of the MetaprojectGeneratedEventArgs class.
         /// </summary>
-        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message)
-            : base(message, null, null, MessageImportance.Low, DateTime.UtcNow, metaProjectPath)
+        public MetaprojectGeneratedEventArgs(string metaprojectXml, string metaprojectPath, string message)
+            : base(message, null, null, MessageImportance.Low, DateTime.UtcNow, metaprojectPath)
         {
-            this.metaProjectXml = metaProjectXml;
-            this.ProjectFile = metaProjectPath;
+            this.metaprojectXml = metaprojectXml;
+            this.ProjectFile = metaprojectPath;
         }
     }
 }

--- a/src/Framework/MetaProjectGeneratedEventArgs.cs
+++ b/src/Framework/MetaProjectGeneratedEventArgs.cs
@@ -1,10 +1,27 @@
-﻿namespace Microsoft.Build.Framework
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Build.Framework
 {
+    /// <summary>
+    /// Arguments for the metaproject generated event.
+    /// </summary>
+    [Serializable]
     public class MetaProjectGeneratedEventArgs : BuildMessageEventArgs
     {
+        /// <summary>
+        /// Path associated with metaproject.
+        /// </summary>
         public string metaProjectPath;
 
-        public MetaProjectGeneratedEventArgs(string metaProjectPath)
+        /// <summary>
+        /// Initializes a new instance of the MetaProjectGeneratedEventArgs class.
+        /// </summary>
+        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message)
+            : base(message, null, null, MessageImportance.Low, DateTime.UtcNow, metaProjectPath)
         {
             this.metaProjectPath = metaProjectPath;
         }

--- a/src/Framework/MetaProjectGeneratedEventArgs.cs
+++ b/src/Framework/MetaProjectGeneratedEventArgs.cs
@@ -13,17 +13,18 @@ namespace Microsoft.Build.Framework
     public class MetaProjectGeneratedEventArgs : BuildMessageEventArgs
     {
         /// <summary>
-        /// Path associated with metaproject.
+        /// Raw xml representing the metaproject.
         /// </summary>
-        public string metaProjectPath;
+        public string metaProjectXml;
 
         /// <summary>
         /// Initializes a new instance of the MetaProjectGeneratedEventArgs class.
         /// </summary>
-        public MetaProjectGeneratedEventArgs(string metaProjectPath, string message)
+        public MetaProjectGeneratedEventArgs(string metaProjectXml, string metaProjectPath, string message)
             : base(message, null, null, MessageImportance.Low, DateTime.UtcNow, metaProjectPath)
         {
-            this.metaProjectPath = metaProjectPath;
+            this.metaProjectXml = metaProjectXml;
+            this.ProjectFile = metaProjectPath;
         }
     }
 }

--- a/src/Framework/MetaProjectGeneratedEventArgs.cs
+++ b/src/Framework/MetaProjectGeneratedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Build.Framework
+{
+    public class MetaProjectGeneratedEventArgs : BuildMessageEventArgs
+    {
+    }
+}

--- a/src/Utilities/MuxLogger.cs
+++ b/src/Utilities/MuxLogger.cs
@@ -117,6 +117,11 @@ namespace Microsoft.Build.Utilities
         public string Parameters { get; set; }
 
         /// <summary>
+        /// Should evaluation events include generated metaprojects?
+        /// </summary>
+        public bool IncludeEvaluationMetaprojects { get; set; }
+
+        /// <summary>
         /// Should evaluation events include profiling information?
         /// </summary>
         public bool IncludeEvaluationProfiles { get; set; }
@@ -151,6 +156,10 @@ namespace Microsoft.Build.Utilities
 
             if (_eventSourceForBuild is IEventSource3 eventSource3)
             {
+                if (IncludeEvaluationMetaprojects)
+                {
+                    eventSource3.IncludeEvaluationMetaprojects();
+                }
                 if (IncludeEvaluationProfiles)
                 {
                     eventSource3.IncludeEvaluationProfiles();


### PR DESCRIPTION
Currently succeeds in collecting ```.metaproj``` files into ```.binlog``` when ```MSBUILDEMITSOLUTION=1```. Example below shows opening the ```.binlog``` from MSBuildStructuredLogViewer where```ConsoleApp1``` has a build dependency on ```ClassLib1```.

<img width="310" alt="metaproj" src="https://user-images.githubusercontent.com/32187633/42006484-ed684fa4-7a2e-11e8-8ddf-d7bb3b679a48.PNG">
