### PR TITLE
Stop passing redundant params in official build

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -55,7 +55,7 @@ steps:
   displayName: Run build.cmd
   inputs:
     filename: '$(comspec)'
-    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" & $(Build.Repository.LocalPath)\build.cmd -skiptests -bootstraponly -pack -sign -configuration Release -properties /p:SignType=$(SignType)"'
+    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" & $(Build.Repository.LocalPath)\build.cmd -pack -sign -configuration Release -properties /p:SignType=$(SignType)"'
 
 - task: CmdLine@1
   displayName: Print bin contents


### PR DESCRIPTION
After #3480 simplified the dev-inner-loop invocation of `build.cmd`, the
official build broke because it passed `-skiptests -bootstraponly`
twice.

I made this change in the non-YAML build which isn't tracked;
making it here in YAML as well.