### PR TITLE
Fix a race condition in ToolLocationHelper

### DIFF
--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -2108,11 +2108,6 @@ namespace Microsoft.Build.Utilities
                 }
             }
 
-            lock (s_locker)
-            {
-                s_cachedReferenceAssemblyPaths[referenceAssemblyCacheKey] = dotNetFrameworkReferenceAssemblies;
-            }
-
             for (int i = 0; i < dotNetFrameworkReferenceAssemblies.Count; i++)
             {
                 if (
@@ -2120,10 +2115,13 @@ namespace Microsoft.Build.Utilities
                         Path.DirectorySeparatorChar.ToString(),
                         StringComparison.Ordinal))
                 {
-                    dotNetFrameworkReferenceAssemblies[i] = string.Concat(
-                        dotNetFrameworkReferenceAssemblies[i],
-                        Path.DirectorySeparatorChar);
+                    dotNetFrameworkReferenceAssemblies[i] += Path.DirectorySeparatorChar;
                 }
+            }
+
+            lock (s_locker)
+            {
+                s_cachedReferenceAssemblyPaths[referenceAssemblyCacheKey] = dotNetFrameworkReferenceAssemblies;
             }
 
             return dotNetFrameworkReferenceAssemblies;


### PR DESCRIPTION
Fixes #3036.  Modifying the `dotNetFrameworkReferenceAssemblies` collection after publishing it bumps its version and breaks the `foreach` loop in the `GetPathToStandardLibraries` method. 