### PR TITLE
Log debug dumps

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -208,6 +208,11 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private bool _disposed;
 
+        /// <summary>
+        /// When the BuildManager was created.
+        /// </summary>
+        private DateTime _instantiationTimeUtc;
+
 #if DEBUG
         /// <summary>
         /// <code>true</code> to wait for a debugger to be attached, otherwise <code>false</code>.
@@ -250,6 +255,7 @@ namespace Microsoft.Build.Execution
             _projectFinishedEventHandler = OnProjectFinished;
             _loggingThreadExceptionEventHandler = OnThreadException;
             _legacyThreadingData = new LegacyThreadingData();
+            _instantiationTimeUtc = DateTime.UtcNow;
         }
 
         /// <summary>
@@ -1409,7 +1415,8 @@ namespace Microsoft.Build.Execution
                     foreach (BuildSubmission submission in _buildSubmissions.Values)
                     {
                         BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, BuildEventContext.InvalidNodeId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
-                        loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath);
+                        string exception = ExceptionHandling.ReadAnyExceptionFromFile(_instantiationTimeUtc);
+                        loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath, exception);
                     }
                 }
                 else if (shutdownPacket.Reason == NodeShutdownReason.Error && _buildSubmissions.Values.Count == 0)
@@ -1418,7 +1425,7 @@ namespace Microsoft.Build.Execution
                     if (shutdownPacket.Exception != null)
                     {
                         ILoggingService loggingService = ((IBuildComponentHost)this).GetComponent(BuildComponentType.LoggingService) as ILoggingService;
-                        loggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", shutdownPacket.Exception.ToString(), ExceptionHandling.DebugDumpPath);
+                        loggingService.LogError(BuildEventContext.Invalid, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath, shutdownPacket.Exception.ToString());
                         OnThreadException(shutdownPacket.Exception);
                     }
                 }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -193,8 +193,8 @@
     <comment>{StrBegin="MSB4162: "}</comment>
   </data>
   <data name="ChildExitedPrematurely" UESanitized="false" Visibility="Public">
-    <value>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</value>
-    <comment>{StrBegin="MSB4166: "}</comment>
+    <value>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</value>
+    <comment>{StrBegin="MSB4166: "} {2} is exception text if any</comment>
   </data>
   <data name="ChooseMustContainWhen" UESanitized="false" Visibility="Public">
     <value>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</value>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech v {1}, budou mít názvy MSBuild_*.failure.txt. Toto umístění je možné změnit nastavením proměnné prostředí MSBUILDDEBUGPATH na jiný adresář.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: Podřízený uzel {0} skončil předčasně. Probíhá ukončení práce. Diagnostické informace naleznete v souborech v {1}, budou mít názvy MSBuild_*.failure.txt. Toto umístění je možné změnit nastavením proměnné prostředí MSBUILDDEBUGPATH na jiný adresář.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Vorgang zum Herunterfahren wird durchgeführt. Diagnoseinformationen finden Sie in den Dateien namens "MSBuild_*.failure.txt" unter "{1}". Dieser Speicherort kann geändert werden, indem Sie die Umgebungsvariable MSBUILDDEBUGPATH auf ein anderes Verzeichnis festlegen.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: Der untergeordnete Knoten "{0}" wurde vorzeitig beendet. Vorgang zum Herunterfahren wird durchgeführt. Diagnoseinformationen finden Sie in den Dateien namens "MSBuild_*.failure.txt" unter "{1}". Dieser Speicherort kann geändert werden, indem Sie die Umgebungsvariable MSBUILDDEBUGPATH auf ein anderes Verzeichnis festlegen.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="new">MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos en "{1}" y recibirá el nombre MSBuild_*.failure.txt. Esta ubicación se puede cambiar estableciendo la variable de entorno MSBUILDDEBUGPATH en un directorio diferente.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: El nodo secundario "{0}" se cerró antes de tiempo. Se finalizará la ejecución ahora. Puede encontrar información de diagnóstico en los archivos en "{1}" y recibirá el nombre MSBuild_*.failure.txt. Esta ubicación se puede cambiar estableciendo la variable de entorno MSBUILDDEBUGPATH en un directorio diferente.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: Fin prématurée du nœud enfant "{0}" . Arrêt. Des informations de diagnostic se trouvent dans des fichiers nommés MSBuild_*.failure.txt dans "{1}". Pour changer d'emplacement, affectez un répertoire différent à la variable d'environnement MSBUILDDEBUGPATH.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: Fin prématurée du nœud enfant "{0}" . Arrêt. Des informations de diagnostic se trouvent dans des fichiers nommés MSBuild_*.failure.txt dans "{1}". Pour changer d'emplacement, affectez un répertoire différent à la variable d'environnement MSBUILDDEBUGPATH.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Arresto in corso. Eventuali informazioni diagnostiche sono disponibili nei file presenti in "{1}" il cui nome è MSBuild_*.failure.txt. È possibile cambiare questo percorso, impostando la variabile di ambiente MSBUILDDEBUGPATH su una directory diversa.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: il nodo figlio "{0}" è stato interrotto in modo anomalo. Arresto in corso. Eventuali informazioni diagnostiche sono disponibili nei file presenti in "{1}" il cui nome è MSBuild_*.failure.txt. È possibile cambiare questo percorso, impostando la variabile di ambiente MSBUILDDEBUGPATH su una directory diversa.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャット ダウンしています。診断情報は "{1}" のファイル内で見つかる可能性があり、MSBuild_*.failure.txt という名前になります。この場所は変更できます。変更するには、MSBUILDDEBUGPATH 環境変数を別のディレクトリに設定します。</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: 子ノード "{0}" は処理の途中で終了しました。シャット ダウンしています。診断情報は "{1}" のファイル内で見つかる可能性があり、MSBuild_*.failure.txt という名前になります。この場所は変更できます。変更するには、MSBUILDDEBUGPATH 環境変数を別のディレクトリに設定します。</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료하는 중입니다. 진단 정보는 "{1}"의 파일에서 MSBuild_*.failure.txt 이름으로 찾을 수 있습니다. 이 위치는 MSBUILDDEBUGPATH 환경 변수를 다른 디렉터리로 설정하여 변경할 수 있습니다.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: 자식 노드 "{0}"이(가) 중간에 종료되었습니다. 종료하는 중입니다. 진단 정보는 "{1}"의 파일에서 MSBuild_*.failure.txt 이름으로 찾을 수 있습니다. 이 위치는 MSBUILDDEBUGPATH 환경 변수를 다른 디렉터리로 설정하여 변경할 수 있습니다.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Trwa zamykanie. Informacje diagnostyczne znajdują się w katalogu „{1}” w plikach o nazwie MSBuild_*.failure.txt. Tę lokalizację można zmienić, ustawiając zmienną środowiskową MSBUILDDEBUGPATH na inny katalog.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: Działanie węzła podrzędnego „{0}” zostało przedwcześnie zakończone. Trwa zamykanie. Informacje diagnostyczne znajdują się w katalogu „{1}” w plikach o nazwie MSBuild_*.failure.txt. Tę lokalizację można zmienić, ustawiając zmienną środowiskową MSBUILDDEBUGPATH na inny katalog.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. Informações de diagnóstico poderão ser encontradas nos arquivos em "{1}" e estarão nomeadas como MSBuild_*.failure.txt. Esse local pode ser alterado por meio da configuração da variável de ambiente MSBUILDDEBUGPATH para um diretório diferente.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: O nó filho "{0}" foi encerrado prematuramente. Desligando. Informações de diagnóstico poderão ser encontradas nos arquivos em "{1}" e estarão nomeadas como MSBuild_*.failure.txt. Esse local pode ser alterado por meio da configuração da variável de ambiente MSBUILDDEBUGPATH para um diretório diferente.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: произошло преждевременное завершение работы дочернего узла "{0}". Идет завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt, находящихся в каталоге "{1}". Этот каталог можно изменить в переменной среды MSBUILDDEBUGPATH.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: произошло преждевременное завершение работы дочернего узла "{0}". Идет завершение работы. Диагностические данные можно найти в файлах с именем MSBuild_*.failure.txt, находящихся в каталоге "{1}". Этот каталог можно изменить в переменной среды MSBUILDDEBUGPATH.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri, "{1}" konumunda bulunabilir ve MSBuild_*.failure.txt olarak adlandırılır. Bu konum, MSBUILDDEBUGPATH ortam değişkeni farklı bir dizine ayarlanarak değiştirilebilir.</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: "{0}" alt düğümü beklenenden önce çıktı. Kapatılıyor. Tanılama bilgileri, "{1}" konumunda bulunabilir ve MSBuild_*.failure.txt olarak adlandırılır. Bu konum, MSBUILDDEBUGPATH ortam değişkeni farklı bir dizine ayarlanarak değiştirilebilir.</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在“{1}”中的文件中找到诊断信息，并将其命名为 MSBuild_*.failure.txt。通过将 MSBUILDDEBUGPATH 环境变量设为其他目录，可更改此位置。</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: 子节点“{0}”过早退出。正在关闭。可以在“{1}”中的文件中找到诊断信息，并将其命名为 MSBuild_*.failure.txt。通过将 MSBUILDDEBUGPATH 环境变量设为其他目录，可更改此位置。</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -190,9 +190,9 @@
         <note>{StrBegin="MSB4162: "}</note>
       </trans-unit>
       <trans-unit id="ChildExitedPrematurely">
-        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.</source>
-        <target state="translated">MSB4166: 子節點 "{0}" 已永久結束。正在關閉。診斷資訊可在 "{1}" 中的檔案內找到，且會命名為 MSBuild_*.failure.txt。您可將 MSBUILDDEBUGPATH 環境變數設定為其他目錄來變更此位置。</target>
-        <note>{StrBegin="MSB4166: "}</note>
+        <source>MSB4166: Child node "{0}" exited prematurely. Shutting down. Diagnostic information may be found in files in "{1}" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.{2}</source>
+        <target state="needs-review-translation">MSB4166: 子節點 "{0}" 已永久結束。正在關閉。診斷資訊可在 "{1}" 中的檔案內找到，且會命名為 MSBuild_*.failure.txt。您可將 MSBUILDDEBUGPATH 環境變數設定為其他目錄來變更此位置。</target>
+        <note>{StrBegin="MSB4166: "} {2} is exception text if any</note>
       </trans-unit>
       <trans-unit id="ChooseMustContainWhen">
         <source>MSB4085: A &lt;Choose&gt; must contain at least one &lt;When&gt;.</source>

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security;
+using System.Text;
 using System.Threading;
 using System.Xml;
 using Microsoft.Build.Shared.FileSystem;
@@ -360,20 +361,23 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string ReadAnyExceptionFromFile(DateTime fromTimeUtc)
         {
-            string result = "";
+            var builder = new StringBuilder();
             IEnumerable<string> files = FileSystems.Default.EnumerateFiles(DebugDumpPath, "MSBuild*failure.txt");
 
             foreach (string file in files)
             {
                 if (File.GetLastWriteTimeUtc(file) >= fromTimeUtc)
                 {
-                    result += Environment.NewLine;
-                    result += file + ":" + Environment.NewLine;
-                    result += File.ReadAllText(file) + Environment.NewLine;
+                    builder.Append(Environment.NewLine);
+                    builder.Append(file);
+                    builder.Append(":");
+                    builder.Append(Environment.NewLine);
+                    builder.Append(File.ReadAllText(file));
+                    builder.Append(Environment.NewLine);
                 }
             }
 
-            return result;
+            return builder.ToString();
         }
 #endif
 


### PR DESCRIPTION
Fix https://github.com/Microsoft/msbuild/issues/1038

When terminating due to a child node crash, we invite the user to look for diagnostic files in %temp%. This is problematic on a CI system, because unless configured especially to understand MSBuild dump files, the user will likely not be able to access them. (Occasionally we encounter this problem in the CoreFX CI for one reason or another.)

* Dump the contents of those dump files to the console, if we are rudely terminating.
* Only do this for files that were written to since the BuildManager was instantiated - so we don't show any stale ones. We could further filter by PID's of our child nodes but wiring this through is messy and does not seem to add anything useful.
* Correct parameter misordering I noticed

I tested this by adding bugs to the child nodes to make them crash.

Old output:
```
     0>MSBUILD : error MSB4166: Child node "2" exited prematurely. Shutting down. Diagnostic information may be found in files in "C:\Users\danmo\AppData\Local\Temp\" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.
     1>Done Building Project "C:\dotnet\1\1.sln" (rebuild target(s)) -- FAILED.
```
New output:
```
     0>MSBUILD : error MSB4166: Child node "2" exited prematurely. Shutting down. Diagnostic information may be found in files in "C:\Users\danmo\AppData\Local\Temp\" and will be named MSBuild_*.failure.txt. This location can be changed by setting the MSBUILDDEBUGPATH environment variable to a different directory.
MSBUILD : error MSB4166: C:\Users\danmo\AppData\Local\Temp\MSBuild_pid-71208_af99fbd50dfb4bf7b6a0dbeff520cd46.failure.txt:
MSBUILD : error MSB4166: UNHANDLED EXCEPTIONS FROM PROCESS 71208:
MSBUILD : error MSB4166: =====================
MSBUILD : error MSB4166: 8/18/2018 4:52:22 PM
MSBUILD : error MSB4166: System.AggregateException: One or more errors occurred. (Parameter "packet" cannot be null.) ---> System.ArgumentNullException: Parameter "packet" cannot be null.
MSBUILD : error MSB4166:    at Microsoft.Build.Shared.ErrorUtilities.VerifyThrowArgumentNull(Object parameter, String parameterName, String resourceName) in C:\git\MSBuild\src\Shared\ErrorUtilities.cs:line 778
...
MSBUILD : error MSB4166:    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
MSBUILD : error MSB4166:    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)<---
MSBUILD : error MSB4166:
MSBUILD : error MSB4166: ===================
MSBUILD : error MSB4166:
MSBUILD : error MSB4166:
     1>Done Building Project "C:\dotnet\1\1.sln" (rebuild target(s)) -- FAILED.
```