### PR TITLE
Specify explicit MicroBuildPluginsSwixBuildVersion

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -30,6 +30,7 @@
   <PropertyGroup>
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
     <UsingToolVSSDK>true</UsingToolVSSDK>
+    <MicroBuildPluginsSwixBuildVersion>1.0.422</MicroBuildPluginsSwixBuildVersion>
   </PropertyGroup>
 
   <!-- Toolset Dependencies -->


### PR DESCRIPTION
This was causing an issue with the internal build signing our vsix package.