### PR TITLE
Optimize RegularExpressionFromFileSpec (#2380)

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1122,16 +1122,10 @@ namespace Microsoft.Build.Shared
                 + FileSpecRegexParts.BeginningOfLine.Length + FileSpecRegexParts.FixedDirWildcardDirSeparator.Length
                 + FileSpecRegexParts.WildcardDirFilenameSeparator.Length + FileSpecRegexParts.EndOfLine.Length
             );
-            matchFileExpression.Append(FileSpecRegexParts.BeginningOfLine);
 
             AppendRegularExpressionFromFixedDirectory(matchFileExpression, fixedDirectoryPart);
-            matchFileExpression.Append(FileSpecRegexParts.FixedDirWildcardDirSeparator);
-
             AppendRegularExpressionFromWildcardDirectory(matchFileExpression, wildcardDirectoryPart);
-            matchFileExpression.Append(FileSpecRegexParts.WildcardDirFilenameSeparator);
-
             AppendRegularExpressionFromFilename(matchFileExpression, filenamePart);
-            matchFileExpression.Append(FileSpecRegexParts.EndOfLine);
 
             return matchFileExpression.ToString();
         }
@@ -1180,6 +1174,8 @@ namespace Microsoft.Build.Shared
 
         private static void AppendRegularExpressionFromFixedDirectory(StringBuilder regex, string fixedDir)
         {
+            regex.Append(FileSpecRegexParts.BeginningOfLine);
+
             /*
              * Capture the leading \\ in UNC paths, so that the doubled slash isn't
              * reduced in a later step.
@@ -1200,7 +1196,10 @@ namespace Microsoft.Build.Shared
 
         private static void AppendRegularExpressionFromWildcardDirectory(StringBuilder regex, string wildcardDir)
         {
+            regex.Append(FileSpecRegexParts.FixedDirWildcardDirSeparator);
+
             // fixed-directory + **\
+
             bool hasRecursiveOperatorAtStart = wildcardDir.Length > 2 && wildcardDir[0] == '*' && wildcardDir[1] == '*';
 
             if (hasRecursiveOperatorAtStart)
@@ -1223,6 +1222,8 @@ namespace Microsoft.Build.Shared
                     AppendRegularExpressionFromChar(regex, ch);
                 }
             }
+
+            regex.Append(FileSpecRegexParts.WildcardDirFilenameSeparator);
         }
 
         private static void AppendRegularExpressionFromFilename(StringBuilder regex, string filename)
@@ -1261,6 +1262,8 @@ namespace Microsoft.Build.Shared
                     i += 2;
                 }
             }
+
+            regex.Append(FileSpecRegexParts.EndOfLine);
         }
 
         /*

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1223,25 +1223,25 @@ namespace Microsoft.Build.Shared
         private static void AppendRegularExpressionFromWildcardDirectory(StringBuilder regex, string wildcardDir)
         {
             // fixed-directory + **\
-            bool hasRecursionOperatorAtStart =
+            bool hasRecursiveOperatorAtStart =
                 wildcardDir.Length > 2 && wildcardDir[0] == '*' && wildcardDir[1] == '*'
                 && FileUtilities.IsAnySlash(wildcardDir[2]);
 
-            if (hasRecursionOperatorAtStart)
+            if (hasRecursiveOperatorAtStart)
             {
                 regex.Append(FileSpecRegexParts.LeftDirs);
             }
-            int startIndex = hasRecursionOperatorAtStart ? IndexOfNextNonCollapsibleChar(wildcardDir, 3) : 0;
+            int startIndex = hasRecursiveOperatorAtStart ? IndexOfNextNonCollapsibleChar(wildcardDir, 3) : 0;
 
             for (int i = startIndex; i < wildcardDir.Length; i = IndexOfNextNonCollapsibleChar(wildcardDir, i + 1))
             {
                 char ch = wildcardDir[i];
 
-                bool isRecursionOperator =
+                bool isRecursiveOperator =
                     i < wildcardDir.Length - 3 && FileUtilities.IsAnySlash(ch) && wildcardDir[i + 1] == '*'
                     && wildcardDir[i + 2] == '*' && FileUtilities.IsAnySlash(wildcardDir[i + 3]);
 
-                if (isRecursionOperator)
+                if (isRecursiveOperator)
                 {
                     regex.Append(FileSpecRegexParts.MiddleDirs);
                     i += 3;

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1327,10 +1327,10 @@ namespace Microsoft.Build.Shared
         private static int IndexOfNextNonCollapsibleChar(string str, int startIndex)
         {
             int i = startIndex;
-            bool isFound = false;
+            bool isNonCollapsibleCharFound = false;
             bool isPrevRecursiveOperator = i > 2 && str[i - 3] == '*' && str[i - 2] == '*';
 
-            while (!isFound && i < str.Length)
+            while (!isNonCollapsibleCharFound && i < str.Length)
             {
                 bool isCurDot = str[i] == '.';
                 bool isPrevSlash = i > 0 && FileUtilities.IsAnySlash(str[i - 1]);
@@ -1358,7 +1358,7 @@ namespace Microsoft.Build.Shared
                 }
                 else
                 {
-                    isFound = true;
+                    isNonCollapsibleCharFound = true;
                 }
             }
 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1141,18 +1141,12 @@ namespace Microsoft.Build.Shared
          *
          * By definition, "**" must appear alone between directory slashes. If there is any remaining "**" then this is not
          * a valid filespec.
-         *
-         * <:tag:> is not a legal form for filespecs. If the
-         * filespec comes in with either "<:" or ":>", return false to
-         * prevent intrusion into the special processing.
          */
-        private static bool IsLegalFileSpec(string fixedDirectoryPart, string wildcardDirectoryPart, string filenamePart) =>
+        private static bool IsLegalFileSpec(string fixedDirectoryPart, string wildcardDirectoryPart,
+            string filenamePart) =>
             !HasDotDot(wildcardDirectoryPart)
             && !HasMisplacedRecursiveOperator(wildcardDirectoryPart)
-            && !HasMisplacedRecursiveOperator(filenamePart)
-            && !HasTags(fixedDirectoryPart)
-            && !HasTags(wildcardDirectoryPart)
-            && !HasTags(filenamePart);
+            && !HasMisplacedRecursiveOperator(filenamePart);
 
         private static bool HasDotDot(string str)
         {
@@ -1177,21 +1171,6 @@ namespace Microsoft.Build.Shared
                                              && i < str.Length - 2 && FileUtilities.IsAnySlash(str[i + 2]);
 
                 if (isRecursiveOperator && !isSurroundedBySlashes)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private static bool HasTags(string str)
-        {
-            for (int i = 0; i < str.Length - 1; i++)
-            {
-                bool isLeftTag = str[i] == '<' && str[i + 1] == ':';
-                bool isRightTag = str[i] == ':' && str[i + 1] == '>';
-
-                if (isLeftTag || isRightTag)
                 {
                     return true;
                 }

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1117,7 +1117,7 @@ namespace Microsoft.Build.Shared
             out bool isLegalFileSpec
         )
         {
-            isLegalFileSpec = IsLegalFileSpec(fixedDirectoryPart, wildcardDirectoryPart, filenamePart);
+            isLegalFileSpec = IsLegalFileSpec(wildcardDirectoryPart, filenamePart);
             if (!isLegalFileSpec)
             {
                 return string.Empty;
@@ -1138,8 +1138,7 @@ namespace Microsoft.Build.Shared
          * By definition, "**" must appear alone between directory slashes. If there is any remaining "**" then this is not
          * a valid filespec.
          */
-        private static bool IsLegalFileSpec(string fixedDirectoryPart, string wildcardDirectoryPart,
-            string filenamePart) =>
+        private static bool IsLegalFileSpec(string wildcardDirectoryPart, string filenamePart) =>
             !HasDotDot(wildcardDirectoryPart)
             && !HasMisplacedRecursiveOperator(wildcardDirectoryPart)
             && !HasMisplacedRecursiveOperator(filenamePart);
@@ -1201,7 +1200,6 @@ namespace Microsoft.Build.Shared
             regex.Append(FileSpecRegexParts.FixedDirWildcardDirSeparator);
 
             // fixed-directory + **\
-
             bool hasRecursiveOperatorAtStart = wildcardDir.Length > 2 && wildcardDir[0] == '*' && wildcardDir[1] == '*';
 
             if (hasRecursiveOperatorAtStart)
@@ -1218,6 +1216,7 @@ namespace Microsoft.Build.Shared
                 if (isRecursiveOperator)
                 {
                     regex.Append(FileSpecRegexParts.MiddleDirs);
+                    i += 3;
                 }
                 else
                 {

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Build.Shared
          * MAX_PATH + FileSpecRegexParts.BeginningOfLine.Length + FileSpecRegexParts.FixedDirWildcardDirSeparator.Length
             + FileSpecRegexParts.WildcardDirFilenameSeparator.Length + FileSpecRegexParts.EndOfLine.Length;
          */
-        private const int FileSpecRegexInitialBufferSize = 300;
+        private const int FileSpecRegexMinLength = 44;
 
         /// <summary>
         /// The Default FileMatcher does not cache directory enumeration.
@@ -1122,8 +1122,16 @@ namespace Microsoft.Build.Shared
             {
                 return string.Empty;
             }
-
-            var matchFileExpression = StringBuilderCache.Acquire(FileSpecRegexInitialBufferSize);
+#if DEBUG
+            ErrorUtilities.VerifyThrow(
+                FileSpecRegexMinLength == FileSpecRegexParts.BeginningOfLine.Length
+                + FileSpecRegexParts.FixedDirWildcardDirSeparator.Length
+                + FileSpecRegexParts.WildcardDirFilenameSeparator.Length
+                + FileSpecRegexParts.EndOfLine.Length,
+                "Checked-in length of known regex components differs from computed length. Update checked-in constant."
+            );
+#endif
+            var matchFileExpression = StringBuilderCache.Acquire(FileSpecRegexMinLength + NativeMethodsShared.MAX_PATH);
 
             AppendRegularExpressionFromFixedDirectory(matchFileExpression, fixedDirectoryPart);
             AppendRegularExpressionFromWildcardDirectory(matchFileExpression, wildcardDirectoryPart);

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1184,9 +1184,8 @@ namespace Microsoft.Build.Shared
              * Capture the leading \\ in UNC paths, so that the doubled slash isn't
              * reduced in a later step.
              */
-            bool isUncPath = fixedDir.Length > 1
-                             && FileUtilities.IsAnySlash(fixedDir[0])
-                             && FileUtilities.IsAnySlash(fixedDir[1]);
+            bool isUncPath = NativeMethodsShared.IsWindows && fixedDir.Length > 1
+                             && fixedDir[0] == '\\' && fixedDir[1] == '\\';
             if (isUncPath)
             {
                 regex.Append(FileSpecRegexParts.UncSlashSlash);

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -70,6 +70,12 @@ namespace Microsoft.Build.Shared
             internal const string SingleCharacter = ".";
             internal const string UncSlashSlash = @"\\\\";
         }
+
+        /*
+         * MAX_PATH + FileSpecRegexParts.BeginningOfLine.Length + FileSpecRegexParts.FixedDirWildcardDirSeparator.Length
+            + FileSpecRegexParts.WildcardDirFilenameSeparator.Length + FileSpecRegexParts.EndOfLine.Length;
+         */
+        private const int FileSpecRegexInitialBufferSize = 300;
 
         /// <summary>
         /// The Default FileMatcher does not cache directory enumeration.
@@ -1117,17 +1123,13 @@ namespace Microsoft.Build.Shared
                 return string.Empty;
             }
 
-            var matchFileExpression = new StringBuilder(
-                fixedDirectoryPart.Length + wildcardDirectoryPart.Length + filenamePart.Length
-                + FileSpecRegexParts.BeginningOfLine.Length + FileSpecRegexParts.FixedDirWildcardDirSeparator.Length
-                + FileSpecRegexParts.WildcardDirFilenameSeparator.Length + FileSpecRegexParts.EndOfLine.Length
-            );
+            var matchFileExpression = StringBuilderCache.Acquire(FileSpecRegexInitialBufferSize);
 
             AppendRegularExpressionFromFixedDirectory(matchFileExpression, fixedDirectoryPart);
             AppendRegularExpressionFromWildcardDirectory(matchFileExpression, wildcardDirectoryPart);
             AppendRegularExpressionFromFilename(matchFileExpression, filenamePart);
 
-            return matchFileExpression.ToString();
+            return StringBuilderCache.GetStringAndRelease(matchFileExpression);
         }
 
         /*

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1556,6 +1556,194 @@ namespace Microsoft.Build.UnitTests
             MatchDriverWithDifferentSlashes(include, exclude, matching, nonMatching, untouchable);
         }
 
+        [Theory]
+        // Empty string is valid
+        [InlineData(
+            "",
+            "",
+            "",
+            "",
+            "^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>)$",
+            false,
+            true
+        )]
+        // ... anywhere is invalid
+        [InlineData(
+            @"...\foo",
+            "",
+            "",
+            "",
+            null,
+            false,
+            false
+        )]
+        // : not placed at second index is invalid
+        [InlineData(
+            "http://www.website.com",
+            "",
+            "",
+            "",
+            null,
+            false,
+            false
+        )]
+        // ** not alone in filename part is invalid
+        [InlineData(
+            "**foo",
+            "",
+            "",
+            "**foo",
+            "",
+            false,
+            false
+        )]
+        // ** not alone in filename part is invalid
+        [InlineData(
+            "foo**",
+            "",
+            "",
+            "foo**",
+            "",
+            false,
+            false
+        )]
+        // ** not alone between slashes in wildcard part is invalid
+        [InlineData(
+            @"**foo\bar",
+            "",
+            @"**foo\",
+            "bar",
+            "",
+            false,
+            false
+        )]
+        // .. placed after any ** is invalid
+        [InlineData(
+            @"**\..\bar",
+            "",
+            @"**\..\",
+            "bar",
+            "",
+            false,
+            false
+        )]
+        // Special regex characters valid in Windows paths
+        [InlineData(
+            @"$()+.[^{\?$()+.[^{\$()+.[^{",
+            @"$()+.[^{\",
+            @"?$()+.[^{\",
+            "$()+.[^{",
+            @"^(?<FIXEDDIR>\$\(\)\+\.\[\^\{[/\\]+)(?<WILDCARDDIR>.\$\(\)\+\.\[\^\{[/\\]+)(?<FILENAME>\$\(\)\+\.\[\^\{)$",
+            true,
+            true
+        )]
+        // Common wildcard characters in wildcard and filename part
+        [InlineData(
+            @"*fo?ba?\*fo?ba?",
+            "",
+            @"*fo?ba?\",
+            "*fo?ba?",
+            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>[^/\\]*fo.ba.[/\\]+)(?<FILENAME>[^/\\]*fo.ba.)$",
+            true,
+            true
+        )]
+        // Special case for ? and * when trailing . in filename part
+        [InlineData(
+            "?oo*.",
+            "",
+            "",
+            "?oo*.",
+            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>[^\.].oo[^\.]*)$",
+            false,
+            true
+        )]
+        // Skip the .* portion of any *.* sequence in filename part
+        [InlineData(
+            "*.*foo*.*",
+            "",
+            "",
+            "*.*foo*.*",
+            @"^(?<FIXEDDIR>)(?<WILDCARDDIR>)(?<FILENAME>[^/\\]*foo[^/\\]*)$",
+            false,
+            true
+        )]
+        // Collapse successive directory separators
+        [InlineData(
+            @"\foo///bar\\\?foo///bar\\\foo",
+            @"\foo///bar\\\",
+            @"?foo///bar\\\",
+            "foo",
+            @"^(?<FIXEDDIR>[/\\]+foo[/\\]+bar[/\\]+)(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
+            true,
+            true
+        )]
+        // Collapse successive relative separators
+        [InlineData(
+            @"\./.\foo/.\./bar\./.\?foo/.\./bar\./.\foo",
+            @"\./.\foo/.\./bar\./.\",
+            @"?foo/.\./bar\./.\",
+            "foo",
+            @"^(?<FIXEDDIR>[/\\]+foo[/\\]+bar[/\\]+)(?<WILDCARDDIR>.foo[/\\]+bar[/\\]+)(?<FILENAME>foo)$",
+            true,
+            true
+        )]
+        // Collapse successive recursive operators
+        [InlineData(
+            @"foo\**/**\bar/**\**/foo\**/**\bar",
+            @"foo\",
+            @"**/**\bar/**\**/foo\**/**\",
+            "bar",
+            @"^(?<FIXEDDIR>foo[/\\]+)(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
+            true,
+            true
+        )]
+        // Collapse all three cases combined
+        [InlineData(
+            @"foo\\\.///**\\\.///**\\\.///bar\\\.///**\\\.///**\\\.///foo\\\.///**\\\.///**\\\.///bar",
+            @"foo\\\.///",
+            @"**\\\.///**\\\.///bar\\\.///**\\\.///**\\\.///foo\\\.///**\\\.///**\\\.///",
+            "bar",
+            @"^(?<FIXEDDIR>foo[/\\]+)(?<WILDCARDDIR>((.*/)|(.*\\)|())bar((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/))foo((/)|(\\)|(/.*/)|(/.*\\)|(\\.*\\)|(\\.*/)))(?<FILENAME>bar)$",
+            true,
+            true
+        )]
+        // Preserve UNC paths in fixed directory part
+        [InlineData(
+            @"\\\.\foo/bar",
+            @"\\\.\foo/",
+            "",
+            "bar",
+            @"^(?<FIXEDDIR>\\\\foo[/\\]+)(?<WILDCARDDIR>)(?<FILENAME>bar)$",
+            false,
+            true
+        )]
+        public void GetFileSpecInfo(
+            string filespec,
+            string expectedFixedDirectoryPart,
+            string expectedWildcardDirectoryPart,
+            string expectedFilenamePart,
+            string expectedMatchFileExpression,
+            bool expectedNeedsRecursion,
+            bool expectedIsLegalFileSpec
+        )
+        {
+            FileMatcher.Default.GetFileSpecInfo(
+                filespec,
+                out string fixedDirectoryPart,
+                out string wildcardDirectoryPart,
+                out string filenamePart,
+                out string matchFileExpression,
+                out bool needsRecursion,
+                out bool isLegalFileSpec
+            );
+
+            fixedDirectoryPart.ShouldBe(expectedFixedDirectoryPart);
+            wildcardDirectoryPart.ShouldBe(expectedWildcardDirectoryPart);
+            filenamePart.ShouldBe(expectedFilenamePart);
+            matchFileExpression.ShouldBe(expectedMatchFileExpression);
+            needsRecursion.ShouldBe(expectedNeedsRecursion);
+            isLegalFileSpec.ShouldBe(expectedIsLegalFileSpec);
+        }
 
         #region Support functions.
 

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1723,6 +1723,7 @@ namespace Microsoft.Build.UnitTests
             );
         }
 
+        [PlatformSpecific(TestPlatforms.Windows)]
         [Theory]
         // Escape pecial regex characters valid in Windows paths
         [InlineData(
@@ -1765,6 +1766,7 @@ namespace Microsoft.Build.UnitTests
             );
         }
 
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
         [Theory]
         // Escape regex characters valid in Unix paths
         [InlineData(

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1737,6 +1737,11 @@ namespace Microsoft.Build.UnitTests
                 out bool isLegalFileSpec
             );
 
+            if (NativeMethodsShared.IsUnixLike)
+            {
+                expectedFixedDirectoryPart = FileUtilities.FixFilePath(expectedFixedDirectoryPart);
+                expectedWildcardDirectoryPart = FileUtilities.FixFilePath(expectedWildcardDirectoryPart);
+            }
             fixedDirectoryPart.ShouldBe(expectedFixedDirectoryPart);
             wildcardDirectoryPart.ShouldBe(expectedWildcardDirectoryPart);
             filenamePart.ShouldBe(expectedFilenamePart);

--- a/src/Shared/UnitTests/FileMatcher_Tests.cs
+++ b/src/Shared/UnitTests/FileMatcher_Tests.cs
@@ -1147,8 +1147,6 @@ namespace Microsoft.Build.UnitTests
             ValidateIllegal("*.cs**");
             ValidateIllegal("...\\*.cs");
             ValidateIllegal("http://www.website.com");
-            ValidateIllegal("<:tag:>");
-            ValidateIllegal("<:\\**");
         }
 
         [Fact]

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -149,6 +149,9 @@
     <Compile Include="..\Shared\ResourceUtilities.cs">
       <Link>Shared\ResourceUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\ReuseableStringBuilder.cs">
+      <Link>Shared\ReuseableStringBuilder.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\StringBuilderCache.cs">
       <Link>Shared\StringBuilderCache.cs</Link>
     </Compile>


### PR DESCRIPTION
Fixes #2380

Got rid of all ```StringBuilder.Replace()``` calls by just iteratively building the regex without the tagging format and with no allocations. Execution time is so low it just gets absorbed into ```GetFileSpecInfo``` in the profiler, the 7ms that shows up is all from ```SplitFileSpec()```.

Perf profile on master:
<img width="851" alt="beforeperf" src="https://user-images.githubusercontent.com/32187633/44610503-4a283880-a7b1-11e8-96a1-c7b844cd768d.PNG">

Perf profile on this PR:
<img width="817" alt="afterperf" src="https://user-images.githubusercontent.com/32187633/44610506-4d232900-a7b1-11e8-8c38-1ba6998da0f5.PNG">
