### PR TITLE
WIP: Disable OutOfProcProjectInstanceBasedBuildDoesNotReloadFromDisk

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -3554,6 +3554,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [InlineData(false)]
         [InlineData(true)]
         [Trait("Category", "mono-osx-failing")] // out-of-proc nodes not working on mono yet
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/3552")]
         public void OutOfProcProjectInstanceBasedBuildDoesNotReloadFromDisk(bool shouldSerializeEntireState)
         {
             const string mainProject = @"<Project>


### PR DESCRIPTION
It fails fairly often in VSTS CI builds. Works around #3552 until we can root-cause it.