### PR TITLE
[WIP] Do not set unchanged environment variables

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -131,4 +131,6 @@ finally {
   if ($prepareMachine) {
     Stop-Processes
   }
+
+  KillProcessesFromRepo
 }

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -21,6 +21,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Experimental.Graph;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.Debugging;
 using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
@@ -3242,6 +3243,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
 </Project>
 ");
+
+            _output.WriteLine(RepositoryInfo.Instance.ArtifactsLogDirectory);
 
             string fileName = _env.CreateFile(".proj").Path;
             File.WriteAllText(fileName, contents);

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1226,6 +1226,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void RestoreOperatingEnvironment()
         {
+            // logic cloned in Microsoft.Build.BackEnd.InProcNode.HandleShutdown
             if (_componentHost.BuildParameters.SaveOperatingEnvironment)
             {
                 ErrorUtilities.VerifyThrow(_requestEntry.RequestConfiguration.SavedCurrentDirectory != null, "Current directory not previously saved.");
@@ -1271,8 +1272,7 @@ namespace Microsoft.Build.BackEnd
                 // If the environment doesn't have the variable set, or if its value differs from what we have saved, set it
                 // to the saved value.  Doing the comparison before setting is faster than unconditionally setting it using
                 // the API.
-                string value;
-                if (!currentEnvironment.TryGetValue(entry.Key, out value) || !String.Equals(entry.Value, value, StringComparison.Ordinal))
+                if (!currentEnvironment.TryGetValue(entry.Key, out var currentValue) || !string.Equals(entry.Value, currentValue, StringComparison.Ordinal))
                 {
                     Environment.SetEnvironmentVariable(entry.Key, entry.Value);
                 }

--- a/src/Shared/Debugging/PrintLineDebugger.cs
+++ b/src/Shared/Debugging/PrintLineDebugger.cs
@@ -97,6 +97,30 @@ namespace Microsoft.Build.Shared.Debugging
             }
         }
 
+        public static PrintLineDebugger CreateWithFallBackWriter(
+            CommonWriterType fallBackWriter,
+            string id = null,
+            bool prependProcessInfo = false)
+        {
+            fallBackWriter = GetStaticWriter() == null
+                ? fallBackWriter
+                : null;
+
+            return Create(fallBackWriter, id, prependProcessInfo);
+        }
+
+        public static PrintLineDebugger Create(
+            CommonWriterType writer = null,
+            string id = null,
+            bool prependProcessInfo = false)
+        {
+            return new PrintLineDebugger(
+                prependProcessInfo
+                    ? $"{ProcessInfo}_{id}"
+                    : id,
+                writer);
+        }
+
         public void Dispose()
         {
             ReleaseUnmanagedResources();
@@ -142,18 +166,6 @@ namespace Microsoft.Build.Shared.Debugging
             }
 
             CommonWriterProperty.Value.SetValue(null, null);
-        }
-
-        public static PrintLineDebugger Create(
-            CommonWriterType writer = null,
-            string id = null,
-            bool prependProcessInfo = false)
-        {
-            return new PrintLineDebugger(
-                prependProcessInfo
-                    ? $"{ProcessInfo}_{id}"
-                    : id,
-                writer);
         }
 
         public CommonWriterType GetWriter()

--- a/src/Shared/Debugging/PrintLineDebuggerWriters.cs
+++ b/src/Shared/Debugging/PrintLineDebuggerWriters.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Shared.Debugging
 
             public static IdBasedFilesWriter FromArtifactLogDirectory()
             {
-                return new IdBasedFilesWriter(ArtifactsLogDirectory);
+                return new IdBasedFilesWriter(RepositoryInfo.Instance.ArtifactsLogDirectory);
             }
         }
 
@@ -65,23 +65,6 @@ namespace Microsoft.Build.Shared.Debugging
         }
 
         public static CommonWriterType StdOutWriter = (id, callsite, args) => Console.WriteLine(SimpleFormat(id, callsite, args));
-
-        private static Lazy<string> _artifactsLogs = new Lazy<string>(
-            () =>
-            {
-                var executingAssembly = FileUtilities.ExecutingAssemblyPath;
-
-                var binPart = $"bin";
-
-                var logIndex = executingAssembly.IndexOf(binPart, StringComparison.Ordinal);
-
-                var artifactsPart = executingAssembly.Substring(0, logIndex);
-                return logIndex < 0
-                    ? null
-                    : Path.Combine(artifactsPart, "log", "Debug");
-            });
-
-        public static string ArtifactsLogDirectory => _artifactsLogs.Value;
 
         public static string SimpleFormat(string id, string callsite, IEnumerable<string> args)
         {

--- a/src/Shared/Debugging/RepositoryInfo.cs
+++ b/src/Shared/Debugging/RepositoryInfo.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Build.Shared.Debugging
+{
+    internal class RepositoryInfo
+    {
+        public static RepositoryInfo Instance = new RepositoryInfo();
+
+        public string ArtifactsLogDirectory => _artifactsLogs.Value;
+
+        public string Configuration { get; } =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+
+        private RepositoryInfo()
+        {
+            _artifactsLogs = new Lazy<string>(ComputeArtifactsLogs);
+        }
+
+        private readonly Lazy<string> _artifactsLogs;
+
+        private string ComputeArtifactsLogs()
+        {
+            var searchPathStrategies = new Func<string>[]
+            {
+                TryFromCurrentAssembly,
+                TryFromAzureCI
+            };
+
+
+            return searchPathStrategies.Select(searchPathStrategy => searchPathStrategy.Invoke()).FirstOrDefault(path => path != null);
+        }
+
+        private string TryFromCurrentAssembly()
+        {
+            var executingAssembly = FileUtilities.ExecutingAssemblyPath;
+
+            var binPart = $"bin";
+
+            var logIndex = executingAssembly.IndexOf(binPart, StringComparison.Ordinal);
+
+            if (logIndex < 0)
+            {
+                return null;
+            }
+
+            var artifactsPart = executingAssembly.Substring(0, logIndex);
+
+            var path = Path.Combine(
+                artifactsPart,
+                "log",
+                Configuration
+                );
+
+            ErrorUtilities.VerifyThrowDirectoryExists(path);
+
+            return path;
+        }
+
+        private string TryFromAzureCI()
+        {
+            var repositoryPathInAzure = Environment.GetEnvironmentVariable("Build_Repository_LocalPath");
+
+            if (repositoryPathInAzure == null)
+            {
+                return null;
+            }
+
+            var path = Path.Combine(repositoryPathInAzure, "artifacts", "logs", ArtifactsLogDirectory);
+
+            ErrorUtilities.VerifyThrowDirectoryExists(path);
+
+            return path;
+        }
+    }
+}

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.Build.Shared.FileSystem;
 
 #if BUILDINGAPPXTASKS
 namespace Microsoft.Build.AppxPackage.Shared
@@ -98,6 +99,16 @@ namespace Microsoft.Build.Shared
                 ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
             }
 #endif
+        }
+
+        public static void VerifyThrowDirectoryExists(string path, string message = null)
+        {
+            VerifyThrowArgumentNull(path, nameof(path));
+
+            if (!FileSystems.Default.DirectoryExists(path))
+            {
+                ThrowInternalError(message ?? $"Directory expected to exist: {path}");
+            }
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -402,13 +402,8 @@ namespace Microsoft.Build.UnitTests
             {
                 foreach (var key in subset.Keys)
                 {
-                    // workaround for https://github.com/Microsoft/msbuild/pull/3866
-                    // if the initial environment had empty keys, then MSBuild will accidentally remove them via Environment.SetEnvironmentVariable
-                    if (operation != "removed" || !string.IsNullOrEmpty((string) subset[key]))
-                    {
-                        superset.Contains(key).ShouldBe(true, $"environment variable {operation}: {key}");
-                        superset[key].ShouldBe(subset[key]);
-                    }
+                    superset.Contains(key).ShouldBe(true, $"environment variable {operation}: {key}");
+                    superset[key].ShouldBe(subset[key]);
                 }
             }
         }


### PR DESCRIPTION
In #3854 this change was causing test `Regress265010 ` to fail with `Shouldly.ShouldAssertException : False\n should be\nTrue\n but was not\n\nAdditional Info:\n environment variable removed: BUILD_REQUESTEDFOREMAIL`

This is now passing due to a workaround in the TestEnvironment: https://github.com/Microsoft/msbuild/blob/exp/net472/src/Shared/UnitTests/TestEnvironment.cs#L372-L374
