### PR TITLE
Prevent flagging of Satellite Assemblies as Primary during Manifest g…

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3953,8 +3953,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
+    <!-- ReferenceCopyLocalPaths can contain satellite assemblies, we need to explicitly exclude those so they don't get flagged as primary assemblies. -->
     <ItemGroup>
-      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
+      <_ReferencedSatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'" 
+                                 Exclude="@(_ReferencedSatelliteAssemblies)">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
     </ItemGroup>
@@ -3986,7 +3989,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         ManagedAssemblies="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
-        SatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)"
+        SatelliteAssemblies="@(_ReferencedSatelliteAssemblies)"
         TargetCulture="$(TargetCulture)">
 
       <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>


### PR DESCRIPTION
…eneration

With the recent change of manifest files getting generated from ReferenceCopyLocalPaths satellite assemblies (like localized <assemblyname>.resources.dll) started getting processed as primary assemblies as well as satellite assemblies.
This caused them to get copied twice to the output folder while publishing, both into the appropriate location (like 'de\<assemblyname>.resources.dll') and into the top level output folder, with the resulting application manifest referencing the incorrect instance of these two.

Explicitly excluding satellite assemblies from the referenced assemblies before they are getting flagged as primary fixes this issue.