### PR TITLE
Generate Microsoft.Build reference source

### DIFF
--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1063,7 +1063,7 @@ namespace Microsoft.Build.Execution
     }
     public partial class OutOfProcNode
     {
-        public OutOfProcNode(string clientToServerPipeHandle, string serverToClientPipeHandle) { }
+        public OutOfProcNode() { }
         public Microsoft.Build.Execution.NodeEngineShutdownReason Run(bool enableReuse, out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
         public Microsoft.Build.Execution.NodeEngineShutdownReason Run(out System.Exception shutdownException) { shutdownException = default(System.Exception); throw null; }
     }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -16,8 +16,7 @@
 
     <EnableDefaultItems>false</EnableDefaultItems>
 
-    <!-- Generate API only for the more limited .NET Core/Standard flavor. -->
-    <GenerateReferenceAssemblySources Condition="'$(TargetFramework)' != 'netcoreapp2.1'">true</GenerateReferenceAssemblySources>
+    <GenerateReferenceAssemblySources>true</GenerateReferenceAssemblySources>
     <CreateTlb>true</CreateTlb>
     <IsPackable>true</IsPackable>
     <Description>This package contains the $(MSBuildProjectName) assembly which is used to create, edit, and evaluate MSBuild projects.</Description>


### PR DESCRIPTION
This was disabled for .NET Standard 2.1, because the .NET Standard 2.0
interface was strictly smaller, so it was a better reference target.
But we now generate only .NET Standard 2.1, so it needs to be enabled
again.