### PR TITLE
Restore private enum value ResourceType.Prerequisite

### DIFF
--- a/src/Tasks/GenerateManifestBase.cs
+++ b/src/Tasks/GenerateManifestBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks
     public abstract class GenerateManifestBase : Task
     {
         private enum AssemblyType { Unspecified, Managed, Native, Satellite };
-        private enum DependencyType { Install };
+        private enum DependencyType { Install, Prerequisite };
 
         private string _processorArchitecture;
         private int _startTime;


### PR DESCRIPTION
The value is produced via enum string parsing even though it is not used in the MSBuild codebase directly