### PR TITLE
Ignore errors during lazy evaluation referenced item discovery

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -68,8 +68,12 @@ namespace Microsoft.Build.Evaluation
         BreakOnNotEmpty = 0x10,
 
         /// <summary>
-        /// When an error occurs expanding a property, just leave it unexpanded.  This should only be used when attempting to log a message with a best effort expansion of a string.
+        /// When an error occurs expanding a property, just leave it unexpanded.
         /// </summary>
+        /// <remarks>
+        /// This should only be used in cases where property evaluation isn't critcal, such as when attempting to log a
+        /// message with a best effort expansion of a string, or when discovering partial information during lazy evaluation.
+        /// </remarks>
         LeavePropertiesUnexpandedOnError = 0x20,
 
         /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -560,14 +560,19 @@ namespace Microsoft.Build.Evaluation
                 // if so we need to add the right item reference.
                 foreach (var metadatumElement in itemElement.Metadata)
                 {
+                    // Since we're just attempting to expand properties in order to find referenced items and not expanding metadata,
+                    // unexpected errors may occur when evaluating property functions on unexpanded metadata. Just ignore them if that happens.
+                    // See: https://github.com/Microsoft/msbuild/issues/3460
+                    const ExpanderOptions expanderOptions = ExpanderOptions.ExpandProperties | ExpanderOptions.LeavePropertiesUnexpandedOnError;
+
                     var valueWithPropertiesExpanded = _expander.ExpandIntoStringLeaveEscaped(
                         metadatumElement.Value,
-                        ExpanderOptions.ExpandProperties,
+                        expanderOptions,
                         metadatumElement.Location);
 
                     var conditionWithPropertiesExpanded = _expander.ExpandIntoStringLeaveEscaped(
                         metadatumElement.Condition,
-                        ExpanderOptions.ExpandProperties,
+                        expanderOptions,
                         metadatumElement.ConditionLocation);
 
                     values.Add(valueWithPropertiesExpanded);


### PR DESCRIPTION
The lazy item evaluator does some discovery to find the items referenced in the metadata. This causes property expansion to happen on unexpanded metadata which can lead to unexpected exceptions (see referenced issue).

Fixes: #3460 
