### PR TITLE
added missing years to copyright statement. Year dates required for M…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ MSBuild
 
 The MIT License (MIT)
 
-Copyright (c) .NET Foundation and contributors
+Copyright (c) 2003-2018 .NET Foundation and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
MIT license requires the year to be stated in the copyright statement. (https://opensource.org/licenses/MIT)

Added dates 2003-2018, where 2003 was first release of MSBuild.