### PR TITLE
Remove a couple string allocations related to GetExtension

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -928,8 +928,7 @@ namespace Microsoft.Build.CommandLine
             bool isolateProjects
         )
         {
-            if (String.Equals(Path.GetExtension(projectFile), ".vcproj", StringComparison.OrdinalIgnoreCase) ||
-                String.Equals(Path.GetExtension(projectFile), ".dsp", StringComparison.OrdinalIgnoreCase))
+            if (FileUtilities.IsVCProjFilename(projectFile) || FileUtilities.IsDspFilename(projectFile))
             {
                 InitializationException.Throw(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("ProjectUpgradeNeededToVcxProj", projectFile), null);
             }

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -959,6 +959,11 @@ namespace Microsoft.Build.Shared
             return HasExtension(filename, ".vcproj");
         }
 
+        internal static bool IsDspFilename(string filename)
+        {
+            return HasExtension(filename, ".dsp");
+        }
+
         /// <summary>
         /// Returns true if the specified filename is a metaproject file (.metaproj), otherwise false.
         /// </summary>


### PR DESCRIPTION
Just 2 small string allocations, so won't make a big dent, but it bothered me every time I saw it.