### PR TITLE
Makes BuildEventArgsReader public

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1428,6 +1428,11 @@ namespace Microsoft.Build.Logging
         public void Replay(string sourceFilePath) { }
         public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
+    public partial class BuildEventArgsReader
+    {
+        public BuildEventArgsReader(System.IO.BinaryReader binaryReader, int fileFormatVersion) { }
+        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1423,6 +1423,11 @@ namespace Microsoft.Build.Logging
         public void Replay(string sourceFilePath) { }
         public void Replay(string sourceFilePath, System.Threading.CancellationToken cancellationToken) { }
     }
+    public partial class BuildEventArgsReader
+    {
+        public BuildEventArgsReader(System.IO.BinaryReader binaryReader, int fileFormatVersion) { }
+        public Microsoft.Build.Framework.BuildEventArgs Read() { throw null; }
+    }
     public delegate void ColorResetter();
     public delegate void ColorSetter(System.ConsoleColor color);
     public partial class ConfigurableForwardingLogger : Microsoft.Build.Framework.IForwardingLogger, Microsoft.Build.Framework.ILogger, Microsoft.Build.Framework.INodeLogger

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Build.Logging
     /// <summary>
     /// Deserializes and returns BuildEventArgs-derived objects from a BinaryReader
     /// </summary>
-    internal class BuildEventArgsReader
+    public class BuildEventArgsReader
     {
         private readonly BinaryReader binaryReader;
         private readonly int fileFormatVersion;


### PR DESCRIPTION
Quick little change to make `BuildEventArgsReader` public as discussed in #3813