### PR TITLE
Disable deterministic source paths for tests

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,9 @@
     <DebugType Condition=" '$(TargetFramework)' != '' and '$(DebugType)' == ''">embedded</DebugType>
     <DebugType Condition="$(TargetFramework.StartsWith('net4')) And '$(MonoBuild)' != 'true'">full</DebugType>
 
+    <!-- Do not mangle paths for test assemblies, because Shoudly assertions want actual on-disk paths. -->
+    <DeterministicSourcePaths Condition="'$(IsTestProject)' == 'true'">false</DeterministicSourcePaths>
+
     <!-- Some hash code implementations may overflow -->
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
 


### PR DESCRIPTION
Shouldly walks the stack trace and extracts source expressions from the
source file identified in the PDB when an assertion fails to provide
nice, contextual error messages. But that broke when we took a
repo-toolset update that opted all projects into deterministic source
paths.

cc @jeffkl