### PR TITLE
Stop IBCMerge for VSSetup project

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -151,7 +151,7 @@
     <Exec Command="tlbexp.exe $(TlbExpVerbosity) /NOLOGO @(TlbExpAssemblyPaths->'/asmpath:&quot;%(Identity)&quot;', ' ') $(TargetPath) /out:$(TargetDir)$(TargetName).tlb" />
   </Target>
 
-  <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4'))" />
+  <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4')) and '$(MicroBuild_EnablePGO)' != 'false'" />
 
   <!-- Import parent targets -->
   <Import Project="..\Directory.Build.targets"/>


### PR DESCRIPTION
src\Package\MSBuild.VSSetup\MSBuild.VSSetup.csproj has an assembly name
that matches a shipped assembly, so the IBCMerge targets attempt to
apply PGO data to it, but it does not have any matching methods because
it's not a real project.

Respect the preexisting `$(MicroBuild_EnablePGO)` when deciding whether
to include the IBCMerge targets.