### PR TITLE
Prepend the last modified project to MSBuildAllProjects

### DIFF
--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4444,10 +4444,14 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 File.SetLastWriteTime(project2.ProjectFile, DateTime.Now);
                 File.SetLastWriteTime(primaryProject.ProjectFile, DateTime.Now.AddHours(-1));
 
-
                 Project project = new Project(primaryProject.ProjectFile, null, null);
 
-                project.GetPropertyValue(Constants.MSBuildAllProjectsPropertyName).ShouldStartWith(project2.ProjectFile);
+                string propertyValue = project.GetPropertyValue(Constants.MSBuildAllProjectsPropertyName);
+
+                propertyValue.ShouldStartWith(project2.ProjectFile);
+
+                propertyValue.ShouldNotContain(primaryProject.ProjectFile, Case.Insensitive);
+                propertyValue.ShouldNotContain(project1.ProjectFile, Case.Insensitive);
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Shouldly;
 using Xunit;
 
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
@@ -1997,7 +1998,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 // the whole list.
                 // We have to dump it into a dictionary because AllEvaluatedProperties contains duplicates, but we're preparing to Properties,
                 // which doesn't, so we need to make sure that the final value in AllEvaluatedProperties is the one that matches.
-                foreach (ProjectProperty property in project.AllEvaluatedProperties.TakeWhile(property => property.Xml == null))
+                foreach (ProjectProperty property in project.AllEvaluatedProperties.Where(property => property.Xml == null))
                 {
                     allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates[property.Name] = property;
                 }
@@ -2024,7 +2025,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 }
 
                 // These are the properties which are defined in some file.
-                IEnumerable<ProjectProperty> restOfAllEvaluatedProperties = project.AllEvaluatedProperties.SkipWhile(property => property.Xml == null);
+                IEnumerable<ProjectProperty> restOfAllEvaluatedProperties = project.AllEvaluatedProperties.Where(property => property.Xml != null);
 
                 Assert.Equal(3, restOfAllEvaluatedProperties.Count());
                 Assert.Equal("1", restOfAllEvaluatedProperties.ElementAt(0).EvaluatedValue);
@@ -4422,6 +4423,56 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 bool result = project.Build(logger);
 
                 Assert.True(result);
+            }
+        }
+
+        [Fact]
+        public void VerifyMSBuildLastModifiedProjectForImport()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                var project1 = testEnvironment.CreateTestProjectWithFiles("<Project />");
+                var project2 = testEnvironment.CreateTestProjectWithFiles("<Project />");
+
+                var primaryProject = testEnvironment.CreateTestProjectWithFiles($@"<Project>
+<Import Project=""{project1.ProjectFile}"" />
+<Import Project=""{project2.ProjectFile}"" />
+</Project>");
+
+                // Project1 and primary project last modified an hour ago, project2 is the newest
+                File.SetLastWriteTime(project1.ProjectFile, DateTime.Now.AddHours(-1));
+                File.SetLastWriteTime(project2.ProjectFile, DateTime.Now);
+                File.SetLastWriteTime(primaryProject.ProjectFile, DateTime.Now.AddHours(-1));
+
+
+                Project project = new Project(primaryProject.ProjectFile, null, null);
+
+                project.GetPropertyValue(Constants.MSBuildAllProjectsPropertyName).ShouldStartWith(project2.ProjectFile);
+            }
+        }
+
+        [Fact]
+        public void VerifyMSBuildLastModifiedProjectIsProject()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                var project1 = testEnvironment.CreateTestProjectWithFiles("<Project />");
+                var project2 = testEnvironment.CreateTestProjectWithFiles("<Project />");
+
+                var primaryProject = testEnvironment.CreateTestProjectWithFiles($@"<Project>
+<Import Project=""{project1.ProjectFile}"" />
+<Import Project=""{project2.ProjectFile}"" />
+</Project>");
+
+                // Project1 and project2 last modified an hour ago, primaryProject is the newest
+                File.SetLastWriteTime(project1.ProjectFile, DateTime.Now.AddHours(-1));
+                File.SetLastWriteTime(project2.ProjectFile, DateTime.Now.AddHours(-1));
+                File.SetLastWriteTime(primaryProject.ProjectFile, DateTime.Now);
+
+
+                Project project = new Project(primaryProject.ProjectFile, null, null);
+
+                project.GetPropertyValue(Constants.MSBuildAllProjectsPropertyName).ShouldStartWith(primaryProject.ProjectFile);
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -1831,11 +1831,9 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             IDictionary<string, ProjectProperty> allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates = new Dictionary<string, ProjectProperty>(StringComparer.OrdinalIgnoreCase);
 
-            // Get all those properties from project.AllEvaluatedProperties which don't have a backing xml. As project.AllEvaluatedProperties
-            // is an ordered collection and since such properties necessarily should occur before other properties, we don't need to scan
-            // the whole list.
-            // We have to dump it into a dictionary because AllEvaluatedProperties contains duplicates, but we're preparing to Properties,
-            // which doesn't, so we need to make sure that the final value in AllEvaluatedProperties is the one that matches.
+            // Get all those properties from project.AllEvaluatedProperties which don't have a backing xml. We have to dump it into a dictionary
+            // because AllEvaluatedProperties contains duplicates, but we're preparing to Properties, which doesn't, so we need to make sure
+            // that the final value in AllEvaluatedProperties is the one that matches.
             foreach (ProjectProperty property in project.AllEvaluatedProperties.TakeWhile(property => property.Xml == null))
             {
                 allEvaluatedPropertiesWithNoBackingXmlAndNoDuplicates[property.Name] = property;

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2754,7 +2754,9 @@ namespace Microsoft.Build.Evaluation
                     Constants.MSBuildAllProjectsPropertyName,
                     oldValue == null
                         ? _lastModifiedProject.FullPath
-                        : String.Format(CultureInfo.CurrentCulture, "{0};{1}", _lastModifiedProject.FullPath, oldValue.EvaluatedValue), isGlobalProperty: false, mayBeReserved: false);
+                        : $"{_lastModifiedProject.FullPath};{oldValue.EvaluatedValue}",
+                    isGlobalProperty: false,
+                    mayBeReserved: false);
 
                 if (oldValue != null)
                 {

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -182,6 +182,8 @@ namespace Microsoft.Build.Internal
 
         // Name of the environment variable that always points to 32-bit program files.
         internal const string programFilesx86 = "ProgramFiles(x86)";
+
+        internal const string MSBuildAllProjectsPropertyName = "MSBuildAllProjects";
     }
 
     /// <summary>

--- a/src/Shared/UnitTests/EngineTestEnvironment.cs
+++ b/src/Shared/UnitTests/EngineTestEnvironment.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Build.UnitTests
         {
             _folder = new TransientTestFolder();
 
-            var projectDir = Path.Combine(TestRoot, relativePathFromRootToProject);
+            var projectDir = Path.GetFullPath(Path.Combine(TestRoot, relativePathFromRootToProject));
             Directory.CreateDirectory(projectDir);
 
-            ProjectFile = Path.Combine(projectDir, "build.proj");
+            ProjectFile = Path.GetFullPath(Path.Combine(projectDir, "build.proj"));
             File.WriteAllText(ProjectFile, ObjectModelHelpers.CleanupFileContents(projectContents));
 
             CreatedFiles = Helpers.CreateFilesInDirectory(TestRoot, files);

--- a/src/Tasks.UnitTests/DirectoryBuildProjectImportTestBase.cs
+++ b/src/Tasks.UnitTests/DirectoryBuildProjectImportTestBase.cs
@@ -118,7 +118,6 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(String.Empty, project.GetPropertyValue(DirectoryBuildProjectBasePathPropertyName), StringComparer.OrdinalIgnoreCase);
             Assert.Equal(String.Empty, project.GetPropertyValue(DirectoryBuildProjectFilePropertyName), StringComparer.OrdinalIgnoreCase);
             Assert.Equal(String.Empty, project.GetPropertyValue(DirectoryBuildProjectPathPropertyName));
-            Assert.DoesNotContain(directoryBuildProjectFilePath, project.GetPropertyValue("MSBuildAllProjects"));
         }
 
         /// <summary>
@@ -147,7 +146,6 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal("true", project.GetPropertyValue(ImportDirectoryBuildProjectPropertyName), StringComparer.OrdinalIgnoreCase);
             Assert.Equal("true", project.GetPropertyValue("WasDirectoryBuildProjectImported"), StringComparer.OrdinalIgnoreCase);
             Assert.Equal(customFilePath, project.GetPropertyValue(DirectoryBuildProjectPathPropertyName));
-            Assert.Contains(customFilePath, project.GetPropertyValue("MSBuildAllProjects"));
         }
 
         /// <summary>
@@ -175,7 +173,6 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(ObjectModelHelpers.TempProjectDir, project.GetPropertyValue(DirectoryBuildProjectBasePathPropertyName), StringComparer.OrdinalIgnoreCase);
             Assert.Equal(DirectoryBuildProjectFile, project.GetPropertyValue(DirectoryBuildProjectFilePropertyName), StringComparer.OrdinalIgnoreCase);
             Assert.Equal(Path.Combine(ObjectModelHelpers.TempProjectDir, DirectoryBuildProjectFile), project.GetPropertyValue(DirectoryBuildProjectPathPropertyName));
-            Assert.Contains(directoryBuildProjectFilePath, project.GetPropertyValue("MSBuildAllProjects"));
         }
     }
 }

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -35,7 +35,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Import Project="$(CustomBeforeMicrosoftCSharpTargets)" Condition="'$(CustomBeforeMicrosoftCSharpTargets)' != '' and Exists('$(CustomBeforeMicrosoftCSharpTargets)')" />
 
     <PropertyGroup>
-        <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
         <DefaultLanguageSourceExtension>.cs</DefaultLanguageSourceExtension>
         <Language>C#</Language>
         <TargetRuntime>Managed</TargetRuntime>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -182,10 +182,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')">
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(DirectoryBuildTargetsPath)</MSBuildAllProjects>
-  </PropertyGroup>
-  
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>
 
   <!-- TODO: https://github.com/Microsoft/msbuild/issues/1062: Remove this temporary hook when possible. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -532,11 +532,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <WebReference_EnableLegacyEventingModel Condition=" '$(WebReference_EnableLegacyEventingModel)' == '' ">false</WebReference_EnableLegacyEventingModel>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <MSBuildAllProjects Condition="Exists('$(MSBuildProjectFullPath).user')">$(MSBuildAllProjects);$(MSBuildProjectFullPath).user</MSBuildAllProjects>
-  </PropertyGroup>
-
   <!--
     These parameters control where to look in the registry for directories to search for
     assemblies in the assembly resolution tasks.

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -29,10 +29,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DirectoryBuildPropsPath Condition="'$(_DirectoryBuildPropsBasePath)' != '' and '$(_DirectoryBuildPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildPropsBasePath)', '$(_DirectoryBuildPropsFile)'))</DirectoryBuildPropsPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')">
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(DirectoryBuildPropsPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
   <Import Project="$(DirectoryBuildPropsPath)" Condition="'$(ImportDirectoryBuildProps)' == 'true' and exists('$(DirectoryBuildPropsPath)')"/>
 
   <!-- 

--- a/src/Tasks/Microsoft.Common.targets
+++ b/src/Tasks/Microsoft.Common.targets
@@ -140,10 +140,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <DirectoryBuildTargetsPath Condition="'$(_DirectoryBuildTargetsBasePath)' != '' and '$(_DirectoryBuildTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectoryBuildTargetsBasePath)', '$(_DirectoryBuildTargetsFile)'))</DirectoryBuildTargetsPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')">
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(DirectoryBuildTargetsPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
   <Import Project="$(DirectoryBuildTargetsPath)" Condition="'$(ImportDirectoryBuildTargets)' == 'true' and exists('$(DirectoryBuildTargetsPath)')"/>
 
   <ImportGroup Condition="'$(MSBuildAssemblyVersion)' == ''">

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.props
@@ -26,8 +26,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportByWildcardBeforeMicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.props\ImportBefore')"/>
 
   <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
     <!-- By default we want to replace subsets with profiles, but we do need a way to turning off this "upgrade" in case a user needs to target a subset-->
     <UpgradeSubsetToProfile Condition="'$(UpgradeSubsetToProfile)' == '' ">true</UpgradeSubsetToProfile>
 

--- a/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.NETFramework.CurrentVersion.targets
@@ -25,10 +25,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Import Project="$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportUserLocationsByWildcardBeforeMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildUserExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore')"/>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore\*" Condition="'$(ImportByWildcardBeforeMicrosoftNetFrameworkTargets)' == 'true' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.NETFramework.targets\ImportBefore')"/>
   
-  <PropertyGroup>
-     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
-
   <Target
       Name="GetFrameworkPaths"
       DependsOnTargets="$(GetFrameworkPathsDependsOn)">

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -35,7 +35,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Import Project="$(CustomBeforeMicrosoftVisualBasicTargets)" Condition="'$(CustomBeforeMicrosoftVisualBasicTargets)' != '' and Exists('$(CustomBeforeMicrosoftVisualBasicTargets)')" />
 
     <PropertyGroup>
-        <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
         <DefaultLanguageSourceExtension>.vb</DefaultLanguageSourceExtension>
         <Language>VB</Language>
         <TargetRuntime>Managed</TargetRuntime>


### PR DESCRIPTION
During evaluation, keep track of the last modified project in the import graph.
Prepend the path to the last modified project to `MSBuildAllProjects`
Stop setting `MSBuildAllProjects` in our targets
Add unit tests

Closes #1299