### PR TITLE
Fix graph build hang

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1288,6 +1288,9 @@ namespace Microsoft.Build.CommandLine
                             // An empty target list here means "no targets" instead of "default targets", so don't even build it.
                             finishedNodes.Add(node);
                             blockedNodes.Remove(node);
+
+                            waitHandle.Set();
+
                             continue;
                         }
 


### PR DESCRIPTION
The code skips a node when no targets are provided. This skipping though needs to set the event to make the loop going again.

Tests will come later.