### PR TITLE
Bump version to 16.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "15.8-preview",
+  "version": "16.0-preview",
   "assemblyVersion": "15.1",
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
Note this does not change the `ToolsVersion` or the file assembly version (what you would use in binding redirects).