### PR TITLE
Walk directories in up-to-date checks on Windows

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -1098,8 +1098,8 @@ namespace Microsoft.Build.BackEnd
             // PERF -- we could change this to ensure that we walk the shortest list first (because we walk that one entirely): 
             //         possibly the outputs list isn't actually the shortest list. However it always is the shortest
             //         in the cases I've seen, and adding this optimization would make the code hard to read.
-            (string fileName, DateTime fileTime) oldestOutput = GetOldestFile(projectDirectory, outputs);
-            (string fileName, DateTime fileTime) newerInput = GetNewerFile(projectDirectory, inputs, oldestOutput.fileTime);
+            (string filePath, DateTime fileTime) oldestOutput = GetOldestFile(projectDirectory, outputs);
+            (string filePath, DateTime fileTime) newerInput = GetNewerFile(projectDirectory, inputs, oldestOutput.fileTime);
             dependencyAnalysisDetailEntry = CompareInputAndOutput(newerInput, oldestOutput);
             return dependencyAnalysisDetailEntry != null;
         }
@@ -1112,7 +1112,7 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
-        private static DependencyAnalysisLogDetail CompareInputAndOutput((string fileName, DateTime fileTime) newerInput, (string fileName, DateTime fileTime) oldestOutput)
+        private static DependencyAnalysisLogDetail CompareInputAndOutput((string filePath, DateTime fileTime) newerInput, (string filePath, DateTime fileTime) oldestOutput)
         {
             bool isMissingOutput = IsInvalidFileTime(oldestOutput.fileTime);
             bool isMissingInput = IsInvalidFileTime(newerInput.fileTime);
@@ -1126,7 +1126,7 @@ namespace Microsoft.Build.BackEnd
 
             OutofdateReason reason = isMissingOutput ? OutofdateReason.MissingOutput
                 : isMissingInput ? OutofdateReason.MissingInput : OutofdateReason.NewerInput;
-            return new DependencyAnalysisLogDetail(newerInput.fileName, oldestOutput.fileName, null, null, reason);
+            return new DependencyAnalysisLogDetail(newerInput.filePath, oldestOutput.filePath, null, null, reason);
         }
 
         private static bool IsInvalidFileTime(DateTime lastWriteTimeUtc)
@@ -1134,7 +1134,7 @@ namespace Microsoft.Build.BackEnd
             return lastWriteTimeUtc == DateTime.MinValue;
         }
 
-        private static (string fileName, DateTime fileTime) GetOldestFile<T>(string projectDirectory, IList<T> escapedFilePaths)
+        private static (string filePath, DateTime fileTime) GetOldestFile<T>(string projectDirectory, IList<T> escapedFilePaths)
         {
             string oldestFilePath = String.Empty;
             DateTime oldestFileTime = DateTime.MaxValue;
@@ -1172,7 +1172,7 @@ namespace Microsoft.Build.BackEnd
             return (oldestFilePath, oldestFileTime);
         }
 
-        private static (string fileName, DateTime fileTime) GetNewerFile<T>(string projectDirectory, IList<T> escapedFilePaths, DateTime oldestFileTime)
+        private static (string filePath, DateTime fileTime) GetNewerFile<T>(string projectDirectory, IList<T> escapedFilePaths, DateTime oldestFileTime)
         {
             if (IsInvalidFileTime(oldestFileTime))
             {

--- a/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TargetUpToDateChecker.cs
@@ -1036,7 +1036,8 @@ namespace Microsoft.Build.BackEnd
                 return new FileDateInfo(arbitraryPath, DateTime.MaxValue);
             }
 #if FEATURE_ENUMERATION
-            if (NativeMethodsShared.IsWindows) {
+            if (NativeMethodsShared.IsWindows)
+            {
                 return GetFileWithTimeConditionByDirectory(projectDirectory, escapedFilePaths, conditionFileTime, condition);
             }
 #endif
@@ -1162,13 +1163,20 @@ namespace Microsoft.Build.BackEnd
         {
             string directoryPath = Path.Combine(projectDirectory, directoryName);
 
-            return new FileSystemEnumerable<FileDateInfo>(
-                directoryPath,
-                (ref FileSystemEntry entry) => new FileDateInfo(entry.FileName.ToString(), entry.LastWriteTimeUtc.DateTime)
-            )
+            try
             {
-                ShouldIncludePredicate = (ref FileSystemEntry entry) => !entry.IsDirectory
-            };
+                return new FileSystemEnumerable<FileDateInfo>(
+                    directoryPath,
+                    (ref FileSystemEntry entry) => new FileDateInfo(entry.FileName.ToString(), entry.LastWriteTimeUtc.DateTime)
+                )
+                {
+                    ShouldIncludePredicate = (ref FileSystemEntry entry) => !entry.IsDirectory
+                };
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return Enumerable.Empty<FileDateInfo>();
+            }
         }
 #endif
 

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -129,6 +129,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);FEATURE_ENUMERATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NAMED_PIPES_FULL_DUPLEX</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_PIPEOPTIONS_CURRENTUSERONLY</DefineConstants>
     <DefineConstants Condition="'$(MachineIndependentBuild)' != 'true'">$(DefineConstants);FEATURE_NODE_REUSE</DefineConstants>


### PR DESCRIPTION
Started with Git for Windows style caching as discussed (listed in the table as FS cache). Pros, very simple to implement and only needed to hook in a couple lines in the up-to-date method. Cons, doesn't perform as well due to hitting huge directories such as the temp folder in many targets, then proceeding to load up the cache with potentially thousands of unnecessary files. Since the cache is just scoped to the method, this ends up happening many, many times. Would perform much better if we had a cache persistent across up-to-date checks, but there's no good way to do invalidation yet. The test project ends up loading around 10k directories, but many of them are duplicates of previous target input/outputs.

Instead, grouping inputs and outputs by directory first, then walking each directory while checking if each walked file is in the set works much better. Still have to create a ton of strings to check hashtables, split then reconstruct paths, and walk unneeded files, but it allows short circuiting the walk when we've found everything in a directory and keeps the dictionary from blowing up in size. Lots of extra code right now since it doesn't fit well at all in the current  ```IsAnyOutOfDate()``` due to the different flow and Enumeration API, but shouldn't be difficult to just create an enumerator from the native calls on .NET Framework now that the logic is all there.

Also have memory usage concerns. Since Dictionary/HashSet can't use ```Span<Char>``` or ```Memory<Char>``` as keys, in both cases there's a good number of extra strings being created compared to before.

.NET Core build times below, averaged over 6 runs each:

| WebLarge Build | GetFileAttributesEx  | System.IO.Enumeration w/ local-scope FS cache | System.IO.Enumeration w/ local-scope input/output cache| 
| ------------- | ------------- | ------------- | ------------- |
| Incremental no-op  | 17527 ms | 16407 ms | 15546 ms |
| Incremental no-op parallel  | 6601 ms | 6199 ms | 5739 ms |
