### PR TITLE
Fix silent failure when attempting to build web projects outside of .NET Framework

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2023,8 +2023,13 @@ EndGlobal
                 ProjectCollection collection = new ProjectCollection();
                 collection.RegisterLogger(logger);
 
-                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
-
+#if !FEATURE_INSTALLED_MSBUILD
+                Assert.Throws<InvalidProjectFileException>(() => {
+#endif
+                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
+#if !FEATURE_INSTALLED_MSBUILD
+                });
+#endif
                 Version ver = new Version("4.34");
                 string message = ResourceUtilities.FormatResourceString("AspNetCompiler.TargetingHigherFrameworksDefaultsTo40", solution.ProjectsInOrder[0].ProjectName, ver.ToString());
                 logger.AssertLogContains(message);

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2023,16 +2023,19 @@ EndGlobal
                 ProjectCollection collection = new ProjectCollection();
                 collection.RegisterLogger(logger);
 
-#if !FEATURE_INSTALLED_MSBUILD
+#if !FEATURE_ASPNET_COMPILER
                 Assert.Throws<InvalidProjectFileException>(() => {
 #endif
-                    ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
-#if !FEATURE_INSTALLED_MSBUILD
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, collection.LoggingService);
+#if !FEATURE_ASPNET_COMPILER
                 });
 #endif
+
+#if FEATURE_ASPNET_COMPILER
                 Version ver = new Version("4.34");
                 string message = ResourceUtilities.FormatResourceString("AspNetCompiler.TargetingHigherFrameworksDefaultsTo40", solution.ProjectsInOrder[0].ProjectName, ver.ToString());
                 logger.AssertLogContains(message);
+#endif
             }
             finally
             {

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1085,6 +1085,16 @@ namespace Microsoft.Build.Construction
 
             if (project.ProjectType == SolutionProjectType.WebProject)
             {
+#if !FEATURE_ASPNET_COMPILER
+                ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile
+                    (
+                    false,
+                    "SubCategoryForSolutionParsingErrors",
+                    new BuildEventFileInfo(_solutionFile.FullPath),
+                    "AspNetCompiler.UnsupportedMSBuildVersion",
+                    project.ProjectName
+                    );
+#else
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, null);
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Clean");
                 AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, "Rebuild");
@@ -1094,6 +1104,7 @@ namespace Microsoft.Build.Construction
                 {
                     AddMetaprojectTargetForWebProject(traversalProject, metaprojectInstance, project, targetName);
                 }
+#endif
             }
             else if ((project.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat) ||
                      (project.CanBeMSBuildProjectFile(out string unknownProjectTypeErrorMessage)))
@@ -2308,6 +2319,6 @@ namespace Microsoft.Build.Construction
                                                             new List<ProjectPropertyGroupTaskPropertyInstance> { property }));
         }
 
-        #endregion // Methods
+#endregion // Methods
     }
 }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -809,7 +809,7 @@
   </data>
     <data name="AspNetCompiler.40NotInstalled">
     <value>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</value>
-    <comment>{StrBegin="MSB4205: "}</comment>
+    <comment>{StrBegin="MSB4249: "}</comment>
   </data>
   <data name="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
     <value>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</value>
@@ -1702,7 +1702,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4249.
+        Next message code should be MSB4250.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -807,8 +807,8 @@
     <value>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</value>
     <comment>{StrBegin="MSB4205: "}</comment>
   </data>
-    <data name="AspNetCompiler.40NotInstalled">
-    <value>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</value>
+  <data name="AspNetCompiler.UnsupportedMSBuildVersion">
+    <value>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</value>
     <comment>{StrBegin="MSB4249: "}</comment>
   </data>
   <data name="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -807,6 +807,10 @@
     <value>MSB4205: The website project in this solution is targeting the v2.0 runtime, but it is not installed.</value>
     <comment>{StrBegin="MSB4205: "}</comment>
   </data>
+    <data name="AspNetCompiler.40NotInstalled">
+    <value>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</value>
+    <comment>{StrBegin="MSB4205: "}</comment>
+  </data>
   <data name="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">
     <value>MSB4204: {0}: Invalid TargetFrameworkMoniker {1}. {2}.</value>
     <comment>{StrBegin="MSB4204: "}</comment>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -808,7 +808,7 @@
     <comment>{StrBegin="MSB4205: "}</comment>
   </data>
   <data name="AspNetCompiler.UnsupportedMSBuildVersion">
-    <value>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</value>
+    <value>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</value>
     <comment>{StrBegin="MSB4249: "}</comment>
   </data>
   <data name="AspNetCompiler.InvalidTargetFrameworkMonikerFromException">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: Došlo k chybě při načítání atributů pro parametry úlohy {0}. {1}</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: Fehler beim Abrufen der Attribute für Parameter in der {0}-Aufgabe. {1}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="new">MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: No se pudieron recuperar los atributos de los parámetros de la tarea "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: Échec lors de l'extraction des attributs des paramètres dans la tâche "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: errore durante il recupero degli attributi per i parametri nell'attività "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: "{0}" タスクでパラメーターの属性を取得できませんでした。{1}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: "{0}" 작업의 매개 변수 특성을 검색하지 못했습니다. {1}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: Wystąpił błąd podczas pobierania atrybutów dla parametrów w zadaniu „{0}”. {1}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: Houve uma falha ao recuperar os atributos dos parâmetros na tarefa "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: не удалось получить атрибуты для параметров в задаче "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: "{0}" görevindeki parametrelerin öznitelikleri alınırken hata oluştu. {1}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: 检索任务“{0}”中参数的特性时失败。{1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -8,9 +8,9 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
-      <trans-unit id="AspNetCompiler.40NotInstalled">
-        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
-        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+      <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
+        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -8,6 +8,11 @@
         <note>{StrBegin="MSB4001: "}UE: This message is shown when a task has more than one .NET property with the same name -- it's unclear which of
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
+      <trans-unit id="AspNetCompiler.40NotInstalled">
+        <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
+        <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
+        <note>{StrBegin="MSB4205: "}</note>
+      </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>
         <target state="translated">MSB4002: 擷取 "{0}" 工作中參數的屬性時發生失敗。{1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -9,8 +9,8 @@
     those properties the task wants to use as a parameter in project files.</note>
       </trans-unit>
       <trans-unit id="AspNetCompiler.UnsupportedMSBuildVersion">
-        <source>MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
-        <target state="new">MSB4205: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
+        <source>MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</source>
+        <target state="new">MSB4249: Unable to build website project "{0}". The ASP.NET compiler is only available on the .NET Framework version of MSBuild.</target>
         <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -11,7 +11,7 @@
       <trans-unit id="AspNetCompiler.40NotInstalled">
         <source>MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</source>
         <target state="new">MSB4205: The website project in this solution is targeting the v4.0 runtime, but it is not installed.</target>
-        <note>{StrBegin="MSB4205: "}</note>
+        <note>{StrBegin="MSB4249: "}</note>
       </trans-unit>
       <trans-unit id="AttributeTypeLoadError">
         <source>MSB4002: There was a failure retrieving the attributes for parameters in the "{0}" task. {1}</source>

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -22,6 +22,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN</DefineConstants>
     <FeatureAppDomain>true</FeatureAppDomain>
     <DefineConstants>$(DefineConstants);FEATURE_APPDOMAIN_UNHANDLED_EXCEPTION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ASPNET_COMPILER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOADFROM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_LOCATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLY_GETENTRYASSEMBLY</DefineConstants>

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -652,7 +652,6 @@ namespace Microsoft.Build.Shared
             return GetDotNetFrameworkSpec(version).GetPathToDotNetFramework(architecture);
         }
 
-#if FEATURE_INSTALLED_MSBUILD
         /// <summary>
         /// Check the registry key and value to see if the .net Framework is installed on the machine.
         /// </summary>
@@ -661,6 +660,9 @@ namespace Microsoft.Build.Shared
         /// <returns>True if the registry key is 1 false if it is not there. This method also return true if the complus enviornment variables are set.</returns>
         private static bool CheckForFrameworkInstallation(string registryEntryToCheckInstall, string registryValueToCheckInstall)
         {
+#if !FEATURE_INSTALLED_MSBUILD
+            return false;
+#else
             // Get the complus install root and version
             string complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT");
             string complusVersion = Environment.GetEnvironmentVariable("COMPLUS_VERSION");
@@ -682,8 +684,8 @@ namespace Microsoft.Build.Shared
             }
 
             return true;
-        }
 #endif
+        }
 
         /// <summary>
         /// Heuristic that first considers the current runtime path and then searches the base of that path for the given
@@ -1306,9 +1308,6 @@ namespace Microsoft.Build.Shared
             /// </summary>
             public virtual string GetPathToDotNetFramework(DotNetFrameworkArchitecture architecture)
             {
-#if !FEATURE_INSTALLED_MSBUILD
-                return null;
-#else
                 string cachedPath;
                 if (this._pathsToDotNetFramework.TryGetValue(architecture, out cachedPath))
                 {
@@ -1350,7 +1349,6 @@ namespace Microsoft.Build.Shared
                 }
 
                 return generatedPathToDotNetFramework;
-#endif
             }
 
             /// <summary>

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -652,6 +652,7 @@ namespace Microsoft.Build.Shared
             return GetDotNetFrameworkSpec(version).GetPathToDotNetFramework(architecture);
         }
 
+#if FEATURE_INSTALLED_MSBUILD
         /// <summary>
         /// Check the registry key and value to see if the .net Framework is installed on the machine.
         /// </summary>
@@ -660,9 +661,6 @@ namespace Microsoft.Build.Shared
         /// <returns>True if the registry key is 1 false if it is not there. This method also return true if the complus enviornment variables are set.</returns>
         private static bool CheckForFrameworkInstallation(string registryEntryToCheckInstall, string registryValueToCheckInstall)
         {
-#if !FEATURE_INSTALLED_MSBUILD
-            return false;
-#else
             // Get the complus install root and version
             string complusInstallRoot = Environment.GetEnvironmentVariable("COMPLUS_INSTALLROOT");
             string complusVersion = Environment.GetEnvironmentVariable("COMPLUS_VERSION");
@@ -684,8 +682,8 @@ namespace Microsoft.Build.Shared
             }
 
             return true;
-#endif
         }
+#endif
 
         /// <summary>
         /// Heuristic that first considers the current runtime path and then searches the base of that path for the given
@@ -1314,17 +1312,17 @@ namespace Microsoft.Build.Shared
                     return cachedPath;
                 }
 
+#if FEATURE_WIN32_REGISTRY
                 // Otherwise, check to see if we're even installed.  If not, return null -- no point in setting the static 
                 // variables to null when that's what they are already.  
-                if (NativeMethodsShared.IsWindows)
+                if (NativeMethodsShared.IsWindows && !CheckForFrameworkInstallation(
+                    this._dotNetFrameworkRegistryKey,
+                    this._dotNetFrameworkSetupRegistryInstalledName
+                    ))
                 {
-                    if (!CheckForFrameworkInstallation(
-                            this._dotNetFrameworkRegistryKey,
-                            this._dotNetFrameworkSetupRegistryInstalledName))
-                    {
-                        return null;
-                    }
+                    return null;
                 }
+#endif
 
                 // We're installed and we haven't found this framework path yet -- so find it!
                 string generatedPathToDotNetFramework =


### PR DESCRIPTION
Found this while debugging tests on #3459 

When generating the metaproject for a web project, if targeting a framework version >= 4.0 and aspnet_compiler.exe 4.0 is not found, ```ToolPath``` is silently set to null and ```ProjectInstance``` will end up failing elsewhere with a ```NullReferenceException```. Not a problem if targeting < 4.0 since the method already used a ```VerifyThrow``` check.