### PR TITLE
Bump VisualStudioVersion to 16.0

### DIFF
--- a/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
+++ b/src/Build.UnitTests/BuildEnvironmentHelper_Tests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Build.Engine.UnitTests
             using (var env = new EmptyVSEnviroment())
             {
                 env.WithEnvironment("VSINSTALLDIR", env.TempFolderRoot);
-                env.WithEnvironment("VisualStudioVersion", "15.0");
+                env.WithEnvironment("VisualStudioVersion", "16.0");
                 BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(ReturnNull, ReturnNull, ReturnNull, env.VsInstanceMock, env.EnvironmentMock, () => false);
 
                 BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory.ShouldBe(env.TempFolderRoot);
@@ -265,8 +265,8 @@ namespace Microsoft.Build.Engine.UnitTests
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "No Visual Studio install for netcore")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [InlineData("15.0")]
-        [InlineData("15.3")]
+        [InlineData("16.0")]
+        [InlineData("16.3")]
         public void BuildEnvironmentDetectsVisualStudioFromSetupInstance(string visualStudioVersion)
         {
             using (var env = new EmptyVSEnviroment())

--- a/src/Build/Definition/ToolsetLocalReader.cs
+++ b/src/Build/Definition/ToolsetLocalReader.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Evaluation
         {
             get
             {
-                yield return new ToolsetPropertyDefinition(MSBuildConstants.CurrentProductVersion, string.Empty, _sourceLocation);
+                yield return new ToolsetPropertyDefinition(MSBuildConstants.CurrentToolsVersion, string.Empty, _sourceLocation);
             }
         }
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Shared
     {
         // Since this class is added as 'link' to shared source in multiple projects,
         // MSBuildConstants.CurrentVisualStudioVersion is not available in all of them.
-        private const string CurrentVisualStudioVersion = "15.0";
+        private const string CurrentVisualStudioVersion = "16.0";
 
         // MSBuildConstants.CurrentToolsVersion
         private const string CurrentToolsVersion = "15.0";

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// The most current ToolsVersion known to this version of MSBuild.
         /// </summary>
-        internal const string CurrentToolsVersion = CurrentVisualStudioVersion;
+        internal const string CurrentToolsVersion = "15.0";
 
         // if you change the key also change the following clones
         // Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.TryIntern

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// The most current Visual Studio Version known to this version of MSBuild.
         /// </summary>
-        internal const string CurrentVisualStudioVersion = "15.0";
+        internal const string CurrentVisualStudioVersion = "16.0";
 
         /// <summary>
         /// The most current ToolsVersion known to this version of MSBuild.
@@ -82,13 +82,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Current version of this MSBuild Engine assembly in the form, e.g, "12.0"
         /// </summary>
-        internal static string CurrentProductVersion
-        {
-            get
-            {
-                return "15.0";
-            }
-        }
+        internal static string CurrentProductVersion => "16.0";
     }
 
     /// <summary>


### PR DESCRIPTION
This will allow MSBuild to find Visual Studio 16 instances and is part
of the larger versioning approach for MSBuild 16.