### PR TITLE
Always throttle log message handling

### DIFF
--- a/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingServicesLogMethod_Tests.cs
@@ -1772,7 +1772,7 @@ namespace Microsoft.Build.UnitTests.Logging
             /// Override the method to log which event was processed so it can be verified in a test
             /// </summary>
             /// <param name="buildEvent">Build event which was asked to be processed</param>
-            internal override void ProcessLoggingEvent(object buildEvent, bool allowThrottling = false)
+            internal override void ProcessLoggingEvent(object buildEvent)
             {
                 if (buildEvent is BuildEventArgs)
                 {


### PR DESCRIPTION
Fixes #3577 by applying the throttling policy to the processing of all
logging events, not just those from other nodes.

While this will slow the build down, it will keep the memory usage of
log events in the to-be-processed queue bounded, preventing the OOM
reported in the bug.