### PR TITLE
Support ctrl-c cancellation when replaying a binary log

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1483,6 +1483,7 @@ namespace Microsoft.Build.Logging
     {
         public BinaryLogReplayEventSource() { }
         public void Replay(string sourceFilePath) { }
+        public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1478,6 +1478,7 @@ namespace Microsoft.Build.Logging
     {
         public BinaryLogReplayEventSource() { }
         public void Replay(string sourceFilePath) { }
+        public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3391,7 +3391,7 @@ namespace Microsoft.Build.CommandLine
 
             try
             {
-                replayEventSource.Replay(binaryLogFilePath);
+                replayEventSource.Replay(binaryLogFilePath, s_cts.Token);
             }
             catch (Exception ex)
             {

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3364,12 +3364,11 @@ namespace Microsoft.Build.CommandLine
             IEnumerable<DistributedLoggerRecord> distributedLoggerRecords,
             int cpuCount)
         {
-            var replayEventSource = new Logging.BinaryLogReplayEventSource();
+            var replayEventSource = new BinaryLogReplayEventSource();
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                var nodeLogger = distributedLoggerRecord.CentralLogger as INodeLogger;
-                if (nodeLogger != null)
+                if (distributedLoggerRecord.CentralLogger is INodeLogger nodeLogger)
                 {
                     nodeLogger.Initialize(replayEventSource, cpuCount);
                 }
@@ -3381,8 +3380,7 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var logger in loggers)
             {
-                var nodeLogger = logger as INodeLogger;
-                if (nodeLogger != null)
+                if (logger is INodeLogger nodeLogger)
                 {
                     nodeLogger.Initialize(replayEventSource, cpuCount);
                 }


### PR DESCRIPTION
I was looking at an issue where I issued an incorrect replay command and tried to cancel it, but it didn't work.

So . . . now it works.

I think we could improve some of the existing cancellation logic by plumbing the same CTS down, but I didn't do that here.