### PR TITLE
filter references before manifest generation

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3959,9 +3959,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
-      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
+      <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
+                                 Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
+      <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
+                               Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
@@ -3988,10 +3992,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath)"
-        ManagedAssemblies="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
+        ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
-        SatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)"
+        SatelliteAssemblies="@(_SatelliteAssemblies)"
         TargetCulture="$(TargetCulture)">
 
       <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3958,17 +3958,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
-    <ItemGroup Condition="!exists('$(ProjectLockFile)')">
-      <_DeploymentReferencePaths Include="@(ReferencePath)">
-        <IsPrimary>true</IsPrimary>
-      </_DeploymentReferencePaths>
-    </ItemGroup>
-    <ItemGroup Condition="exists('$(ProjectLockFile)')">
-      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
-                                 Exclude="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)"
+    <ItemGroup>
+      <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
                                  Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
+      <_DeploymentReferencePaths Include="@(ReferencePath)" Condition="'%(CopyLocal)' == 'false'" />
+      <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
+                               Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
@@ -3995,10 +3993,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath)"
-        ManagedAssemblies="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
+        ManagedAssemblies="@(_ManifestManagedReferences)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
-        SatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)"
+        SatelliteAssemblies="@(_SatelliteAssemblies)"
         TargetCulture="$(TargetCulture)">
 
       <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3958,14 +3958,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
-    <ItemGroup>
-      <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
-      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
+    <ItemGroup Condition="!exists('$(ProjectLockFile)')">
+      <_DeploymentReferencePaths Include="@(ReferencePath)">
+        <IsPrimary>true</IsPrimary>
+      </_DeploymentReferencePaths>
+    </ItemGroup>
+    <ItemGroup Condition="exists('$(ProjectLockFile)')">
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
+                                 Exclude="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)"
                                  Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
-      <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
-                               Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>
 
     <!-- Copy the application executable from Obj folder to app.publish folder.
@@ -3992,10 +3995,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         EntryPoint="@(_DeploymentClickOnceApplicationExecutable)"
         ExtraFiles="@(_DebugSymbolsIntermediatePath);$(IntermediateOutputPath)$(TargetName).xml;@(_ReferenceRelatedPaths)"
         Files="@(ContentWithTargetPath);@(_DeploymentManifestIconFile);@(AppConfigWithTargetPath)"
-        ManagedAssemblies="@(_ManifestManagedReferences)"
+        ManagedAssemblies="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
         NativeAssemblies="@(NativeReferenceFile);@(_DeploymentNativePrerequisite)"
         PublishFiles="@(PublishFile)"
-        SatelliteAssemblies="@(_SatelliteAssemblies)"
+        SatelliteAssemblies="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)"
         TargetCulture="$(TargetCulture)">
 
       <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3960,11 +3960,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
       <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
+      <_DeploymentReferencePaths Include="@(ReferencePath)" Condition="'%(CopyLocal)' == 'false'" />
       <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
                                  Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
-      <_DeploymentReferencePaths Include="@(ReferencePath)" Condition="'%(CopyLocal)' == 'false'" />
       <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
                                Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3957,14 +3957,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_SGenDllsRelatedToCurrentDll Include="@(SerializationAssembly->'%(FullPath)')" Condition="'%(Extension)' == '.dll'"/>
     </ItemGroup>
 
+    <ItemGroup Condition="!exists('$(ProjectLockFile)')">
+      <_CopyLocalFalseRefPaths Include="@(ReferencePath)" Condition="'%(CopyLocal)' == 'false'" />
+      <_CopyLocalFalseRefPathsWithExclusion Include="@(_CopyLocalFalseRefPaths)"
+                                            Exclude="@(ReferenceCopyLocalPaths);@(_NETStandardLibraryNETFrameworkLib)" />
+    </ItemGroup>
+
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
       <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
-      <_DeploymentReferencePaths Include="@(ReferencePath)" Condition="'%(CopyLocal)' == 'false'" />
       <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
                                  Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
+      <_DeploymentReferencePaths Include="@(_DeploymentReferencePaths);@(_CopyLocalFalseRefPathsWithExclusion)" />
       <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
                                Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -621,6 +621,14 @@ namespace Microsoft.Build.Tasks
             // OpenScope and returns null if not an assembly, which is much faster.
 
             AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
+            if(identity == null)
+            {
+                // It is possible that a native dll gets passed in here that was declared as a content file
+                // in a referenced nuget package and calling AssemblyIdentity. We just need to ignore those, 
+                // since they aren't actually references we care about. So we filter them out.
+                return true;
+            }
+
             if (identity != null && identity.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion))
             {
                 return true;

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -624,12 +624,12 @@ namespace Microsoft.Build.Tasks
             if(identity == null)
             {
                 // It is possible that a native dll gets passed in here that was declared as a content file
-                // in a referenced nuget package and calling AssemblyIdentity. We just need to ignore those, 
-                // since they aren't actually references we care about. So we filter them out.
+                // in a referenced nuget package, which will yield null here. We just need to ignore those, 
+                // since those aren't actually references we care about.
                 return true;
             }
 
-            if (identity != null && identity.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion))
+            if (identity.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion))
             {
                 return true;
             }


### PR DESCRIPTION
With the recent change of using ReferenceCopyLocalPaths for manifest creation there are a few edge cases that broke:
- if there is a native dll referenced as a Content file in a nuget package it was incorrectly assumed it was a managed reference, which could cause build breaks.
- the ClickOnce application files window was not always properly populated.
- files that were set as "Include" in the application files window but had Copy Local set to false were not correctly published
- .NET Core reference libraries were incorrectly published with ClickOnce

This change also introduces an item group "_ExcludedAssembliesFromManifestGeneration" that allows users to manually specify files that should explicitly be excluded from the list of dependencies for the manifest generation, in case there are further cases emerging of files in nuget packages getting incorrectly flagged as a reference. This allows the user to unblock themselves by explicitly excluding the faulty files.