### PR TITLE
Update FileUtilities to include the current app domain id

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Shared
         {
             if (cacheDirectory == null)
             {
-                cacheDirectory = Path.Combine(Path.GetTempPath(), String.Format(CultureInfo.CurrentUICulture, "MSBuild{0}", Process.GetCurrentProcess().Id));
+                cacheDirectory = Path.Combine(Path.GetTempPath(), String.Format(CultureInfo.CurrentUICulture, "MSBuild{0}-{1}", Process.GetCurrentProcess().Id, AppDomain.CurrentDomain.Id));
             }
 
             return cacheDirectory;


### PR DESCRIPTION
This avoids race conditions such as #3712, where the field https://github.com/Microsoft/msbuild/blob/0591c15d6c638cad38091fbe625dde968f86748d/src/Shared/FileUtilities.cs#L44 can be set to the same value depending on the current app domain.