### PR TITLE
Avoid bootstrap publish collision

### DIFF
--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <OutputPath>$(OutputPath)$(TargetFramework.ToLowerInvariant())\</OutputPath>
+    <PublishDir>$(OutputPath)$(TargetFramework.ToLowerInvariant())\publish</PublishDir>
     <IntermediateOutputPath>$(IntermediateOutputPath)$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
The publish directory was reused between TFs of the MSBuild.Bootstrap
project, resulting in occasional errors like

```
error MSB3026: Could not copy "/mnt/j/w/Microsoft_msbuild/master/innerloop_Ubuntu16.04_CoreCLR_prtest/artifacts/Debug/bin/MSBuild.Bootstrap/publish/fr/Microsoft.Build.Tasks.Core.resources.dll" to "/mnt/j/w/Microsoft_msbuild/master/innerloop_Ubuntu16.04_CoreCLR_prtest/artifacts/Debug/bootstrap/netcoreapp2.1/MSBuild/fr/Microsoft.Build.Tasks.Core.resources.dll". Beginning retry 1 in 1000ms. The process cannot access the file '/mnt/j/w/Microsoft_msbuild/master/innerloop_Ubuntu16.04_CoreCLR_prtest/artifacts/Debug/bin/MSBuild.Bootstrap/publish/fr/Microsoft.Build.Tasks.Core.resources.dll' because it is being used by another process. [/mnt/j/w/Microsoft_msbuild/master/innerloop_Ubuntu16.04_CoreCLR_prtest/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj]
```

Our custom override of `OutputPath` wasn't getting picked up in the
right places to override `PublishDir` as well, so override it manually
in the same place.