### PR TITLE
PROCESS_BASIC_INFORMATION struct definition

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -308,12 +308,12 @@ namespace Microsoft.Build.Shared
 
             public uint Size
             {
-                get {
-#if (CLR2COMPATIBILITY)
-                    return (uint)Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION));
-#else
-                    return (uint)Marshal.SizeOf<PROCESS_BASIC_INFORMATION>();
-#endif
+                get
+                {
+                    unsafe
+                    {
+                        return (uint)sizeof(PROCESS_BASIC_INFORMATION);
+                    }
                 }
             }
         };

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -308,7 +308,13 @@ namespace Microsoft.Build.Shared
 
             public uint Size
             {
-                get { return (uint)sizeof(PROCESS_BASIC_INFORMATION); }
+                get {
+#if (CLR2COMPATIBILITY)
+                    return (uint)Marshal.SizeOf(typeof(PROCESS_BASIC_INFORMATION));
+#else
+                    return (uint)Marshal.SizeOf<PROCESS_BASIC_INFORMATION>();
+#endif
+                }
             }
         };
 

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -299,16 +299,16 @@ namespace Microsoft.Build.Shared
         [StructLayout(LayoutKind.Sequential)]
         private struct PROCESS_BASIC_INFORMATION
         {
-            public IntPtr ExitStatus;
+            public uint ExitStatus;
             public IntPtr PebBaseAddress;
-            public IntPtr AffinityMask;
-            public IntPtr BasePriority;
-            public IntPtr UniqueProcessId;
-            public IntPtr InheritedFromUniqueProcessId;
+            public UIntPtr AffinityMask;
+            public int BasePriority;
+            public UIntPtr UniqueProcessId;
+            public UIntPtr InheritedFromUniqueProcessId;
 
-            public int Size
+            public uint Size
             {
-                get { return (6 * IntPtr.Size); }
+                get { return (uint)sizeof(PROCESS_BASIC_INFORMATION); }
             }
         };
 
@@ -1435,7 +1435,7 @@ namespace Microsoft.Build.Shared
 
         [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
         [DllImport("NTDLL.DLL")]
-        private static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, int cb, ref int pSize);
+        private static extern int NtQueryInformationProcess(SafeProcessHandle hProcess, PROCESSINFOCLASS pic, ref PROCESS_BASIC_INFORMATION pbi, uint cb, ref int pSize);
 
         [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Class name is NativeMethodsShared for increased clarity")]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
Somehow we've been getting away with an invalid definition here for 5+ years.

```C
//
// Basic and Extended Basic Process Information
//  NtQueryInformationProcess using ProcessBasicInformation
//

typedef struct _PROCESS_BASIC_INFORMATION {
    NTSTATUS ExitStatus;
    PPEB PebBaseAddress;
    ULONG_PTR AffinityMask;
    KPRIORITY BasePriority;
    ULONG_PTR UniqueProcessId;
    ULONG_PTR InheritedFromUniqueProcessId;
} PROCESS_BASIC_INFORMATION,*PPROCESS_BASIC_INFORMATION;
```

Fixes #3638.

Co-Authored-By: Jeremy Kuhne <jeremy.kuhne@microsoft.com>