### PR TITLE
Static Graph: Add the ability to hook ProjectInstance creation to allow creation of Projects first

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1414,19 +1414,21 @@ namespace Microsoft.Build.Graph
         public ProjectGraph(Microsoft.Build.Graph.ProjectGraphEntryPoint entryPoint) { }
         public ProjectGraph(Microsoft.Build.Graph.ProjectGraphEntryPoint entryPoint, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints) { }
-        public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Graph.ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(string entryProjectFile) { }
         public ProjectGraph(string entryProjectFile, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectGraph(string entryProjectFile, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Graph.ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(string[] entryProjectTargets) { throw null; }
+        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProjectGraphEntryPoint

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1409,19 +1409,21 @@ namespace Microsoft.Build.Graph
         public ProjectGraph(Microsoft.Build.Graph.ProjectGraphEntryPoint entryPoint) { }
         public ProjectGraph(Microsoft.Build.Graph.ProjectGraphEntryPoint entryPoint, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints) { }
-        public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectGraph(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> entryPoints, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Graph.ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(System.Collections.Generic.IEnumerable<string> entryProjectFiles, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public ProjectGraph(string entryProjectFile) { }
         public ProjectGraph(string entryProjectFile, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
+        public ProjectGraph(string entryProjectFile, Microsoft.Build.Evaluation.ProjectCollection projectCollection, Microsoft.Build.Graph.ProjectGraph.ProjectInstanceFactoryFunc projectInstanceFactory) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(string[] entryProjectTargets) { throw null; }
+        public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
     public partial struct ProjectGraphEntryPoint

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -402,13 +402,13 @@ namespace Microsoft.Build.Graph.UnitTests
                 var entryPointNode1 = projectGraph.EntryPointNodes.First();
                 var entryPointNode2 = projectGraph.EntryPointNodes.Last();
 
-                // The entrypoints should not be the same node, but should point to the same project
+                // The entry points should not be the same node, but should point to the same project
                 entryPointNode1.ShouldNotBe(entryPointNode2);
                 entryPointNode1.ProjectInstance.FullPath.ShouldBe(entryPointNode2.ProjectInstance.FullPath);
                 entryPointNode1.GlobalProperties["Platform"].ShouldBe("x86");
                 entryPointNode2.GlobalProperties["Platform"].ShouldBe("x64");
 
-                // The entrypoints should not not have the same project reference, but should point to the same project reference file
+                // The entry points should not have the same project reference, but should point to the same project reference file
                 entryPointNode1.ProjectReferences.Count.ShouldBe(1);
                 entryPointNode2.ProjectReferences.Count.ShouldBe(1);
                 entryPointNode1.ProjectReferences.First().ShouldNotBe(entryPointNode2.ProjectReferences.First());
@@ -441,13 +441,13 @@ namespace Microsoft.Build.Graph.UnitTests
                 var entryPointNode1 = projectGraph.EntryPointNodes.First();
                 var entryPointNode2 = projectGraph.EntryPointNodes.Last();
 
-                // The entrypoints should not be the same node, but should point to the same project
+                // The entry points should not be the same node, but should point to the same project
                 entryPointNode1.ShouldNotBe(entryPointNode2);
                 entryPointNode1.ProjectInstance.FullPath.ShouldBe(entryPointNode2.ProjectInstance.FullPath);
                 entryPointNode1.GlobalProperties["Platform"].ShouldBe("x86");
                 entryPointNode2.GlobalProperties["Platform"].ShouldBe("x64");
 
-                // The entrypoints should have the same project reference since it's platform-agnostic
+                // The entry points should have the same project reference since they're platform-agnostic
                 entryPointNode1.ProjectReferences.Count.ShouldBe(1);
                 entryPointNode2.ProjectReferences.Count.ShouldBe(1);
                 entryPointNode1.ProjectReferences.First().ShouldBe(entryPointNode2.ProjectReferences.First());

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Graph
         /// <param name="entryProjectFile">The project file to use as the entry point in constructing the graph</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(string entryProjectFile)
-            : this(new ProjectGraphEntryPoint(entryProjectFile).AsEnumerable(), ProjectCollection.GlobalProjectCollection)
+            : this(new ProjectGraphEntryPoint(entryProjectFile).AsEnumerable(), ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Graph
         /// <param name="entryProjectFiles">The project files to use as the entry points in constructing the graph</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(IEnumerable<string> entryProjectFiles)
-            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles), ProjectCollection.GlobalProjectCollection)
+            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles), ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Graph
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(string entryProjectFile, ProjectCollection projectCollection)
-            : this(new ProjectGraphEntryPoint(entryProjectFile).AsEnumerable(), projectCollection)
+            : this(new ProjectGraphEntryPoint(entryProjectFile).AsEnumerable(), projectCollection, null)
         {
         }
 
@@ -81,7 +81,27 @@ namespace Microsoft.Build.Graph
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(IEnumerable<string> entryProjectFiles, ProjectCollection projectCollection)
-            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles), projectCollection)
+            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles), projectCollection, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a graph starting from the given project file, evaluating with the global project collection and no global properties.
+        /// </summary>
+        /// <param name="entryProjectFile">The project file to use as the entry point in constructing the graph</param>
+        /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
+        /// <param name="projectInstanceFactory">
+        /// A delegate used for constructing a <see cref="ProjectInstance"/>, called for each
+        /// project created during graph creation. This value can be null, which uses
+        /// a default implementation that calls the ProjectInstance constructor. See the remarks
+        /// on the <see cref="ProjectInstanceFactoryFunc"/> for other scenarios.
+        /// </param>
+        /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
+        /// <exception cref="System.InvalidOperationException">
+        /// If a null reference is returned from <paramref name="projectInstanceFactory"/>.
+        /// </exception>
+        public ProjectGraph(string entryProjectFile, ProjectCollection projectCollection, ProjectInstanceFactoryFunc projectInstanceFactory)
+            : this(new ProjectGraphEntryPoint(entryProjectFile).AsEnumerable(), projectCollection, projectInstanceFactory)
         {
         }
 
@@ -92,7 +112,7 @@ namespace Microsoft.Build.Graph
         /// <param name="globalProperties">The global properties to use for all projects. May be null, in which case no global properties will be set.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(string entryProjectFile, IDictionary<string, string> globalProperties)
-            : this(new ProjectGraphEntryPoint(entryProjectFile, globalProperties).AsEnumerable(), ProjectCollection.GlobalProjectCollection)
+            : this(new ProjectGraphEntryPoint(entryProjectFile, globalProperties).AsEnumerable(), ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -103,7 +123,7 @@ namespace Microsoft.Build.Graph
         /// <param name="globalProperties">The global properties to use for all projects. May be null, in which case no global properties will be set.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(IEnumerable<string> entryProjectFiles, IDictionary<string, string> globalProperties)
-            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles, globalProperties), ProjectCollection.GlobalProjectCollection)
+            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles, globalProperties), ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -115,7 +135,7 @@ namespace Microsoft.Build.Graph
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(string entryProjectFile, IDictionary<string, string> globalProperties, ProjectCollection projectCollection)
-            : this(new ProjectGraphEntryPoint(entryProjectFile, globalProperties).AsEnumerable(), projectCollection)
+            : this(new ProjectGraphEntryPoint(entryProjectFile, globalProperties).AsEnumerable(), projectCollection, null)
         {
         }
 
@@ -127,7 +147,7 @@ namespace Microsoft.Build.Graph
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(IEnumerable<string> entryProjectFiles, IDictionary<string, string> globalProperties, ProjectCollection projectCollection)
-            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles, globalProperties), projectCollection)
+            : this(ProjectGraphEntryPoint.CreateEnumerable(entryProjectFiles, globalProperties), projectCollection, null)
         {
         }
 
@@ -137,7 +157,7 @@ namespace Microsoft.Build.Graph
         /// <param name="entryPoint">The entry point to use in constructing the graph</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(ProjectGraphEntryPoint entryPoint)
-            : this(entryPoint.AsEnumerable(), ProjectCollection.GlobalProjectCollection)
+            : this(entryPoint.AsEnumerable(), ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -147,7 +167,7 @@ namespace Microsoft.Build.Graph
         /// <param name="entryPoints">The entry points to use in constructing the graph</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(IEnumerable<ProjectGraphEntryPoint> entryPoints)
-            : this(entryPoints, ProjectCollection.GlobalProjectCollection)
+            : this(entryPoints, ProjectCollection.GlobalProjectCollection, null)
         {
         }
 
@@ -158,7 +178,7 @@ namespace Microsoft.Build.Graph
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
         public ProjectGraph(ProjectGraphEntryPoint entryPoint, ProjectCollection projectCollection)
-            : this(entryPoint.AsEnumerable(), projectCollection)
+            : this(entryPoint.AsEnumerable(), projectCollection, null)
         {
         }
 
@@ -167,10 +187,24 @@ namespace Microsoft.Build.Graph
         /// </summary>
         /// <param name="entryPoints">The entry points to use in constructing the graph</param>
         /// <param name="projectCollection">The collection with which all projects in the graph should be associated. May not be null.</param>
+        /// <param name="projectInstanceFactory">
+        /// A delegate used for constructing a <see cref="ProjectInstance"/>, called for each
+        /// project created during graph creation. This value can be null, which uses
+        /// a default implementation that calls the ProjectInstance constructor. See the remarks
+        /// on <see cref="ProjectInstanceFactoryFunc"/> for other scenarios.
+        /// </param>
         /// <exception cref="InvalidProjectFileException">If the evaluation of any project in the graph fails.</exception>
-        public ProjectGraph(IEnumerable<ProjectGraphEntryPoint> entryPoints, ProjectCollection projectCollection)
+        /// <exception cref="System.InvalidOperationException">
+        /// If a null reference is returned from <paramref name="projectInstanceFactory"/>.
+        /// </exception>
+        public ProjectGraph(
+            IEnumerable<ProjectGraphEntryPoint> entryPoints,
+            ProjectCollection projectCollection,
+            ProjectInstanceFactoryFunc projectInstanceFactory)
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectCollection, nameof(projectCollection));
+
+            projectInstanceFactory = projectInstanceFactory ?? DefaultProjectInstanceFactory;
 
             var nodeStates = new Dictionary<ProjectGraphNode, NodeState>();
             var entryPointNodes = new List<ProjectGraphNode>();
@@ -185,8 +219,8 @@ namespace Microsoft.Build.Graph
                 entryPointConfigurationMetadata.Add(configurationMetadata);
             }
 
-            LoadGraph(projectsToEvaluate, projectCollection, tasksInProgress);
-            foreach(var configurationMetadata in entryPointConfigurationMetadata)
+            LoadGraph(projectsToEvaluate, projectCollection, tasksInProgress, projectInstanceFactory);
+            foreach (var configurationMetadata in entryPointConfigurationMetadata)
             {
                 entryPointNodes.Add(_allParsedProjects[configurationMetadata]);
                 if (!nodeStates.TryGetValue(_allParsedProjects[configurationMetadata], out var _))
@@ -316,17 +350,60 @@ namespace Microsoft.Build.Graph
             return targetLists;
         }
 
+        /// <summary>
+        /// A callback used for constructing a <see cref="ProjectInstance"/> for a specific
+        /// <see cref="ProjectGraphEntryPoint"/> instance.
+        /// </summary>
+        /// <param name="projectPath">The path to the project file to parse.</param>
+        /// <param name="globalProperties">The global properties to be used for creating the ProjectInstance.</param>
+        /// <param name="projectCollection">The <see cref="ProjectCollection"/> context for parsing.</param>
+        /// <returns>A <see cref="ProjectInstance"/> instance. This value must not be null.</returns>
+        /// <remarks>
+        /// The default version of this delegate used by ProjectGraph simply calls the
+        /// ProjectInstance constructor with information from the parameters. This delegate
+        /// is provided as a hook to allow scenarios like creating a <see cref="Project"/>
+        /// instance before converting it to a ProjectInstance for use by the ProjectGraph.
+        ///
+        /// The returned ProjectInstance will be stored and provided with the ProjectGraph.
+        /// If this callback chooses to generate an immutable ProjectInstance, e.g. by
+        /// using <see cref="Project.CreateProjectInstance()"/> with the flag
+        /// <see cref="ProjectInstanceSettings.Immutable"/>, the resulting ProjectGraph
+        /// nodes might not be buildable.
+        /// </remarks>
+        public delegate ProjectInstance ProjectInstanceFactoryFunc(
+            string projectPath,
+            Dictionary<string, string> globalProperties,
+            ProjectCollection projectCollection);
+
+        internal static ProjectInstance DefaultProjectInstanceFactory(
+            string projectPath,
+            Dictionary<string, string> globalProperties,
+            ProjectCollection projectCollection)
+        {
+            return new ProjectInstance(
+                projectPath,
+                globalProperties,
+                MSBuildConstants.CurrentToolsVersion,
+                projectCollection);
+        }
+
         private ProjectGraphNode CreateNewNode(
             ConfigurationMetadata configurationMetadata,
-            ProjectCollection projectCollection)
+            ProjectCollection projectCollection,
+            ProjectInstanceFactoryFunc projectInstanceFactory)
         {
             // TODO: ProjectInstance just converts the dictionary back to a PropertyDictionary, so find a way to directly provide it.
             var globalProperties = configurationMetadata.GlobalProperties.ToDictionary();
-            var projectInstance = new ProjectInstance(
+
+            var projectInstance = projectInstanceFactory(
                 configurationMetadata.ProjectFullPath,
                 globalProperties,
-                configurationMetadata.ToolsVersion,
                 projectCollection);
+            if (projectInstance == null)
+            {
+                throw new InvalidOperationException(ResourceUtilities.GetResourceString("NullReferenceFromProjectInstanceFactory"));
+            }
+
             var graphNode = new ProjectGraphNode(
                 projectInstance,
                 globalProperties);
@@ -338,7 +415,11 @@ namespace Microsoft.Build.Graph
         /// Load a graph with root node at entryProjectFile
         /// Maintain a queue of projects to be processed and evaluate projects in parallel
         /// </summary>
-        private void LoadGraph(ConcurrentQueue<ConfigurationMetadata> projectsToEvaluate, ProjectCollection projectCollection, ConcurrentDictionary<ConfigurationMetadata, object> tasksInProgress)
+        private void LoadGraph(
+            ConcurrentQueue<ConfigurationMetadata> projectsToEvaluate,
+            ProjectCollection projectCollection,
+            ConcurrentDictionary<ConfigurationMetadata, object> tasksInProgress,
+            ProjectInstanceFactoryFunc projectInstanceFactory)
         {
             var evaluationWaitHandle = new AutoResetEvent(false);
             while (projectsToEvaluate.Count != 0 || tasksInProgress.Count != 0)
@@ -349,7 +430,7 @@ namespace Microsoft.Build.Graph
                     projectToEvaluate = projectsToEvaluate.Dequeue();
                     var task = new Task(() =>
                     {
-                        ProjectGraphNode parsedProject = CreateNewNode(projectToEvaluate, projectCollection);
+                        ProjectGraphNode parsedProject = CreateNewNode(projectToEvaluate, projectCollection, projectInstanceFactory);
                         IEnumerable<ProjectItemInstance> projectReferenceItems = parsedProject.ProjectInstance.GetItems(ProjectReferenceItemName);
                         foreach (var projectReferenceToParse in projectReferenceItems)
                         {

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1710,7 +1710,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="CircularDependencyInProjectGraph" UESanitized="false" Visibility="Public">
     <value>MSB4251: There is a circular dependency involving the following projects: {0}</value>
     <comment>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </comment>
   </data>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1721,13 +1721,20 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: Do not localize the following words: ProjectReference.
     </comment>
   </data>
+  <data name="NullReferenceFromProjectInstanceFactory" UESanitized="false" Visibility="Public">
+    <value>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</value>
+    <comment>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4253.
+        Next message code should be MSB4254.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Operaci nelze dokončit, protože funkce BeginBuild ještě nebyla zavolána.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Der Vorgang kann nicht abgeschlossen werden, da BeginBuild noch nicht aufgerufen wurde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -64,6 +64,14 @@
         <target state="new">The operation cannot be completed because BeginBuild has not yet been called.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -64,6 +64,14 @@
         <target state="translated">La operación no se puede completar porque todavía no se llamó a BeginBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Impossible d'effectuer l'opération car la méthode BeginBuild n'a pas encore été appelée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Non è possibile completare l'operazione perché BeginBuild non è stato ancora chiamato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -64,6 +64,14 @@
         <target state="translated">BeginBuild がまだ呼び出されていないため、操作を完了できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -64,6 +64,14 @@
         <target state="translated">BeginBuild가 아직 호출되지 않았으므로 작업을 완료할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Nie można zakończyć operacji, ponieważ metoda BeginBuild nie została jeszcze wywołana.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -64,6 +64,14 @@
         <target state="translated">A operação não pode ser concluída porque BeginBuild ainda não foi chamado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -64,6 +64,14 @@
         <target state="translated">Не удается завершить операцию, так как ещё не был вызван BeginBuild.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -64,6 +64,14 @@
         <target state="translated">BeginBuild henüz çağrılmadığı için işlem tamamlanamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -64,6 +64,14 @@
         <target state="translated">无法完成该操作，因为尚未调用 BeginBuild。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -50,7 +50,7 @@
         <source>MSB4251: There is a circular dependency involving the following projects: {0}</source>
         <target state="new">MSB4251: There is a circular dependency involving the following projects: {0}</target>
         <note>
-      {StrBegin="MSB4251:" This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
+      {StrBegin="MSB4251:"} This message is shown when a graph build detects a target referenced in a circular manner -- a project cannot
       request a target to build itself (perhaps via a chain of other targets)
     </note>
       </trans-unit>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -64,6 +64,14 @@
         <target state="translated">無法完成作業，因為尚未呼叫 BeginBuild。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NullReferenceFromProjectInstanceFactory">
+        <source>MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</source>
+        <target state="new">MSB4253: A null reference was returned from a user-provided ProjectInstanceFactoryFunc callback. This is not allowed.</target>
+        <note>
+      {StrBegin="MSB4253: "}
+      LOCALIZATION:  Do not localize the following words: ProjectInstanceFactoryFunc.
+    </note>
+      </trans-unit>
       <trans-unit id="ProjectGraphDoesNotSupportProjectReferenceWithToolset">
         <source>MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</source>
         <target state="new">MSB4250: ProjectGraph does not support ProjectReference items with the ToolsVersion metadata set. Found ProjectReference "{0}" with ToolsVersion in file "{1}"</target>


### PR DESCRIPTION
Note name change from Project to ProjectInstance for previously existing public API. Can restore old name Project and make new addition something like 'UnevaluatedProject' if downstream consumers might be affected.
