### PR TITLE
Refer to Compilers package unconditionally

### DIFF
--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -955,14 +955,21 @@
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
+  <!-- Tasks need to mimic redistributing the compilers, so add references to both full framework and .net core -->
+  <ItemGroup>
+    <!-- reference both when repotoolset is not adding compiler references -->
+    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'" />
+    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'" />
+
+    <!-- reference the missing package when repotoolset is adding compiler references based on MSBuildRuntimeType https://github.com/dotnet/roslyn-tools/blob/master/src/RepoToolset/tools/Compiler.props -->
+    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and '$(MSBuildRuntimeType)' == 'Core'" />
+    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
-    <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <!-- Can remove condition when we move to a toolset containing this change https://github.com/dotnet/roslyn-tools/pull/312 -->
-    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'"/>
-    
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 
@@ -978,10 +985,6 @@
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->
     <PackageReference Include="Microsoft.Win32.Registry" />
 
-    <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <!-- Can remove condition when we move to a toolset containing this change https://github.com/dotnet/roslyn-tools/pull/312 -->
-    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'" />
-    
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -955,20 +955,11 @@
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Repotools will add a PackageReference for the compilers package based on the current runtime.
-         To bootstrap, we will need the compilers for both runtimes to copy the output. -->
-    <PackageReference
-      Condition="'$(MSBuildRuntimeType)' == 'Core' and '$(TargetFrameworkIdentifier)' == '.NETFramework'"
-      Include="Microsoft.Net.Compilers" ExcludeAssets="all" />
-    <PackageReference
-      Condition="'$(MSBuildRuntimeType)' != 'Core' and '$(TargetFrameworkIdentifier)' != '.NETFramework'"
-      Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
+
+    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" />
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 
@@ -985,6 +976,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
+    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" />
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="RoslynTools.RepoToolset">
+<Project Sdk="RoslynTools.RepoToolset">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
 

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -959,7 +959,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
-    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" />
+    <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
+    <!-- Can remove condition when we move to a toolset containing this change https://github.com/dotnet/roslyn-tools/pull/312 -->
+    <PackageReference Include="Microsoft.Net.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'"/>
+    
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 
@@ -976,7 +979,9 @@
     <PackageReference Include="Microsoft.Win32.Registry" />
 
     <!-- Reference compilers package without using assets, so we can copy them to the output directory under the Roslyn folder -->
-    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" />
+    <!-- Can remove condition when we move to a toolset containing this change https://github.com/dotnet/roslyn-tools/pull/312 -->
+    <PackageReference Include="Microsoft.NETCore.Compilers" ExcludeAssets="all" Condition="'$(UsingToolMicrosoftNetCompilers)' == 'false'" />
+    
     <Content Include="$(NuGetPackageRoot)microsoft.netcore.compilers\$(MicrosoftNetCoreCompilersVersion)\tools\**\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 


### PR DESCRIPTION
MSBuild's unit tests depend on a functional MSBuild deployment,
including Roslyn tasks and targets. These weren't getting copied on the
initial build because the NuGet package that contained them (for full
framework) wasn't guaranteed to be restored. Relax the conditions on
the PackageReference that attempted to ensure that.