### PR TITLE
Update bindingRedirect versions of Workflow build tasks dlls

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -61,11 +61,11 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -53,13 +53,13 @@
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
-          <codeBase version="15.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
+          <codeBase version="16.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
-          <codeBase version="15.0.0.0" href=".\amd64\XamlBuildTask.dll" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
+          <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
To adapt assemblies version changes in Dev16. These two assemblies are dropped to msbuild folder when installing VS, so they have the same version with VS.
