### PR TITLE
Update reference links in wiki documentation markdown files

### DIFF
--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -7,9 +7,9 @@ Because our focus right now is on maintaining backwards compatibility, the team 
 - Only contributions referencing an approved Issue will be accepted.
 - Pull requests that do not merge easily with the tip of the master branch will be declined. The author will be asked to merge with tip and submit a new pull request.
 - Submissions must meet functional and performance expectations, including scenarios for which the team doesn't yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests.
-- Submissions must follow the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/wiki/Contributing#c-coding-style)
+- Submissions must follow the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
 
-When you are ready to proceed with making a change, get set up to [[build|Building Testing and Debugging]] the code and familiarize yourself with our workflow and our coding conventions. These two blogs posts on contributing code to open source projects are good too: Open Source Contribution Etiquette by Miguel de Icaza and Don’t “Push” Your Pull Requests by Ilya Grigorik.
+When you are ready to proceed with making a change, get set up to [build](Home.md "See 'Building Testing and Debugging'") the code and familiarize yourself with our workflow and our coding conventions. These two blogs posts on contributing code to open source projects are good too: Open Source Contribution Etiquette by Miguel de Icaza and Don’t “Push” Your Pull Requests by Ilya Grigorik.
 
 You must sign a Contributor License Agreement (CLA) before submitting your pull request. To complete the CLA, submit a request via the form and electronically sign the CLA when you receive the email containing the link to the document. You need to complete the CLA only once to cover all Microsoft Open Technologies OSS projects.
 
@@ -33,4 +33,4 @@ Please follow these guidelines when creating new issues in the issue tracker:
 - Subscribe to notifications for the created issue in case there are any follow up questions.
 
 ### Coding Conventions
-- Use the coding style outlined in the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/wiki/Contributing#c-coding-style)
+- Use the coding style outlined in the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)

--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -33,4 +33,4 @@ Please follow these guidelines when creating new issues in the issue tracker:
 - Subscribe to notifications for the created issue in case there are any follow up questions.
 
 ### Coding Conventions
-- Use the coding style outlined in the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
+- Use the coding style outlined in the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)

--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -7,7 +7,7 @@ Because our focus right now is on maintaining backwards compatibility, the team 
 - Only contributions referencing an approved Issue will be accepted.
 - Pull requests that do not merge easily with the tip of the master branch will be declined. The author will be asked to merge with tip and submit a new pull request.
 - Submissions must meet functional and performance expectations, including scenarios for which the team doesn't yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests.
-- Submissions must follow the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
+- Submissions must follow the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
 
 When you are ready to proceed with making a change, get set up to [build](Home.md "See 'Building Testing and Debugging'") the code and familiarize yourself with our workflow and our coding conventions. These two blogs posts on contributing code to open source projects are good too: Open Source Contribution Etiquette by Miguel de Icaza and Don’t “Push” Your Pull Requests by Ilya Grigorik.
 

--- a/documentation/wiki/Home.md
+++ b/documentation/wiki/Home.md
@@ -1,9 +1,9 @@
 # Getting Started
 
  * Building Testing and Debugging
-   * [Full Framework MSBuild](https://github.com/Microsoft/msbuild/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild)
-   * [.Net Core MSBuild](https://github.com/Microsoft/msbuild/wiki/Building-Testing-and-Debugging-on-.Net-Core-MSBuild)
-   * [Mono MSBuild](https://github.com/Microsoft/msbuild/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild)
+   * [Full Framework MSBuild](Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md)
+   * [.Net Core MSBuild](Building-Testing-and-Debugging-on-.Net-Core-MSBuild.md)
+   * [Mono MSBuild](Building-Testing-and-Debugging-on-Mono-MSBuild.md)
  * [Contributing Code](Contributing-Code.md)
  * [MSBuild Roadmap](Roadmap.md)
  * [MSBuild Resources](MSBuild-Resources.md)


### PR DESCRIPTION
Hi! I am new to this repo, and as I was going through the docs I found some links in the paragraphs point to the github wiki pages, where they show another url to the markdown files.

I have updated the following:
`Home.md`
- The links for each platform under `Building Testing and Debugging` from wiki pages to md files

`Contributing-Code.md`
- The link for `.Net Foundation Coding Guidelines` from [wiki page](https://github.com/dotnet/corefx/wiki/Contributing#c-coding-style) to [corefx contribution.md](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/contributing.md)
- Replace the wording for `[[build|Building Testing and Debugging]]` with `build` which links to [Home.md](https://github.com/Microsoft/msbuild/blob/master/documentation/wiki/Home.md) (with tooltip to reference the "Building Testing and Debugging" section)

Not sure if this is needed, but I bet it could save some new comers a few mouse clicks! And also gave me a chance to try contributing!

Feel free to compare the [new](https://github.com/isiahto/msbuild/tree/ito/wiki-doc-fix/documentation/wiki) and [old](https://github.com/Microsoft/msbuild/tree/master/documentation/wiki) version of `Home.md` and `
Contributing-Code.md`.