### PR TITLE
Use reference assemblies

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -68,6 +68,13 @@ steps:
     filename: 'artifacts\nbgv.exe'
     arguments: 'cloud --version=$(NBGV_SemVer1)'
 
+- task: CmdLine@1
+  displayName: Just log every file
+  inputs:
+    filename: dir
+    arguments: '/s /b $(Build.ArtifactStagingDirectory)\..>artifacts\$(BuildConfiguration)\log\Everyfile.log'
+  condition: always()
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: logs'
   inputs:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,6 +52,8 @@
     -->
 
     <NoWarn>$(NoWarn);NU1603;NU5105;1701;1702</NoWarn>
+
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug-MONO'">

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -31,6 +31,8 @@
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
     <UsingToolVSSDK>true</UsingToolVSSDK>
     <MicroBuildPluginsSwixBuildVersion>1.0.422</MicroBuildPluginsSwixBuildVersion>
+
+    <RoslynToolsSignToolVersion>1.0.0-beta2-dev3</RoslynToolsSignToolVersion>
   </PropertyGroup>
 
   <!-- Toolset Dependencies -->
@@ -40,5 +42,11 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <VSWhereVersion>2.2.7</VSWhereVersion>
   </PropertyGroup>
+
+  <Target Name="MungeSignToolArguments" BeforeTargets="Sign">
+    <ItemGroup>
+      <SignToolArgs Include='-msbuildBinaryLog "$(ArtifactsLogDir)\signtool.binlog"' />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
We didn't turn these on for a while because we needed our bootstrap compilers to support them, but we should be long past that now. This will speed up incremental builds in the repo.