### PR TITLE
Avoid casting Enumerable.Empty to IList

### DIFF
--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -2331,7 +2331,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     _loadedProjects.TryGetValue(fullPath, out List<Project> candidates);
 
-                    return candidates ?? (IList<Project>)Enumerable.Empty<Project>();
+                    return candidates ?? (IList<Project>)Array.Empty<Project>();
                 }
             }
 


### PR DESCRIPTION
Fixes #3834.