### PR TITLE
Semver2 version for NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,11 +46,12 @@
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
 
     <!-- NU1603: Microsoft.xunit.netcore.extensions package has dependencies to versions which aren't published, so ignore those warnings
+         NU5105: we're explicitly opting in to semver2, as is most of .NET Core
         CS1701 and CS1702 are by default ignored by Microsoft.NET.Sdk, but if you define the NoWarn property in Directory.Build.props,
         you don't get those defaults.
     -->
 
-    <NoWarn>$(NoWarn);NU1603;1701;1702</NoWarn>
+    <NoWarn>$(NoWarn);NU1603;NU5105;1701;1702</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-MONO'">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -122,10 +122,10 @@
     -->
     <PropertyGroup Condition=" '$(PrereleaseVersion)' != '' and '$(DisableNerdbankVersioning)' != 'true'">
       <!-- Override the NuGet package version provided by Nerdbank.GitVersioning -->
-      <PackageVersion>$(MajorMinorVersion).0$(PrereleaseVersion)-$([System.Int32]::Parse($(BuildVersionNumberComponent)).ToString('D6'))</PackageVersion>
+      <PackageVersion>$(MajorMinorVersion).0$(PrereleaseVersion).$(BuildVersionNumberComponent)$(SemVerBuildSuffix)</PackageVersion>
 
-      <!-- When building localling, append -private to distinguish official builds -->
-      <PackageVersion Condition="'$(OfficialBuild)' != 'true'">$(PackageVersion)-private</PackageVersion>
+      <!-- When building locally, append .private to distinguish official builds -->
+      <PackageVersion Condition="'$(OfficialBuild)' != 'true'">$(PackageVersion).private</PackageVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(PrereleaseVersion)' == '' and '$(DisableNerdbankVersioning)' != 'true'">


### PR DESCRIPTION
This brings us in line with the [Arcade standard](https://github.com/dotnet/arcade/blob/master/Documentation/Versioning.md#net-core-ecosystem-v2---versioning), while preserving the wildcard-ability of referring to `major.minor.0-prerelease*`.

Produces a package name like `Microsoft.Build.Framework.16.0.0-preview.12.nupkg`.

fyi @natemcmaster 