### PR TITLE
Fail the build on target cache misses during isolated project builds

### DIFF
--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.Graph.UnitTests
+{
+    public class IsolateProjectsTests
+    {
+        private readonly string _project = @"
+                <Project DefaultTargets='BuildSelf'>
+                    <Target Name='BuildReference'>
+                        <MSBuild Projects='{0}' Targets='ReferenceTarget'/>
+                    </Target>
+
+                    <Target Name='BuildSelf'>
+                        <MSBuild Projects='$(MSBuildThisFile)' Targets='SelfTarget'/>
+                    </Target>
+
+                    <Target Name='SelfTarget'>
+                    </Target>
+                </Project>";
+
+        private readonly string _reference = @"
+                <Project>
+                    <Target Name='ReferenceTarget'>
+                    </Target>
+                </Project>";
+
+        private readonly ITestOutputHelper _testOutput;
+
+        public IsolateProjectsTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
+        [Theory]
+        [InlineData(BuildResultCode.Success, new string[] {})]
+        [InlineData(BuildResultCode.Success, new[] {"BuildSelf"})]
+        public void CacheEnforcementShouldAcceptSelfReferences(BuildResultCode expectedBuildResult, string[] targets)
+        {
+            AssertBuild(targets,
+                (result, logger) =>
+                {
+                    result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+                    logger.Errors.ShouldBeEmpty();
+                });
+        }
+
+        [Fact]
+        public void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt()
+        {
+            AssertBuild(new []{"BuildReference"},
+                (result, logger) =>
+                {
+                    result.OverallResult.ShouldBe(BuildResultCode.Failure);
+
+                    logger.ErrorCount.ShouldBe(1);
+
+                    logger.Errors.First().Message.ShouldStartWith("MSB4252:");
+                });
+        }
+
+        [Fact]
+        public void CacheEnforcementShouldAcceptPreviouslyBuiltReferences()
+        {
+            AssertBuild(new []{"BuildReference"},
+                (result, logger) =>
+                {
+                    result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+                    logger.Errors.ShouldBeEmpty();
+                },
+                buildReference: true);
+        }
+
+        private void AssertBuild(string[] targets, Action<BuildResult, MockLogger> assert, bool buildReference = false)
+        {
+            using (var env = TestEnvironment.Create())
+            using (var buildManager = new BuildManager())
+            {
+                var projectFile = env.CreateFile().Path;
+                var referenceFile = env.CreateFile().Path;
+
+                File.WriteAllText(projectFile, string.Format(_project, referenceFile));
+                File.WriteAllText(referenceFile, _reference);
+
+                var logger = new MockLogger(_testOutput);
+
+                var buildParameters = new BuildParameters
+                {
+                    IsolateProjects = true,
+                    Loggers = new ILogger[] {logger},
+                    EnableNodeReuse = false,
+                    DisableInProcNode = true
+                };
+
+                var rootRequest = new BuildRequestData(
+                    projectFile,
+                    new Dictionary<string, string>(),
+                    MSBuildConstants.CurrentToolsVersion,
+                    targets,
+                    null);
+
+                try
+                {
+                    buildManager.BeginBuild(buildParameters);
+
+                    if (buildReference)
+                    {
+                        buildManager.BuildRequest(
+                            new BuildRequestData(
+                                referenceFile,
+                                new Dictionary<string, string>(),
+                                MSBuildConstants.CurrentToolsVersion,
+                                new[] {"ReferenceTarget"},
+                                null))
+                            .OverallResult.ShouldBe(BuildResultCode.Success);
+                    }
+
+                    var result = buildManager.BuildRequest(rootRequest);
+
+                    assert(result, logger);
+                }
+                finally
+                {
+                    buildManager.EndBuild();
+                }
+            }
+        }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -850,13 +850,11 @@ namespace Microsoft.Build.Execution
                     }
 
                     // Submit the build request.
-                    BuildRequestBlocker blocker = new BuildRequestBlocker(-1, Array.Empty<string>(),
-                        new[] {submission.BuildRequest});
                     _workQueue.Post(() =>
                     {
                         try
                         {
-                            IssueRequestToScheduler(submission, allowMainThreadBuild, blocker);
+                            IssueBuildSubmissionToScheduler(submission, allowMainThreadBuild);
                         }
                         catch (BuildAbortedException bae)
                         {
@@ -1074,9 +1072,10 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// The submission is a top level build request entering the BuildManager.
         /// Sends the request to the scheduler with optional legacy threading semantics behavior.
         /// </summary>
-        private void IssueRequestToScheduler(BuildSubmission submission, bool allowMainThreadBuild, BuildRequestBlocker blocker)
+        private void IssueBuildSubmissionToScheduler(BuildSubmission submission, bool allowMainThreadBuild)
         {
             bool resetMainThreadOnFailure = false;
             try
@@ -1096,6 +1095,8 @@ namespace Microsoft.Build.Execution
                             _legacyThreadingData.MainThreadSubmissionId = submission.SubmissionId;
                         }
                     }
+
+                    BuildRequestBlocker blocker = new BuildRequestBlocker(-1, Array.Empty<string>(), new[] {submission.BuildRequest});
 
                     HandleNewRequest(Scheduler.VirtualNode, blocker);
                 }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -517,6 +517,12 @@ namespace Microsoft.Build.BackEnd
                                     {
                                         // We have a result, give it back to this request.
                                         currentEntry.ReportResult(cacheResponse.Results);
+
+                                        TraceEngine(
+                                            "Request {0} (node request {1}) with targets ({2}) satisfied from cache",
+                                            request.GlobalRequestId,
+                                            request.NodeRequestId,
+                                            string.Join(";", request.Targets));
                                     }
                                     else
                                     {
@@ -1150,6 +1156,12 @@ namespace Microsoft.Build.BackEnd
 
                             // Log the fact that we handled this from the cache.
                             _nodeLoggingContext.LogRequestHandledFromCache(newRequest, _configCache[newRequest.ConfigurationId], response.Results);
+
+                            TraceEngine(
+                                "Request {0} (node request {1}) with targets ({2}) satisfied from cache",
+                                newRequest.GlobalRequestId,
+                                newRequest.NodeRequestId,
+                                string.Join(",", request.Targets));
 
                             // Can't report the result directly here, because that could cause the request to go from
                             // Waiting to Ready.

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1357,6 +1357,8 @@ namespace Microsoft.Build.BackEnd
             {
                 lock (this)
                 {
+                    FileUtilities.EnsureDirectoryExists(_debugDumpPath);
+
                     using (StreamWriter file = FileUtilities.OpenWrite(String.Format(CultureInfo.CurrentCulture, Path.Combine(_debugDumpPath, @"EngineTrace_{0}.txt"), Process.GetCurrentProcess().Id), append: true))
                     {
                         string message = String.Format(CultureInfo.CurrentCulture, format, stuff);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1812,6 +1812,12 @@ namespace Microsoft.Build.BackEnd
             int nodeId = _schedulingData.GetAssignedNodeForRequestConfiguration(request.ConfigurationId);
             NodeLoggingContext nodeContext = new NodeLoggingContext(_componentHost.LoggingService, nodeId, true);
             nodeContext.LogRequestHandledFromCache(request, configuration, result);
+
+            TraceScheduler(
+                "Request {0} (node request {1}) with targets ({2}) satisfied from cache",
+                request.GlobalRequestId,
+                request.NodeRequestId,
+                string.Join(";", request.Targets));
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2213,6 +2213,8 @@ namespace Microsoft.Build.BackEnd
         {
             if (_debugDumpState)
             {
+                FileUtilities.EnsureDirectoryExists(_debugDumpPath);
+
                 StreamWriter file = FileUtilities.OpenWrite(String.Format(CultureInfo.CurrentCulture, Path.Combine(_debugDumpPath, "SchedulerTrace_{0}.txt"), Process.GetCurrentProcess().Id), append: true);
                 file.Write("{0}({1})-{2}: ", Thread.CurrentThread.Name, Thread.CurrentThread.ManagedThreadId, _schedulingData.EventTime.Ticks);
                 file.WriteLine(format, stuff);
@@ -2230,6 +2232,7 @@ namespace Microsoft.Build.BackEnd
             {
                 if (_schedulingData != null)
                 {
+                    FileUtilities.EnsureDirectoryExists(_debugDumpPath);
                     using (StreamWriter file = FileUtilities.OpenWrite(String.Format(CultureInfo.CurrentCulture, Path.Combine(_debugDumpPath, "SchedulerState_{0}.txt"), Process.GetCurrentProcess().Id), append: true))
                     {
                         file.WriteLine("Scheduler state at timestamp {0}:", _schedulingData.EventTime.Ticks);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2231,7 +2231,18 @@ namespace Microsoft.Build.BackEnd
 
                         foreach (int nodeId in _availableNodes.Keys)
                         {
-                            file.WriteLine("Node {0} {1} ({2} assigned requests, {3} configurations)", nodeId, _schedulingData.IsNodeWorking(nodeId) ? String.Format(CultureInfo.InvariantCulture, "Active ({0} executing)", _schedulingData.GetExecutingRequestByNode(nodeId).BuildRequest.GlobalRequestId) : "Idle", _schedulingData.GetScheduledRequestsCountByNode(nodeId), _schedulingData.GetConfigurationsCountByNode(nodeId, false, null));
+                            file.WriteLine(
+                                "Node {0} {1} ({2} assigned requests, {3} configurations)",
+                                nodeId,
+                                _schedulingData.IsNodeWorking(nodeId)
+                                    ? string.Format(
+                                        CultureInfo.InvariantCulture,
+                                        "Active ({0} executing)",
+                                        _schedulingData.GetExecutingRequestByNode(nodeId)
+                                            .BuildRequest.GlobalRequestId)
+                                    : "Idle",
+                                _schedulingData.GetScheduledRequestsCountByNode(nodeId),
+                                _schedulingData.GetConfigurationsCountByNode(nodeId, false, null));
 
                             List<SchedulableRequest> scheduledRequestsByNode = new List<SchedulableRequest>(_schedulingData.GetScheduledRequestsByNode(nodeId));
 
@@ -2407,7 +2418,21 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void DumpRequestSpec(StreamWriter file, SchedulableRequest request, int indent, string prefix)
         {
-            file.WriteLine("{0}{1}{2}: [{3}] {4}{5} ({6}){7} ({8})", new String(' ', indent * 2), (prefix == null) ? "" : prefix, request.BuildRequest.GlobalRequestId, _schedulingData.GetAssignedNodeForRequestConfiguration(request.BuildRequest.ConfigurationId), _schedulingData.IsRequestScheduled(request) ? "RUNNING " : "", request.State, request.BuildRequest.ConfigurationId, _configCache[request.BuildRequest.ConfigurationId].ProjectFullPath, String.Join(", ", request.BuildRequest.Targets.ToArray()));
+            var buildRequest = request.BuildRequest;
+
+            file.WriteLine(
+                "{0}{1}{2}: [{3}] {4}{5} ({6}){7} ({8})",
+                new string(' ', indent * 2),
+                prefix ?? "",
+                buildRequest.GlobalRequestId,
+                _schedulingData.GetAssignedNodeForRequestConfiguration(buildRequest.ConfigurationId),
+                _schedulingData.IsRequestScheduled(request)
+                    ? "RUNNING "
+                    : "",
+                request.State,
+                buildRequest.ConfigurationId,
+                _configCache[buildRequest.ConfigurationId].ProjectFullPath,
+                string.Join(", ", buildRequest.Targets.ToArray()));
         }
 
         /// <summary>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1714,13 +1714,20 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       request a target to build itself (perhaps via a chain of other targets)
     </comment>
   </data>
+  <data name="CacheMissesNotAllowedInIsolatedGraphBuilds" UESanitized="false" Visibility="Public">
+    <value>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</value>
+    <comment>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4252.
+        Next message code should be MSB4253.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Operaci nebylo možno dokončit, protože sestavení již probíhá.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Nejde rozbalit metadata ve výrazu {0}. {1}</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Der Vorgang kann nicht abgeschlossen werden, da bereits ein Buildvorgang stattfindet.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Metadaten können im Ausdruck "{0}" nicht erweitert werden. {1}</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -31,6 +31,14 @@
         <target state="new">The operation cannot be completed because a build is already in progress.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="new">MSB4248: Cannot expand metadata in expression "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -31,6 +31,14 @@
         <target state="translated">La operación no se puede completar porque ya hay una compilación en curso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: No se pueden expandir los metadatos en la expresión "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Impossible d'effectuer l'opération car une génération est déjà en cours.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Impossible d'étendre les métadonnées dans l'expression "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Non è possibile completare l'operazione perché è già in corso una compilazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: non è possibile espandere i metadati nell'espressione "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -31,6 +31,14 @@
         <target state="translated">ビルドは既に進行中であるため、操作を完了できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 式 "{0}" の中のメタデータを展開できません。 {1}</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -31,6 +31,14 @@
         <target state="translated">빌드가 이미 진행되고 있으므로 작업을 완료할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: "{0}" 식에서 메타데이터를 확장할 수 없습니다. {1}</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Nie można zakończyć tej operacji, ponieważ trwa kompilacja.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Nie można rozwinąć metadanych w wyrażeniu „{0}”. {1}</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -31,6 +31,14 @@
         <target state="translated">A operação não pode ser concluída porque uma compilação está em andamento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: Não é possível expandir os metadados na expressão "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Не удалось завершить операцию, так как уже выполняется сборка.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: невозможно развернуть метаданные в выражении "{0}". {1}</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -31,6 +31,14 @@
         <target state="translated">Bir oluşturma zaten devam ettiği için işlem tamamlanamıyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: "{0}" ifadesindeki meta veriler genişletilemiyor. {1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -31,6 +31,14 @@
         <target state="translated">无法完成此操作，因为已经在进行某个生成。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 无法在表达式“{0}”中展开元数据。{1}</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -31,6 +31,14 @@
         <target state="translated">無法完成作業，因為建置已經在進行中。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CacheMissesNotAllowedInIsolatedGraphBuilds">
+        <source>MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</source>
+        <target state="new">MSB4252: Project "{0}" has a reference to "{1}" ({2} target(s)) but the reference has not been previously built. In graph based builds this probably means that the reference is not explicitly specified as a ProjectReference item in "{0}".</target>
+        <note>
+      {StrBegin="MSB4252:"}
+      LOCALIZATION: Do not localize the following words: ProjectReference.
+    </note>
+      </trans-unit>
       <trans-unit id="CannotExpandItemMetadata">
         <source>MSB4248: Cannot expand metadata in expression "{0}". {1}</source>
         <target state="translated">MSB4248: 無法在運算式 "{0}" 中展開中繼資料。{1}</target>

--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -1333,6 +1333,14 @@ namespace Microsoft.Build.Shared
             return String.IsNullOrEmpty(directoryName) ? String.Empty : NormalizePath(directoryName, file);
         }
 
+        internal static void EnsureDirectoryExists(string directoryPath)
+        {
+            if (directoryPath != null && !DefaultFileSystem.DirectoryExists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+        }
+
         // Method is simple set of function calls and may inline;
         // we don't want it inlining into the tight loop that calls it as an exit case,
         // so mark as non-inlining

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -365,13 +365,17 @@ namespace Microsoft.Build.UnitTests
             AssertDictionaryInclusion(_initialEnvironment, environment, "added");
             AssertDictionaryInclusion(environment, _initialEnvironment, "removed");
 
-            // a includes b
-            void AssertDictionaryInclusion(IDictionary a, IDictionary b, string operation)
+            void AssertDictionaryInclusion(IDictionary superset, IDictionary subset, string operation)
             {
-                foreach (var key in b.Keys)
+                foreach (var key in subset.Keys)
                 {
-                    a.Contains(key).ShouldBe(true, $"environment variable {operation}: {key}");
-                    a[key].ShouldBe(b[key]);
+                    // workaround for https://github.com/Microsoft/msbuild/pull/3866
+                    // if the initial environment had empty keys, then MSBuild will accidentally remove them via Environment.SetEnvironmentVariable
+                    if (operation != "removed" || !string.IsNullOrEmpty((string) subset[key]))
+                    {
+                        superset.Contains(key).ShouldBe(true, $"environment variable {operation}: {key}");
+                        superset[key].ShouldBe(subset[key]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves #3686.

Finding the best spot to put the check was a bit interesting. The alternative I thought the most was to put the check in the cache itself, and then have the cache users specify whether they want enforcement or not for each cache lookup. Since performing the lookup and acting upon misses needs a lot of scheduler internal data, I decided to put everything in the Scheduler.

Another issue is how to actually stop the build from the Scheduler. The current solution returns a failed BuildResult to stop the build and then issues a separate error to have something appear to loggers. I can't find a good spot to have the failed build result automagically generate a build error in some of the more normal places (somewhere in ProjectBuilder / TargetBuilder / TaskBuilder so the error originates from within a project, like all other msbuild errors).