### PR TITLE
Adjust build.cmd for common dev usage

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -NoLogo -NoProfile -ExecutionPolicy ByPass "%~dp0build\build.ps1" -build %*
+powershell -NoLogo -NoProfile -ExecutionPolicy ByPass "%~dp0build\build.ps1" -build -bootstraponly -skiptests %*
 exit /b %ErrorLevel%

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -11,6 +11,7 @@ Param(
   [switch] $norestore,
   [switch] $sign,
   [switch] $skiptests,
+  [switch] $test,
   [switch] $bootstrapOnly,
   [string] $verbosity = "minimal",
   [string] $hostType,
@@ -33,6 +34,7 @@ function Print-Usage() {
     Write-Host "  -build                  Build solution"
     Write-Host "  -rebuild                Rebuild solution"
     Write-Host "  -skipTests              Don't run tests"
+    Write-Host "  -test                   Run tests. Ignores skipTests"
     Write-Host "  -bootstrapOnly          Don't run build again with bootstrapped MSBuild"
     Write-Host "  -sign                   Sign build outputs"
     Write-Host "  -pack                   Package build outputs into NuGet packages and Willow components"
@@ -255,7 +257,7 @@ function Build {
   $testStage0 = $false
   if ($bootstrapOnly)
   {
-    $testStage0 = $test
+    $testStage0 = $runTests
   }
 
   $msbuildArgs = AddLogCmd "Build" $commonMSBuildArgs
@@ -293,7 +295,7 @@ function Build {
     # - Don't pack
     # - Do run tests (if not skipped)
     # - Don't try to create a bootstrap deployment
-    CallMSBuild $RepoToolsetBuildProj @msbuildArgs /nr:false /p:Restore=$restore /p:Build=$build /p:Rebuild=$rebuild /p:Test=$test /p:Sign=false /p:Pack=false /p:CreateBootstrap=false @properties
+    CallMSBuild $RepoToolsetBuildProj @msbuildArgs /nr:false /p:Restore=$restore /p:Build=$build /p:Rebuild=$rebuild /p:Test=$runTests /p:Sign=false /p:Pack=false /p:CreateBootstrap=false @properties
   }
   
   if ($ci)
@@ -372,7 +374,7 @@ $VersionsProps = Join-Path $PSScriptRoot "Versions.props"
 
 $log = -not $nolog
 $restore = -not $norestore
-$test = -not $skiptests
+$runTests = (-not $skiptests) -or $test
 
 if ($hostType -eq '')
 {


### PR DESCRIPTION
`build -bootstraponly -skiptests` becomes `build`. I do this many many times a day.
`build -bootstraponly` becomes `build -test`

I do the bootstrap build so rarely (once every two months?), that I might as well call the ps script at that point.