### PR TITLE
WIP: Ensure DefaultProjectTypeGuid is set when cross-targeting.

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.CSharp.CrossTargeting.targets
@@ -16,6 +16,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->
   <PropertyGroup>
      <CSharpDesignTimeTargetsPath Condition="'$(CSharpDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.CSharp.DesignTime.targets</CSharpDesignTimeTargetsPath>
+     <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</DefaultProjectTypeGuid>
   </PropertyGroup>
   <Import Project="$(CSharpDesignTimeTargetsPath)" Condition="'$(CSharpDesignTimeTargetsPath)' != '' and Exists('$(CSharpDesignTimeTargetsPath)')" />
 

--- a/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CrossTargeting.targets
@@ -16,6 +16,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Import design time targets before the common crosstargeting targets, which import targets from Nuget. -->
   <PropertyGroup>
      <VisualBasicDesignTimeTargetsPath Condition="'$(VisualBasicDesignTimeTargetsPath)'==''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.VisualBasic.DesignTime.targets</VisualBasicDesignTimeTargetsPath>
+     <DefaultProjectTypeGuid Condition=" '$(DefaultProjectTypeGuid)' == '' ">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</DefaultProjectTypeGuid>
   </PropertyGroup>
   <Import Project="$(VisualBasicDesignTimeTargetsPath)" Condition="'$(VisualBasicDesignTimeTargetsPath)' != '' and Exists('$(VisualBasicDesignTimeTargetsPath)')" />
 


### PR DESCRIPTION
For C# and VB projects that are cross-targeted, the cross-targeting targets are
evaluated from the root project and not the "current version" targets for the
languages (this is currently where `DefaultProjectTypeGuid` is set for each
language).  The "current version" targets are evaluated only from the "inner"
builds perform for each framework target; thus the `DefaultProjectTypeGuid` is
never set from the evaluation of a cross-targeted project file.

This means that when `dotnet` evaluates the project to determine the default
project type GUID to use for a command like `dotnet sln add`, it fails to do
and displays an error message to the user.

See related CLI issue dotnet/cli#9477.

The fix is to duplicate setting `DefaultProjectTypeGuid` in the cross-targeting
targets.  This allows the property to be visible when evaluating the root
project file.