### PR TITLE
Reduce IO calls in SystemState

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2911,7 +2911,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <returns>The last write time.</returns>
         private static DateTime GetLastWriteTime(string path)
         {
-            return DateTime.FromOADate(0.0);
+            return fileExists(path) ? DateTime.FromFileTimeUtc(1) : DateTime.FromFileTimeUtc(0);
         }
 
         /// <summary>

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -617,14 +617,14 @@ namespace Microsoft.Build.Tasks
         {
             if (instanceLocalLastModifiedCache.TryGetValue(path, out DateTime cachedLastModified))
             {
-                return IsExistingFileTime(cachedLastModified);
+                return FileTimestampIndicatesFileExists(cachedLastModified);
             }
             DateTime lastModified = getLastWriteTime(path);
             instanceLocalLastModifiedCache[path] = lastModified;
-            return IsExistingFileTime(lastModified);
+            return FileTimestampIndicatesFileExists(lastModified);
         }
 
-        private bool IsExistingFileTime(DateTime lastModified)
+        private bool FileTimestampIndicatesFileExists(DateTime lastModified)
         {
             // TODO: Standardize LastWriteTime value for nonexistent files. See https://github.com/Microsoft/msbuild/issues/3699
             return lastModified != DateTime.MinValue && lastModified != DateTime.FromFileTimeUtc(0);

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -619,6 +619,8 @@ namespace Microsoft.Build.Tasks
             {
                 return FileTimestampIndicatesFileExists(cachedLastModified);
             }
+
+            // Cache miss; fall back to actual check and populate cache with result
             DateTime lastModified = getLastWriteTime(path);
             instanceLocalLastModifiedCache[path] = lastModified;
             return FileTimestampIndicatesFileExists(lastModified);


### PR DESCRIPTION
Split from #3660 

```FileExists()``` calls are cached separately from ```GetLastWriteTime()``` calls even though file existence can be determined from the return value. Within ```ReferenceTable.ComputeClosure()```, this effectively doubles IO on Windows since ```AssemblyInformation.IsWinMDFile()``` results in a duplicate check for last write time on files already checked for existence.

Below are just copypasta perf measurements before splitting from the previous PR, however I should still run this on it's own to get a more accurate measurement of changes.

-------------------------------
Locally goes from master hovering around
```
     5221 ms  ResolveAssemblyReferences                129 calls
    16113 ms  Build                                    130 calls
```
to
```
     4326 ms  ResolveAssemblyReferences                129 calls
    15407 ms  Build                                    130 calls
```

### DesignTimeBuild Time (ms) (src\msbuild.A vs src\msbuild.B)
Test | Overall | Significant δ  | Value
:--- | :--- | :--- | :---
DotnetConsoleProject | :white_check_mark: | yes | 35.8974 -> 34.0461 (-5.157%)
DotnetWebProject | :ok_hand: | no | 226.6734 -> 226.7153 (0.018%)
DotnetMvcProject | ::ok_hand: | no | 229.9469 -> 229.5218 (-0.185%)
Picasso | :white_check_mark: | yes | 1527.1186 -> 1521.5351 (-0.366%)
SmallP2POldCsproj | :white_check_mark: | yes | 67.1589 -> 66.396 (-1.136%)
SmallP2PNewCsproj | :red_circle: | yes | 616.5941 -> 623.5553 (1.129%)
LargeP2POldCsproj | :red_circle: | yes | 10878.239 -> 10899.0847 (0.192%)
OrchardCore | :white_check_mark: | yes | 47732.8632 -> 47392.2282 (-0.714%)
