### PR TITLE
Do not always call ReferenceTable.ComputeClosure() twice (#2625)

### DIFF
--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2206,18 +2206,12 @@ namespace Microsoft.Build.Tasks
                         );
                     }
 
-
                     IReadOnlyCollection<DependentAssembly> allRemappedAssemblies = CombineRemappedAssemblies(appConfigRemappedAssemblies, autoUnifiedRemappedAssemblies);
-                    List<DependentAssembly> idealAssemblyRemappings = null;
-                    List<AssemblyNameReference> idealAssemblyRemappingsIdentities = null;
+                    List<DependentAssembly> idealAssemblyRemappings = autoUnifiedRemappedAssemblies;
+                    List<AssemblyNameReference> idealAssemblyRemappingsIdentities = autoUnifiedRemappedAssemblyReferences;
                     bool shouldRerunClosure = autoUnifiedRemappedAssemblies?.Count > 0  || excludedReferencesExist;
 
-                    if (AutoUnify && FindDependencies && shouldRerunClosure)
-                    {
-                        idealAssemblyRemappings = autoUnifiedRemappedAssemblies;
-                        idealAssemblyRemappingsIdentities = autoUnifiedRemappedAssemblyReferences;
-                    }
-                    else
+                    if (!AutoUnify || !FindDependencies || shouldRerunClosure)
                     {
                         // Compute all dependencies.
                         dependencyTable.ComputeClosure(allRemappedAssemblies, _assemblyFiles, _assemblyNames, generalResolutionExceptions);

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2210,9 +2210,9 @@ namespace Microsoft.Build.Tasks
                     IReadOnlyCollection<DependentAssembly> allRemappedAssemblies = CombineRemappedAssemblies(appConfigRemappedAssemblies, autoUnifiedRemappedAssemblies);
                     List<DependentAssembly> idealAssemblyRemappings = null;
                     List<AssemblyNameReference> idealAssemblyRemappingsIdentities = null;
-                    bool hasConflicts = autoUnifiedRemappedAssemblies != null && autoUnifiedRemappedAssemblies.Count > 0;
+                    bool shouldRerunClosure = autoUnifiedRemappedAssemblies?.Count > 0  || excludedReferencesExist;
 
-                    if (AutoUnify && FindDependencies && !hasConflicts && !excludedReferencesExist)
+                    if (AutoUnify && FindDependencies && shouldRerunClosure)
                     {
                         idealAssemblyRemappings = autoUnifiedRemappedAssemblies;
                         idealAssemblyRemappingsIdentities = autoUnifiedRemappedAssemblyReferences;

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -2206,36 +2206,48 @@ namespace Microsoft.Build.Tasks
                         );
                     }
 
+
                     IReadOnlyCollection<DependentAssembly> allRemappedAssemblies = CombineRemappedAssemblies(appConfigRemappedAssemblies, autoUnifiedRemappedAssemblies);
+                    List<DependentAssembly> idealAssemblyRemappings = null;
+                    List<AssemblyNameReference> idealAssemblyRemappingsIdentities = null;
+                    bool hasConflicts = autoUnifiedRemappedAssemblies != null && autoUnifiedRemappedAssemblies.Count > 0;
 
-                    // Compute all dependencies.
-                    dependencyTable.ComputeClosure(allRemappedAssemblies, _assemblyFiles, _assemblyNames, generalResolutionExceptions);
-
-                    try
+                    if (AutoUnify && FindDependencies && !hasConflicts && !excludedReferencesExist)
                     {
-                        excludedReferencesExist = false;
-                        if (redistList != null && redistList.Count > 0)
+                        idealAssemblyRemappings = autoUnifiedRemappedAssemblies;
+                        idealAssemblyRemappingsIdentities = autoUnifiedRemappedAssemblyReferences;
+                    }
+                    else
+                    {
+                        // Compute all dependencies.
+                        dependencyTable.ComputeClosure(allRemappedAssemblies, _assemblyFiles, _assemblyNames, generalResolutionExceptions);
+
+                        try
                         {
-                            excludedReferencesExist = dependencyTable.MarkReferencesForExclusion(blackList);
+                            excludedReferencesExist = false;
+                            if (redistList != null && redistList.Count > 0)
+                            {
+                                excludedReferencesExist = dependencyTable.MarkReferencesForExclusion(blackList);
+                            }
                         }
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.ProblemDeterminingFrameworkMembership", e.Message);
-                        return false;
-                    }
+                        catch (InvalidOperationException e)
+                        {
+                            Log.LogErrorWithCodeFromResources("ResolveAssemblyReference.ProblemDeterminingFrameworkMembership", e.Message);
+                            return false;
+                        }
 
-                    if (excludedReferencesExist)
-                    {
-                        dependencyTable.RemoveReferencesMarkedForExclusion(false /* Remove the reference and warn*/, subsetOrProfileName);
-                    }
+                        if (excludedReferencesExist)
+                        {
+                            dependencyTable.RemoveReferencesMarkedForExclusion(false /* Remove the reference and warn*/, subsetOrProfileName);
+                        }
 
-                    // Resolve any conflicts.
-                    dependencyTable.ResolveConflicts
-                    (
-                        out List<DependentAssembly> idealAssemblyRemappings,
-                        out List<AssemblyNameReference> idealAssemblyRemappingsIdentities
-                    );
+                        // Resolve any conflicts.
+                        dependencyTable.ResolveConflicts
+                        (
+                            out idealAssemblyRemappings,
+                            out idealAssemblyRemappingsIdentities
+                        );
+                    }
 
                     // Build the output tables.
                     dependencyTable.GetReferenceItems


### PR DESCRIPTION
Fixes #2625

Calling ```ComputeClosure()``` again when both no conflicts and excluded references exist results in an identical output.