### PR TITLE
Unset global TargetFramework properties for synthetic project references

### DIFF
--- a/src/Tasks/ResolveProjectBase.cs
+++ b/src/Tasks/ResolveProjectBase.cs
@@ -277,6 +277,7 @@ namespace Microsoft.Build.Tasks
                     item.SetMetadata("LinkLibraryDependencies", "false");
                     item.SetMetadata("CopyLocal", "false");
                     item.SetMetadata("SkipGetTargetFrameworkProperties", "true");
+                    item.SetMetadata("GlobalPropertiesToRemove", "TargetFramework");
 
                     updatedProjectReferenceList.Add(item);
                 }


### PR DESCRIPTION
Fixes #3626

Since the synthetic p2p won't re-negotiate a `TargetFramework` value to set due to the `SkipGetTargetFrameworkProperties` metadata, remove the the global property from moving across the reference by setting it as `GlobalPropertiesToRemove` metadata.

cc @rainersigwald @AndyGerlicher @jeffkl @nguerrera @natemcmaster 