### PR TITLE
Add /graphBuild parameter

### DIFF
--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -775,6 +775,49 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void GraphBuildSwitchIdentificationTests()
+        {
+            CommandLineSwitches.ParameterizedSwitch parameterizedSwitch;
+            string duplicateSwitchErrorMessage;
+            bool multipleParametersAllowed;
+            string missingParametersErrorMessage;
+            bool unquoteParameters;
+            bool emptyParametersAllowed;
+
+            Assert.True(CommandLineSwitches.IsParameterizedSwitch("graph", out parameterizedSwitch, out duplicateSwitchErrorMessage, out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters, out emptyParametersAllowed));
+            Assert.Equal(CommandLineSwitches.ParameterizedSwitch.GraphBuild, parameterizedSwitch);
+            Assert.Null(duplicateSwitchErrorMessage);
+            Assert.False(multipleParametersAllowed);
+            Assert.Null(missingParametersErrorMessage);
+            Assert.True(unquoteParameters);
+            Assert.False(emptyParametersAllowed);
+
+            Assert.True(CommandLineSwitches.IsParameterizedSwitch("GRAPH", out parameterizedSwitch, out duplicateSwitchErrorMessage, out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters, out emptyParametersAllowed));
+            Assert.Equal(CommandLineSwitches.ParameterizedSwitch.GraphBuild, parameterizedSwitch);
+            Assert.Null(duplicateSwitchErrorMessage);
+            Assert.False(multipleParametersAllowed);
+            Assert.Null(missingParametersErrorMessage);
+            Assert.True(unquoteParameters);
+            Assert.False(emptyParametersAllowed);
+
+            Assert.True(CommandLineSwitches.IsParameterizedSwitch("graphbuild", out parameterizedSwitch, out duplicateSwitchErrorMessage, out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters, out emptyParametersAllowed));
+            Assert.Equal(CommandLineSwitches.ParameterizedSwitch.GraphBuild, parameterizedSwitch);
+            Assert.Null(duplicateSwitchErrorMessage);
+            Assert.False(multipleParametersAllowed);
+            Assert.Null(missingParametersErrorMessage);
+            Assert.True(unquoteParameters);
+            Assert.False(emptyParametersAllowed);
+
+            Assert.True(CommandLineSwitches.IsParameterizedSwitch("graphBuild", out parameterizedSwitch, out duplicateSwitchErrorMessage, out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters, out emptyParametersAllowed));
+            Assert.Equal(CommandLineSwitches.ParameterizedSwitch.GraphBuild, parameterizedSwitch);
+            Assert.Null(duplicateSwitchErrorMessage);
+            Assert.False(multipleParametersAllowed);
+            Assert.Null(missingParametersErrorMessage);
+            Assert.True(unquoteParameters);
+            Assert.False(emptyParametersAllowed);
+        }
+
+        [Fact]
         public void SetParameterlessSwitchTests()
         {
             CommandLineSwitches switches = new CommandLineSwitches();
@@ -1173,7 +1216,8 @@ namespace Microsoft.Build.UnitTests
                                         profilerLogger: null,
                                         enableProfiler: false,
                                         interactive: false,
-                                        isolateProjects: false);
+                                        isolateProjects: false,
+                                        graphBuild: false);
                 }
                 finally
                 {

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Build.CommandLine
             RestoreProperty,
             Interactive,
             IsolateProjects,
+            GraphBuild,
             NumberOfParameterizedSwitches,
         }
 
@@ -277,6 +278,7 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "restoreproperty", "rp" },             ParameterizedSwitch.RestoreProperty,            null,                           true,           "MissingRestorePropertyError",         true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "interactive" },                       ParameterizedSwitch.Interactive,                null,                           false,          null,                                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "isolateprojects", "isolate" },        ParameterizedSwitch.IsolateProjects,            null ,                          false,          null,                                  true,   false  ),
+            new ParameterizedSwitchInfo(  new string[] { "graphbuild", "graph" },               ParameterizedSwitch.GraphBuild,                 null ,                          false,          null,                                  true,   false  ),
         };
 
         /// <summary>

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -731,6 +731,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </value>
     <comment>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -747,6 +749,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </value>
     <comment>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -730,11 +730,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </value>
     <comment>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</comment>
+  </data>
+  <data name="HelpMessage_36_GraphBuildSwitch" UESanitized="false" Visibility="Public">
+    <value>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </value>
+    <comment>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </comment>
   </data>
   <data name="InvalidConfigurationFile" Visibility="Public">
     <value>MSBUILD : Configuration error MSB1043: The application could not start. {0}</value>
@@ -1087,6 +1105,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </comment>
   </data>
+  <data name="InvalidGraphBuildValue" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : error MSB1057: Graph build value is not valid. {0}</value>
+    <comment>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
   <data name="AbortingBuild" UESanitized="true" Visibility="Public">
     <value>Attempting to cancel the build...</value>
   </data>
@@ -1157,7 +1184,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!--
         The command line message bucket is: MSB1001 - MSB1999
 
-        Next error code should be MSB1057.
+        Next error code should be MSB1058.
 
         Don't forget to update this comment after using the new code.
   -->

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -127,6 +127,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -135,11 +136,39 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -996,6 +1025,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -128,6 +128,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -137,6 +139,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -153,6 +157,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -163,6 +169,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -820,6 +849,16 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation.All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. Todos os direitos reservados.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -117,6 +117,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -126,6 +128,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -142,6 +146,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -152,6 +158,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -116,6 +116,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -124,11 +125,39 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -806,6 +835,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -117,6 +117,7 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -808,6 +837,16 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -118,6 +118,8 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -117,6 +117,7 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -125,11 +126,39 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      that the project graph be statically discoverable at
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
+                     (Short form: /isolate)
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
       LOCALIZATION: "/isolateProjects" should not be localized.
       LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.</note>
+      </trans-unit>
+      <trans-unit id="HelpMessage_36_GraphBuildSwitch">
+        <source>  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </source>
+        <target state="new">  /graphBuild[:True|False]
+                     Causes MSBuild to construct and build a project graph.
+
+                     Constructing a graph involves identifying project
+                     references to form dependencies. Building that graph
+                     involves attempting to build project references prior
+                     to the projects that reference them, differing from
+                     traditional MSBuild scheduling.
+                     (Short form: /graph)
+    </target>
+        <note>
+      LOCALIZATION: "MSBuild" should not be localized.
+      LOCALIZATION: "/graphBuild" and "/graph" should not be localized.
+      LOCALIZATION: None of the lines should be longer than a standard width console window, eg 80 chars.
+    </note>
       </trans-unit>
       <trans-unit id="HelpMessage_3_SwitchesHeader">
         <source>Switches:
@@ -807,6 +836,16 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
       {StrBegin="MSBUILD : Configuration error MSB1043: "}
       UE: This error is shown when the msbuild.exe.config file had invalid content.
       LOCALIZATION: The prefix "MSBUILD : Configuration error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="InvalidGraphBuildValue">
+        <source>MSBUILD : error MSB1057: Graph build value is not valid. {0}</source>
+        <target state="new">MSBUILD : error MSB1057: Graph build value is not valid. {0}</target>
+        <note>
+      {StrBegin="MSBUILD : error MSB1057: "}
+      UE: This message does not need in-line parameters because the exception takes care of displaying the invalid arg.
+      This error is shown when a user specifies a value for the /graphBuild parameter that is not equivalent to Boolean.TrueString or Boolean.FalseString.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
     </note>
       </trans-unit>
       <trans-unit id="InvalidInteractiveValue">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -118,6 +118,8 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /isolateProjects[:True|False]
                      Causes MSBuild to build each project in isolation.
@@ -127,6 +129,8 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      evaluation time, but can improve scheduling and reduce
                      memory overhead when building a large set of projects.
                      (Short form: /isolate)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.
@@ -143,6 +147,8 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </source>
         <target state="new">  /graphBuild[:True|False]
                      Causes MSBuild to construct and build a project graph.
@@ -153,6 +159,8 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      to the projects that reference them, differing from
                      traditional MSBuild scheduling.
                      (Short form: /graph)
+
+                     This flag is experimental and may not work as intended.
     </target>
         <note>
       LOCALIZATION: "MSBuild" should not be localized.

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -558,6 +558,7 @@ namespace Microsoft.Build.CommandLine
                 bool enableProfiler = false;
                 bool interactive = false;
                 bool isolateProjects = false;
+                bool graphBuild = false;
 
                 CommandLineSwitches switchesFromAutoResponseFile;
                 CommandLineSwitches switchesNotFromAutoResponseFile;
@@ -589,6 +590,7 @@ namespace Microsoft.Build.CommandLine
                         ref enableProfiler,
                         ref restoreProperties,
                         ref isolateProjects,
+                        ref graphBuild,
                         recursing: false
                         ))
                 {
@@ -625,7 +627,7 @@ namespace Microsoft.Build.CommandLine
 #if FEATURE_XML_SCHEMA_VALIDATION
                             needToValidateProject, schemaFile,
 #endif
-                            cpuCount, enableNodeReuse, preprocessWriter, detailedSummary, warningsAsErrors, warningsAsMessages, enableRestore, profilerLogger, enableProfiler, interactive, isolateProjects))
+                            cpuCount, enableNodeReuse, preprocessWriter, detailedSummary, warningsAsErrors, warningsAsMessages, enableRestore, profilerLogger, enableProfiler, interactive, isolateProjects, graphBuild))
                             {
                                 exitType = ExitType.BuildError;
                             }
@@ -926,7 +928,8 @@ namespace Microsoft.Build.CommandLine
             ProfilerLogger profilerLogger,
             bool enableProfiler,
             bool interactive,
-            bool isolateProjects
+            bool isolateProjects,
+            bool graphBuild
         )
         {
             if (String.Equals(Path.GetExtension(projectFile), ".vcproj", StringComparison.OrdinalIgnoreCase) ||
@@ -1143,7 +1146,7 @@ namespace Microsoft.Build.CommandLine
 
                             if (!restoreOnly)
                             {
-                                if (isolateProjects)
+                                if (graphBuild)
                                 {
                                     results = ExecuteGraphBuild(projectFile, targets, buildManager, projectCollection, globalProperties);
                                 }
@@ -1956,6 +1959,7 @@ namespace Microsoft.Build.CommandLine
             ref bool enableProfiler,
             ref Dictionary<string, string> restoreProperties,
             ref bool isolateProjects,
+            ref bool graphBuild,
             bool recursing
         )
         {
@@ -2068,6 +2072,7 @@ namespace Microsoft.Build.CommandLine
                                                                ref enableProfiler,
                                                                ref restoreProperties,
                                                                ref isolateProjects,
+                                                               ref graphBuild,
                                                                recursing: true
                                                              );
                         }
@@ -2118,6 +2123,11 @@ namespace Microsoft.Build.CommandLine
                     if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.IsolateProjects))
                     {
                         isolateProjects = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.IsolateProjects], defaultValue: true, resourceName: "InvalidIsolateProjectsValue");
+                    }
+
+                    if (commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.GraphBuild))
+                    {
+                        graphBuild = ProcessBooleanSwitch(commandLineSwitches[CommandLineSwitches.ParameterizedSwitch.GraphBuild], defaultValue: true, resourceName: "InvalidGraphBuildValue");
                     }
 
                     // figure out which loggers are going to listen to build events
@@ -3562,6 +3572,7 @@ namespace Microsoft.Build.CommandLine
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_32_ProfilerSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_34_InteractiveSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_35_IsolateProjectsSwitch"));
+            Console.WriteLine(AssemblyResources.GetString("HelpMessage_36_GraphBuildSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_7_ResponseFile"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_8_NoAutoResponseSwitch"));
             Console.WriteLine(AssemblyResources.GetString("HelpMessage_5_NoLogoSwitch"));


### PR DESCRIPTION
The reasoning for yet another param (in addition to `/isolateProjects`) is based on these various scenarios:

1. `/graphBuild` - Construct and build a graph without isolation enforcement ("unexpected" calls into project references are permitted)
2. `/graphBuild /isolateProjects` - Construct and build a graph with isolation enforcement.
3. `/isolateProjects` - Build one single project with isolation enforcement. This scenario will require deserializing results from dependencies in some way (yet to be finalized).

Closes: #3755 