### PR TITLE
 Use bool to check for dummy CopyOnWriteDictionary

### DIFF
--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Build.Collections
         /// <summary>
         /// A special single dummy instance that always appears empty.
         /// </summary>
-        internal static CopyOnWriteDictionary<K, V> Dummy { get; } = new CopyOnWriteDictionary<K, V>();
+        internal static CopyOnWriteDictionary<K, V> Dummy { get; } = new CopyOnWriteDictionary<K, V> { _isDummy = true };
 
         /// <summary>
         /// Whether this is a dummy instance that always appears empty.
@@ -186,15 +186,16 @@ namespace Microsoft.Build.Collections
         {
             get
             {
-                if (ReferenceEquals(this, Dummy))
+                if (_isDummy)
                 {
                     ErrorUtilities.VerifyThrow(backing == null || backing.Count == 0, "count"); // check count without recursion
-                    return true;
                 }
 
-                return false;
+                return _isDummy;
             }
         }
+
+        private bool _isDummy;
 
         /// <summary>
         /// Comparer used for keys


### PR DESCRIPTION
Noticed a decent chunk of time in ```CopyOnWriteDictionary``` is spent just comparing references with the static dummy. Probably negligible perf gain but super easy fix. Right side is with changes. Ran this on top of the ```HybridDictionary``` removal since that was originally dominating all the runtime in here.

![dictionarydummy](https://user-images.githubusercontent.com/32187633/45581472-84867200-b853-11e8-9277-1d1f36549709.png)
