### PR TITLE
 fix publish of COM manifest files and don't publish CopyLocal=false files

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3971,7 +3971,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
       <_DeploymentReferencePaths Include="@(_DeploymentReferencePaths);@(_CopyLocalFalseRefPathsWithExclusion)" />
-      <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly)"
+      <_ManifestManagedReferences Include="@(_DeploymentReferencePaths);@(ReferenceDependencyPaths);@(_SGenDllsRelatedToCurrentDll);@(SerializationAssembly);@(ReferenceCOMWrappersToCopyLocal)"
                                Exclude="@(_SatelliteAssemblies);@(_ReferenceScatterPaths);@(_ExcludedAssembliesFromManifestGeneration)" />
     </ItemGroup>
 
@@ -4005,11 +4005,18 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SatelliteAssemblies="@(_SatelliteAssemblies)"
         TargetCulture="$(TargetCulture)">
 
-      <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependencies"/>
+      <Output TaskParameter="OutputAssemblies" ItemName="_DeploymentManifestDependenciesUnfiltered"/>
       <Output TaskParameter="OutputFiles" ItemName="_DeploymentManifestFiles"/>
       <Output TaskParameter="OutputEntryPoint" ItemName="_DeploymentResolvedManifestEntryPoint"/>
 
     </ResolveManifestFiles>
+
+    <!-- We have to filter items out of the dependencies that have neither CopyLocal set to true, -->
+    <!-- nor the dependency type manually set to 'Install'.                                       -->
+    <ItemGroup>
+      <_DeploymentManifestDependencies Include="@(_DeploymentManifestDependenciesUnfiltered)" 
+          Condition="!('%(_DeploymentManifestDependenciesUnfiltered.CopyLocal)' == 'false' And '%(_DeploymentManifestDependenciesUnfiltered.DependencyType)' != 'Install')" />
+    </ItemGroup>
 
     <PropertyGroup>
       <_DeploymentManifestType>ClickOnce</_DeploymentManifestType>

--- a/src/Tasks/ResolveManifestFiles.cs
+++ b/src/Tasks/ResolveManifestFiles.cs
@@ -621,7 +621,7 @@ namespace Microsoft.Build.Tasks
             // OpenScope and returns null if not an assembly, which is much faster.
 
             AssemblyIdentity identity = AssemblyIdentity.FromManagedAssembly(item.ItemSpec);
-            if(identity == null)
+            if (item.ItemSpec.EndsWith(".dll") && identity == null)
             {
                 // It is possible that a native dll gets passed in here that was declared as a content file
                 // in a referenced nuget package, which will yield null here. We just need to ignore those, 
@@ -629,7 +629,7 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            if (identity.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion))
+            if (identity != null && identity.IsInFramework(Constants.DotNetFrameworkIdentifier, TargetFrameworkVersion))
             {
                 return true;
             }


### PR DESCRIPTION
PR #3732 introduced some code to filter native assemblies of the collection of managed input assemblies to the ResolveManifestFiles task. There are cases where registration-free COM manifests are included in the input here and those got accidentally filtered out, so we need to ensure that we only filter actual dlls.

Furthermore we identified some edge cases where there were files included in the ClickOnce manifest that had CopyLocal set to false, so we have to ensure to filter those out before we resolve the references.