### PR TITLE
Adding methods to locate folders and files in VS installs

### DIFF
--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -433,6 +433,7 @@ namespace Microsoft.Build.Utilities
         public static void ClearSDKStaticCache() { }
         public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+        public static string FindRootFolderWhereAllFilesExist(string possibleRoots, string relativeFilePaths) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersExInfo> GetAssemblyFoldersExInfo(string registryRoot, string targetFrameworkVersion, string registryKeySuffix, string osVersion, string platform, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersFromConfigInfo> GetAssemblyFoldersFromConfigInfo(string configFile, string targetFrameworkVersion, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
         public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
@@ -442,6 +443,8 @@ namespace Microsoft.Build.Utilities
         public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
         public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
         public static string GetDotNetFrameworkVersionFolderPrefix(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> GetFoldersInVSInstalls(System.Version minVersion=null, System.Version maxVersion=null, string subFolder=null) { throw null; }
+        public static string GetFoldersInVSInstallsAsString(string minVersionString=null, string maxVersionString=null, string subFolder=null) { throw null; }
         public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion) { throw null; }
         public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion, string[] sdkRoots) { throw null; }
         public static string GetPathToBuildTools(string toolsVersion) { throw null; }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -274,6 +274,7 @@ namespace Microsoft.Build.Utilities
         public static void ClearSDKStaticCache() { }
         public static System.Collections.Generic.IDictionary<string, string> FilterPlatformExtensionSDKs(System.Version targetPlatformVersion, System.Collections.Generic.IDictionary<string, string> extensionSdks) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> FilterTargetPlatformSdks(System.Collections.Generic.IList<Microsoft.Build.Utilities.TargetPlatformSDK> targetPlatformSdkList, System.Version osVersion, System.Version vsVersion) { throw null; }
+        public static string FindRootFolderWhereAllFilesExist(string possibleRoots, string relativeFilePaths) { throw null; }
         public static System.Collections.Generic.IList<Microsoft.Build.Utilities.AssemblyFoldersFromConfigInfo> GetAssemblyFoldersFromConfigInfo(string configFile, string targetFrameworkVersion, System.Reflection.ProcessorArchitecture targetProcessorArchitecture) { throw null; }
         public static string GetDisplayNameForTargetFrameworkDirectory(string targetFrameworkDirectory, System.Runtime.Versioning.FrameworkName frameworkName) { throw null; }
         public static string GetDotNetFrameworkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
@@ -282,6 +283,8 @@ namespace Microsoft.Build.Utilities
         public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
         public static string GetDotNetFrameworkSdkRootRegistryKey(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version, Microsoft.Build.Utilities.VisualStudioVersion visualStudioVersion) { throw null; }
         public static string GetDotNetFrameworkVersionFolderPrefix(Microsoft.Build.Utilities.TargetDotNetFrameworkVersion version) { throw null; }
+        public static System.Collections.Generic.IEnumerable<string> GetFoldersInVSInstalls(System.Version minVersion=null, System.Version maxVersion=null, string subFolder=null) { throw null; }
+        public static string GetFoldersInVSInstallsAsString(string minVersionString=null, string maxVersionString=null, string subFolder=null) { throw null; }
         public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion) { throw null; }
         public static string GetLatestSDKTargetPlatformVersion(string sdkIdentifier, string sdkVersion, string[] sdkRoots) { throw null; }
         public static string GetPathToBuildTools(string toolsVersion) { throw null; }

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -244,6 +244,11 @@ namespace Microsoft.Build.Utilities
         private static List<string> s_targetFrameworkMonikers = null;
 
         /// <summary>
+        /// Cache the VS Install folders for particular range of VS versions
+        /// </summary>
+        private static Dictionary<string, string[]> s_vsInstallFolders;
+
+        /// <summary>
         /// Character used to separate search paths specified for MSBuildExtensionsPath* in
         /// the config file
         /// </summary>
@@ -1381,6 +1386,133 @@ namespace Microsoft.Build.Utilities
             }
         }
 
+        /// <summary>
+        ///  Returns folders in VS installs of specifid range of versions, starting with 15.0.
+        /// </summary>
+        /// <param name="minVersion">Optional. If specified, only VS instances with this or bigger version will be included.</param>
+        /// <param name="maxVersion">Optional. If specified, only VS instances with smaller versions will be included. For instance, 16.0 means that only 15.* versions will be included.</param>
+        /// <param name="subFolder">Optional. If specified, the returned list will contain [VSInstallDir][subFolder] paths</param>
+        /// <returns>Returns folders in VS installs in VS version descending order</returns>
+        public static IEnumerable<string> GetFoldersInVSInstalls(Version minVersion = null, Version maxVersion = null, string subFolder = null)
+        {
+            string versionRange = string.Format("{0};{1}", minVersion == null ? String.Empty : minVersion.ToString(), maxVersion == null ? String.Empty : maxVersion.ToString());
+            string[] vsInstallFolders;
+
+            lock (s_locker)
+            {
+                if (s_vsInstallFolders == null)
+                {
+                    s_vsInstallFolders = new Dictionary<string, string[]>();
+                }
+
+                if (!s_vsInstallFolders.TryGetValue(versionRange, out vsInstallFolders))
+                {
+                    IList<VisualStudioInstance> vsInstances = VisualStudioLocationHelper.GetInstances();
+
+                    var vsInstancePaths = vsInstances
+                        .Where(i => (minVersion == null || i.Version >= minVersion) && (maxVersion == null || i.Version < maxVersion))
+                        .OrderByDescending(i => i.Version)
+                        .Select(i => i.Path);
+
+                    vsInstallFolders = vsInstancePaths.ToArray();
+                    s_vsInstallFolders[versionRange] = vsInstallFolders;
+                }
+            }
+
+            var folders = string.IsNullOrEmpty(subFolder) ? vsInstallFolders : vsInstallFolders.Select(i => Path.Combine(i, subFolder));
+
+            return folders;
+        }
+
+        /// <summary>
+        ///  Returns folders in VS installs of specifid range of versions (starting with 15.0) separated by ';'.
+        /// </summary>
+        /// <param name="minVersionString">Optional. If specified, only VS instances with this or bigger version will be included.</param>
+        /// <param name="maxVersionString">Optional. If specified, only VS instances with smaller versions will be included. For instance, 16.0 means that only 15.* versions will be included.</param>
+        /// <param name="subFolder">Optional. If specified, the returned list will contain [VSInstallDir][subFolder] paths</param>
+        /// <returns>Returns folders in VS installs in VS version descending order separated by ';'</returns>
+        public static string GetFoldersInVSInstallsAsString(string minVersionString = null, string maxVersionString = null, string subFolder = null)
+        {
+            string foldersString = string.Empty;
+
+            try
+            {
+                Version minVersion, maxVersion;
+
+                if (string.IsNullOrEmpty(minVersionString) || !Version.TryParse(minVersionString, out minVersion))
+                {
+                    minVersion = null;
+                }
+                if (string.IsNullOrEmpty(maxVersionString) || !Version.TryParse(maxVersionString, out maxVersion))
+                {
+                    maxVersion = null;
+                }
+
+                var folders = GetFoldersInVSInstalls(minVersion, maxVersion, subFolder);
+
+                if (folders.Count() > 0)
+                {
+                    foldersString = string.Join(";", folders);
+                }
+            }
+            catch(Exception e)
+            {
+                // this method will be used in vc props and we don't want to fail project load if it throws for some non critical reason.
+                if (ExceptionHandling.IsCriticalException(e))
+                {
+                    throw;
+                }
+            }
+
+            return foldersString;
+        }
+
+        /// <summary>
+        /// Finds first folder in the list which contains all given files. Returns an empty string if not found.
+        /// </summary>
+        /// <param name="possibleRoots">Root folders separated by ';'</param>
+        /// <param name="relativeFilePaths">Relative file paths to find under root folders, separated by ';'.</param>
+        /// <returns>The first root folder in the given list, which contains all files. Empty string if not found.</returns>
+        public static string FindRootFolderWhereAllFilesExist(string possibleRoots, string relativeFilePaths)
+        {
+            if (!string.IsNullOrEmpty(possibleRoots))
+            {
+                var roots = possibleRoots.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                var files = relativeFilePaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+                bool allFilesFound;
+                foreach (var root in roots)
+                {
+                    allFilesFound = true;
+                    foreach (var file in files)
+                    {
+                        try
+                        {
+                            string fullPath = Path.Combine(root, file);
+
+                            if (!FileSystems.Default.FileExists(fullPath))
+                            {
+                                allFilesFound = false;
+                                break;
+                            }
+                        }
+                        catch (ArgumentException)
+                        {
+                            allFilesFound = false;
+                            break;
+                        }
+                    }
+
+                    if(allFilesFound)
+                    {
+                        return root;
+                    }
+                }
+            }
+
+            return string.Empty;
+        }
+        
         /// <summary>
         /// Tries to parse the "version" out of a platformMoniker. 
         /// </summary>

--- a/src/Utilities/ToolLocationHelper.cs
+++ b/src/Utilities/ToolLocationHelper.cs
@@ -1395,7 +1395,7 @@ namespace Microsoft.Build.Utilities
         /// <returns>Returns folders in VS installs in VS version descending order</returns>
         public static IEnumerable<string> GetFoldersInVSInstalls(Version minVersion = null, Version maxVersion = null, string subFolder = null)
         {
-            string versionRange = string.Format("{0};{1}", minVersion == null ? String.Empty : minVersion.ToString(), maxVersion == null ? String.Empty : maxVersion.ToString());
+            string versionRange = $"{minVersion?.ToString() ?? string.Empty};{maxVersion?.ToString() ?? string.Empty}";
             string[] vsInstallFolders;
 
             lock (s_locker)
@@ -1425,7 +1425,7 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
-        ///  Returns folders in VS installs of specifid range of versions (starting with 15.0) separated by ';'.
+        ///  Returns folders in VS installs of specified range of versions (starting with 15.0) separated by ';'.
         /// </summary>
         /// <param name="minVersionString">Optional. If specified, only VS instances with this or bigger version will be included.</param>
         /// <param name="maxVersionString">Optional. If specified, only VS instances with smaller versions will be included. For instance, 16.0 means that only 15.* versions will be included.</param>


### PR DESCRIPTION
VC build needs to be able to use toolsets installed by older VS versions (native multitargeting). Before VS2017 the vc targets locations were written in the registry. To figure out Vs2017 install locations we have to call the installer API.  There also might be several instances on the machine and we need to be able to use a toolset installed in any of the instances.

Here is how the added functions are going to be used in cpp props:
 
```xml
<PropertyGroup>
    <_VCTargetPath15Folders>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetFoldersInVSInstallsAsString('15.0', '16.0', 'Common7\IDE\VC\VCTargets'))</_VCTargetPath15Folders>
    <_VCTargetsPathForToolset Condition="'$(_VCTargetPath15Folders)' != ''">$([Microsoft.Build.Utilities.ToolLocationHelper]::FindRootFolderWhereAllFilesExist($(_VCTargetPath15Folders), $(_RelativeToolsetFiles)))</_VCTargetsPathForToolset>
  </PropertyGroup>
```