### PR TITLE
Introduce MSBuildLastModifiedProject

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectFormatting_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectFormatting_Tests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Build.Engine.OM.UnitTests.Construction
 <Project DefaultTargets='Build' ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'>
   <Target
     Name=""XamlPreCompile""
-    Inputs=""$(MSBuildAllProjects);
+    Inputs=""$(MSBuildNewestProject);$(MSBuildAllProjects);
            @(Compile);
            @(_CoreCompileResourceInputs);""
   />

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -1997,7 +1997,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 // the whole list.
                 // We have to dump it into a dictionary because AllEvaluatedProperties contains duplicates, but we're preparing to Properties,
                 // which doesn't, so we need to make sure that the final value in AllEvaluatedProperties is the one that matches.
-                foreach (ProjectProperty property in project.AllEvaluatedProperties.TakeWhile(property => property.Xml == null))
+                foreach (ProjectProperty property in project.AllEvaluatedProperties.Where(property => property.Xml == null))
                 {
                     allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates[property.Name] = property;
                 }
@@ -2024,7 +2024,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 }
 
                 // These are the properties which are defined in some file.
-                IEnumerable<ProjectProperty> restOfAllEvaluatedProperties = project.AllEvaluatedProperties.SkipWhile(property => property.Xml == null);
+                IEnumerable<ProjectProperty> restOfAllEvaluatedProperties = project.AllEvaluatedProperties.Where(property => property.Xml != null);
 
                 Assert.Equal(3, restOfAllEvaluatedProperties.Count());
                 Assert.Equal("1", restOfAllEvaluatedProperties.ElementAt(0).EvaluatedValue);

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Internal
         internal const string startupDirectory = "MSBuildStartupDirectory";
         internal const string buildNodeCount = "MSBuildNodeCount";
         internal const string lastTaskResult = "MSBuildLastTaskResult";
-        internal const string newestProject = "MSBuildNewestProject";
+        internal const string lastModifiedProject = "MSBuildLastModifiedProject";
         internal const string extensionsPathSuffix = "MSBuild";
         internal const string userExtensionsPathSuffix = "Microsoft\\MSBuild";
         internal const string programFiles32 = "MSBuildProgramFiles32";
@@ -86,7 +86,7 @@ namespace Microsoft.Build.Internal
             programFiles32,
             assemblyVersion,
             version,
-            newestProject
+            lastModifiedProject
         };
 
         /// <summary>

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Build.Internal
         internal const string startupDirectory = "MSBuildStartupDirectory";
         internal const string buildNodeCount = "MSBuildNodeCount";
         internal const string lastTaskResult = "MSBuildLastTaskResult";
+        internal const string newestProject = "MSBuildNewestProject";
         internal const string extensionsPathSuffix = "MSBuild";
         internal const string userExtensionsPathSuffix = "Microsoft\\MSBuild";
         internal const string programFiles32 = "MSBuildProgramFiles32";
@@ -84,7 +85,8 @@ namespace Microsoft.Build.Internal
             lastTaskResult,
             programFiles32,
             assemblyVersion,
-            version
+            version,
+            newestProject
         };
 
         /// <summary>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2217,7 +2217,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ====================================================================================================
   -->
   <Target Name="GenerateBindingRedirects"
-    Inputs="$(MSBuildAllProjects);@(AppConfigFile);$(ResolveAssemblyReferencesStateFile);$(IntermediateOutputPath);@(SuggestedBindingRedirects)"
+    Inputs="$(MSBuildNewestProject);$(MSBuildAllProjects);@(AppConfigFile);$(ResolveAssemblyReferencesStateFile);$(IntermediateOutputPath);@(SuggestedBindingRedirects)"
     Outputs="$(_GenerateBindingRedirectsIntermediateAppConfig)"
     Condition="'$(AutoGenerateBindingRedirects)' == 'true' and '$(GenerateBindingRedirectsOutputType)' == 'true'">
 
@@ -2518,7 +2518,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Target Name="ExportWindowsMDFile"
           DependsOnTargets="Compile"
           Condition="'$(ExportWinMDFile)' == 'true'"
-          Inputs="@(IntermediateAssembly);@(DocFileItem);@(_DebugSymbolsIntermediatePath);@(ReferencePathWithRefAssemblies);$(MSBuildAllProjects)"
+          Inputs="@(IntermediateAssembly);@(DocFileItem);@(_DebugSymbolsIntermediatePath);@(ReferencePathWithRefAssemblies);$(MSBuildNewestProject);$(MSBuildAllProjects)"
           Outputs="$(_IntermediateWindowsMetadataPath);$(WinMDExpOutputPdb);$(WinMDOutputDocumentationFile)"
   >
 
@@ -3050,7 +3050,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Sources="@(EmbeddedResource)"
         UseSourcePath="$(UseSourcePath)"
         References="@(ReferencePathWithRefAssemblies)"
-        AdditionalInputs="$(MSBuildAllProjects)"
+        AdditionalInputs="$(MSBuildNewestProject);$(MSBuildAllProjects)"
         NeverLockTypeAssemblies="$(GenerateResourceNeverLockTypeAssemblies)"
         StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).GenerateResource.cache"
         StronglyTypedClassName="%(EmbeddedResource.StronglyTypedClassName)"
@@ -3080,7 +3080,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Sources="@(EmbeddedResource)"
         UseSourcePath="$(UseSourcePath)"
         References="@(ReferencePath)"
-        AdditionalInputs="$(MSBuildAllProjects)"
+        AdditionalInputs="$(MSBuildNewestProject);$(MSBuildAllProjects)"
         NeverLockTypeAssemblies="$(GenerateResourceNeverLockTypeAssemblies)"
         StateFile="$(IntermediateOutputPath)$(MSBuildProjectFile).GenerateResource.cache"
         StronglyTypedClassName="%(EmbeddedResource.StronglyTypedClassName)"
@@ -3149,7 +3149,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="CompileLicxFiles"
       Condition="'@(_LicxFile)'!=''"
       DependsOnTargets="$(CompileLicxFilesDependsOn)"
-      Inputs="$(MSBuildAllProjects);@(_LicxFile);@(ReferencePathWithRefAssemblies);@(ReferenceDependencyPaths)"
+      Inputs="$(MSBuildNewestProject);$(MSBuildAllProjects);@(_LicxFile);@(ReferencePathWithRefAssemblies);@(ReferenceDependencyPaths)"
       Outputs="$(IntermediateOutputPath)$(TargetFileName).licenses">
 
     <PropertyGroup>
@@ -3356,7 +3356,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="GenerateAdditionalSources"
           BeforeTargets="BeforeCompile"
           DependsOnTargets="PrepareForBuild;GetReferenceAssemblyPaths"
-          Inputs="$(MSBuildAllProjects)"
+          Inputs="$(MSBuildNewestProject);$(MSBuildAllProjects)"
           Outputs="$(AssemblyAttributesPath)"
           Condition="'@(AssemblyAttributes)' != '' and '$(GenerateAdditionalSources)' == 'true'">
     <WriteCodeFragment
@@ -3523,7 +3523,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Name="GenerateSerializationAssemblies"
       Condition="'$(_SGenGenerateSerializationAssembliesConfig)' == 'On' or ('@(WebReferenceUrl)'!='' and '$(_SGenGenerateSerializationAssembliesConfig)' == 'Auto')"
       DependsOnTargets="AssignTargetPaths;Compile;ResolveKeySource"
-      Inputs="$(MSBuildAllProjects);@(IntermediateAssembly)"
+      Inputs="$(MSBuildNewestProject);@(IntermediateAssembly);$(MSBuildAllProjects)"
       Outputs="$(IntermediateOutputPath)$(_SGenDllName)">
 
     <PropertyGroup>
@@ -3618,7 +3618,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <Target Name="GenerateSatelliteAssemblies"
-          Inputs="$(MSBuildAllProjects);@(_SatelliteAssemblyResourceInputs);$(IntermediateOutputPath)$(TargetName)$(TargetExt)"
+          Inputs="$(MSBuildNewestProject);@(_SatelliteAssemblyResourceInputs);$(IntermediateOutputPath)$(TargetName)$(TargetExt);$(MSBuildAllProjects)"
           Outputs="$(IntermediateOutputPath)%(Culture)\$(TargetName).resources.dll"
           Condition="'@(_SatelliteAssemblyResourceInputs)' != '' and '$(GenerateSatelliteAssembliesForCore)' != 'true'">
 

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -177,7 +177,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
     <Target
         Name="XamlPreCompile"
-        Inputs="$(MSBuildAllProjects);
+        Inputs="$(MSBuildNewestProject);$(MSBuildAllProjects);
                 @(Compile);
                 @(_CoreCompileResourceInputs);
                 $(ApplicationIcon);


### PR DESCRIPTION
Represents the project in the import graph with the most recent last modified time.  This is a step towards deprecating `MSBuildAllProjects`.

If the project is an in-memory project but has no imports, the property is not set.  If the project is an in-memory project and has imports, the property does not include the project itself.

Closes #3591