### PR TITLE
Add /interactive switch

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -949,6 +949,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> ForwardingLoggers { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } set { } }
         public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } set { } }
+        public bool Interactive { get { throw null; } set { } }
         public bool LegacyThreadingSemantics { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> Loggers { get { throw null; } set { } }
         public bool LogInitialPropertiesAndItems { get { throw null; } set { } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -944,6 +944,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Logging.ForwardingLoggerRecord> ForwardingLoggers { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } set { } }
         public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } set { } }
+        public bool Interactive { get { throw null; } set { } }
         public bool LegacyThreadingSemantics { get { throw null; } set { } }
         public System.Collections.Generic.IEnumerable<Microsoft.Build.Framework.ILogger> Loggers { get { throw null; } set { } }
         public bool LogInitialPropertiesAndItems { get { throw null; } set { } }

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -207,6 +207,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private ProjectLoadSettings _projectLoadSettings = ProjectLoadSettings.Default;
 
+        private bool _interactive;
+
         /// <summary>
         /// Constructor for those who intend to set all properties themselves.
         /// </summary>
@@ -283,6 +285,7 @@ namespace Microsoft.Build.Execution
             WarningsAsErrors = other.WarningsAsErrors == null ? null : new HashSet<string>(other.WarningsAsErrors, StringComparer.OrdinalIgnoreCase);
             WarningsAsMessages = other.WarningsAsMessages == null ? null : new HashSet<string>(other.WarningsAsMessages, StringComparer.OrdinalIgnoreCase);
             _projectLoadSettings = other._projectLoadSettings;
+            _interactive = other._interactive;
         }
 
 #if FEATURE_THREAD_PRIORITY
@@ -713,6 +716,15 @@ namespace Microsoft.Build.Execution
             set => _projectLoadSettings = value;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating if the build is allowed to interact with the user.
+        /// </summary>
+        public bool Interactive
+        {
+            get => _interactive;
+            set => _interactive = value;
+        }
+
 
         /// <summary>
         /// Retrieves a toolset.
@@ -762,6 +774,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _logTaskInputs);
             translator.Translate(ref _logInitialPropertiesAndItems);
             translator.TranslateEnum(ref _projectLoadSettings, (int) _projectLoadSettings);
+            translator.Translate(ref _interactive);
 
             // ProjectRootElementCache is not transmitted.
             // ResetCaches is not transmitted.

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Build.Evaluation
             _submissionId = submissionId;
             _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
 
-            // In 15.9 we add support for the global property "NuGetInteractive" to allow SDK resolvers to be interactive.
+            // In 15.9 we added support for the global property "NuGetInteractive" to allow SDK resolvers to be interactive.
             // In 16.0 we added the /interactive command-line argument so the line below keeps back-compat
             _interactive = interactive || String.Equals("true", _data.GlobalPropertiesDictionary.GetProperty("NuGetInteractive")?.EvaluatedValue, StringComparison.OrdinalIgnoreCase);
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2586,7 +2586,8 @@ namespace Microsoft.Build.Execution
                 ProjectRootElementCache,
                 buildEventContext,
                 sdkResolverService ?? SdkResolverService.Instance,
-                submissionId);
+                submissionId,
+                interactive: buildParameters.Interactive);
 
             ErrorUtilities.VerifyThrow(EvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");
         }

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Build.Internal
         internal const string version = "MSBuildVersion";
         internal const string osName = "OS";
         internal const string frameworkToolsRoot = "MSBuildFrameworkToolsRoot";
+        internal const string interactive = "MSBuildInteractive";
 
         /// <summary>
         /// Lookup for reserved property names. Intentionally do not include MSBuildExtensionsPath* or MSBuildUserExtensionsPath in this list.  We need tasks to be able to override those.
@@ -84,7 +85,8 @@ namespace Microsoft.Build.Internal
             lastTaskResult,
             programFiles32,
             assemblyVersion,
-            version
+            version,
+            interactive
         };
 
         /// <summary>

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1345,6 +1345,20 @@ namespace Microsoft.Build.UnitTests
             commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.ProfileEvaluation][0].ShouldBe("no-file");
         }
 
+        [Fact]
+        public void ProcessBooleanSwitchTest()
+        {
+            MSBuildApp.ProcessBooleanSwitch(new string[0], defaultValue: true, resourceName: null).ShouldBeTrue();
+
+            MSBuildApp.ProcessBooleanSwitch(new string[0], defaultValue: false, resourceName: null).ShouldBeFalse();
+
+            MSBuildApp.ProcessBooleanSwitch(new [] { "true" }, defaultValue: false, resourceName: null).ShouldBeTrue();
+
+            MSBuildApp.ProcessBooleanSwitch(new[] { "false" }, defaultValue: true, resourceName: null).ShouldBeFalse();
+
+            Should.Throw<CommandLineSwitchException>(() => MSBuildApp.ProcessBooleanSwitch(new[] { "invalid" }, defaultValue: true, resourceName: "InvalidRestoreValue"));
+        }
+
         /// <summary>
         /// Verifies that when the /profileevaluation switch is used with invalid filenames an error is shown.
         /// </summary>

--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -1128,7 +1128,8 @@ namespace Microsoft.Build.UnitTests
                                         warningsAsMessages: null,
                                         enableRestore: false,
                                         profilerLogger: null,
-                                        enableProfiler: false);
+                                        enableProfiler: false,
+                                        interactive: false);
                 }
                 finally
                 {

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -2017,6 +2017,25 @@ namespace Microsoft.Build.UnitTests
             logContents.ShouldContain("E2C73B5843F94B63B067D9BEB2C4EC52", () => logContents);
         }
 
+        [Theory]
+        [InlineData("/interactive")]
+        [InlineData("/p:NuGetInteractive=true")]
+        [InlineData("/interactive /p:NuGetInteractive=true")]
+        public void InteractiveSetsBuiltInProperty(string arguments)
+        {
+            string projectContents = ObjectModelHelpers.CleanupFileContents(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+
+  <Target Name=""Build"">
+    <Message Text=""MSBuildInteractive = [$(MSBuildInteractive)]"" />
+  </Target>
+  
+</Project>");
+
+            string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: arguments);
+
+            logContents.ShouldContain("MSBuildInteractive = [true]");
+        }
+
         private string CopyMSBuild()
         {
             string dest = null;

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -103,6 +103,7 @@ namespace Microsoft.Build.CommandLine
             Restore,
             ProfileEvaluation,
             RestoreProperty,
+            Interactive,
             NumberOfParameterizedSwitches,
         }
 
@@ -281,6 +282,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "restore", "r" },                      ParameterizedSwitch.Restore,                    null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "profileevaluation", "prof" },         ParameterizedSwitch.ProfileEvaluation,          null,                           false,          "MissingProfileParameterError",        true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "restoreproperty", "rp" },             ParameterizedSwitch.RestoreProperty,            null,                           true,           "MissingRestorePropertyError",         true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "interactive" },                       ParameterizedSwitch.Interactive,                null,                           false,          null,                                  true,   false  ),
         };
 
         /// <summary>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -710,9 +710,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <data name="HelpMessage_34_InteractiveSwitch" UESanitized="false" Visibility="Public">
     <value>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -707,6 +707,21 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </comment>
   </data>
+  <data name="HelpMessage_34_InteractiveSwitch" UESanitized="false" Visibility="Public">
+    <value>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </value>
+    <comment>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
+  </data>
   <data name="InvalidConfigurationFile" Visibility="Public">
     <value>MSBUILD : Configuration error MSB1043: The application could not start. {0}</value>
     <comment>
@@ -1035,6 +1050,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <data name="InvalidRestoreValue" UESanitized="true" Visibility="Public">
     <value>MSBUILD : error MSB1052: Restore value is not valid. {0}</value>
     <comment>{StrBegin="MSBUILD : error MSB1052: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
+  <data name="InvalidInteractiveValue" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1056: Interactive value is not valid. {0}</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1056: "}
       UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
       This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -98,18 +98,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -95,6 +95,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -950,6 +974,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -774,6 +798,16 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -84,6 +84,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -760,6 +784,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -87,18 +87,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -88,18 +88,18 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -85,6 +85,30 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -762,6 +786,16 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -85,6 +85,30 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
     </note>
       </trans-unit>
+      <trans-unit id="HelpMessage_34_InteractiveSwitch">
+        <source>  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </source>
+        <target state="new">  /interactive[:True|False]
+                     Indicates that actions in the build are allowed to
+                     interact with the user.  When enabled, the build can
+                     block indefinitely so it should only be specified
+                     in an environment where a user is present.
+                     Specifying /interactive is the same as specifying
+                     /interactive:true.  Use the parameter to override a
+                     value that comes from a response file.
+    </target>
+        <note>
+      LOCALIZATION: "/interactive" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
+      </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
 </source>
@@ -761,6 +785,16 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidInteractiveValue">
+        <source>MSBUILD : error MSB1056: Interactive value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1056: Interactive value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1056: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a restore value that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidLoggerError">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -88,18 +88,18 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       <trans-unit id="HelpMessage_34_InteractiveSwitch">
         <source>  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.
     </source>
         <target state="new">  /interactive[:True|False]
                      Indicates that actions in the build are allowed to
-                     interact with the user.  When enabled, the build can
-                     block indefinitely so it should only be specified
-                     in an environment where a user is present.
+                     interact with the user.  Do not use this argument
+                     in an automated scenario where interactivity is
+                     not expected.
                      Specifying /interactive is the same as specifying
                      /interactive:true.  Use the parameter to override a
                      value that comes from a response file.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -555,6 +555,7 @@ namespace Microsoft.Build.CommandLine
                 bool enableRestore = Traits.Instance.EnableRestoreFirst;
                 ProfilerLogger profilerLogger = null;
                 bool enableProfiler = false;
+                bool interactive = false;
 
                 CommandLineSwitches switchesFromAutoResponseFile;
                 CommandLineSwitches switchesNotFromAutoResponseFile;
@@ -581,6 +582,7 @@ namespace Microsoft.Build.CommandLine
                         ref warningsAsErrors,
                         ref warningsAsMessages,
                         ref enableRestore,
+                        ref interactive,
                         ref profilerLogger,
                         ref enableProfiler,
                         ref restoreProperties,
@@ -620,7 +622,7 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_XML_SCHEMA_VALIDATION
                             needToValidateProject, schemaFile,
 #endif
-                            cpuCount, enableNodeReuse, preprocessWriter, detailedSummary, warningsAsErrors, warningsAsMessages, enableRestore, profilerLogger, enableProfiler))
+                            cpuCount, enableNodeReuse, preprocessWriter, detailedSummary, warningsAsErrors, warningsAsMessages, enableRestore, profilerLogger, enableProfiler, interactive))
                             {
                                 exitType = ExitType.BuildError;
                             }
@@ -919,7 +921,8 @@ namespace Microsoft.Build.CommandLine
             ISet<string> warningsAsMessages,
             bool enableRestore,
             ProfilerLogger profilerLogger,
-            bool enableProfiler
+            bool enableProfiler,
+            bool interactive
         )
         {
             if (String.Equals(Path.GetExtension(projectFile), ".vcproj", StringComparison.OrdinalIgnoreCase) ||
@@ -1080,6 +1083,7 @@ namespace Microsoft.Build.CommandLine
                     parameters.LogTaskInputs = logTaskInputs;
                     parameters.WarningsAsErrors = warningsAsErrors;
                     parameters.WarningsAsMessages = warningsAsMessages;
+                    parameters.Interactive = interactive;
 
                     // Propagate the profiler flag into the project load settings so the evaluator
                     // can pick it up
@@ -1905,6 +1909,7 @@ namespace Microsoft.Build.CommandLine
             ref ISet<string> warningsAsErrors,
             ref ISet<string> warningsAsMessages,
             ref bool enableRestore,
+            ref bool interactive,
             ref ProfilerLogger profilerLogger,
             ref bool enableProfiler,
             ref Dictionary<string, string> restoreProperties,
@@ -2015,6 +2020,7 @@ namespace Microsoft.Build.CommandLine
                                                                ref warningsAsErrors,
                                                                ref warningsAsMessages,
                                                                ref enableRestore,
+                                                               ref interactive,
                                                                ref profilerLogger,
                                                                ref enableProfiler,
                                                                ref restoreProperties,
@@ -2057,7 +2063,12 @@ namespace Microsoft.Build.CommandLine
 
                     if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Restore))
                     {
-                        enableRestore = ProcessRestoreSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Restore]);
+                        enableRestore = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Restore], defaultValue: true, resourceName: "InvalidRestoreValue");
+                    }
+
+                    if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Interactive))
+                    {
+                        interactive = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.Interactive], defaultValue: true, resourceName: "InvalidInteractiveValue");
                     }
 
                     // figure out which loggers are going to listen to build events
@@ -2232,27 +2243,27 @@ namespace Microsoft.Build.CommandLine
             return warningsAsMessages;
         }
 
-        internal static bool ProcessRestoreSwitch(string[] parameters)
+        internal static bool ProcessBooleanSwitch(string[] parameters, bool defaultValue, string resourceName)
         {
-            bool enableRestore = true;
+            bool value = defaultValue;
 
             if (parameters.Length > 0)
             {
                 try
                 {
-                    enableRestore = bool.Parse(parameters[parameters.Length - 1]);
+                    value = bool.Parse(parameters[parameters.Length - 1]);
                 }
                 catch (FormatException ex)
                 {
-                    CommandLineSwitchException.Throw("InvalidRestoreValue", parameters[parameters.Length - 1], ex.Message);
+                    CommandLineSwitchException.Throw(resourceName, parameters[parameters.Length - 1], ex.Message);
                 }
                 catch (ArgumentNullException ex)
                 {
-                    CommandLineSwitchException.Throw("InvalidRestoreValue", parameters[parameters.Length - 1], ex.Message);
+                    CommandLineSwitchException.Throw(resourceName, parameters[parameters.Length - 1], ex.Message);
                 }
             }
 
-            return enableRestore;
+            return value;
         }
 
         /// <summary>
@@ -3522,6 +3533,7 @@ namespace Microsoft.Build.CommandLine
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_31_RestoreSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_33_RestorePropertySwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_32_ProfilerSwitch"));
+            Console.WriteLine(AssemblyResources.GetString("HelpMessage_34_InteractiveSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_7_ResponseFile"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_8_NoAutoResponseSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_5_NoLogoSwitch"));


### PR DESCRIPTION
Sets built-in property `MSBuildInteractive` and is passed to SDK resolvers
Keeps back compat with existing `NuGetInteractive` global property