### PR TITLE
Fix cache misses for out of cone globs

### DIFF
--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Build.UnitTests.Definition
                 {
                     foreach (var globData in ContextPinsGlobExpansionCacheData)
                     {
-                        object[] globDataArray = (object[]) globData;
+                        var globDataArray = (object[]) globData;
 
                         yield return new[]
                         {
@@ -308,7 +308,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             var projectSpecs = _projectsWithOutOfConeGlobs
                 .Select(p => string.Format(p, itemSpecDirectoryPart))
-                .Select((p ,i) => (Path.Combine(testDirectory, $"ProjectDirectory{i}", $"Project{i}.proj"), p));
+                .Select((p, i) => new ProjectSpecification(Path.Combine(testDirectory, $"ProjectDirectory{i}", $"Project{i}.proj"), p));
 
             var context = EvaluationContext.Create(policy);
 
@@ -433,27 +433,45 @@ namespace Microsoft.Build.UnitTests.Definition
         private void EvaluateProjects(IEnumerable<string> projectContents, EvaluationContext context, Action<Project> afterEvaluationAction)
         {
             EvaluateProjects(
-                projectContents.Select((p, i) => (Path.Combine(_env.DefaultTestDirectory.FolderPath, $"Project{i}.proj"), p)),
+                projectContents.Select((p, i) => new ProjectSpecification(Path.Combine(_env.DefaultTestDirectory.FolderPath, $"Project{i}.proj"), p)),
                 context,
                 afterEvaluationAction);
+        }
+
+        private struct ProjectSpecification
+        {
+            public string ProjectPath { get; }
+            public string ProjectContents { get; }
+
+            public ProjectSpecification(string projectPath, string projectContents)
+            {
+                ProjectPath = projectPath;
+                ProjectContents = projectContents;
+            }
+
+            public void Deconstruct(out string projectPath, out string projectContents)
+            {
+                projectPath = this.ProjectPath;
+                projectContents = this.ProjectContents;
+            }
         }
 
         /// <summary>
         /// Should be at least two test projects to test cache visibility between projects
         /// </summary>
-        private void EvaluateProjects(IEnumerable<(string ProjectPath, string ProjectContents)> projectSpecs, EvaluationContext context, Action<Project> afterEvaluationAction)
+        private void EvaluateProjects(IEnumerable<ProjectSpecification> projectSpecs, EvaluationContext context, Action<Project> afterEvaluationAction)
         {
             var collection = _env.CreateProjectCollection().Collection;
 
             var projects = new List<Project>();
 
-            foreach (var spec in projectSpecs)
+            foreach (var (projectPath, projectContents) in projectSpecs)
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(spec.ProjectPath));
-                File.WriteAllText(spec.ProjectPath, spec.ProjectContents.Cleanup());
+                Directory.CreateDirectory(Path.GetDirectoryName(projectPath));
+                File.WriteAllText(projectPath, projectContents.Cleanup());
 
                 var project = Project.FromFile(
-                    spec.ProjectPath,
+                    projectPath,
                     new ProjectOptions
                     {
                         ProjectCollection = collection,

--- a/src/Build/Utilities/FileSpecMatchTester.cs
+++ b/src/Build/Utilities/FileSpecMatchTester.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Internal
         // this method parses the glob and extracts the fixed directory part in order to normalize it and make it absolute
         // without this normalization step, strings pointing outside the globbing cone would still match when they shouldn't
         // for example, we dont want "**/*.cs" to match "../Shared/Foo.cs"
-        // todo: glob rooting partially duplicated with MSBuildGlob.Parse
+        // todo: glob rooting knowledge partially duplicated with MSBuildGlob.Parse and FileMatcher.ComputeFileEnumerationCacheKey
         private static Regex CreateRegex(string unescapedFileSpec, string currentDirectory)
         {
             Regex regex = null;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -148,7 +148,13 @@ namespace Microsoft.Build.Shared
         /// <returns></returns>
         internal static bool HasWildcards(string filespec)
         {
-            return -1 != filespec.IndexOfAny(s_wildcardCharacters);
+            // Perf Note: Doing a [Last]IndexOfAny(...) is much faster than compiling a
+            // regular expression that does the same thing, regardless of whether
+            // filespec contains one of the characters.
+            // Choose LastIndexOfAny instead of IndexOfAny because it seems more likely
+            // that wildcards will tend to be towards the right side.
+
+            return -1 != filespec.LastIndexOfAny(s_wildcardCharacters);
         }
 
         /// <summary>
@@ -1732,11 +1738,6 @@ namespace Microsoft.Build.Shared
         )
         {
             // For performance. Short-circuit iff there is no wildcard.
-            // Perf Note: Doing a [Last]IndexOfAny(...) is much faster than compiling a
-            // regular expression that does the same thing, regardless of whether
-            // filespec contains one of the characters.
-            // Choose LastIndexOfAny instead of IndexOfAny because it seems more likely
-            // that wildcards will tend to be towards the right side.
             if (!HasWildcards(filespecUnescaped))
             {
                 return CreateArrayWithSingleItemIfNotExcluded(filespecUnescaped, excludeSpecsUnescaped);

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1793,13 +1793,9 @@ namespace Microsoft.Build.Shared
                 filespecUnescaped = FileUtilities.GetFullPathNoThrow(filespecUnescaped);
             }
 
-            var filespecIsAnAbsoluteGlobPointingOutsideOfProjectCone =
-                Path.IsPathRooted(filespecUnescaped) &&
-                !filespecUnescaped.StartsWith(projectDirectoryUnescaped, StringComparison.OrdinalIgnoreCase);
-
             // Don't include the project directory when the glob is independent of it.
             // Otherwise, if the project-directory-independent glob is used in multiple projects we'll get cache misses
-            if (!filespecIsAnAbsoluteGlobPointingOutsideOfProjectCone)
+            if (!FilespecIsAnAbsoluteGlobPointingOutsideOfProjectCone(projectDirectoryUnescaped, filespecUnescaped))
             {
                 sb.Append(projectDirectoryUnescaped);
             }
@@ -1815,6 +1811,20 @@ namespace Microsoft.Build.Shared
             }
 
             return sb.ToString();
+
+            bool FilespecIsAnAbsoluteGlobPointingOutsideOfProjectCone(string projectDirectory, string filespec)
+            {
+                try
+                {
+                    return Path.IsPathRooted(filespec) &&
+                           !filespec.StartsWith(projectDirectory, StringComparison.OrdinalIgnoreCase);
+                }
+                catch
+                {
+                    // glob expansion is "supposed" to silently fail on IO exceptions
+                    return false;
+                }
+            }
         }
 
         enum SearchAction

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1796,8 +1796,8 @@ namespace Microsoft.Build.Shared
                 Path.IsPathRooted(filespecUnescaped) &&
                 !filespecUnescaped.StartsWith(projectDirectoryUnescaped, StringComparison.OrdinalIgnoreCase);
 
-            // If we include the project directory when the filespec does not depend on it we'll get cache misses
-            // when the project directory independent glob repeats for each project.
+            // Don't include the project directory when the glob is independent of it.
+            // Otherwise, if the project-directory-independent glob is used in multiple projects we'll get cache misses
             if (!filespecIsAnAbsoluteGlobPointingOutsideOfProjectCone)
             {
                 sb.Append(projectDirectoryUnescaped);

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1787,7 +1787,7 @@ namespace Microsoft.Build.Shared
 
             var sb = new StringBuilder();
 
-            if (filespecUnescaped.Contains("..", StringComparison.Ordinal))
+            if (filespecUnescaped.Contains(".."))
             {
                 filespecUnescaped = FileUtilities.GetFullPathNoThrow(filespecUnescaped);
             }


### PR DESCRIPTION
Out of cone globs do not depend on the project directory, so do not include the project directory in the out of cone glob key. Noticed this while debugging stepping my way through some vcxproj builds.