### PR TITLE
Throw BadImageFormatException for zero-byte files

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -204,13 +204,23 @@ namespace Microsoft.Build.Shared
             using (var stream = File.OpenRead(path))
             using (var peFile = new PEReader(stream))
             {
-                // If the file does not contain PE metadata, throw BadImageFormatException to preserve
-                // behavior from AssemblyName.GetAssemblyName(). RAR will deal with this correctly.
-                if (!peFile.HasMetadata)
+                bool hasMetadata = false;
+                try
                 {
-                    throw new BadImageFormatException(string.Format(CultureInfo.CurrentCulture,
-                        AssemblyResources.GetString("ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata"),
-                        path));
+                    // This can throw if the stream is too small, which means
+                    // the assembly doesn't have metadata.
+                    hasMetadata = peFile.HasMetadata;
+                }
+                finally
+                {
+                    // If the file does not contain PE metadata, throw BadImageFormatException to preserve
+                    // behavior from AssemblyName.GetAssemblyName(). RAR will deal with this correctly.
+                    if (!hasMetadata)
+                    {
+                        throw new BadImageFormatException(string.Format(CultureInfo.CurrentCulture,
+                            AssemblyResources.GetString("ResolveAssemblyReference.AssemblyDoesNotContainPEMetadata"),
+                            path));
+                    }
                 }
 
                 var metadataReader = peFile.GetMetadataReader();


### PR DESCRIPTION
There was a case missed in ac2d03c that caused the S.R.M error to be
worse than the equivalent full-framework error: when
`PEReader.HasMetadata` itself throws because the file is _really_ not
a PE file (for example, it has no content at all).

Related to #3560.

Output from the simple repro there on .net core now:

```
s:\work\zero-byte-ref>dotnet s:\msbuild2\artifacts\Debug\bootstrap\netcoreapp2.1\MSBuild\MSBuild.dll s:\work\zero-byte-ref\zero-byte-ref.csproj /flp:v=diag /v:m
Waiting for debugger to attach (C:\Program Files\dotnet\dotnet.exe PID 18152).  Press enter to continue...

Microsoft (R) Build Engine version 15.9.9-preview+gd05d07205a for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

s:\msbuild2\artifacts\Debug\bootstrap\netcoreapp2.1\MSBuild\Microsoft.Common.CurrentVersion.targets(2110,5): warning MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. Assembly file 's:\work\zero-byte-ref\deliberately.zero.bytes.dll' could not be opened -- PE image doesn't contain managed metadata. [s:\work\zero-byte-ref\zero-byte-ref.csproj]
  zero-byte-ref -> s:\work\zero-byte-ref\bin\Debug\netstandard2.0\zero-byte-ref.dll
```

and full framework

```
s:\work\zero-byte-ref>s:\msbuild2\artifacts\Debug\bootstrap\net46\MSBuild\15.0\Bin\MSBuild.exe s:\work\zero-byte-ref\zero-byte-ref.csproj /flp:v=diag /t:rebuild /v:m
Waiting for debugger to attach (s:\msbuild2\artifacts\Debug\bootstrap\net46\MSBuild\15.0\Bin\MSBuild.exe PID 12232).  Press enter to continue...

Microsoft (R) Build Engine version 15.9.9-preview+gd05d07205a for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

C:\Program Files\dotnet\sdk\2.1.500-preview-009266\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInfere
nce.targets(143,5): message NETSDK1057: You are working with a preview version of the .NET Core SDK. You can define the
 SDK version via a global.json file in the current project. More at https://go.microsoft.com/fwlink/?linkid=869452 [s:\
work\zero-byte-ref\zero-byte-ref.csproj]
s:\msbuild2\artifacts\Debug\bootstrap\net46\MSBuild\15.0\Bin\Microsoft.Common.CurrentVersion.targets(2110,5): warning M
SB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. Could not load file or assembly 'deli
berately.zero.bytes.dll' or one of its dependencies. An attempt was made to load a program with an incorrect format. [s
:\work\zero-byte-ref\zero-byte-ref.csproj]
  zero-byte-ref -> s:\work\zero-byte-ref\bin\Debug\netstandard2.0\zero-byte-ref.dll
```

This isn't a perfect fix but I can't see a great way to ensure that we get the full path in both scenarios, since the full framework doesn't put it in their error.

If we do go toward using `System.Reflection.Metadata` in all circumstances (which I'm currently thinking might be nice, but I don't know if there are corner cases that the COM APIs handle that it doesn't), this could fix the problem entirely.