### PR TITLE
Propagate fileSystem to Get*OfFileAbove intrinsic methods

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ConstructionEditing_Tests.cs
@@ -3206,7 +3206,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             using (var env = TestEnvironment.Create())
             {
-                var testSdkRoot = env.CreateFolder().FolderPath;
+                var testSdkRoot = env.CreateFolder().Path;
                 var testSdkDirectory = Path.Combine(testSdkRoot, "MSBuildUnitTestSdk", "Sdk");
                 Directory.CreateDirectory(testSdkDirectory);
 

--- a/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
@@ -440,9 +440,23 @@ multi-line comment here
             AddChildWithExistingSiblingsViaInsertBeforeChild(project, expected);
         }
 
-        private void AssertWhiteSpacePreservation(string projectContents, string updatedProject,
+        private void AssertWhiteSpacePreservation(
+            string projectContents,
+            string updatedProject,
             Action<ProjectRootElement, Project> act)
         {
+            // Each OS uses its own line endings. Using WSL on Windows leads to LF on Windows which messes up the tests. This happens due to git LF <-> CRLF conversions.
+            if (NativeMethodsShared.IsWindows)
+            {
+                projectContents = Regex.Replace(projectContents, @"[^\r]\n", "\r\n", RegexOptions.Multiline);
+                updatedProject = Regex.Replace(updatedProject, @"[^\r]\n", "\r\n", RegexOptions.Multiline);
+            }
+            else
+            {
+                projectContents = Regex.Replace(projectContents, @"\r\n", "\n", RegexOptions.Multiline);
+                updatedProject = Regex.Replace(updatedProject, @"\r\n", "\n", RegexOptions.Multiline);
+            }
+
             // Note: This test will write the project file to disk rather than using in-memory streams.
             // Using streams can cause issues with CRLF characters being replaced by LF going in to
             // ProjectRootElement. Saving to disk mimics the real-world behavior so we can specifically

--- a/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/IntrinsicTask_Tests.cs
@@ -2115,7 +2115,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             using (var env = TestEnvironment.Create())
             {
                 var projectDirectory = env.CreateFolder();
-                env.SetCurrentDirectory(projectDirectory.FolderPath);
+                env.SetCurrentDirectory(projectDirectory.Path);
 
                 var file1 = env.CreateFile(projectDirectory).Path;
                 var file2 = env.CreateFile(projectDirectory).Path;
@@ -2125,7 +2125,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 <Target Name='t'>
                     <ItemGroup>
                         <i1 Include='" + file1 + ";" + file2 + @";other'/>
-                        <i1 Remove='" + projectDirectory.FolderPath + Path.DirectorySeparatorChar + @"*.tmp'/>
+                        <i1 Remove='" + projectDirectory.Path + Path.DirectorySeparatorChar + @"*.tmp'/>
                     </ItemGroup>
                 </Target></Project>");
                 IntrinsicTask task = CreateIntrinsicTask(content);

--- a/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverLoader_Tests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             using (var env = TestEnvironment.Create(_output))
             {
-                var root = env.CreateFolder().FolderPath;
+                var root = env.CreateFolder().Path;
                 var resolverPath = Path.Combine(root, "MyTestResolver");
                 var resolverManifest = Path.Combine(resolverPath, "MyTestResolver.xml");
 
@@ -212,7 +212,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             using (var env = TestEnvironment.Create(_output))
             {
-                var root = env.CreateFolder().FolderPath;
+                var root = env.CreateFolder().Path;
                 var resolverPath = Path.Combine(root, "MyTestResolver");
                 var resolverManifest = Path.Combine(resolverPath, "MyTestResolver.xml");
 
@@ -236,7 +236,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             using (var env = TestEnvironment.Create(_output))
             {
-                var root = env.CreateFolder().FolderPath;
+                var root = env.CreateFolder().Path;
                 var resolverPath = Path.Combine(root, "MyTestResolver");
 
                 Directory.CreateDirectory(resolverPath);
@@ -252,7 +252,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
             using (var env = TestEnvironment.Create(_output))
             {
-                var root = env.CreateFolder().FolderPath;
+                var root = env.CreateFolder().Path;
                 var resolverPath = Path.Combine(root, "MyTestResolver");
                 var resolverManifest = Path.Combine(resolverPath, "MyTestResolver.xml");
 

--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -2257,7 +2257,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             secondaryItemsByName.ImportItems(thirdItemGroup);
             secondaryItemsByName.ImportItems(trueItemGroup);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, secondaryItemsByName);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, secondaryItemsByName, FileSystems.Default);
             return expander;
         }
 

--- a/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionFile_Tests.cs
@@ -708,11 +708,11 @@ namespace Microsoft.Build.UnitTests.Construction
             using (var env = TestEnvironment.Create())
             {
                 var solutionFolder = env.CreateFolder(Path.Combine(FileUtilities.GetTemporaryDirectory(), "sln"));
-                var projectFolder = env.CreateFolder(Path.Combine(solutionFolder.FolderPath, "RelativePath"));
+                var projectFolder = env.CreateFolder(Path.Combine(solutionFolder.Path, "RelativePath"));
 
                 SolutionFile p = new SolutionFile();
-                p.FullPath = Path.Combine(solutionFolder.FolderPath, "RelativePath", "project file");
-                p.SolutionFileDirectory = Path.GetFullPath(solutionFolder.FolderPath);
+                p.FullPath = Path.Combine(solutionFolder.Path, "RelativePath", "project file");
+                p.SolutionFileDirectory = Path.GetFullPath(solutionFolder.Path);
                 ProjectInSolution proj = new ProjectInSolution(p);
 
                 p.ParseFirstProjectLine

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4298,7 +4298,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyConditionEvaluatorResetStateOnFailure()
         {
             PropertyDictionary<ProjectPropertyInstance> propertyBag = new PropertyDictionary<ProjectPropertyInstance>();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, FileSystems.Default);
             string condition = " '$(TargetOSFamily)' >= '3' ";
 
             // Give an incorrect value for the property "TargetOSFamily", and then the evaluation should throw an exception.

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandAllIntoTaskItems0()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             IList<TaskItem> itemsOut = expander.ExpandIntoTaskItemsLeaveEscaped("", ExpanderOptions.ExpandProperties, null);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandAllIntoTaskItems1()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             IList<TaskItem> itemsOut = expander.ExpandIntoTaskItemsLeaveEscaped("foo", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -67,7 +67,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void ExpandAllIntoTaskItems2()
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             IList<TaskItem> itemsOut = expander.ExpandIntoTaskItemsLeaveEscaped("foo;bar", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -94,7 +94,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             itemsByType.ImportItems(ig);
             itemsByType.ImportItems(ig2);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, itemsByType);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, itemsByType, FileSystems.Default);
 
             IList<TaskItem> itemsOut = expander.ExpandIntoTaskItemsLeaveEscaped("foo;bar;@(compile);@(resource)", ExpanderOptions.ExpandPropertiesAndItems, MockElementLocation.Instance);
 
@@ -115,7 +115,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("b", "bbb"));
             pg.Set(ProjectPropertyInstance.Create("c", "cc;dd"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             IList<TaskItem> itemsOut = expander.ExpandIntoTaskItemsLeaveEscaped("foo$(a);$(b);$(c)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -139,7 +139,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("b", "bbb"));
             pg.Set(ProjectPropertyInstance.Create("c", "cc;dd"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             ProjectItemInstanceFactory itemFactory = new ProjectItemInstanceFactory(project, "i");
             IList<ProjectItemInstance> itemsOut = expander.ExpandIntoItemsLeaveEscaped("foo$(a);$(b);$(c);$(d", itemFactory, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -156,7 +156,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             ProjectInstance project = ProjectHelpers.CreateEmptyProjectInstance();
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$()", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             Assert.Equal(String.Empty, result);
@@ -780,7 +780,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             itemMetadataTable["Language"] = "english";
             IMetadataTable itemMetadata = new StringMetadataTable(itemMetadataTable);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, ig, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, ig, itemMetadata, FileSystems.Default);
 
             return expander;
         }
@@ -802,7 +802,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             ig.Add(i0);
             ig.Add(i1);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, ig);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, ig, FileSystems.Default);
 
             return expander;
         }
@@ -1269,7 +1269,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             IList<TaskItem> taskItems = expander.ExpandIntoTaskItemsLeaveEscaped(
                 "@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; " +
@@ -1301,7 +1301,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             string stringToExpand = "@(Resource->'%(Filename)') ;";
             Assert.Equal(
@@ -1354,7 +1354,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             XmlAttribute xmlattribute = (new XmlDocument()).CreateAttribute("dummy");
             xmlattribute.Value = "@(IntermediateAssembly->'')";
@@ -1380,7 +1380,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             XmlAttribute xmlattribute = (new XmlDocument()).CreateAttribute("dummy");
             xmlattribute.Value = "@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; " +
@@ -1402,7 +1402,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             XmlAttribute xmlattribute = (new XmlDocument()).CreateAttribute("dummy");
             xmlattribute.Value = "@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; " +
@@ -1424,7 +1424,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             XmlAttribute xmlattribute = (new XmlDocument()).CreateAttribute("dummy");
 
@@ -1457,7 +1457,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             string value = @"@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; $(OutputPath) ; $(TargetPath) ; %(Language)_%(Culture)";
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             Assert.Equal(@"@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ;  ; %(NonExistent) ; \jk ; l\mno%3bpqr\stu ; @(IntermediateAssembly->'%(RelativeDir)') ; %(Language)_%(Culture)", expander.ExpandIntoStringAndUnescape(value, ExpanderOptions.ExpandProperties, MockElementLocation.Instance));
 
@@ -1478,7 +1478,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             StringMetadataTable itemMetadata;
             CreateComplexPropertiesItemsMetadata(out lookup, out itemMetadata);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(lookup, lookup, itemMetadata, FileSystems.Default);
 
             string value = "@(Resource->'%(Filename)') ; @(Content) ; @(NonExistent) ; $(NonExistent) ; %(NonExistent) ; " +
                 "$(OutputPath) ; $(TargetPath) ; %(Language)_%(Culture)";
@@ -1520,7 +1520,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$(HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\9.0\VSTSDB@VSTSDBDirectory)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1536,7 +1536,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$(Solutions.VSVersion)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1554,7 +1554,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 expander.ExpandIntoStringLeaveEscaped(@"$(HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\9.0\VSTSDB@XXXXDBDirectory)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -1572,7 +1572,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 expander.ExpandIntoStringLeaveEscaped(@"$(HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\9.0\VSTSDB@VSTSDBDirectoryX)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -1586,7 +1586,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", "String", RegistryValueKind.String);
@@ -1607,7 +1607,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 UTF8Encoding enc = new UTF8Encoding();
@@ -1631,7 +1631,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", 123456, RegistryValueKind.DWord);
@@ -1653,7 +1653,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 string envVar = NativeMethodsShared.IsWindows ? "TEMP" : "USER";
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", "%" + envVar + "%", RegistryValueKind.ExpandString);
@@ -1674,7 +1674,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", (long)123456789123456789, RegistryValueKind.QWord);
@@ -1695,7 +1695,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", new string[] { "A", "B", "C", "D" }, RegistryValueKind.MultiString);
@@ -1792,7 +1792,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.Convert]::ChangeType('null',$(SomeStuff.GetType())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1808,7 +1808,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.Convert]::ChangeType(,$(SomeStuff.GetType())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1824,7 +1824,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.ToUpperInvariant())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1840,7 +1840,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("FileName", "    foo.ext   "));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(FileName.Trim())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1856,7 +1856,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.Length)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1872,7 +1872,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.get_Length())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1888,7 +1888,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.ToLowerInvariant())_goop", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1904,7 +1904,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.SubString(13))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1920,7 +1920,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.SubString(8))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1937,7 +1937,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("RootPath", Path.Combine(s_rootPathPrefix, "this", "is", "the", "root")));
             pg.Set(ProjectPropertyInstance.Create("MyPath", Path.Combine(s_rootPathPrefix, "this", "is", "the", "root", "my", "project", "is", "here.proj")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(MyPath.SubString($(RootPath.Length)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1954,7 +1954,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("Value", "3"));
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.SubString(1$(Value)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -1971,7 +1971,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("PathRoot", Path.Combine(s_rootPathPrefix, "goo")));
             pg.Set(ProjectPropertyInstance.Create("PathRoot2", Path.Combine(s_rootPathPrefix, "goop") + Path.DirectorySeparatorChar));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$(PathRoot2.Endswith(" + Path.DirectorySeparatorChar + "))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             Assert.Equal("True", result);
@@ -1989,7 +1989,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("Value", "3"));
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.SubString(1$(Value)).ToLowerInvariant().SubString($(Value)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2007,7 +2007,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("Value", "3"));
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.ToUpperInvariant().ToLowerInvariant())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             Assert.Equal("this is some stuff", result);
@@ -2023,7 +2023,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("Value", "12345"));
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "1234567890"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.SubString($(Value.get_Length())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2038,7 +2038,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([MSBuild]::__GetListTest())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2054,7 +2054,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("List", "A-B-C-D"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(List.Split(-))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2072,7 +2072,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.Environment]::GetEnvironmentVariables())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance).ToUpperInvariant();
             string expected = ("OS=" + Environment.GetEnvironmentVariable("OS")).ToUpperInvariant();
@@ -2090,7 +2090,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("List", "A-B-C-D"));
             pg.Set(ProjectPropertyInstance.Create("Splitter", "-"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(List.Split($(Splitter.ToCharArray())))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2107,7 +2107,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("PathRoot", Path.Combine(s_rootPathPrefix, "goo")));
             pg.Set(ProjectPropertyInstance.Create("PathRoot2", Path.Combine(s_rootPathPrefix, "goop") + Path.DirectorySeparatorChar));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             Assert.True(
                 ConditionEvaluator.EvaluateCondition(
@@ -2145,7 +2145,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pg.Set(ProjectPropertyInstance.Create("Value", "3"));
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("[$(SomeStuff($(Value)))]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2164,7 +2164,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pg.Set(ProjectPropertyInstance.Create("Value", "3"));
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("[$(SomeStuff.Lgg)]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2182,7 +2182,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pg.Set(ProjectPropertyInstance.Create("Value", "3"));
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.ToUpperInvariant().Foo)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2200,7 +2200,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pg.Set(ProjectPropertyInstance.Create("Value", "3"));
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("[$(SomeStuff($(System.DateTime.Now)))]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2218,7 +2218,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("$(SomeStuff.ToLowerInvariant()_goop)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2235,7 +2235,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("[$(SomeStuff.Substring(HELLO!))]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2252,7 +2252,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("[$(SomeStuff.Substring(-10))]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2268,7 +2268,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped("$(([System.DateTime]::Now).ToString(\"MM.dd.yyyy\"))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             }
@@ -2282,7 +2282,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("[%(LowerLetterList.Identity.ToUpper())]", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2298,7 +2298,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("System", "The System Namespace"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$(System)", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2317,7 +2317,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("ParentPath", Path.Combine(s_rootPathPrefix, "abc", "def")));
             pg.Set(ProjectPropertyInstance.Create("FilePath", Path.Combine(s_rootPathPrefix, "abc", "def", "foo.cpp")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::MakeRelative($(ParentPath), `$(FilePath)`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2334,7 +2334,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("Drive", s_rootPathPrefix));
             pg.Set(ProjectPropertyInstance.Create("File", Path.Combine("foo", "file.txt")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine($(Drive), `$(File)`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2350,7 +2350,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("ver1", @"1.2.3.4"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             object result = expander.ExpandPropertiesLeaveTypedAndEscaped(@"$([System.Version]::new($(ver1)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2374,7 +2374,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("ver1", @"1.2.3.4"));
             pg.Set(ProjectPropertyInstance.Create("ver2", @"2.2.3.4"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Version]::new($(ver1)).CompareTo($([System.Version]::new($(ver2)))))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2394,7 +2394,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 try
                 {
@@ -2417,7 +2417,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string env = Environment.GetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS");
 
@@ -2446,7 +2446,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string env = Environment.GetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS");
 
@@ -2480,7 +2480,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", Path.Combine("foo", "file.txt")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" + s_rootPathPrefix + "`, `$(File)`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2496,7 +2496,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", "foo goo" + Path.DirectorySeparatorChar + "file.txt"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" +
                 Path.Combine(s_rootPathPrefix, "foo goo")  + "`, `$(File)`))",
@@ -2514,7 +2514,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", Path.Combine("foo bar", "baz.txt")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" +
                 Path.Combine(s_rootPathPrefix, "foo baz") + @"`, `$(File)`))",
@@ -2532,7 +2532,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", Path.Combine("foo bar", "baz.txt")));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" +
                 Path.Combine(s_rootPathPrefix, "foo baz") + @" `, `$(File)`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -2548,7 +2548,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string dateTime = "'" + _dateToParse + "'";
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.DateTime]::Parse(" + dateTime + ").ToString(\"yyyy/MM/dd HH:mm:ss\"))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -2564,7 +2564,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
             string dateTime = "'" + _dateToParse + "'";
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.DateTime]::Parse(" + dateTime + ").ToString(\"MM.dd.yyyy\"))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2579,7 +2579,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.DateTime]::Now.ToString(\"MM.dd.yyyy\"))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2595,7 +2595,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", "foo" + Path.DirectorySeparatorChar + "file.txt"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine(`" +
                 s_rootPathPrefix +
@@ -2613,7 +2613,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("File", "foo" + Path.DirectorySeparatorChar + "file.txt"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             // Support enum combines as Enum.Parse expects them
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Text.RegularExpressions.Regex]::IsMatch(`-42`, `^-?\d+(\.\d{2})?$`, `RegexOptions.IgnoreCase,RegexOptions.Singleline`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -2638,7 +2638,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
             string dateTime = "'" + _dateToParse + "'";
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.DateTime]::Parse(" + dateTime + ").ToString(`yyyy/MM/dd HH:mm:ss`))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2653,7 +2653,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Environment]::GetFolderPath(SpecialFolder.System))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2687,7 +2687,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 .Replace("$$architecture$$", architecture);
 
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string currentPlatformString = Helpers.GetOSPlatformAsString();
 
@@ -2705,7 +2705,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void IsOsPlatformShouldBeCaseInsensitiveToParameter()
         {
             var pg = new PropertyDictionary<ProjectPropertyInstance>();
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             var osPlatformLowerCase = Helpers.GetOSPlatformAsString().ToLower();
 
@@ -2722,7 +2722,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped("$([System.String]::Equals(`a`, `A`, StringComparison.OrdinalIgnoreCase))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             Assert.Equal(true.ToString(), result);
@@ -2745,7 +2745,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pg.Set(ProjectPropertyInstance.Create("StartingDirectory", directoryStart));
                 pg.Set(ProjectPropertyInstance.Create("FileToFind", tempFile));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetDirectoryNameOfFileAbove($(StartingDirectory), $(FileToFind)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2779,7 +2779,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("FileToFind", Path.GetFileName(fileToFind)));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringAndUnescape(@"$([MSBuild]::GetPathOfFileAbove($(FileToFind)))", ExpanderOptions.ExpandProperties, mockElementLocation);
 
@@ -2822,7 +2822,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("FileWithPath", fileWithPath));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::GetPathOfFileAbove($(FileWithPath)))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             });
@@ -2838,7 +2838,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
 #if FEATURE_CULTUREINFO_GETCULTURES
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.Globalization.CultureInfo]::GetCultureInfo(`en-US`).ToString())", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -2857,7 +2857,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::Add(40, 2))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2872,7 +2872,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::Add(39.9, 2.1))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2887,7 +2887,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::ValueOrDefault('', '42'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2908,7 +2908,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             pg["BonkersTargetsPath"] = ProjectPropertyInstance.Create("BonkersTargetsPath", "Bonkers");
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::ValueOrDefault('$(BonkersTargetsPath)', '42'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2931,7 +2931,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('CurrentRuntime', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2948,7 +2948,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('   CurrentRuntime    ', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -2964,7 +2964,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 ProjectPropertyInstance.Create("MyPath", "one"),
                 ProjectPropertyInstance.Create("MySecondPath", "two"),
-            }));
+            }), FileSystems.Default);
 
             Assert.Equal(
                 $"{Path.GetFullPath("one")}{Path.DirectorySeparatorChar}",
@@ -2985,7 +2985,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('ASDF', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3008,7 +3008,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg["Runtime"] = ProjectPropertyInstance.Create("Runtime", "CurrentRuntime");
             pg["Architecture"] = ProjectPropertyInstance.Create("Architecture", "CurrentArchitecture");
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('$(Runtime)', '$(Architecture)'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3032,7 +3032,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
                 string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::DoesTaskHostExist('CLR2', 'CurrentArchitecture'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3058,7 +3058,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string tempFile = FileUtilities.GetTemporaryFile();
             try
@@ -3084,7 +3084,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         {
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([MSBuild]::Add(39.9, 2.1))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3158,7 +3158,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
             pg.Set(ProjectPropertyInstance.Create("SomeStuff", "This IS SOME STUff"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$( SomeStuff )", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3175,7 +3175,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeProperty", "Value"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue("Value", "%" + envVar + "%", RegistryValueKind.ExpandString);
@@ -3198,7 +3198,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeProperty", "Value"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue(String.Empty, "%" + envVar + "%", RegistryValueKind.ExpandString);
@@ -3221,7 +3221,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeProperty", "Value"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue(String.Empty, "%" + envVar + "%", RegistryValueKind.ExpandString);
@@ -3244,7 +3244,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 PropertyDictionary<ProjectPropertyInstance> pg = new PropertyDictionary<ProjectPropertyInstance>();
                 pg.Set(ProjectPropertyInstance.Create("SomeProperty", "Value"));
 
-                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+                Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
                 RegistryKey key = Registry.CurrentUser.CreateSubKey(@"Software\Microsoft\MSBuild_test");
 
                 key.SetValue(String.Empty, "%" + envVar + "%", RegistryValueKind.ExpandString);
@@ -3278,7 +3278,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             ItemDictionary<ProjectItemInstance> itemsByType = new ItemDictionary<ProjectItemInstance>();
             itemsByType.ImportItems(ig);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, itemsByType, itemMetadata);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, itemsByType, itemMetadata, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(@"$([System.IO.Path]::Combine($(SomePath),%(Compile.Identity)))", ExpanderOptions.ExpandAll, MockElementLocation.Instance);
 
@@ -3316,7 +3316,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             pg.Set(ProjectPropertyInstance.Create("input", @"EXPORT a"));
             pg.Set(ProjectPropertyInstance.Create("propertycontainingnullasastring", @"null"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             var validTests = new List<string[]> {
                 new string[] {"$(input.ToString()[1])", "X"},
@@ -3571,7 +3571,7 @@ $(
 
             pg.Set(ProjectPropertyInstance.Create("SomeProperty", path));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             // Verify a constant expands properly
             string result = expander.ExpandIntoStringLeaveEscaped($"$([MSBuild]::EnsureTrailingSlash('{path}'))", ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
@@ -3597,7 +3597,7 @@ $(
 
             pg.Set(ProjectPropertyInstance.Create("SomeProperty", "6C8546D5297C424F962201B0E0E9F142"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(pg, FileSystems.Default);
 
             string result = expander.ExpandIntoStringLeaveEscaped(propertyFunction, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
 
@@ -3759,7 +3759,7 @@ $(
         {
             var properties = new PropertyDictionary<ProjectPropertyInstance>();
             properties.Set(ProjectPropertyInstance.Create(propertyName, propertyValue));
-            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(properties);
+            var expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(properties, FileSystems.Default);
             string result = expander.ExpandIntoStringLeaveEscaped(expression, ExpanderOptions.ExpandProperties, MockElementLocation.Instance);
             result.ShouldBe(expected);
         }

--- a/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemSpec_Tests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.UnitTests.BackEnd;
 using Shouldly;
 using Xunit;
@@ -84,7 +85,7 @@ namespace Microsoft.Build.UnitTests.OM.Evaluation
         {
             var itemDictionary = ToItemDictionary(items);
 
-            return new ProjectInstanceExpander(new PropertyDictionary<ProjectPropertyInstance>(), itemDictionary);
+            return new ProjectInstanceExpander(new PropertyDictionary<ProjectPropertyInstance>(), itemDictionary, (IFileSystem) FileSystems.Default);
         }
 
         private static ItemDictionary<ProjectItemInstance> ToItemDictionary(Dictionary<string, string[]> itemTypes)

--- a/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Preprocessor_Tests.cs
@@ -843,7 +843,7 @@ namespace Microsoft.Build.UnitTests.Preprocessor
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
-                string testSdkDirectory = env.CreateFolder().FolderPath;
+                string testSdkDirectory = env.CreateFolder().Path;
 
                 var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
                 {
@@ -932,8 +932,8 @@ namespace Microsoft.Build.UnitTests.Preprocessor
         {
             using (TestEnvironment env = TestEnvironment.Create())
             {
-                string sdk1 = env.CreateFolder().FolderPath;
-                string sdk2 = env.CreateFolder().FolderPath;
+                string sdk1 = env.CreateFolder().Path;
+                string sdk2 = env.CreateFolder().Path;
 
                 var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(new Dictionary<string, string>
                 {

--- a/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         {
             _env = TestEnvironment.Create();
 
-            _testSdkRoot = _env.CreateFolder().FolderPath;
+            _testSdkRoot = _env.CreateFolder().Path;
             _testSdkDirectory = Path.Combine(_testSdkRoot, SdkName, "Sdk");
             _sdkPropsPath = Path.Combine(_testSdkDirectory, "Sdk.props");
             _sdkTargetsPath = Path.Combine(_testSdkDirectory, "Sdk.targets");
@@ -337,7 +337,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
             var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.FileBasedMockSdkResolver(mapping));
 
             // Create a normal project (p1) which imports an SDK style project (p2).
-            var projectFolder = _env.CreateFolder().FolderPath;
+            var projectFolder = _env.CreateFolder().Path;
 
             var p1 = @"<Project> <Import Project=""p2.proj"" /> </Project>";
             var p2 = string.Format(projectFormatString, SdkName, projectInnerContents);

--- a/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTreeExpression_Tests.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Build.UnitTests
             metadataDictionary["Culture"] = "french";
             StringMetadataTable itemMetadata = new StringMetadataTable(metadataDictionary);
 
-            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, itemMetadata);
+            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, itemMetadata, FileSystems.Default);
 
             foreach (string file in FilesWithExistenceChecks)
             {

--- a/src/Build.UnitTests/ExpressionTree_Tests.cs
+++ b/src/Build.UnitTests/ExpressionTree_Tests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.UnitTests
         public void SimpleEvaluationTests()
         {
             Parser p = new Parser();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);
 
             AssertParseEvaluate(p, "true", expander, true);
             AssertParseEvaluate(p, "on", expander, true);
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests
         public void EqualityTests()
         {
             Parser p = new Parser();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);
 
             AssertParseEvaluate(p, "true == on", expander, true);
             AssertParseEvaluate(p, "TrUe == On", expander, true);
@@ -68,7 +68,7 @@ namespace Microsoft.Build.UnitTests
         public void RelationalTests()
         {
             Parser p = new Parser();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);
 
             AssertParseEvaluate(p, "1234 < 1235", expander, true);
             AssertParseEvaluate(p, "1234 <= 1235", expander, true);
@@ -87,7 +87,7 @@ namespace Microsoft.Build.UnitTests
         public void AndandOrTests()
         {
             Parser p = new Parser();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);
 
             AssertParseEvaluate(p, "true == on and 1234 < 1235", expander, true);
         }
@@ -99,7 +99,7 @@ namespace Microsoft.Build.UnitTests
         {
             Parser p = new Parser();
             GenericExpressionNode tree;
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), new ItemDictionary<ProjectItemInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), new ItemDictionary<ProjectItemInstance>(), FileSystems.Default);
             expander.Metadata = new StringMetadataTable(null);
             bool value;
 
@@ -151,7 +151,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("x86", "x86"));
             propertyBag.Set(ProjectPropertyInstance.Create("no", "no"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, new ItemDictionary<ProjectItemInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, new ItemDictionary<ProjectItemInstance>(), FileSystems.Default);
             AssertParseEvaluate(p, "$(foo)", expander, true);
             AssertParseEvaluate(p, "!$(foo)", expander, false);
             // Test properties with strings
@@ -189,7 +189,7 @@ namespace Microsoft.Build.UnitTests
             itemBag.Add(new ProjectItemInstance(parentProject, "Compile", "baz.cs", parentProject.FullPath));
             itemBag.Add(new ProjectItemInstance(parentProject, "Boolean", "true", parentProject.FullPath));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), itemBag, FileSystems.Default);
 
             AssertParseEvaluate(p, "@(Compile) == 'foo.cs;bar.cs;baz.cs'", expander, true);
             AssertParseEvaluate(p, "@(Compile,' ') == 'foo.cs bar.cs baz.cs'", expander, true);
@@ -232,7 +232,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("AnotherTestQuote", "Here's Johnny!"));
             propertyBag.Set(ProjectPropertyInstance.Create("Atsign", "Test the @ replacement"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, FileSystems.Default);
 
             AssertParseEvaluate(p, "'simplestring: true foo.cs;bar.cs;baz.cs' == '$(simple): $(foo) @(compile)'", expander, true);
             AssertParseEvaluate(p, "'$(c1) $(c2)' == 'Another (complex) one. Another (complex) one.'", expander, true);
@@ -264,7 +264,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("c1", "Another (complex) one."));
             propertyBag.Set(ProjectPropertyInstance.Create("c2", "Another (complex) one."));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, FileSystems.Default);
 
             AssertParseEvaluate(p, "(($(foo) != 'two' and $(bar)) and 5 >= 1) or $(one) == 1", expander, true);
             AssertParseEvaluate(p, "(($(foo) != 'twoo' or !$(bar)) and 5 >= 1) or $(two) == 1", expander, true);
@@ -285,7 +285,7 @@ namespace Microsoft.Build.UnitTests
 
             PropertyDictionary<ProjectPropertyInstance> propertyBag = new PropertyDictionary<ProjectPropertyInstance>();
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, FileSystems.Default);
 
             AssertParseEvaluateThrow(p, "@(Compile) > 0", expander, null);
         }
@@ -314,7 +314,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("c1", "Another (complex) one."));
             propertyBag.Set(ProjectPropertyInstance.Create("c2", "Another (complex) one."));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, itemBag, FileSystems.Default);
 
             AssertParseEvaluate(p, "(($(foo) != 'two' and $(bar)) and 5 >= 1) or $(one) == 1", expander, true);
         }
@@ -331,7 +331,7 @@ namespace Microsoft.Build.UnitTests
             itemBag.Add(new ProjectItemInstance(parentProject, "Compile", "bar.cs", parentProject.FullPath));
             itemBag.Add(new ProjectItemInstance(parentProject, "Compile", "baz.cs", parentProject.FullPath));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), itemBag);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), itemBag, FileSystems.Default);
             Dictionary<string, List<string>> conditionedProperties = new Dictionary<string, List<string>>();
             ConditionEvaluator.IConditionEvaluationState state =
                                new ConditionEvaluator.ConditionEvaluationState<ProjectPropertyInstance, ProjectItemInstance>
@@ -423,7 +423,7 @@ namespace Microsoft.Build.UnitTests
             propertyBag.Set(ProjectPropertyInstance.Create("foo", "4"));
             propertyBag.Set(ProjectPropertyInstance.Create("bar", "32"));
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, new ItemDictionary<ProjectItemInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(propertyBag, new ItemDictionary<ProjectItemInstance>(), FileSystems.Default);
 
             AssertParseEvaluate(p, "!true", expander, false);
             AssertParseEvaluate(p, "!(true)", expander, false);
@@ -514,7 +514,7 @@ namespace Microsoft.Build.UnitTests
         public void NegativeTests()
         {
             Parser p = new Parser();
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>());
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(new PropertyDictionary<ProjectPropertyInstance>(), FileSystems.Default);
 
             AssertParseEvaluateThrow(p, "foo", expander);
             AssertParseEvaluateThrow(p, "0", expander);

--- a/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/ItemBucket.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -100,7 +101,7 @@ namespace Microsoft.Build.BackEnd
             }
 
             _metadata = metadata;
-            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_lookup, _lookup, new StringMetadataTable(metadata));
+            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_lookup, _lookup, new StringMetadataTable(metadata), FileSystems.Default);
 
             _bucketSequenceNumber = bucketSequenceNumber;
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetEntry.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Build.BackEnd
             _targetSpecification = targetSpecification;
             _parentTarget = parentTarget;
             _buildReason = buildReason;
-            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(baseLookup, baseLookup);
+            _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(baseLookup, baseLookup, FileSystems.Default);
             _state = TargetEntryState.Dependencies;
             _baseLookup = baseLookup;
             _host = host;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -26,6 +26,7 @@ using System.Globalization;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Globbing;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 using EvaluationItemSpec = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
 using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemExpressionFragment<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
@@ -3192,7 +3193,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Prepares the data object for evaluation.
             /// </summary>
-            public void InitializeForEvaluation(IToolsetProvider toolsetProvider)
+            public void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem)
             {
                 DefaultTargets = null;
                 Properties = new PropertyDictionary<ProjectProperty>();
@@ -3200,7 +3201,7 @@ namespace Microsoft.Build.Evaluation
                 Items = new ItemDictionary<ProjectItem>();
                 ItemsIgnoringCondition = new ItemDictionary<ProjectItem>();
                 ItemsByEvaluatedIncludeCache = new MultiDictionary<string, ProjectItem>(StringComparer.OrdinalIgnoreCase);
-                Expander = new Expander<ProjectProperty, ProjectItem>(Properties, Items);
+                Expander = new Expander<ProjectProperty, ProjectItem>(Properties, Items, fileSystem);
                 ItemDefinitions = new RetrievableEntryHashSet<ProjectItemDefinition>(MSBuildNameIgnoreCaseComparer.Default);
                 Targets = new RetrievableEntryHashSet<ProjectTargetInstance>(StringComparer.OrdinalIgnoreCase);
                 ImportClosure = new List<ResolvedImport>();

--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -457,7 +458,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (null != metadatum && Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(metadatum.EvaluatedValueEscaped))
                 {
-                    Expander<ProjectProperty, ProjectItem> expander = new Expander<ProjectProperty, ProjectItem>(null, null, new BuiltInMetadataTable(this));
+                    Expander<ProjectProperty, ProjectItem> expander = new Expander<ProjectProperty, ProjectItem>(null, null, new BuiltInMetadataTable(this), FileSystems.Default);
 
                     value = expander.ExpandIntoStringLeaveEscaped(metadatum.EvaluatedValueEscaped, ExpanderOptions.ExpandBuiltInMetadata, metadatum.Location);
                 }

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -974,7 +974,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (_expander == null)
                 {
-                    _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_propertyBag);
+                    _expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(_propertyBag, FileSystems.Default);
                 }
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))

--- a/src/Build/Definition/ToolsetReader.cs
+++ b/src/Build/Definition/ToolsetReader.cs
@@ -460,7 +460,7 @@ namespace Microsoft.Build.Evaluation
 
             IEnumerable<ToolsetPropertyDefinition> rawProperties = GetPropertyDefinitions(toolsVersion.Name);
 
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(initialProperties);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(initialProperties, FileSystems.Default);
 
             foreach (ToolsetPropertyDefinition property in rawProperties)
             {
@@ -677,7 +677,7 @@ namespace Microsoft.Build.Evaluation
 
             if (accumulateProperties)
             {
-                expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(initialProperties);
+                expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(initialProperties, FileSystems.Default);
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -219,10 +219,12 @@ namespace Microsoft.Build.Evaluation
             ErrorUtilities.VerifyThrowInternalNull(data, nameof(data));
             ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
 
-            // Create containers for the evaluation results
-            data.InitializeForEvaluation(toolsetProvider);
+            _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
-            _expander = new Expander<P, I>(data, data);
+            // Create containers for the evaluation results
+            data.InitializeForEvaluation(toolsetProvider, _evaluationContext.FileSystem);
+
+            _expander = new Expander<P, I>(data, data, _evaluationContext.FileSystem);
 
             // This setting may change after the build has started, therefore if the user has not set the property to true on the build parameters we need to check to see if it is set to true on the environment variable.
             _expander.WarnForUninitializedProperties = BuildParameters.WarnOnUninitializedProperty || Traits.Instance.EscapeHatches.WarnOnUninitializedProperty;
@@ -242,7 +244,6 @@ namespace Microsoft.Build.Evaluation
             _projectRootElementCache = projectRootElementCache;
             _sdkResolverService = sdkResolverService;
             _submissionId = submissionId;
-            _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
             _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
         }
 

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Collections;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.SdkResolution;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -207,7 +208,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>
-        void InitializeForEvaluation(IToolsetProvider toolsetProvider);
+        void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem);
 
         /// <summary>
         /// Indicates to the data block that evaluation has completed,

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Win32;
 
 // Needed for DoesTaskHostExistForParameters
@@ -317,9 +318,9 @@ namespace Microsoft.Build.Evaluation
         /// <param name="startingDirectory">The directory to start the search in.</param>
         /// <param name="fileName">The name of the file to search for.</param>
         /// <returns>The full path of the directory containing the file if it is found, otherwise an empty string. </returns>
-        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
+        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName, IFileSystem fileSystem)
         {
-            return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName);
+            return FileUtilities.GetDirectoryNameOfFileAbove(startingDirectory, fileName, fileSystem);
         }
 
         /// <summary>
@@ -329,9 +330,9 @@ namespace Microsoft.Build.Evaluation
         /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
         /// of the file containing the property function.</param>
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
-        internal static string GetPathOfFileAbove(string file, string startingDirectory)
+        internal static string GetPathOfFileAbove(string file, string startingDirectory, IFileSystem fileSystem)
         {
-            return FileUtilities.GetPathOfFileAbove(file, startingDirectory);
+            return FileUtilities.GetPathOfFileAbove(file, startingDirectory, fileSystem);
         }
 
         /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -276,9 +277,9 @@ namespace Microsoft.Build.Evaluation
                 return _wrappedData.GetTarget(targetName);
             }
 
-            public void InitializeForEvaluation(IToolsetProvider toolsetProvider)
+            public void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem)
             {
-                _wrappedData.InitializeForEvaluation(toolsetProvider);
+                _wrappedData.InitializeForEvaluation(toolsetProvider, fileSystem);
             }
 
             public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult)

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -41,7 +42,7 @@ namespace Microsoft.Build.Evaluation
 
                 _evaluatorData = new EvaluatorData(_lazyEvaluator._outerEvaluatorData, itemType => GetReferencedItems(itemType, ImmutableHashSet<string>.Empty));
                 _itemFactory = new ItemFactoryWrapper(_itemElement, _lazyEvaluator._itemFactory);
-                _expander = new Expander<P, I>(_evaluatorData, _evaluatorData);
+                _expander = new Expander<P, I>(_evaluatorData, _evaluatorData, _lazyEvaluator.FileSystem);
 
                 _itemSpec.Expander = _expander;
             }

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Build.Evaluation
         public LazyItemEvaluator(IEvaluatorData<P, I, M, D> data, IItemFactory<I, I> itemFactory, LoggingContext loggingContext, EvaluationProfiler evaluationProfiler, EvaluationContext evaluationContext)
         {
             _outerEvaluatorData = data;
-            _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData);
+            _outerExpander = new Expander<P, I>(_outerEvaluatorData, _outerEvaluatorData, evaluationContext.FileSystem);
             _evaluatorData = new EvaluatorData(_outerEvaluatorData, itemType => GetItems(itemType));
-            _expander = new Expander<P, I>(_evaluatorData, _evaluatorData);
+            _expander = new Expander<P, I>(_evaluatorData, _evaluatorData, evaluationContext.FileSystem);
             _itemFactory = itemFactory;
             _loggingContext = loggingContext;
             _evaluationProfiler = evaluationProfiler;

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1215,7 +1215,8 @@ namespace Microsoft.Build.Execution
         /// Initializes the object for evaluation.
         /// Only called during evaluation, so does not check for immutability.
         /// </summary>
-        void IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.InitializeForEvaluation(IToolsetProvider toolsetProvider)
+        void IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.
+            InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem)
         {
             // All been done in the constructor.  We don't allow re-evaluation of project instances.
         }
@@ -1743,7 +1744,7 @@ namespace Microsoft.Build.Execution
         /// </comment>
         public string ExpandString(string unexpandedValue)
         {
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this, FileSystems.Default);
 
             string result = expander.ExpandIntoStringAndUnescape(unexpandedValue, ExpanderOptions.ExpandPropertiesAndItems, ProjectFileLocation);
 
@@ -1761,7 +1762,7 @@ namespace Microsoft.Build.Execution
         /// </comment>
         public bool EvaluateCondition(string condition)
         {
-            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this);
+            Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this, FileSystems.Default);
 
             bool result = ConditionEvaluator.EvaluateCondition(
                 condition,

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -17,6 +17,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Construction;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Shared.FileSystem;
 
 namespace Microsoft.Build.Execution
 {
@@ -1242,7 +1243,7 @@ namespace Microsoft.Build.Execution
 
                 if (null != metadatum && Expander<ProjectProperty, ProjectItem>.ExpressionMayContainExpandableExpressions(metadatum.EvaluatedValueEscaped))
                 {
-                    Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(null, null, new BuiltInMetadataTable(null, this));
+                    Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(null, null, new BuiltInMetadataTable(null, this), FileSystems.Default);
 
                     // We don't have a location to use, but this is very unlikely to error
                     value = expander.ExpandIntoStringLeaveEscaped(metadatum.EvaluatedValueEscaped, ExpanderOptions.ExpandBuiltInMetadata, ElementLocation.EmptyLocation);

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1137,10 +1137,12 @@ namespace Microsoft.Build.Shared
         /// Locate a file in either the directory specified or a location in the
         /// directory structure above that directory.
         /// </summary>
-        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName)
+        internal static string GetDirectoryNameOfFileAbove(string startingDirectory, string fileName, IFileSystem fileSystem = null)
         {
+            fileSystem = fileSystem ?? DefaultFileSystem;
+
             // Canonicalize our starting location
-            string lookInDirectory = Path.GetFullPath(startingDirectory);
+            string lookInDirectory = GetFullPath(startingDirectory);
 
             do
             {
@@ -1150,7 +1152,7 @@ namespace Microsoft.Build.Shared
                 // If we successfully locate the file in the directory that we're
                 // looking in, simply return that location. Otherwise we'll
                 // keep moving up the tree.
-                if (DefaultFileSystem.FileExists(possibleFileDirectory))
+                if (fileSystem.FileExists(possibleFileDirectory))
                 {
                     // We've found the file, return the directory we found it in
                     return lookInDirectory;
@@ -1173,9 +1175,10 @@ namespace Microsoft.Build.Shared
         /// </summary>
         /// <param name="file">The file to search for.</param>
         /// <param name="startingDirectory">An optional directory to start the search in.  The default location is the directory
-        /// of the file containing the property function.</param>
+        ///     of the file containing the property function.</param>
+        /// <param name="fileSystem">The filesystem</param>
         /// <returns>The full path of the file if it is found, otherwise an empty string.</returns>
-        internal static string GetPathOfFileAbove(string file, string startingDirectory)
+        internal static string GetPathOfFileAbove(string file, string startingDirectory, IFileSystem fileSystem = null)
         {
             // This method does not accept a path, only a file name
             if (file.Any(i => i.Equals(Path.DirectorySeparatorChar) || i.Equals(Path.AltDirectorySeparatorChar)))
@@ -1184,7 +1187,7 @@ namespace Microsoft.Build.Shared
             }
 
             // Search for a directory that contains that file
-            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file);
+            string directoryName = GetDirectoryNameOfFileAbove(startingDirectory, file, fileSystem);
 
             return String.IsNullOrEmpty(directoryName) ? String.Empty : NormalizePath(directoryName, file);
         }

--- a/src/Shared/UnitTests/EngineTestEnvironment.cs
+++ b/src/Shared/UnitTests/EngineTestEnvironment.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests
     {
         private readonly TransientTestFolder _folder;
 
-        public string TestRoot => _folder.FolderPath;
+        public string TestRoot => _folder.Path;
 
         public string[] CreatedFiles { get; }
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Build.UnitTests
                 "file.bak.txt"
             })
             {
-                File.WriteAllBytes(Path.Combine(testFolder.FolderPath, file), new byte[1]);
+                File.WriteAllBytes(Path.Combine(testFolder.Path, file), new byte[1]);
             }
 
-            string[] fileMatches = FileMatcher.Default.GetFiles(testFolder.FolderPath, pattern);
+            string[] fileMatches = FileMatcher.Default.GetFiles(testFolder.Path, pattern);
 
             fileMatches.Length.ShouldBe(expectedMatchCount, $"Matches: '{String.Join("', '", fileMatches)}'");
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Build.UnitTests
             TransientTestFolder testFolder = _env.CreateFolder();
 
             // Create directories and files
-            foreach (string fullPath in GetFilesComplexGlobbingMatchingInfo.FilesToCreate.Select(i => Path.Combine(testFolder.FolderPath, i.ToPlatformSlash())))
+            foreach (string fullPath in GetFilesComplexGlobbingMatchingInfo.FilesToCreate.Select(i => Path.Combine(testFolder.Path, i.ToPlatformSlash())))
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
                 
@@ -80,7 +80,7 @@ namespace Microsoft.Build.UnitTests
 
             void Verify(string include, string[] excludes, bool shouldHaveNoMatches = false, string customMessage = null)
             {
-                string[] matchedFiles = FileMatcher.Default.GetFiles(testFolder.FolderPath, include, excludes?.ToList());
+                string[] matchedFiles = FileMatcher.Default.GetFiles(testFolder.Path, include, excludes?.ToList());
 
                 if (shouldHaveNoMatches)
                 {
@@ -1191,7 +1191,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Regress367780_CrashOnStarDotDot()
         {
-            string workingPath = _env.CreateFolder().FolderPath;
+            string workingPath = _env.CreateFolder().Path;
             string workingPathSubfolder = Path.Combine(workingPath, "SubDir");
             string offendingPattern = Path.Combine(workingPath, @"*\..\bar");
             string[] files = new string[0];
@@ -1205,7 +1205,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Regress141071_StarStarSlashStarStarIsLiteral()
         {
-            string workingPath = _env.CreateFolder().FolderPath;
+            string workingPath = _env.CreateFolder().Path;
             string fileName = Path.Combine(workingPath, "MyFile.txt");
             string offendingPattern = Path.Combine(workingPath, @"**\**");
 
@@ -1222,7 +1222,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void Regress14090_TrailingDotMatchesNoExtension()
         {
-            string workingPath = _env.CreateFolder().FolderPath;
+            string workingPath = _env.CreateFolder().Path;
             string workingPathSubdir = Path.Combine(workingPath, "subdir");
             string workingPathSubdirBing = Path.Combine(workingPathSubdir, "bing");
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -50,7 +50,7 @@ public class MSBuildTestAssemblyFixture : IDisposable
         string newTempPath = Path.Combine(Path.GetTempPath(), subdirectory);
         var assemblyTempFolder = _testEnvironment.CreateFolder(newTempPath);
 
-        _testEnvironment.SetTempPath(assemblyTempFolder.FolderPath);
+        _testEnvironment.SetTempPath(assemblyTempFolder.Path);
 
         _testEnvironment.CreateFile(
             transientTestFolder: assemblyTempFolder,

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Build.UnitTests
         public TransientTempPath CreateNewTempPath()
         {
             var folder = CreateFolder();
-            return SetTempPath(folder.FolderPath, true);
+            return SetTempPath(folder.Path, true);
         }
 
         /// <summary>
@@ -197,10 +197,7 @@ namespace Microsoft.Build.UnitTests
 
         public TransientTestFile CreateFile(TransientTestFolder transientTestFolder, string fileName, string contents = "")
         {
-            var file = WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, Path.GetFileNameWithoutExtension(fileName), Path.GetExtension(fileName)));
-            File.WriteAllText(file.Path, contents);
-
-            return file;
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.Path, fileName, contents));
         }
 
         /// <summary>
@@ -211,7 +208,7 @@ namespace Microsoft.Build.UnitTests
         /// <param name="extension">Extension of the file (defaults to '.tmp')</param>
         public TransientTestFile CreateFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
         {
-            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension,
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.Path, extension,
                 createFile: true, expectedAsOutput: false));
         }
 
@@ -234,7 +231,7 @@ namespace Microsoft.Build.UnitTests
         /// <returns></returns>
         public TransientTestFile GetTempFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
         {
-            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension,
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.Path, extension,
                 createFile: false, expectedAsOutput: false));
         }
 
@@ -256,7 +253,7 @@ namespace Microsoft.Build.UnitTests
         /// <returns></returns>
         public TransientTestFile ExpectFile(TransientTestFolder transientTestFolder, string extension = ".tmp")
         {
-            return WithTransientTestState(new TransientTestFile(transientTestFolder.FolderPath, extension, createFile: false, expectedAsOutput: true));
+            return WithTransientTestState(new TransientTestFile(transientTestFolder.Path, extension, createFile: false, expectedAsOutput: true));
         }
 
         /// <summary>
@@ -267,7 +264,7 @@ namespace Microsoft.Build.UnitTests
         {
             var folder = WithTransientTestState(new TransientTestFolder(folderPath, createFolder));
 
-            Assert.True(!(createFolder ^ FileSystems.Default.DirectoryExists(folder.FolderPath)));
+            Assert.True(!(createFolder ^ FileSystems.Default.DirectoryExists(folder.Path)));
 
             return folder;
         }
@@ -520,11 +517,11 @@ namespace Microsoft.Build.UnitTests
             Path = FileUtilities.GetTemporaryFile(rootPath, extension, createFile);
         }
 
-        public TransientTestFile(string rootPath, string fileNameWithoutExtension, string extension)
+        public TransientTestFile(string rootPath, string fileName, string contents = null)
         {
-            Path = System.IO.Path.Combine(rootPath, fileNameWithoutExtension + extension);
+            Path = System.IO.Path.Combine(rootPath, fileName);
 
-            File.WriteAllText(Path, string.Empty);
+            File.WriteAllText(Path, contents ?? string.Empty);
         }
 
         public string Path { get; }
@@ -543,34 +540,49 @@ namespace Microsoft.Build.UnitTests
                 FileUtilities.DeleteNoThrow(Path);
             }
         }
+
+        public void Delete()
+        {
+            File.Delete(Path);
+        }
     }
 
     public class TransientTestFolder : TransientTestState
     {
         public TransientTestFolder(string folderPath = null, bool createFolder = true)
         {
-            FolderPath = folderPath ?? FileUtilities.GetTemporaryDirectory(createFolder);
+            Path = folderPath ?? FileUtilities.GetTemporaryDirectory(createFolder);
 
             if (createFolder)
             {
-                Directory.CreateDirectory(FolderPath);
+                Directory.CreateDirectory(Path);
             }
         }
 
-        public string FolderPath { get; }
+        public TransientTestFolder CreateDirectory(string directoryName)
+        {
+            return new TransientTestFolder(System.IO.Path.Combine(Path, directoryName));
+        }
+
+        public TransientTestFile CreateFile(string fileName, string contents = null)
+        {
+            return new TransientTestFile(Path, fileName, contents);
+        }
+
+        public string Path { get; }
 
         public override void Revert()
         {
             // Basic checks to make sure we're not deleting something very obviously wrong (e.g.
             // the entire temp drive).
-            Assert.NotNull(FolderPath);
-            Assert.NotEqual(string.Empty, FolderPath);
-            Assert.NotEqual(@"\", FolderPath);
-            Assert.NotEqual(@"/", FolderPath);
-            Assert.NotEqual(Path.GetFullPath(Path.GetTempPath()), Path.GetFullPath(FolderPath));
-            Assert.True(Path.IsPathRooted(FolderPath));
+            Assert.NotNull(Path);
+            Assert.NotEqual(string.Empty, Path);
+            Assert.NotEqual(@"\", Path);
+            Assert.NotEqual(@"/", Path);
+            Assert.NotEqual(System.IO.Path.GetFullPath(System.IO.Path.GetTempPath()), System.IO.Path.GetFullPath(Path));
+            Assert.True(System.IO.Path.IsPathRooted(Path));
 
-            FileUtilities.DeleteDirectoryNoThrow(FolderPath, true);
+            FileUtilities.DeleteDirectoryNoThrow(Path, true);
         }
     }
 
@@ -619,11 +631,11 @@ namespace Microsoft.Build.UnitTests
 
         public static TransientZipArchive Create(TransientTestFolder source, TransientTestFolder destination, string filename = "test.zip")
         {
-            Directory.CreateDirectory(destination.FolderPath);
+            Directory.CreateDirectory(destination.Path);
 
-            string path = System.IO.Path.Combine(destination.FolderPath, filename);
+            string path = System.IO.Path.Combine(destination.Path, filename);
 
-            ZipFile.CreateFromDirectory(source.FolderPath, path);
+            ZipFile.CreateFromDirectory(source.Path, path);
 
             return new TransientZipArchive
             {

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent(new String('!', 10000000)),
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent("Success!"),
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Execute().ShouldBeTrue();
 
-                FileInfo file = new FileInfo(Path.Combine(folder.FolderPath, "foo.txt"));
+                FileInfo file = new FileInfo(Path.Combine(folder.Path, "foo.txt"));
 
                 file.Exists.ShouldBeTrue(() => file.FullName);
 
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     DestinationFileName = new TaskItem(filename),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => response),
                     SourceUrl = "http://success/foo.txt"
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Execute().ShouldBeTrue();
 
-                FileInfo file = new FileInfo(Path.Combine(folder.FolderPath, filename));
+                FileInfo file = new FileInfo(Path.Combine(folder.Path, filename));
 
                 file.Exists.ShouldBeTrue(() => file.FullName);
 
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     DestinationFileName = new TaskItem(filename),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
@@ -149,7 +149,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 downloadFile.Execute().ShouldBeTrue();
 
-                FileInfo file = new FileInfo(Path.Combine(folder.FolderPath, filename));
+                FileInfo file = new FileInfo(Path.Combine(folder.Path, filename));
 
                 file.Exists.ShouldBeTrue(() => file.FullName);
 
@@ -202,7 +202,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile()
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new MockHttpContent(content.Length, stream =>
@@ -257,7 +257,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     HttpMessageHandler = new MockHttpMessageHandler((message, token) => new HttpResponseMessage(HttpStatusCode.OK)
                     {
                         Content = new StringContent("C197675A3CC64CAA80680128CF4578C9")

--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -3134,13 +3134,13 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         {
             using (var env = TestEnvironment.Create())
             {
-                env.SetCurrentDirectory(env.DefaultTestDirectory.FolderPath);
+                env.SetCurrentDirectory(env.DefaultTestDirectory.Path);
 
                 string fileRef = "<data name=\"TextFile1\" type=\"System.Resources.ResXFileRef, System.Windows.Forms\">" +
                                 $"<value>.\\tmp_dir\\test_file.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value></data>";
 
                 env.CreateFile(
-                        env.CreateFolder(Path.Combine(env.DefaultTestDirectory.FolderPath, "tmp_dir")),
+                        env.CreateFolder(Path.Combine(env.DefaultTestDirectory.Path, "tmp_dir")),
                         "test_file.txt", "xyz");
 
                 string resxFile = env.CreateFile("test.resx").Path;

--- a/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
+++ b/src/Tasks.UnitTests/GetReferencePaths_Tests.cs
@@ -299,9 +299,9 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string frameworkRootDir = Path.Combine(env.DefaultTestDirectory.FolderPath, "framework-root");
+                string frameworkRootDir = Path.Combine(env.DefaultTestDirectory.Path, "framework-root");
                 var framework41Directory = env.CreateFolder(Path.Combine(frameworkRootDir, Path.Combine("MyFramework", "v4.1") + Path.DirectorySeparatorChar));
-                var redistListDirectory = env.CreateFolder(Path.Combine(framework41Directory.FolderPath, "RedistList"));
+                var redistListDirectory = env.CreateFolder(Path.Combine(framework41Directory.Path, "RedistList"));
 
                 string redistListContents =
                         "<FileList Redist='Microsoft-Windows-CLRCoreComp' Name='.NET Framework 4.1'>" +
@@ -316,14 +316,14 @@ namespace Microsoft.Build.UnitTests
                 GetReferenceAssemblyPaths getReferencePaths = new GetReferenceAssemblyPaths();
                 getReferencePaths.BuildEngine = engine;
                 getReferencePaths.TargetFrameworkMoniker = targetFrameworkMoniker;
-                getReferencePaths.RootPath = env.CreateFolder().FolderPath;
+                getReferencePaths.RootPath = env.CreateFolder().Path;
                 getReferencePaths.RootPath = frameworkRootDir;
                 getReferencePaths.TargetFrameworkFallbackSearchPaths = $"/foo/bar;{frameworkRootDir}";
                 getReferencePaths.Execute();
                 string[] returnedPaths = getReferencePaths.ReferenceAssemblyPaths;
                 string displayName = getReferencePaths.TargetFrameworkMonikerDisplayName;
                 Assert.Equal(1, returnedPaths.Length);
-                Assert.True(returnedPaths[0].Equals(framework41Directory.FolderPath, StringComparison.OrdinalIgnoreCase));
+                Assert.True(returnedPaths[0].Equals(framework41Directory.Path, StringComparison.OrdinalIgnoreCase));
                 Assert.Equal(0, engine.Log.Length); // "Expected the log to contain nothing"
                 Assert.True(displayName.Equals(".NET Framework 4.1", StringComparison.OrdinalIgnoreCase));
             }

--- a/src/Tasks.UnitTests/PortableTasks_Tests.cs
+++ b/src/Tasks.UnitTests/PortableTasks_Tests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.UnitTests
             {
                 bool successfulExit;
 
-                var folder = env.CreateFolder().FolderPath;
+                var folder = env.CreateFolder().Path;
                 var projFile = Path.Combine(folder, ProjectFileName);
 
                 foreach (var file in new DirectoryInfo(ProjectFilePath).GetFiles())

--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 Unzip unzip = new Unzip
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(source.FolderPath),
+                    DestinationFolder = new TaskItem(source.Path),
                     OverwriteReadOnlyFiles = true,
                     SkipUnchangedFiles = false,
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
@@ -60,7 +60,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 Unzip unzip = new Unzip
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(destination.FolderPath),
+                    DestinationFolder = new TaskItem(destination.Path),
                     OverwriteReadOnlyFiles = true,
                     SkipUnchangedFiles = false,
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
@@ -68,8 +68,8 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 unzip.Execute().ShouldBeTrue(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.FolderPath, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
-                _mockEngine.Log.ShouldContain(Path.Combine(destination.FolderPath, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "BE78A17D30144B549D21F71D5C633F7D.txt"), () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(Path.Combine(destination.Path, "A04FF4B88DF14860B7C73A8E75A4FB76.txt"), () => _mockEngine.Log);
             }
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 Unzip unzip = new Unzip
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(source.FolderPath),
+                    DestinationFolder = new TaskItem(source.Path),
                     OverwriteReadOnlyFiles = false,
                     SkipUnchangedFiles = false,
                     SourceFiles = new ITaskItem[] { new TaskItem(zipArchive.Path) }
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 Unzip unzip = new Unzip
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
+                    DestinationFolder = new TaskItem(folder.Path),
                     SourceFiles = new ITaskItem[] { new TaskItem(file.Path), }
                 };
 
@@ -170,8 +170,8 @@ namespace Microsoft.Build.Tasks.UnitTests
                 Unzip unzip = new Unzip
                 {
                     BuildEngine = _mockEngine,
-                    DestinationFolder = new TaskItem(folder.FolderPath),
-                    SourceFiles = new ITaskItem[] { new TaskItem(Path.Combine(testEnvironment.DefaultTestDirectory.FolderPath, "foo.zip")), }
+                    DestinationFolder = new TaskItem(folder.Path),
+                    SourceFiles = new ITaskItem[] { new TaskItem(Path.Combine(testEnvironment.DefaultTestDirectory.Path, "foo.zip")), }
                 };
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);

--- a/src/Tasks.UnitTests/ZipDirectory_Tests.cs
+++ b/src/Tasks.UnitTests/ZipDirectory_Tests.cs
@@ -27,18 +27,18 @@ namespace Microsoft.Build.Tasks.UnitTests
                 testEnvironment.CreateFile(sourceFolder, "6DE6060259C44DB6B145159376751C22.txt", "6DE6060259C44DB6B145159376751C22");
                 testEnvironment.CreateFile(sourceFolder, "CDA3DD8C25A54A7CAC638A444CB1EAD0.txt", "CDA3DD8C25A54A7CAC638A444CB1EAD0");
 
-                string zipFilePath = Path.Combine(testEnvironment.CreateFolder(createFolder: true).FolderPath, "test.zip");
+                string zipFilePath = Path.Combine(testEnvironment.CreateFolder(createFolder: true).Path, "test.zip");
 
                 ZipDirectory zipDirectory = new ZipDirectory
                 {
                     BuildEngine = _mockEngine,
                     DestinationFile = new TaskItem(zipFilePath),
-                    SourceDirectory = new TaskItem(sourceFolder.FolderPath)
+                    SourceDirectory = new TaskItem(sourceFolder.Path)
                 };
 
                 zipDirectory.Execute().ShouldBeTrue(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(sourceFolder.FolderPath, () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(sourceFolder.Path, () => _mockEngine.Log);
                 _mockEngine.Log.ShouldContain(zipFilePath, () => _mockEngine.Log);
 
                 using (FileStream stream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -75,12 +75,12 @@ namespace Microsoft.Build.Tasks.UnitTests
                     BuildEngine = _mockEngine,
                     DestinationFile = new TaskItem(file.Path),
                     Overwrite = true,
-                    SourceDirectory = new TaskItem(sourceFolder.FolderPath)
+                    SourceDirectory = new TaskItem(sourceFolder.Path)
                 };
 
                 zipDirectory.Execute().ShouldBeTrue(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain(sourceFolder.FolderPath, () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain(sourceFolder.Path, () => _mockEngine.Log);
                 _mockEngine.Log.ShouldContain(file.Path, () => _mockEngine.Log);
 
                 using (FileStream stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                 {
                     BuildEngine = _mockEngine,
                     DestinationFile = new TaskItem(file.Path),
-                    SourceDirectory = new TaskItem(folder.FolderPath)
+                    SourceDirectory = new TaskItem(folder.Path)
                 };
 
                 zipDirectory.Execute().ShouldBeFalse(() => _mockEngine.Log);

--- a/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
+++ b/src/Utilities.UnitTests/ToolLocationHelper_Tests.cs
@@ -2564,7 +2564,7 @@ namespace Microsoft.Build.UnitTests
             {
                 string frameworkName = "Foo Framework";
                 string frameworkVersion = "v0.1";
-                string rootDir = Path.Combine(env.DefaultTestDirectory.FolderPath, "framework-root");
+                string rootDir = Path.Combine(env.DefaultTestDirectory.Path, "framework-root");
 
                 string asmPath = CreateNewFrameworkAndGetAssembliesPath(env, frameworkName, frameworkVersion, rootDir);
 
@@ -2593,7 +2593,7 @@ namespace Microsoft.Build.UnitTests
             {
                 string frameworkName = "Foo Framework";
                 string frameworkVersion = "v0.1";
-                string customFrameworkRootPath = Path.Combine(env.DefaultTestDirectory.FolderPath, "framework-root");
+                string customFrameworkRootPath = Path.Combine(env.DefaultTestDirectory.Path, "framework-root");
 
                 string asmPath = CreateNewFrameworkAndGetAssembliesPath(env, frameworkName, frameworkVersion, customFrameworkRootPath);
                 string fallbackSearchPaths = $"/foo/bar;{customFrameworkRootPath};/a/b";
@@ -2616,8 +2616,8 @@ namespace Microsoft.Build.UnitTests
             {
                 string frameworkName = "Foo Framework";
                 string frameworkVersion = "v0.1";
-                string rootDir = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
-                string fallbackPath = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string rootDir = Path.Combine(env.CreateFolder().Path, "framework-root");
+                string fallbackPath = Path.Combine(env.CreateFolder().Path, "framework-root");
 
                 string asmPathForRoot = CreateNewFrameworkAndGetAssembliesPath(env, frameworkName, frameworkVersion, rootDir);
                 CreateNewFrameworkAndGetAssembliesPath(env, frameworkName, frameworkVersion, fallbackPath);
@@ -2647,7 +2647,7 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
 
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, null,
                                                     (string frameworkName, string frameworkVersion, string frameworkProfile, string customFrameworkDir, string fallbackSearchPaths)
@@ -2660,9 +2660,9 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
                 string searchPaths = $"/foo/bar;{customFrameworkDirToUse}";
-                string rootDir = env.CreateFolder().FolderPath;
+                string rootDir = env.CreateFolder().Path;
 
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, searchPaths,
                                                     (string frameworkName, string frameworkVersion, string frameworkProfile, string customFrameworkDir, string fallbackSearchPaths)
@@ -2677,7 +2677,7 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
                 string searchPaths = $"/foo/bar;{customFrameworkDirToUse}";
 
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, searchPaths,
@@ -2694,7 +2694,7 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, null,
                                                     (string frameworkName, string frameworkVersion, string frameworkProfile, string customFrameworkDir, string fallbackSearchPaths)
                                                          => ToolLocationHelper.GetPathToReferenceAssemblies(
@@ -2709,9 +2709,9 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
                 string searchPaths = $"{customFrameworkDirToUse};/a/b";
-                string rootDir = env.CreateFolder().FolderPath;
+                string rootDir = env.CreateFolder().Path;
 
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, searchPaths,
                                                     (string frameworkName, string frameworkVersion, string frameworkProfile, string customFrameworkDir, string fallbackSearchPaths)
@@ -2726,7 +2726,7 @@ namespace Microsoft.Build.UnitTests
         {
             using (var env = TestEnvironment.Create())
             {
-                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().FolderPath, "framework-root");
+                string customFrameworkDirToUse = Path.Combine(env.CreateFolder().Path, "framework-root");
                 string searchPaths = $"{customFrameworkDirToUse};/a/b";
                 CheckGetPathToReferenceAssemblies(env, customFrameworkDirToUse, searchPaths,
                                                     (string frameworkName, string frameworkVersion, string frameworkProfile, string customFrameworkDir, string fallbackSearchPaths)

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Build.UnitTests
             {
                 using (var env = TestEnvironment.Create())
                 {
-                    string tempDirectory = env.CreateFolder().FolderPath;
+                    string tempDirectory = env.CreateFolder().Path;
                     env.SetCurrentDirectory(tempDirectory);
                     env.SetEnvironmentVariable("PATH", $"{tempDirectory}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}");
                     Directory.SetCurrentDirectory(tempDirectory);


### PR DESCRIPTION
GetDirectoryNameOfFileAbove is called twice per each project evaluation to search for Directory.Build.{Props|Targets}