### PR TITLE
Update static-graph spec

### DIFF
--- a/documentation/specs/static-graph.md
+++ b/documentation/specs/static-graph.md
@@ -1,24 +1,19 @@
 - [Static Graph](#static-graph)
-    - [Overview](#overview)
-        - [Motivations](#motivations)
-        - [M1 - MVP](#m1---mvp)
-        - [M1 non-goals](#m1-non-goals)
-        - [M2 - Single Project Enforcement](#m2---single-project-enforcement)
-        - [M3 - Dependency Tracking](#m3---dependency-tracking)
-        - [M4 - Ready for Caching/Distribution](#m4---ready-for-cachingdistribution)
-        - [M5 - Performance](#m5---performance)
-    - [Project Graph](#project-graph)
-        - [Building a project graph](#building-a-project-graph)
-        - [Public API](#public-api)
-    - [Inferring which targets to run and cache for a project within the graph](#inferring-which-targets-to-run-and-cache-for-a-project-within-the-graph)
-        - [Graph operations](#graph-operations)
-            - [Specifying graph operations](#specifying-graph-operations)
-            - [Inferring graph operations for a specific node](#inferring-graph-operations-for-a-specific-node)
-        - [Export Targets](#export-targets)
-            - [Syntax](#syntax)
-            - [Building using export targets](#building-using-export-targets)
-    - [Distribution](#distribution)
-    - [I/O Tracking](#io-tracking)
+  - [Overview](#overview)
+    - [Motivations](#motivations)
+    - [M1 - MVP](#m1---mvp)
+    - [M1 non-goals](#m1-non-goals)
+    - [M2 - Single Project Enforcement](#m2---single-project-enforcement)
+    - [M3 - Dependency Tracking](#m3---dependency-tracking)
+    - [M4 - Ready for Caching/Distribution](#m4---ready-for-cachingdistribution)
+    - [M5 - Performance](#m5---performance)
+  - [Project Graph](#project-graph)
+    - [Building a project graph](#building-a-project-graph)
+    - [Public API](#public-api)
+  - [Inferring which targets to run for a project within the graph](#inferring-which-targets-to-run-for-a-project-within-the-graph)
+  - [Building a single project](#building-a-single-project)
+  - [Distribution](#distribution)
+  - [I/O Tracking](#io-tracking)
 
 # Static Graph
 
@@ -95,9 +90,7 @@ Because we are using ProjectReferences to determine the graph, we will need to d
 
 **OPEN ISSUE:** What about MSBuild calls which pass in global properties not on the ProjectReference? Worse, if the global properties are computed at runtime? The sfproj SDK does this with PublishDir, which tells the project where to put its outputs so the parent sfproj can consume them. We may need to work with sfproj folks and other SDK owners, which may not be necessarily a bad thing since already the sfproj SDK requires 2 complete builds of dependencies (ProjectReference + this PublishDir thing) and can be optimized. A possible short term fix: Add nodes to graph to special case these kinds of SDKs.
 
-Note that we are not taking into account different target lists. Since we're going down the route of export targets (see below), there's no need to track the specific targets which projects need to call in the p2p relationship. This is important to call out though since this means that the project graph feature may not be very usable outside of the export targets feature, meaning the features may be somewhat coupled.
-
-Also note that graph cycles are disallowed, even if they're using disconnected targets. This is a breaking change, as today you can have two projects where each project depends on a target from the other project, but that target doesn't depend the default target or anything in its target graph.
+Note that graph cycles are disallowed, even if they're using disconnected targets. This is a breaking change, as today you can have two projects where each project depends on a target from the other project, but that target doesn't depend the default target or anything in its target graph.
 
 ### Building a project graph
 There are conceptually two options when building a project graph: building the entire graph or building a single project in the graph. There is one other scenario, which is building a part of the graph (a project and everything it needs), but that's effectively just rooting the graph at that project and building that whole new graph.
@@ -125,6 +118,9 @@ This is a proposal for what the public API may look like:
 
             // All project nodes in the graph.
             IReadOnlyCollection<ProjectGraphNode> ProjectNodes { get; }
+
+            // Build the graph with the given target, if any
+            BuildResult Build(string target = null);
         }
 
         public class ProjectGraphNode
@@ -143,49 +139,100 @@ This is a proposal for what the public API may look like:
         }
     }
 
-## Inferring which targets to run and cache for a project within the graph
+## Inferring which targets to run for a project within the graph
 
-One property of the static build graph is that a project (project, globalproperties, toolsversion) is "built" / visited only once when the project graph is executed.
+One property of the static build graph is that a project (project, globalproperties, toolsversion) is "built" / visited only once when the project graph is executed. This is in conflict with current P2P patterns (project to project) where a project may be built multiple times during a build with different targets and global properties (examples in [p2p protocol](https://github.com/Microsoft/msbuild/blob/master/documentation/ProjectReference-Protocol.md)).
 
-This is in conflict with current P2P patterns (project to project) where a project may be built multiple times during a build with different targets and global properties (examples in [p2p protocol](https://github.com/Microsoft/msbuild/blob/master/documentation/ProjectReference-Protocol.md)). Thus we need a mechanism through which the project files self describe all the ways they can be built in. We need a public interface of msbuild targets w.r.t. the build graph. We call this interface the **exported targets**.
+Additionaly, projects are built bottom up, whereas the classical msbuild scheduler builds projects top down. In the top down traversal, the parent project chooses which targets to call on the child projects. But in the bottom up traversal, we don't know the entry targets for a child because we visit the children before the parents.
 
-Executing projects with export targets within the graph means changing the behavior of the MSBuild task to always pull the target results from cache rather than actually evaluating and executing the list targets. This has several benefits such as each project having a concrete lifetime within the build, may reduce re-evaluation cost, and opens up maybe caching and distribution scenarios.
+We need to represent project to project calling patterns in such a way that a graph build can infer the entry targets for a project. These protocols apply to an entire graph. They can be regular or irregular. **Regular** operations consist of recursively calling the same target on all children (e.g. build, clean, rebuild). **Irregular** operations consist of calling different targets on different nodes in the graph (e.g. publish calls publish on the root node but build on the rest). As a complication, today nothing prevents projects to turn regular operations into irregular operations (e.g. a project file reimplements Clean by calling Clean2 on children).
 
-In addition to export targets, we also need to represent operations on entire msbuild p2p graphs in such a way that a graph build can infer the entry targets for a project. Graph operations are operations that apply to an entire graph. They can be regular or irregular. Regular operations consist of recursively calling the same target on all children (e.g. restore, clean, rebuild). Irregular operations consist of calling different targets on different nodes in the graph (e.g. publish calls publish on the root node but build on the rest). As a complication, today nothing prevents projects to turn regular operations into irregular operations (e.g. a project file reimplements Clean by calling Clean2 on children).
+Some project reference protocols require multiple calls (MSBuild task calls) between the parent and child project. Therefore we need to not only specify the entry targets, but also the helper targets.
 
-### Graph operations
-#### Specifying graph operations
-#### Inferring graph operations for a specific node
+Therefore the project reference protocols will need to be explicitily described. Each project specifies the project reference protocol targets it supports, in the form of a taret mapping:
 
-### Export Targets
-#### Syntax
-- Option 1: <ExportTarget Name="GetTargetPath" />.
-  - Pros: Easy to search, very extensible (can export targets which you don't "own")
-  - Cons: Separated from the target definition, breaking change
-- Option 2: <Target Name="GetTargetPath" Exported="true">
-  - Pros: Near target definition, mostly reuses existing syntax
-  - Cons: Not as extensible, breaking change
-- Option 3: <Project DefaultTargets="Build" ExportTargets="GetTargetPath">
-  - Pros: Easy to find (ish. Could be defined in imported props/targets), similar to DefaultTargets and InitialTargets, not a breaking change
-  - Cons: Separated from the target definition
-- Option 4: Item: @(MSBuildExportedTargets)
-  - Pros: Easy to use and query, completely non-breaking
-  - Cons: Bad actors can override instead of append
+$target \to targetList$
 
-**Option 4** seems like the best choice.
+$target$ represents the project reference entry target, and $targetList$ represents the list of targets that $target$ ends up calling on each child.
 
-#### Building using export targets
-When using export targets, the project graph is required to build the projects in the correct order. An individual project will be built using `/p:BuildProjectReferences=false` to avoid recursive builds inside a project
+For example, a simple recursive rule would be $A \to A$, which says that a project called with target $A$ will call target $A$ on its children. Here's an example execution with two nodes:
 
-**OPEN ISSUE:** Can we get away with not setting `/p:BuildProjectReferences=false`? It would mean we'd need to export Build, Rebuild, and Clean, but would eliminate any need for setting extra global properties. Perhaps this is fine, or perhaps the entry point for a project is always considered exported?
+```
+Build A+-->Proj1   A->A
+             +
+             |
+             | A
+             |
+             v
+           Proj2   A->A
+```
 
-When building a project, run the initial targets, default targets, and export targets. Export targets will run last, assuming they're not needed earlier in the build by other targets. Likely the implementation of this will simply be to push the export targets onto the target execution stack in reverse order before the default and initial targets.
+Proj1 depends on Proj2, and we want to build the graph with target $A$. Proj1 gets inspected for the project reference protocol for target $A$ (represented to the right of Proj1). The protocol says the children will be called with $A$. Therefore Proj2 gets built with target $A$. After Proj2 builds, Proj1 then also builds with $A$ (because Proj1 is the root of the graph).
 
-After execution, the results of the export targets will be cached and the project can be disposed. Note that this gives project execution a concrete start and end, while previously projects needed to remain active just in case any other project needed to execute a target on it.
+A project reference protocol could contain multiple targets, for example $A \to B, A$. This means that building $A$ on the parent will lead to $B$ and $A$ getting called on the children. If all nodes in the graph repeat the same rule, then the rule is repeated recursively on all nodes (this would be a regular operation). However, a node can choose to implement the protocol differently, which would lead to an irregular protocol. In the following example, the entry targets are:
+- Proj4 is built with targets $B, A, C, D$. On multiple parents, the incoming targets get concatenated. The order does not matter, as MSBuild has non-deterministic p2p ordering.
+- Proj3 and Proj2 build with $B, A$, as specified by the rule in Proj1.
+- Proj1 builds with A, because it's the root of the graph.
+
+```
+            A+-->Proj1   A->B, A
+                 /    \
+           B, A /      \ B, A
+               /        \
+              v          v
+  A->B, A   Proj3      Proj2   A->C, D
+             \            /
+        B, A  \          /  C, D
+               \        /
+                \      /
+                 v    v
+                 Proj4   A->B, A
+```
+
+The common project reference protocols (Build, Rebuild, Restore, Clean) will be specified by the common props and targets file in the msbuild repository. Other SDKs can implement their own protocols (e.g. ASPNET implementing Publish).
+
+Here are the rules for the common protocols:
+
+$Build \to GetTargetFrameworks, \langle default \rangle, GetNativeManifest, GetCopyToOutputDirectoryItems$
+
+The default target (represented here as $\langle default \rangle$) is resolved for each project.
+
+$Clean \to GetTargetFrameworks, Clean$
+
+$Rebuild \to \$Clean, \$Build$
+
+$Rebuild$ maps to two referenced protocols. $\$Clean$ and $\$Build$ get substituted with the contents of the $Clean$ and $Build$ protocols.
+
+Restore is a composition of two rules:
+- $Restore \to \_IsProjectRestoreSupported, \_GenerateRestoreProjectPathWalk, \_GenerateRestoreGraphProjectEntry$
+
+- $\_GenerateRestoreProjectPathWalk \to \_IsProjectRestoreSupported, \_GenerateRestoreProjectPathWalk, \_GenerateRestoreGraphProjectEntry$
+
+**Open Issue:** Restore is a bit complicated, and we may need new concepts to represent it. The root project calls the recursive $\_GenerateRestoreProjectPathWalk$ on itself to collect the children closure, and then after the recursion call returns (after having walked the graph), it calls the other targets on each returned child in a non-recursive manner. So the above protocol is not a truthful representation of what happens, but it correctly captures all targets called on each node in the graph.
+
+**Open Issue:** How do we differentiate between targets called on the outer build project and targets called on the inner build projects?
+
+We'll represent the project reference protocols as items in MSBuild:
+```xml
+<PropertyGroup>
+  <ProjectReferenceTargetsForClean>GetTargetFrameworks;Clean</ProjectReferenceTargetsForClean>
+</PropertyGroup>
+
+<ItemGroup>
+  <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)"/>
+</ItemGroup>
+```
+
+## Building a single project
+The project graph is required to build the projects in the correct order. An individual project will be built using `/p:BuildProjectReferences=false` to avoid recursive builds inside a project.
+
+**OPEN ISSUE:** Can we get away with not setting `/p:BuildProjectReferences=false`?
+
+When building a project, run the initial targets and the entry targets as computed by the [project reference protocol](#inferring-which-targets-to-run-for-a-project-within-the-graph).
+
+After execution, the results of the entry targets will be cached in the BuildManager and the project can be disposed. Note that this gives project execution a concrete start and end, while previously projects needed to remain active just in case any other project needed to execute a target on it.
 
 For projects which depend on other projects, the MSBuild task will look up the target result in the cache. If the target is missing from the cache, an error will be logged and the build will fail. If the project is calling into itself either via `CallTarget` or via `MSBuild` with a different set of global properties, this will be always allowed (support for cross-targeting).
-
-This makes the P2P contract explicit as it requires both projects to declare targets which are part of the contract.
 
 Initially this result cache will just be in-memory, similar to the existing MSBuild target result cache, but eventually could persist across builds so that an incremental build of a particular project in the project graph would not require re-evaluation or any target execution in that project's dependencies. This may have significant perf improvements for incremental builds.
 


### PR DESCRIPTION
We're replacing export targets with the more generic mechanism of explicit project reference protocols. There were a couple of problems with export targets:
- required the child projects to know about all the possible targets that any parent can call them with.
- some export targets could have bad effects when run together (e.g. Build and Clean)
- inefficient to run all export targets when only a small subset is actually needed


