### PR TITLE
Add AspNetCore specific properties for csproj intellisense

### DIFF
--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1100,6 +1100,16 @@ elementFormDefault="qualified">
         </xs:annotation>
     </xs:element>
     <xs:element name="AspNetConfiguration" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
+    <xs:element name="AspNetCoreHostingModel" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_textPackageId _locComment="" -->Indicates whether to run an ASP.NET Core application using IIS in-process or out-of-process.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="AspNetCoreHostingName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+        <xs:annotation>
+            <xs:documentation><!-- _locID_textPackageId _locComment="" -->Indicates which AspNetCoreModule version to use. Versions include V1 and V2.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
     <xs:element name="AssemblyKeyContainerName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="AssemblyKeyProviderName" type="msb:StringPropertyType" substitutionGroup="msb:Property"/>
     <xs:element name="AssemblyName" type="msb:StringPropertyType" substitutionGroup="msb:Property">

--- a/src/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -1105,7 +1105,7 @@ elementFormDefault="qualified">
             <xs:documentation><!-- _locID_textPackageId _locComment="" -->Indicates whether to run an ASP.NET Core application using IIS in-process or out-of-process.</xs:documentation>
         </xs:annotation>
     </xs:element>
-    <xs:element name="AspNetCoreHostingName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
+    <xs:element name="AspNetCoreModuleName" type="msb:StringPropertyType" substitutionGroup="msb:Property">
         <xs:annotation>
             <xs:documentation><!-- _locID_textPackageId _locComment="" -->Indicates which AspNetCoreModule version to use. Versions include V1 and V2.</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
AspNetCore is adding a new feature to support inprocess hosting with IIS. We have a few csproj elements that can be specified that we would like to add for intellisense. There doesn't seem to be any extensibility points, so I went ahead and added them to the CommonTypes file.

cc/ @AndyGerlicher @shirhatti  