### PR TITLE
RAR test diagnosability

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference
                 {
-                    BuildEngine = new MockEngine(),
+                    BuildEngine = new MockEngine(_output),
                     Assemblies = new ITaskItem[] {new TaskItem("assemblyfromconfig2")},
                     SearchPaths = new[] {moniker}
                 };
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference
                 {
-                    BuildEngine = new MockEngine(),
+                    BuildEngine = new MockEngine(_output),
                     Assemblies = new ITaskItem[] {new TaskItem("assemblyfromconfig_common.dll")},
                     SearchPaths = new[] {moniker},
                     TargetProcessorArchitecture = "x86"
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference
                 {
-                    BuildEngine = new MockEngine(),
+                    BuildEngine = new MockEngine(_output),
                     Assemblies = new ITaskItem[] { new TaskItem("v5assembly.dll") },
                     SearchPaths = new[] { moniker },
                     TargetProcessorArchitecture = "x86"
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
                 // Try again changing only the processor architecture
                 t = new ResolveAssemblyReference
                 {
-                    BuildEngine = new MockEngine(),
+                    BuildEngine = new MockEngine(_output),
                     Assemblies = new ITaskItem[] { new TaskItem("v5assembly.dll") },
                     SearchPaths = new[] { moniker },
                     TargetProcessorArchitecture = "AMD64"
@@ -147,7 +147,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference
                 {
-                    BuildEngine = new MockEngine(),
+                    BuildEngine = new MockEngine(_output),
                     Assemblies = new ITaskItem[] {new TaskItem("assemblyfromconfig_common.dll")},
                     SearchPaths = new[] {moniker},
                     TargetProcessorArchitecture = "x86"
@@ -172,7 +172,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 
             try
             {
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
                 ResolveAssemblyReference t = new ResolveAssemblyReference
                 {
                     BuildEngine = engine,

--- a/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;
 using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -53,7 +54,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 
                 Assert.Equal(1, t.ResolvedFiles.Length);
                 Assert.Equal(Path.Combine(s_rootPathPrefix, "assemblyfromconfig", "folder2", "assemblyfromconfig2.dll"), t.ResolvedFiles[0].ItemSpec);
-                AssertNoCase(moniker, t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+                t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(moniker, StringCompareShould.IgnoreCase);
             }
             finally
             {
@@ -83,7 +84,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 
                 Assert.Equal(1, t.ResolvedFiles.Length);
                 Assert.Equal(Path.Combine(s_rootPathPrefix, "assemblyfromconfig", "folder_x86", "assemblyfromconfig_common.dll"), t.ResolvedFiles[0].ItemSpec);
-                AssertNoCase(moniker, t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+                t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(moniker, StringCompareShould.IgnoreCase);
             }
             finally
             {
@@ -113,7 +114,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 
                 Assert.Equal(1, t.ResolvedFiles.Length);
                 Assert.Equal(Path.Combine(s_rootPathPrefix, "assemblyfromconfig", "folder501000x86", "v5assembly.dll"), t.ResolvedFiles[0].ItemSpec);
-                AssertNoCase(moniker, t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+                t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(moniker, StringCompareShould.IgnoreCase);
 
                 // Try again changing only the processor architecture
                 t = new ResolveAssemblyReference
@@ -128,7 +129,7 @@ namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 
                 Assert.Equal(1, t.ResolvedFiles.Length);
                 Assert.Equal(Path.Combine(s_rootPathPrefix, "assemblyfromconfig", "folder5010x64", "v5assembly.dll"), t.ResolvedFiles[0].ItemSpec);
-                AssertNoCase(moniker, t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+                t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(moniker, StringCompareShould.IgnoreCase);
             }
             finally
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/AssemblyFoldersFromConfig_Tests.cs
@@ -11,12 +11,13 @@ using Microsoft.Build.UnitTests;
 using Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.Tasks.UnitTests.AssemblyDependency
 {
     public class AssemblyFoldersFromConfig_Tests : ResolveAssemblyReferenceTestFixture
     {
-        public AssemblyFoldersFromConfig_Tests()
+        public AssemblyFoldersFromConfig_Tests(ITestOutputHelper output) : base(output)
         {
             s_existentFiles.AddRange(new[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
@@ -5,11 +5,16 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.AppConfig
 {
     public sealed class FilePrimary : ResolveAssemblyReferenceTestFixture
     {
+        public FilePrimary(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// In this case,
         /// - A single primary file reference to assembly version 1.0.0.0 was passed in.

--- a/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Console.WriteLine("Performing VersioningAndUnification.AppConfig.FilePrimary.Exists() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -81,7 +81,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void BadAppconfigOldVersion()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -134,7 +134,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void BadAppconfigNewVersion()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -217,7 +217,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
 
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames = new TaskItem[]
                 {
@@ -279,7 +279,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsDifferentName()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -332,7 +332,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsOldVersionRange()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void HighVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -436,7 +436,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void LowVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/FilePrimary.cs
@@ -4,6 +4,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,7 +68,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -307,7 +308,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -360,7 +361,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -413,7 +414,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -344,7 +344,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -418,7 +418,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -490,7 +490,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -554,7 +554,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -618,7 +618,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -684,7 +684,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -749,7 +749,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -817,7 +817,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
@@ -28,6 +29,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private GetAssemblyRuntimeVersion _runtimeVersion = new GetAssemblyRuntimeVersion(MockGetRuntimeVersion);
         private GetPathFromFusionName _getPathFromFusionName = new GetPathFromFusionName(MockGetPathFromFusionName);
         private GetGacEnumerator _gacEnumerator = new GetGacEnumerator(MockAssemblyCacheEnumerator);
+
+        public GlobalAssemblyCacheTests(ITestOutputHelper output) : base(output)
+        {
+        }
 
         /// <summary>
         /// Verify when the GAC enumerator returns

--- a/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/GlobalAssemblyCacheTests.cs
@@ -651,7 +651,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 isWinMDFile,
                 readMachineTypeFromPEHeader));
 
-            Console.WriteLine (((MockEngine)t.BuildEngine).Log);
             Assert.True(string.Equals(t.DependsOnNETStandard, "true", StringComparison.OrdinalIgnoreCase)); //                 "Expected netstandard dependency found during build."
 
             // intelli build mode

--- a/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
@@ -51,21 +51,21 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Trait("Category", "mono-osx-failing")]
         public void SDkNameMatchInRADirectory()
         {
-            ResolveSDKFromRefereneAssemblyLocation("DebugX86SDKWinMD", @"C:\FakeSDK\References\Debug\X86\DebugX86SDKWinMD.Winmd");
-            ResolveSDKFromRefereneAssemblyLocation("DebugNeutralSDKWinMD", @"C:\FakeSDK\References\Debug\Neutral\DebugNeutralSDKWinMD.Winmd");
-            ResolveSDKFromRefereneAssemblyLocation("x86SDKWinMD", @"C:\FakeSDK\References\CommonConfiguration\x86\x86SDKWinMD.Winmd");
-            ResolveSDKFromRefereneAssemblyLocation("NeutralSDKWinMD", @"C:\FakeSDK\References\CommonConfiguration\Neutral\NeutralSDKWinMD.Winmd");
-            ResolveSDKFromRefereneAssemblyLocation("SDKReference", @"C:\FakeSDK\References\Debug\X86\SDKReference.dll");
-            ResolveSDKFromRefereneAssemblyLocation("DebugX86SDKRA", @"C:\FakeSDK\References\Debug\X86\DebugX86SDKRA.dll");
-            ResolveSDKFromRefereneAssemblyLocation("DebugNeutralSDKRA", @"C:\FakeSDK\References\Debug\Neutral\DebugNeutralSDKRA.dll");
-            ResolveSDKFromRefereneAssemblyLocation("x86SDKRA", @"C:\FakeSDK\References\CommonConfiguration\x86\x86SDKRA.dll");
-            ResolveSDKFromRefereneAssemblyLocation("NeutralSDKRA", @"C:\FakeSDK\References\CommonConfiguration\Neutral\NeutralSDKRA.dll");
+            ResolveSDKFromRefereneAssemblyLocation("DebugX86SDKWinMD", @"C:\FakeSDK\References\Debug\X86\DebugX86SDKWinMD.Winmd", _output);
+            ResolveSDKFromRefereneAssemblyLocation("DebugNeutralSDKWinMD", @"C:\FakeSDK\References\Debug\Neutral\DebugNeutralSDKWinMD.Winmd", _output);
+            ResolveSDKFromRefereneAssemblyLocation("x86SDKWinMD", @"C:\FakeSDK\References\CommonConfiguration\x86\x86SDKWinMD.Winmd", _output);
+            ResolveSDKFromRefereneAssemblyLocation("NeutralSDKWinMD", @"C:\FakeSDK\References\CommonConfiguration\Neutral\NeutralSDKWinMD.Winmd", _output);
+            ResolveSDKFromRefereneAssemblyLocation("SDKReference", @"C:\FakeSDK\References\Debug\X86\SDKReference.dll", _output);
+            ResolveSDKFromRefereneAssemblyLocation("DebugX86SDKRA", @"C:\FakeSDK\References\Debug\X86\DebugX86SDKRA.dll", _output);
+            ResolveSDKFromRefereneAssemblyLocation("DebugNeutralSDKRA", @"C:\FakeSDK\References\Debug\Neutral\DebugNeutralSDKRA.dll", _output);
+            ResolveSDKFromRefereneAssemblyLocation("x86SDKRA", @"C:\FakeSDK\References\CommonConfiguration\x86\x86SDKRA.dll", _output);
+            ResolveSDKFromRefereneAssemblyLocation("NeutralSDKRA", @"C:\FakeSDK\References\CommonConfiguration\Neutral\NeutralSDKRA.dll", _output);
         }
 
-        private static void ResolveSDKFromRefereneAssemblyLocation(string referenceName, string expectedPath)
+        private static void ResolveSDKFromRefereneAssemblyLocation(string referenceName, string expectedPath, ITestOutputHelper output)
         {
             // Create the engine.
-            MockEngine engine = new MockEngine(_output);
+            MockEngine engine = new MockEngine(output);
             TaskItem taskItem = new TaskItem(referenceName);
             taskItem.SetMetadata("SDKName", "FakeSDK, Version=1.0");
 

--- a/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void SDkNameNotInResolvedSDKListButOnSearchPath()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem taskItem = new TaskItem(@"SDKWinMD");
             taskItem.SetMetadata("SDKName", "NotInstalled, Version=1.0");
 
@@ -65,7 +65,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private static void ResolveSDKFromRefereneAssemblyLocation(string referenceName, string expectedPath)
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem taskItem = new TaskItem(referenceName);
             taskItem.SetMetadata("SDKName", "FakeSDK, Version=1.0");
 

--- a/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/InstalledSDKResolverFixture.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -11,6 +12,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class InstalledSDKResolverFixture : ResolveAssemblyReferenceTestFixture
     {
+        public InstalledSDKResolverFixture(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Verify that we do not find the winmd file even if it on the search path if the sdkname does not match something passed into the ResolvedSDKs property.
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalDependenciesWhenParentReferenceInGacFalseAllParentsInGac()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -148,7 +148,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ValidateFrameworkNameError()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -186,7 +186,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalDependenciesWhenParentReferenceInGacFalseSomeParentsInGac()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -249,7 +249,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalDependenciesWhenParentReferenceInGacTrueAllParentsInGac()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -298,7 +298,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalDependenciesWhenParentReferenceInGacTrueSomeParentsInGac()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -339,7 +339,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalDependenciesWhenParentReferenceNotInGac()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -376,7 +376,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void CopyLocalLegacyBehavior()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
                     {
@@ -420,7 +420,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Console.WriteLine("Performing Miscellaneous.Basic() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Construct a list of assembly files.
             ITaskItem[] assemblyFiles = new TaskItem[]
@@ -744,7 +744,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             for (int i = 0; i < fxVersions.Length; i++)
             {
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
                 // Now, pass feed resolved primary references into ResolveAssemblyReference.
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
                 t.BuildEngine = engine;
@@ -798,7 +798,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void NOPForEmptyItemLists()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Now, pass feed resolved primary references into ResolveAssemblyReference.
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -826,7 +826,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Console.WriteLine("Performing Miscellaneous.DefaultRelatedFileExtensionsAreUsed() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Construct a list of assembly files.
             ITaskItem[] assemblies = new TaskItem[]
@@ -888,7 +888,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Console.WriteLine("Performing Miscellaneous.DefaultRelatedFileExtensionsAreUsed() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Construct a list of assembly files.
             ITaskItem[] assemblies = new TaskItem[]
@@ -925,7 +925,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Console.WriteLine("Performing Miscellaneous.InputRelatedFileExtensionsAreUsed() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Construct a list of assembly files.
             ITaskItem[] assemblies = new TaskItem[]
@@ -977,7 +977,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Console.WriteLine("Performing SimulateCreateProjectAgainstWhidbey() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Now, pass feed resolved primary references into ResolveAssemblyReference.
             ResolveAssemblyReference t = new ResolveAssemblyReference();
@@ -1036,7 +1036,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("mscorlib") };
             t.CandidateAssemblyFiles = new string[] { "|" };
@@ -1057,7 +1057,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("mscorlib") };
             t.AssemblyFiles = new ITaskItem[] { new TaskItem("|") };
@@ -1077,7 +1077,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("|!@#$%::") };
 
@@ -1103,7 +1103,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.TargetFrameworkDirectories = new string[] { "\nc:\\blah\\v2.0.1234" };
 
@@ -1123,7 +1123,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("mscorlib") };
             t.SearchPaths = new string[] { "|" };
@@ -1143,7 +1143,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("mscorlib") };
             t.AppConfigFile = "|";
@@ -1163,7 +1163,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             t.Assemblies = new ITaskItem[] {
                 new TaskItem("System.Xml"), new TaskItem("System.Nonexistent")
             };
@@ -1195,7 +1195,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             t.Assemblies = new ITaskItem[]
             {
                 new TaskItem("DependsOnSimpleA")
@@ -1219,7 +1219,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             t.Assemblies = new ITaskItem[]
             {
                 new TaskItem("DependsOnSimpleA")
@@ -1247,7 +1247,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             ITaskItem i = new TaskItem("My.Assembly");
 
@@ -1275,7 +1275,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("mscorlib") };
             t.SearchPaths = new string[]
@@ -1299,7 +1299,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyGrid") };
             t.SearchPaths = DefaultPaths;
@@ -1320,7 +1320,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("CustomComponent") };
             t.SearchPaths = DefaultPaths;
@@ -1342,7 +1342,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyGrid") };
             t.SearchPaths = new string[] { @"{Registry:Software\Microsoft\.NetFramework,2.0,AssemblyFoldersEx}" };
@@ -1366,7 +1366,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchDoesNotMatch()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1392,7 +1392,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchMSILX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1416,7 +1416,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyProcessArchitectureMismatchWarning()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A"), new TaskItem("B") };
@@ -1442,7 +1442,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyProcessArchitectureMismatchWarningDefault()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A"), new TaskItem("B") };
@@ -1467,7 +1467,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyProcessArchitectureMismatchError()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A"), new TaskItem("B") };
@@ -1495,7 +1495,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchNoneX86()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1516,7 +1516,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchNoneMix()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1545,7 +1545,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchMSILLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1571,7 +1571,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchNoneLastFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1596,7 +1596,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchX86FirstFolder()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1620,7 +1620,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchX86MSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1643,7 +1643,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchX86None()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1666,7 +1666,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchNoneNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1688,7 +1688,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArcMSILNone()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1710,7 +1710,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchNoneMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1733,7 +1733,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void AssemblyFoldersExProcessorArchMSILMSIL()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             t.BuildEngine = mockEngine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
@@ -1757,7 +1757,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("A") };
             t.SearchPaths = new string[] { @"{Registry:Software\Regress714052,v2.0.0,X86}" };
@@ -1782,7 +1782,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             ITaskItem assemblyToResolve = new TaskItem("MyGrid");
             assemblyToResolve.SetMetadata("HintPath", @"C:\MyComponents\MyGrid.dll");
@@ -1804,7 +1804,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyRawDropControl") };
             t.SearchPaths = DefaultPaths;
@@ -1825,7 +1825,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyHKLMControl") };
             t.SearchPaths = DefaultPaths;
@@ -1850,7 +1850,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyHKLMandHKCUControl") };
             t.SearchPaths = DefaultPaths;
@@ -1870,7 +1870,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyControlWithFutureTargetNDPVersion") };
             t.SearchPaths = DefaultPaths;
@@ -1890,7 +1890,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyNDP1Control") };
             t.SearchPaths = DefaultPaths;
@@ -1910,7 +1910,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyControlWithPastTargetNDPVersion") };
             t.SearchPaths = DefaultPaths;
@@ -1930,7 +1930,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyControlWithServicePack") };
             t.SearchPaths = DefaultPaths;
@@ -1956,7 +1956,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyDeviceControlAssembly") };
             t.SearchPaths = new string[]
@@ -1995,7 +1995,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyDeviceControlAssembly") };
             t.SearchPaths = new string[]
@@ -2310,7 +2310,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("MyDeviceControlAssembly") };
             t.SearchPaths = new string[]
@@ -2386,7 +2386,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("System.XML") };
             t.SearchPaths = new string[] { "{CandidateAssemblyFiles}" };
@@ -2407,7 +2407,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             TaskItem item = new TaskItem("System.XML");
             item.SetMetadata("RequiredTargetFramework", "v4.0.255");
             t.Assemblies = new ITaskItem[] { item };
@@ -2427,7 +2427,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             TaskItem item = new TaskItem("System.XML");
             item.SetMetadata("RequiredTargetFramework", "v4.0.255");
             t.Assemblies = new ITaskItem[] { item };
@@ -2448,7 +2448,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("System.XML") };
@@ -2495,7 +2495,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem(Path.Combine(s_myVersion20Path, "System.Xml.dll")) };
             t.SearchPaths = new string[]
@@ -2990,7 +2990,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             string testPath = Path.Combine(Path.GetTempPath(), @"RawFileNameRelative");
             string previousCurrentDirectory = Directory.GetCurrentDirectory();
@@ -3028,7 +3028,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             string testPath = Path.Combine(Path.GetTempPath(), @"RawFileNameRelative");
             string previousCurrentDirectory = Directory.GetCurrentDirectory();
@@ -3064,7 +3064,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             string testPath = Path.Combine(Path.GetTempPath(), @"RawFileNameRelative");
             string previousCurrentDirectory = Directory.GetCurrentDirectory();
@@ -3101,7 +3101,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             ITaskItem taskItem = new TaskItem(Path.Combine(s_myVersion20Path, "System.Xml.dll"));
             taskItem.SetMetadata("SpecificVersion", "false");
@@ -3126,7 +3126,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             ITaskItem taskItem = new TaskItem(Path.Combine(s_myVersion20Path, "System.Xml.dll"));
             taskItem.SetMetadata("SpecificVersion", "true");
@@ -3151,7 +3151,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -3181,7 +3181,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             TaskItem item = new TaskItem(@"c:\DoesntExist\System.Xml.dll");
@@ -3214,7 +3214,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem(@"c:\DoesntExist\System.Xml.dll") };
@@ -3236,7 +3236,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem("VendorAssembly") };
             t.SearchPaths = new string[] { "{CandidateAssemblyFiles}" };
@@ -3254,7 +3254,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveToGAC()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] { new TaskItem("System") };
@@ -3272,7 +3272,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveToGACSpecificVersion()
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             TaskItem item = new TaskItem("System");
@@ -3370,7 +3370,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
             t.Assemblies = new ITaskItem[]
             {
@@ -3440,7 +3440,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem(AssemblyRef.SystemData) };
             t.SearchPaths = new string[]
@@ -3463,7 +3463,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] { new TaskItem(AssemblyRef.SystemData) };
             t.SearchPaths = new string[]
@@ -3486,7 +3486,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void PrivateItemInFrameworksGetsCopyLocalTrue()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Create the mocks.
             Microsoft.Build.Shared.FileExists fileExists = new Microsoft.Build.Shared.FileExists(FileExists);
@@ -3521,7 +3521,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void NoFrameworkDirectoriesStillCopyLocal()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Also construct a set of assembly names to pass in.
             ITaskItem[] assemblyNames = new TaskItem[]
@@ -3547,7 +3547,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void Regress284485_PrivateItemWithBogusValue()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // Also construct a set of assembly names to pass in.
             ITaskItem[] assemblyNames = new TaskItem[]
@@ -3592,7 +3592,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -3637,7 +3637,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] {
@@ -3698,7 +3698,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] {
@@ -3743,7 +3743,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[] {
@@ -3784,7 +3784,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
             t.AutoUnify = true;
 
@@ -3824,7 +3824,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -3861,7 +3861,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -3907,7 +3907,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -3949,7 +3949,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -3994,7 +3994,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4036,7 +4036,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4075,7 +4075,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4111,7 +4111,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4146,7 +4146,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4175,7 +4175,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4200,7 +4200,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] {
                 new TaskItem(@"System.XML, Version=9.9.9999.9, Culture=neutral, PublicKeyToken=abababababababab")
@@ -4223,7 +4223,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[] {
                 new TaskItem(@"System.XML, Version=9.9.9999.9, Culture=neutral, PublicKeyToken=abababababababab")
@@ -4244,7 +4244,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine m = new MockEngine();
+            MockEngine m = new MockEngine(_output);
             t.BuildEngine = m;
 
             t.Assemblies = new ITaskItem[]
@@ -4279,7 +4279,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4318,7 +4318,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4358,7 +4358,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4397,7 +4397,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4438,7 +4438,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4477,7 +4477,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4515,7 +4515,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -4566,7 +4566,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             t.BuildEngine = engine;
 
             t.Assemblies = new ITaskItem[]
@@ -4627,7 +4627,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4690,7 +4690,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4733,7 +4733,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4789,7 +4789,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4841,7 +4841,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4883,7 +4883,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -4910,7 +4910,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void Regress284466_DirectoryIntoAssemblyFiles()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
                     {
@@ -4953,7 +4953,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyFiles = new TaskItem[]
                     {
@@ -4993,7 +4993,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5024,7 +5024,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.AssemblyFiles = new ITaskItem[]
@@ -5048,7 +5048,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5075,7 +5075,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5119,7 +5119,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5156,7 +5156,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5197,7 +5197,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5236,7 +5236,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5273,7 +5273,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5302,7 +5302,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5332,7 +5332,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void Regress271273_BogusAppConfig()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
                     {
@@ -5374,7 +5374,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -5416,7 +5416,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -5462,7 +5462,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -5488,7 +5488,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5540,7 +5540,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -5576,7 +5576,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -5689,7 +5689,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -5742,7 +5742,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -6177,7 +6177,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             string microsoftBuildEnginePath = Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5\\Microsoft.Build.Engine.dll");
             string systemXmlPath = Path.Combine(ObjectModelHelpers.TempProjectDir, "v3.5\\System.Xml.dll");
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -6552,7 +6552,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -6685,7 +6685,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTablePrimaryItemInBlackList()
         {
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             ResolveAssemblyReference rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
 
@@ -6724,7 +6724,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTablePrimaryItemInBlackListSpecificVersionTrue()
         {
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             ResolveAssemblyReference rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
 
@@ -6802,7 +6802,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void ReferenceTablePrimaryItemInBlackListRemoveOnlyNoWarn()
         {
-            MockEngine mockEngine = new MockEngine();
+            MockEngine mockEngine = new MockEngine(_output);
             ResolveAssemblyReference rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
 
@@ -7383,7 +7383,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         private static void InitializeRARwithMockEngine(out MockEngine mockEngine, out ResolveAssemblyReference rar)
         {
-            mockEngine = new MockEngine();
+            mockEngine = new MockEngine(_output);
             rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
         }
@@ -7420,7 +7420,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// </summary>
         private void InitializeMockEngine(out ReferenceTable referenceTable, out MockEngine mockEngine, out ResolveAssemblyReference rar)
         {
-            mockEngine = new MockEngine();
+            mockEngine = new MockEngine(_output);
             rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
 
@@ -7481,7 +7481,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 explicitSubsetListPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("v3.5\\SubsetList\\ExplicitList.xml", _xmlOnlySubset);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}" };
 
@@ -7566,7 +7566,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
                 // These are the assemblies we are going to try and resolve
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}" };
@@ -7651,7 +7651,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
                 // These are the assemblies we are going to try and resolve
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}" };
@@ -7691,7 +7691,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
 
                 // These are the assemblies we are going to try and resolve
                 t.Assemblies = new ITaskItem[] { new TaskItem("System.Xml") };
@@ -7725,7 +7725,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
                 // These are the assemblies we are going to try and resolve
                 t.Assemblies = new ITaskItem[] { new TaskItem("System.Xml") };
 
@@ -7761,7 +7761,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             try
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
                 // These are the assemblies we are going to try and resolve
                 t.Assemblies = new ITaskItem[] { new TaskItem("System.Xml") };
 
@@ -7864,7 +7864,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-                t.BuildEngine = new MockEngine();
+                t.BuildEngine = new MockEngine(_output);
 
                 t.Assemblies = new ITaskItem[]
             {
@@ -7948,7 +7948,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -7980,7 +7980,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -8016,7 +8016,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8054,7 +8054,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8089,7 +8089,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             // NB: These are what common targets would set when AutoGenerateBindingRedirects is enabled.
@@ -8132,7 +8132,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8159,7 +8159,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8192,7 +8192,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8235,7 +8235,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8277,7 +8277,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new ITaskItem[]
@@ -8309,7 +8309,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.Assemblies = new TaskItem[]
@@ -8354,7 +8354,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
             t.BuildEngine = e;
 
             t.AssemblyFiles = new ITaskItem[]
@@ -8397,7 +8397,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
 
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
 
             t.Assemblies = new ITaskItem[]
             {
@@ -8451,7 +8451,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private int RunTargetFrameworkFilteringTest(string projectTargetFramework)
         {
             ResolveAssemblyReference t = new ResolveAssemblyReference();
-            t.BuildEngine = new MockEngine();
+            t.BuildEngine = new MockEngine(_output);
             t.Assemblies = new ITaskItem[]
             {
                 new TaskItem("A"),
@@ -8841,7 +8841,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 t.AssemblyFiles = new ITaskItem[] { new TaskItem(Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll")) };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };
@@ -8889,7 +8889,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 TaskItem item = new TaskItem(Path.Combine(s_myComponentsMiscPath, "DependsOn9Also.dll"));
                 item.SetMetadata("SpecificVersion", "true");
@@ -8933,7 +8933,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(_fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };
@@ -8980,7 +8980,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(_fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };
@@ -9034,7 +9034,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(fullRedistListContents, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 TaskItem item = new TaskItem(@"DependsOnOnlyv4Assemblies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
                 t.Assemblies = new ITaskItem[] { item };
@@ -9088,7 +9088,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 GenerateRedistAndProfileXmlLocations(fullRedistListContentsErrors, _engineOnlySubset, out profileRedistList, out fullRedistList, fullFrameworkDirectory, targetFrameworkDirectory);
 
                 ResolveAssemblyReference t = new ResolveAssemblyReference();
-                MockEngine e = new MockEngine();
+                MockEngine e = new MockEngine(_output);
                 t.BuildEngine = e;
                 t.Assemblies = new ITaskItem[] { new TaskItem("Microsoft.Build.Engine"), new TaskItem("System.Xml") };
                 t.SearchPaths = new string[] { @"{TargetFrameworkDirectory}", fullFrameworkDirectory };

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -13,6 +13,7 @@ using Microsoft.Win32;
 using Xunit;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using ItemMetadataNames = Microsoft.Build.Tasks.ItemMetadataNames;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -86,6 +87,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             "<File AssemblyName='Microsoft.Build.Engine' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
             "<File AssemblyName='System.Xml' Version='2.0.0.0' PublicKeyToken='b03f5f7f11d50a3a' Culture='Neutral' FileVersion='2.0.50727.208' InGAC='true' />" +
             "</FileList >";
+
+        public Miscellaneous(ITestOutputHelper output) : base(output)
+        {
+        }
 
 
 

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -7381,9 +7381,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             mockEngine.AssertLogContains(rar.Log.FormatResourceString("ResolveAssemblyReference.FrameworkDirectoryOnProfiles", item.ItemSpec));
         }
 
-        private static void InitializeRARwithMockEngine(out MockEngine mockEngine, out ResolveAssemblyReference rar)
+        private static void InitializeRARwithMockEngine(ITestOutputHelper output, out MockEngine mockEngine, out ResolveAssemblyReference rar)
         {
-            mockEngine = new MockEngine(_output);
+            mockEngine = new MockEngine(output);
             rar = new ResolveAssemblyReference();
             rar.BuildEngine = mockEngine;
         }

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -14,6 +14,7 @@ using Xunit;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using ItemMetadataNames = Microsoft.Build.Tasks.ItemMetadataNames;
 using Xunit.Abstractions;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -767,7 +768,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                         {
                             assembliesFound[j] = true;
                             string assemblyName = Enum.GetName(typeof(EmbedInteropTypes_Indices), j);
-                            AssertNoCase(fxVersion + ": unexpected CopyValue for " + assemblyName, expectedCopyLocal[j, i], copyLocal);
+                            copyLocal.ShouldBe(expectedCopyLocal[j, i], fxVersion + ": unexpected CopyValue for " + assemblyName, StringCompareShould.IgnoreCase);
                             break;
                         }
                     }

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -7322,7 +7322,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            InitializeRARwithMockEngine(out mockEngine, out rar);
+            InitializeRARwithMockEngine(_output, out mockEngine, out rar);
 
             rar.TargetFrameworkSubsets = new string[] { "Client" };
             rar.ProfileName = "Client";
@@ -7339,7 +7339,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            InitializeRARwithMockEngine(out mockEngine, out rar);
+            InitializeRARwithMockEngine(_output, out mockEngine, out rar);
 
             rar.InstalledAssemblySubsetTables = new ITaskItem[] { new TaskItem("Client.xml") };
             rar.ProfileName = "Client";
@@ -7358,7 +7358,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            InitializeRARwithMockEngine(out mockEngine, out rar);
+            InitializeRARwithMockEngine(_output, out mockEngine, out rar);
             rar.ProfileName = "Client";
             Assert.False(rar.Execute());
             mockEngine.AssertLogContains(rar.Log.FormatResourceString("ResolveAssemblyReference.MustSetProfileNameAndFolderLocations"));
@@ -7373,7 +7373,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         {
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            InitializeRARwithMockEngine(out mockEngine, out rar);
+            InitializeRARwithMockEngine(_output, out mockEngine, out rar);
             TaskItem item = new TaskItem("Client.xml");
             rar.ProfileName = "Client";
             rar.FullFrameworkAssemblyTables = new ITaskItem[] { item };

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -549,7 +549,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
                 else
                 {
-                    Console.WriteLine(item.ItemSpec);
                     Assert.True(false, String.Format("A new resolved file called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
@@ -580,7 +579,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
                 else
                 {
-                    Console.WriteLine(item.ItemSpec);
                     Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
@@ -588,7 +586,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // Process the related files.
             foreach (ITaskItem item in t.RelatedFiles)
             {
-                Console.WriteLine(item.ItemSpec);
                 Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
             }
 
@@ -611,7 +608,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
                 else
                 {
-                    Console.WriteLine(item.ItemSpec);
                     Assert.True(false, String.Format("A new dependency called '{0}' was found. If this is intentional, then add unittests above.", item.ItemSpec));
                 }
             }
@@ -778,7 +774,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                     if (j == assembliesCount)
                     {
-                        Console.WriteLine(item.ItemSpec);
                         Assert.True(false, String.Format("{0}: A new resolved file called '{1}' was found. If this is intentional, then add unittests above.", fxVersion, item.ItemSpec));
                     }
                 }

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -139,8 +139,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("false", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("false", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
         }
 
 
@@ -218,9 +218,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("false", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("true", t.ResolvedFiles[1].GetMetadata("CopyLocal"));
-            AssertNoCase("true", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+            t.ResolvedFiles[1].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -280,8 +280,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("true", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("false", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -330,9 +330,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("false", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("true", t.ResolvedFiles[1].GetMetadata("CopyLocal"));
-            AssertNoCase("true", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+            t.ResolvedFiles[1].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
         }
 
         [Fact]
@@ -364,8 +364,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("true", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("false", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -403,8 +403,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase("true", t.ResolvedFiles[0].GetMetadata("CopyLocal"));
-            AssertNoCase("false", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedFiles[0].GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -480,61 +480,61 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 if (String.Compare(item.ItemSpec, Path.Combine(s_myVersion20Path, "System.XML.dll"), StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     systemXmlFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("1776", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
-                    AssertNoCase("System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", item.GetMetadata("FusionName"));
-                    AssertNoCase("v2.0.50727", item.GetMetadata(ItemMetadataNames.imageRuntime));
-                    AssertNoCase("NOPE", item.GetMetadata(ItemMetadataNames.winMDFile));
-                    AssertNoCase("IMPL", item.GetMetadata(ItemMetadataNames.winmdImplmentationFile));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("1776", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("FusionName").ShouldBe("System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
+                    item.GetMetadata(ItemMetadataNames.imageRuntime).ShouldBe("v2.0.50727", StringCompareShould.IgnoreCase);
+                    item.GetMetadata(ItemMetadataNames.winMDFile).ShouldBe("NOPE", StringCompareShould.IgnoreCase);
+                    item.GetMetadata(ItemMetadataNames.winmdImplmentationFile).ShouldBe("IMPL", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "System.Data.dll")))
                 {
                     systemDataFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
-                    AssertNoCase("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", item.GetMetadata("FusionName"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("FusionName").ShouldBe("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "MyGacAssembly.dll")))
                 {
                     myGacAssemblyFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(s_myPrivateAssemblyRelPath))
                 {
                     myPrivateAssemblyFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("true", item.GetMetadata("CopyLocal"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(Path.Combine("MyProject", "MyCopyLocalAssembly.dll")))
                 {
                     myCopyLocalAssemblyFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("true", item.GetMetadata("CopyLocal"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(Path.Combine("MyProject", "MyDontCopyLocalAssembly.dll")))
                 {
                     myDontCopyLocalAssemblyFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(s_myMissingAssemblyRelPath))
                 {
                     missingAssemblyFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
 
                     // Its debatable whether this file should be CopyLocal or not.
                     // It doesn't exist on disk, but is it ResolveAssemblyReference's job to make sure that it does?
                     // For now, let the default CopyLocal rules apply.
-                    AssertNoCase("true", item.GetMetadata("CopyLocal"));
-                    AssertNoCase("MyMissingAssembly", item.GetMetadata("FusionName"));
+                    item.GetMetadata("CopyLocal").ShouldBe("true", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("FusionName").ShouldBe("MyMissingAssembly", StringCompareShould.IgnoreCase);
                 }
                 else if (String.Compare(item.ItemSpec, Path.Combine(s_myProjectPath, "System.Xml.dll"), StringComparison.OrdinalIgnoreCase) == 0)
                 {
@@ -560,18 +560,18 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "SysTem.dll")))
                 {
                     systemFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
-                    AssertNoCase("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", item.GetMetadata("FusionName"));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("FusionName").ShouldBe("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
                 }
                 else if (item.ItemSpec.EndsWith(Path.Combine("v2.0.MyVersion", "mscorlib.dll")))
                 {
                     mscorlibFound = true;
-                    AssertNoCase("", item.GetMetadata("DestinationSubDirectory"));
-                    AssertNoCase("1776", item.GetMetadata("RandomAttributeThatShouldBeForwarded"));
-                    AssertNoCase("false", item.GetMetadata("CopyLocal"));
-                    AssertNoCase("v2.0.50727", item.GetMetadata(ItemMetadataNames.imageRuntime));
+                    item.GetMetadata("DestinationSubDirectory").ShouldBe("", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("RandomAttributeThatShouldBeForwarded").ShouldBe("1776", StringCompareShould.IgnoreCase);
+                    item.GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
+                    item.GetMetadata(ItemMetadataNames.imageRuntime).ShouldBe("v2.0.50727", StringCompareShould.IgnoreCase);
                     Assert.Equal(0, item.GetMetadata(ItemMetadataNames.winMDFile).Length);
                     Assert.Equal(0, item.GetMetadata(ItemMetadataNames.winmdImplmentationFile).Length);
 
@@ -1304,7 +1304,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(@"C:\MyComponents\MyGrid.dll", t.ResolvedFiles[0].ItemSpec);
-            AssertNoCase(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1325,7 +1325,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(@"C:\MyComponentsB\CustomComponent.dll", t.ResolvedFiles[0].ItemSpec);
-            AssertNoCase(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1347,7 +1347,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(@"C:\MyComponents\MyGrid.dll", t.ResolvedFiles[0].ItemSpec);
-            AssertNoCase(@"{Registry:Software\Microsoft\.NetFramework,2.0,AssemblyFoldersEx}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Microsoft\.NetFramework,2.0,AssemblyFoldersEx}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1400,7 +1400,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(0, mockEngine.Warnings);
             Assert.Equal(0, mockEngine.Errors);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1426,7 +1426,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(0, mockEngine.Errors);
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"A", "X86");
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"B", "X86");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1451,7 +1451,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(0, mockEngine.Errors);
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"A", "X86");
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"B", "X86");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1477,7 +1477,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(2, mockEngine.Errors);
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"A", "X86");
             mockEngine.AssertLogContainsMessageFromResource(resourceDelegate, "ResolveAssemblyReference.MismatchBetweenTargetedAndReferencedArch", "MSIL", @"B", "X86");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1500,7 +1500,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1525,7 +1525,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.Equal(0, mockEngine.Warnings);
             Assert.Equal(0, mockEngine.Errors);
             Assert.True(t.ResolvedFiles[0].ItemSpec.Equals(@"C:\Regress714052\Mix\a.winmd", StringComparison.OrdinalIgnoreCase));
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,Mix}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,Mix}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1551,7 +1551,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(t.ResolvedFiles[0].ItemSpec, @"C:\Regress714052\MSIL\A.dll");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1577,7 +1577,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(t.ResolvedFiles[0].ItemSpec, @"C:\Regress714052\MSIL\A.dll");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", StringCompareShould.IgnoreCase);
         }
         /// <summary>
         /// The above but now requires us to make sure the processor architecture of what we are targeting matches what we are resolving.
@@ -1602,7 +1602,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(t.ResolvedFiles[0].ItemSpec, @"C:\Regress714052\X86\A.dll");
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,AssemblyFoldersEX}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1625,7 +1625,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1648,7 +1648,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,None}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,None}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1671,7 +1671,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,None}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,None}", StringCompareShould.IgnoreCase);
         }
         /// <summary>
         /// The above but now requires us to make sure the processor architecture of what we are targeting matches what we are resolving.
@@ -1693,7 +1693,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,None}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,None}", StringCompareShould.IgnoreCase);
         }
         /// <summary>
         /// The above but now requires us to make sure the processor architecture of what we are targeting matches what we are resolving.
@@ -1715,7 +1715,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1738,7 +1738,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Execute(t);
 
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,MSIL}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1762,7 +1762,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(@"C:\Regress714052\X86\A.dll", t.ResolvedFiles[0].ItemSpec);
-            AssertNoCase(@"{Registry:Software\Regress714052,v2.0.0,X86}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Regress714052,v2.0.0,X86}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -1809,7 +1809,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.Equal(1, t.ResolvedFiles.Length);
             Assert.Equal(@"C:\MyRawDropControls\MyRawDropControl.dll", t.ResolvedFiles[0].ItemSpec);
-            AssertNoCase(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -4925,7 +4925,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
             Assert.True(
                 engine.Log.Contains
                 (

--- a/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void Exists()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsDifferentName()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -152,7 +152,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsOldVersionRange()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void HighVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -260,7 +260,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void LowVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -72,7 +73,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -126,7 +127,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -181,7 +182,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -235,7 +236,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -289,7 +290,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);

--- a/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/NonSpecificVersionStrictPrimary.cs
@@ -3,11 +3,16 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.AppConfig
 {
     public sealed class NonSpecificVersionStrictPrimary : ResolveAssemblyReferenceTestFixture
     {
+        public NonSpecificVersionStrictPrimary(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Return the default search paths.
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnif
 using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -15,6 +16,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class Perf : ResolveAssemblyReferenceTestFixture
     {
+        public Perf(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Theory]
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "mono-windows-failing")]
@@ -27,7 +32,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             // keeps remoting from timing out the object.
             Console.WriteLine("Performing Perf.AutoUnifyUsesMinimumIO() test");
 
-            StronglyNamedDependencyAutoUnify t = new StronglyNamedDependencyAutoUnify();
+            StronglyNamedDependencyAutoUnify t = new StronglyNamedDependencyAutoUnify(_output);
 
             try
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Perf.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 StartIOMonitoring();
 
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames =
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             {
                 StartIOMonitoring();
 
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames =
                 {

--- a/src/Tasks.UnitTests/AssemblyDependency/ReferenceTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ReferenceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -10,6 +11,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class ReferenceTests : ResolveAssemblyReferenceTestFixture
     {
+        public ReferenceTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Check to make sure if, the specific version metadata is set on a primary reference, that true is returned from CheckForSpecificMetadataOnParent
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2760,8 +2760,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
             }
 
-            Console.WriteLine("subKey={0}", subKey);
-            Assert.True(false, "New GetRegistrySubKeyNames parameters encountered, need to add unittesting support");
+            Assert.True(false, $"New GetRegistrySubKeyNames parameters encountered, need to add unittesting support for subKey={subKey}");
             return null;
         }
 
@@ -2904,8 +2903,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 }
             }
 
-            Console.WriteLine("subKey={0}", subKey);
-            Assert.True(false, "New GetRegistrySubKeyDefaultValue parameters encountered, need to add unittesting support");
+            Assert.True(false, $"New GetRegistrySubKeyDefaultValue parameters encountered, need to add unittesting support for subKey={subKey}");
             return null;
         }
 

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2919,16 +2919,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         /// <summary>
-        /// Assert that two strings are equal without regard to case.
-        /// </summary>
-        /// <param name="expected">The expected string.</param>
-        /// <param name="actual">The actual string.</param>
-        internal protected static void AssertNoCase(string expected, string actual)
-        {
-            actual.ShouldBe(expected, StringCompareShould.IgnoreCase);
-        }
-
-        /// <summary>
         /// Write out an appConfig file.
         /// Return the filename that was written.
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -13,6 +13,7 @@ using Microsoft.Win32;
 using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -164,9 +165,13 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 </FileList>"
             ;
 
-        public ResolveAssemblyReferenceTestFixture()
+        protected readonly ITestOutputHelper _output;
+
+        public ResolveAssemblyReferenceTestFixture(ITestOutputHelper output)
         {
             Environment.SetEnvironmentVariable("MSBUILDDISABLEASSEMBLYFOLDERSEXCACHE", "1");
+
+            _output = output;
         }
 
         public void Dispose()

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -14,6 +14,7 @@ using FrameworkNameVersioning = System.Runtime.Versioning.FrameworkName;
 using SystemProcessorArchitecture = System.Reflection.ProcessorArchitecture;
 using Xunit;
 using Xunit.Abstractions;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -2924,12 +2925,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <param name="actual">The actual string.</param>
         internal protected static void AssertNoCase(string expected, string actual)
         {
-            if (0 != String.Compare(expected, actual, StringComparison.OrdinalIgnoreCase))
-            {
-                string message = String.Format("Expected value '{0}' but received '{1}'", expected, actual);
-                Console.WriteLine(message);
-                Assert.True(false, message);
-            }
+            actual.ShouldBe(expected, StringCompareShould.IgnoreCase);
         }
 
         /// <summary>
@@ -2939,11 +2935,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <param name="actual">The actual string.</param>
         internal protected static void AssertNoCase(string message, string expected, string actual)
         {
-            if (0 != String.Compare(expected, actual, StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine(message);
-                Assert.True(false, message);
-            }
+            actual.ShouldBe(expected, message, StringCompareShould.IgnoreCase);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/ResolveAssemblyReferenceTestFixture.cs
@@ -2929,16 +2929,6 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         }
 
         /// <summary>
-        /// Assert that two strings are equal without regard to case.
-        /// </summary>
-        /// <param name="expected">The expected string.</param>
-        /// <param name="actual">The actual string.</param>
-        internal protected static void AssertNoCase(string message, string expected, string actual)
-        {
-            actual.ShouldBe(expected, message, StringCompareShould.IgnoreCase);
-        }
-
-        /// <summary>
         /// Write out an appConfig file.
         /// Return the filename that was written.
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -68,8 +69,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
-            AssertNoCase(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", t.ResolvedFiles[0].GetMetadata("ResolvedFrom"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
+            t.ResolvedFiles[0].GetMetadata("ResolvedFrom").ShouldBe(@"{Registry:Software\Microsoft\.NetFramework,v2.0,AssemblyFoldersEx}", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -125,7 +126,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -180,7 +181,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -235,7 +236,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", t.ResolvedFiles[0].GetMetadata("FusionName"));
+            t.ResolvedFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, ProcessorArchitecture=MSIL", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);

--- a/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Console.WriteLine("Performing VersioningAndUnification.Prerequisite.SpecificVersionPrimary.Exists() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsDifferentName()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -151,7 +151,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsOldVersionRange()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void HighVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -260,7 +260,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void LowVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/SpecificVersionPrimary.cs
@@ -4,11 +4,16 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.AppConfig
 {
     public sealed class SpecificVersionPrimary : ResolveAssemblyReferenceTestFixture
     {
+        public SpecificVersionPrimary(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// In this case,
         /// - A single primary version-strict reference was passed in to assembly version 1.0.0.0

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -67,10 +68,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
             Assert.Equal(0, engine.Errors);
             Assert.Equal(0, engine.Warnings);
-            AssertNoCase
-                (
-                    "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=" + AssemblyRef.EcmaPublicKey, t.ResolvedDependencyFiles[0].GetMetadata("FusionName")
-                );
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName")
+                .ShouldBe("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=" + AssemblyRef.EcmaPublicKey, StringCompareShould.IgnoreCase);
 
             engine.AssertLogContains
                 (
@@ -82,7 +81,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                     String.Format(AssemblyResources.GetString("ResolveAssemblyReference.NotCopyLocalBecausePrerequisite"))
                 );
 
-            AssertNoCase("false", t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal"));
+            t.ResolvedDependencyFiles[0].GetMetadata("CopyLocal").ShouldBe("false", StringCompareShould.IgnoreCase);
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
@@ -6,16 +6,21 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.Prerequisite
 {
     public sealed class StronglyNamedDependency : ResolveAssemblyReferenceTestFixture
     {
+        public StronglyNamedDependency(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Return the default search paths.
         /// </summary>
         /// <value></value>
-            new internal string[] DefaultPaths
+        new internal string[] DefaultPaths
             {
                 get { return new string[] { s_myApp_V10Path, @"C:\Framework\Whidbey", @"C:\Framework\Everett" }; }
             }

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependency.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Console.WriteLine("Performing VersioningAndUnification.Prerequisite.StronglyNamedDependency.Exists() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void HighVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -130,7 +130,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         [Fact]
         public void VerifyAssemblyPulledOutOfFrameworkDoesntGetFrameworkFileAttribute()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
                 string actualFrameworkDirectory = s_myVersion20Path;
                 string alternativeFrameworkDirectory = s_myVersion40Path;

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -4,6 +4,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -69,7 +70,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
-            AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
             engine.AssertLogContains
                 (
                     String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
@@ -207,7 +208,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
 
             // Cleanup.
             File.Delete(appConfigFile);
@@ -259,7 +260,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
-            AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
             engine.AssertLogContains
                 (
                     String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "1.0.0.0", appConfigFile, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))
@@ -391,7 +392,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
-            AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
             engine.AssertLogContains
                 (
                     String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAppConfig"), "0.5.0.0", appConfigFile, Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"))

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void Exists()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
 
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames = new TaskItem[]
                 {
@@ -179,7 +179,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsDifferentName()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -231,7 +231,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void ExistsOldVersionRange()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void HighVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -363,7 +363,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void LowVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -413,7 +413,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void GarbageVersionInAppConfigFile()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -457,7 +457,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void GarbageAppConfigMissingOldVersion()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -505,7 +505,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void GarbageAppConfigMissingNewVersion()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -554,7 +554,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void GarbageAppConfigAssemblyNameMissingPKTAndCulture()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -600,7 +600,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void AppConfigSpecifiedWhenAutoUnifyEqualsTrue()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -647,7 +647,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void AppConfigDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAppConfig.cs
@@ -5,16 +5,21 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.AppConfig
 {
     public sealed class StronglyNamedDependencyAppConfig : ResolveAssemblyReferenceTestFixture
     {
+        public StronglyNamedDependencyAppConfig(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Return the default search paths.
         /// </summary>
         /// <value></value>
-            new internal string[] DefaultPaths
+        new internal string[] DefaultPaths
             {
                 get { return new string[] { s_myApp_V05Path, s_myApp_V10Path, s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
         }

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
@@ -5,16 +5,21 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAndUnification.AutoUnify
 {
     public sealed class StronglyNamedDependencyAutoUnify : ResolveAssemblyReferenceTestFixture
     {
+        public StronglyNamedDependencyAutoUnify(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Return the default search paths.
         /// </summary>
         /// <value></value>
-            new internal string[] DefaultPaths
+        new internal string[] DefaultPaths
         {
                 get { return new string[] { s_myApp_V05Path, s_myApp_V10Path, s_myApp_V20Path, s_myApp_V30Path, s_myComponentsV05Path, s_myComponentsV10Path, s_myComponentsV20Path, s_myComponentsV30Path }; }
         }

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
@@ -4,6 +4,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -75,8 +76,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             if (rarSimulationMode.HasFlag(RARSimulationMode.LoadAndBuildProject))
             {
                 Assert.True(succeeded);
-                AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(s_unifyMeDll_V20Path, t.ResolvedDependencyFiles[0].ItemSpec);
+                t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
+                t.ResolvedDependencyFiles[0].ItemSpec.ShouldBe(s_unifyMeDll_V20Path, StringCompareShould.IgnoreCase);
 
                 engine.AssertLogContains
                 (
@@ -151,8 +152,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
                 Assert.Equal(1, t.ResolvedFiles.Length); // "Expected there to only be one resolved file"
                     Assert.True(t.ResolvedFiles[0].ItemSpec.Contains(Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))); // "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
                 Assert.Equal(1, t.ResolvedDependencyFiles.Length); // "Expected there to be two resolved dependencies"
-                AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                    AssertNoCase(s_unifyMeDll_V10Path, t.ResolvedDependencyFiles[0].ItemSpec);
+                t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
+                    t.ResolvedDependencyFiles[0].ItemSpec.ShouldBe(s_unifyMeDll_V10Path, StringCompareShould.IgnoreCase);
 
                 engine.AssertLogDoesntContain
                     (
@@ -391,8 +392,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Assert.Equal(2, t.ResolvedFiles.Length); // "Expected to find two resolved assemblies"
                 Assert.True(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V10Path, "DependsOnUnified.dll"))); // "Expected the ItemSpec of the resolved file to be the item spec of the 1.0.0.0 assembly");
                 Assert.True(ContainsItem(t.ResolvedFiles, Path.Combine(s_myApp_V20Path, "DependsOnUnified.dll"))); // "Expected the ItemSpec of the resolved file to be the item spec of the 2.0.0.0 assembly");
-            AssertNoCase("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(s_unifyMeDll_V20Path, t.ResolvedDependencyFiles[0].ItemSpec);
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
+                t.ResolvedDependencyFiles[0].ItemSpec.ShouldBe(s_unifyMeDll_V20Path, StringCompareShould.IgnoreCase);
 
             engine.AssertLogContains
                 (
@@ -451,8 +452,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             bool succeeded = Execute(t);
 
             Assert.True(succeeded);
-            AssertNoCase("UnifyMe, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
-                AssertNoCase(s_unifyMeDll_V30Path, t.ResolvedDependencyFiles[0].ItemSpec);
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
+                t.ResolvedDependencyFiles[0].ItemSpec.ShouldBe(s_unifyMeDll_V30Path, StringCompareShould.IgnoreCase);
 
             engine.AssertLogContains
                 (
@@ -509,7 +510,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
             Assert.True(succeeded);
             Assert.Equal(1, t.ResolvedDependencyFiles.Length);
-            AssertNoCase("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", t.ResolvedDependencyFiles[0].GetMetadata("FusionName"));
+            t.ResolvedDependencyFiles[0].GetMetadata("FusionName").ShouldBe("UnifyMe, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", StringCompareShould.IgnoreCase);
             engine.AssertLogContains
                 (
                     String.Format(AssemblyResources.GetString("ResolveAssemblyReference.UnificationByAutoUnify"), "0.5.0.0", Path.Combine(s_myApp_V05Path, "DependsOnUnified.dll"))

--- a/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/StronglyNamedDependencyAutoUnify.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             Console.WriteLine("Performing VersioningAndUnification.AutoUnify.StronglyNamedDependency.Exists() test");
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -127,7 +127,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
 
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames = new TaskItem[]
                 {
@@ -211,7 +211,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
 
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames = new TaskItem[]
                 {
@@ -292,7 +292,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
 
 
                 // Create the engine.
-                MockEngine engine = new MockEngine();
+                MockEngine engine = new MockEngine(_output);
 
                 ITaskItem[] assemblyNames = new TaskItem[]
                 {
@@ -365,7 +365,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
             File.WriteAllText(subsetListPath, engineOnlySubset);
 
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -430,7 +430,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void MultipleUnifiedFromNames()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {
@@ -488,7 +488,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.VersioningAnd
         public void LowVersionDoesntExist()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyNames = new TaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyIgnoreVersionForFrameworkReference.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyIgnoreVersionForFrameworkReference.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -11,6 +12,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class VerifyIgnoreVersionForFrameworkReference : ResolveAssemblyReferenceTestFixture
     {
+        public VerifyIgnoreVersionForFrameworkReference(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Verify that we ignore the version information on the assembly
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyIgnoreVersionForFrameworkReference.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyIgnoreVersionForFrameworkReference.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void IgnoreVersionBasic()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOn9, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
 
@@ -47,7 +47,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"))); // "Expected to find assembly, but didn't."
 
             // Do the resolution without the metadata, expect it to not work since we should not be able to find Dependson9 version 10.0.0.0
-            e = new MockEngine();
+            e = new MockEngine(_output);
 
             item = new TaskItem("DependsOn9, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
 
@@ -76,7 +76,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void IgnoreVersionBasicTestMetadata()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOn9, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             item.SetMetadata("IgnoreVersionForFrameworkReference", "True");
@@ -100,7 +100,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Assert.True(ContainsItem(t.ResolvedFiles, Path.Combine(s_myComponentsMiscPath, "DependsOn9.dll"))); // "Expected to find assembly, but didn't."
 
             // Do the resolution without the metadata, expect it to not work since we should not be able to find Dependson9 version 10.0.0.0
-            e = new MockEngine();
+            e = new MockEngine(_output);
 
             item = new TaskItem("DependsOn9, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
 
@@ -129,7 +129,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void IgnoreVersionDisableIfSpecificVersionTrue()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOn9, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             item.SetMetadata("IgnoreVersionForFrameworkReference", "True");
@@ -159,7 +159,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void IgnoreVersionDisableIfHintPath()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOn9, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089");
             item.SetMetadata("IgnoreVersionForFrameworkReference", "True");

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -11,6 +12,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class VerifyTargetFrameworkAttribute : ResolveAssemblyReferenceTestFixture
     {
+        public VerifyTargetFrameworkAttribute(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Verify there are no warnings if the target framework identifier passed to rar and the target framework identifier in the dll do not match.
         /// </summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkAttribute.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void FrameworksDoNotMatch()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -49,7 +49,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void LowerVersionSameFrameworkDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -76,7 +76,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void SameVersionSameFrameworkDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionButSpecificVersionDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOnFoo45Framework, Version=4.5.0.0, PublicKeyToken=null, Culture=Neutral");
             item.SetMetadata("SpecificVersion", "true");
@@ -133,7 +133,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void LowerVersionSameFrameworkInDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -162,7 +162,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void SameVersionSameFrameworkInDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -191,7 +191,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionButSpecificVersionInDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("IndirectDependsOnFoo45Framework, Version=0.0.0.0, PublicKeyToken=null, Culture=Neutral");
             item.SetMetadata("SpecificVersion", "true");
@@ -223,7 +223,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionInDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("IndirectDependsOnFoo45Framework, Version=0.0.0.0, PublicKeyToken=null, Culture=Neutral");
 
@@ -253,7 +253,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionInDirectIgnoreMismatch()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("IndirectDependsOnFoo45Framework, Version=0.0.0.0, PublicKeyToken=null, Culture=Neutral");
 
@@ -285,7 +285,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionDirectIgnoreMismatch()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOnFoo45Framework");
 
@@ -317,7 +317,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherVersionDirect()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOnFoo45Framework");
 
@@ -350,7 +350,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Trait("Category", "mono-osx-failing")]
         public void HigherVersionDirectDependenciesFalse()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             TaskItem item = new TaskItem("DependsOnFoo45Framework");
 

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkHigherThanRedist.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkHigherThanRedist.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void TargetCurrentTargetFramework()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void RemapAssemblyBasic()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -98,7 +98,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherThanHighestInRedistList()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -127,7 +127,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Trait("Category", "mono-osx-failing")]
         public void HigherThanHighestInRedistListForMSBuildAssembly()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -177,7 +177,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherThanHighestInRedistList3rdPartyRedist()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -203,7 +203,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void HigherThanHighestInRedistListWithSpecificVersionMetadata()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -234,7 +234,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void DependenciesHigherThanHighestInRedistList()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -264,7 +264,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Trait("Category", "mono-osx-failing")]
         public void DependenciesHigherThanHighestInRedistListForMSBuildAssembly()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -316,7 +316,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void DependenciesHigherThanHighestInRedistListSpecificVersionMetadata()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -349,7 +349,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void TwoDependenciesHigherThanHighestInRedistListIgnoreOnOne()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -383,7 +383,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void TwoDependenciesHigherThanHighestInRedistListIgnoreOnBoth()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -416,7 +416,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void TwoDependenciesSameNameDependOnHigherVersion()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -448,7 +448,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void MixedDependenciesSpecificVersionOnHigherVersionMetadataSet()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {
@@ -489,7 +489,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         [Fact]
         public void MixedDependenciesSpecificVersionOnLowerVersionMetadataSet()
         {
-            MockEngine e = new MockEngine();
+            MockEngine e = new MockEngine(_output);
 
             ITaskItem[] items = new ITaskItem[]
             {

--- a/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkHigherThanRedist.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/VerifyTargetFrameworkHigherThanRedist.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 {
@@ -13,6 +14,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     /// </summary>
     public sealed class VerifyTargetFrameworkHigherThanRedist : ResolveAssemblyReferenceTestFixture
     {
+        public VerifyTargetFrameworkHigherThanRedist(ITestOutputHelper output) : base(output)
+        {
+        }
+
         /// <summary>
         /// Verify there are no warnings when the assembly being resolved is not in the redist list and only has dependencies to references in the redist list with the same
         /// version as is described in the redist list.

--- a/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 using ItemMetadataNames = Microsoft.Build.Tasks.ItemMetadataNames;
 
 namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
@@ -15,6 +16,10 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
     [Trait("Category", "non-mono-tests")]
     public sealed class WinMDTests : ResolveAssemblyReferenceTestFixture
     {
+        public WinMDTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         #region AssemblyInformationIsWinMDFile Tests
 
         /// <summary>

--- a/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyP2PHaveCorrectMetadataWinMD()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem taskItem = new TaskItem(@"C:\WinMD\SampleWindowsRuntimeOnly.Winmd");
 
             ITaskItem[] assemblyFiles = new TaskItem[]
@@ -187,7 +187,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyP2PHaveCorrectMetadataWinMDManaged()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem taskItem = new TaskItem(@"C:\WinMD\SampleWindowsRuntimeAndCLR.Winmd");
 
             ITaskItem[] assemblyFiles = new TaskItem[]
@@ -225,7 +225,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void VerifyP2PHaveCorrectMetadataNonWinMD()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -256,7 +256,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void IgnoreReferenceToMscorlib()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void MixedWinMDGoodReferenceToMscorlib()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -318,7 +318,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void WinMdFileDependsOnAnotherWinMDFile()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -358,7 +358,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveWinmdBesideDll()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -390,7 +390,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveWinmdBesideDll2()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -422,7 +422,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void WinMdFileDependsOnAnotherWinMDFileWithFrameworkDependencies()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {
@@ -459,7 +459,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void DotNetAssemblyDependsOnAWinMDFile()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem item = new TaskItem(@"DotNetAssemblyDependsOnWinMD");
             // This should not be used for anything, it is recalculated in rar, this is to make sure it is not forwarded to child items.
             item.SetMetadata(ItemMetadataNames.imageRuntime, "FOO");
@@ -504,7 +504,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveWinmdWithInvalidPENativeDependency()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem item = new TaskItem(@"DependsOnInvalidPeHeader");
             ITaskItem[] assemblyFiles = new TaskItem[] { item };
 
@@ -536,7 +536,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveWinmdWithArchitectureDependencyMatchingArchitecturesX86()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem item = new TaskItem("DependsOnX86");
             ITaskItem[] assemblyFiles = new TaskItem[] { item };
 
@@ -568,7 +568,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void ResolveWinmdWithArchitectureDependencyAnyCPUNative()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             // IMAGE_FILE_MACHINE unknown is supposed to work on all machine types
             TaskItem item = new TaskItem("DependsOnAnyCPUUnknown");
@@ -631,7 +631,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private void VerifyImplementationArchitecture(string winmdName, string targetProcessorArchitecture, string implementationFileArch, string warnOrErrorOnTargetArchitectureMismatch)
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             TaskItem item = new TaskItem(winmdName);
             ITaskItem[] assemblyFiles = new TaskItem[] { item };
 
@@ -701,7 +701,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         public void DotNetAssemblyDependsOnAWinMDFileWithVersion255()
         {
             // Create the engine.
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {


### PR DESCRIPTION
A little Friday refactoring, in the hopes of setting RAR changes up for clearer failures.

I suggest going a commit at a time. I tried to add `[manual]` to commits that were all manual; those probably deserve more attention.

The biggest changes were inlining a simplified definition for `AssertNoCase` which is mostly just a complexity reduction.

The biggest _win_ with this PR is pulling all the log output into the test helper, so it'll be visible from VSTS/the HTML test log.