### PR TITLE
Use single-instance CancellationToken.None

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Logging
         /// <param name="sourceFilePath">The full file path of the binary log file</param>
         public void Replay(string sourceFilePath)
         {
-            Replay(sourceFilePath, new CancellationToken(canceled: false));
+            Replay(sourceFilePath, CancellationToken.None);
         }
 
         /// <summary>


### PR DESCRIPTION
I didn't know this existed, but it's a better default than creating a new token.

Followup for #3518.