### PR TITLE
Remove scatter files from manifest dependencies for ClickOnce

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3989,11 +3989,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)"
         TargetCulture="$(TargetCulture)">
 
-      <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>
+      <Output TaskParameter="OutputAssemblies" ItemName="_UnfilteredDeploymentManifestDependencies"/>
       <Output TaskParameter="OutputFiles" ItemName="_DeploymentManifestFiles"/>
       <Output TaskParameter="OutputEntryPoint" ItemName="_DeploymentResolvedManifestEntryPoint"/>
 
     </ResolveManifestFiles>
+    
+    <!-- _DeploymentManifestDependencies contains every file that has to be copied locally, we have to filter out scatter files, 
+    <!-- since those aren't actually depencies for the ClickOnce manifest. -->
+    <ItemGroup>
+      <_DeploymentManifestDependencies Include="@(_UnfilteredDeploymentManifestDependencies)" Exclude="@(_ReferenceScatterPaths)" />
+    </ItemGroup>
 
     <PropertyGroup>
       <_DeploymentManifestType>ClickOnce</_DeploymentManifestType>


### PR DESCRIPTION
[This previous PR](https://github.com/Microsoft/msbuild/pull/3382) introduced a change to use ReferenceCopyLocalPaths files as dependencies to generate the ClickOnce manifest. 
However, if the project contains scatter files that are native assemblies, we incorrectly recognize those files as managed dependencies which causes ClickOnce publishing to fail. (See comments in linked PR.)

This changes removes the scatter files from the _DeploymentManifestDependencies ItemGroup which should fix that issue.