### PR TITLE
Move graph build logic to the BuildManager

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -926,13 +926,16 @@ namespace Microsoft.Build.Execution
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildResult BuildRequest(Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public void CancelAllSubmissions() { }
         public void Dispose() { }
         public void EndBuild() { }
         ~BuildManager() { }
         public Microsoft.Build.Execution.ProjectInstance GetProjectInstanceForBuild(Microsoft.Build.Evaluation.Project project) { throw null; }
         public Microsoft.Build.Execution.BuildSubmission PendBuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildSubmission PendBuildRequest(Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public void ResetCaches() { }
         public void ShutdownAllNodes() { }
     }
@@ -1042,6 +1045,48 @@ namespace Microsoft.Build.Execution
         public void ExecuteAsync(Microsoft.Build.Execution.BuildSubmissionCompleteCallback callback, object context) { }
     }
     public delegate void BuildSubmissionCompleteCallback(Microsoft.Build.Execution.BuildSubmission submission);
+    public sealed partial class GraphBuildRequestData
+    {
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public Microsoft.Build.Execution.BuildRequestDataFlags Flags { get { throw null; } }
+        public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } }
+        public Microsoft.Build.Graph.ProjectGraph ProjectGraph { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> ProjectGraphEntryPoints { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> TargetNames { get { throw null; } }
+    }
+    public sealed partial class GraphBuildResult
+    {
+        internal GraphBuildResult() { }
+        public bool CircularDependency { get { throw null; } }
+        public System.Exception Exception { get { throw null; } }
+        public Microsoft.Build.Execution.BuildResult this[Microsoft.Build.Graph.ProjectGraphNode node] { get { throw null; } }
+        public Microsoft.Build.Execution.BuildResultCode OverallResult { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, Microsoft.Build.Execution.BuildResult> ResultsByNode { get { throw null; } }
+        public int SubmissionId { get { throw null; } }
+    }
+    public partial class GraphBuildSubmission
+    {
+        internal GraphBuildSubmission() { }
+        public object AsyncContext { get { throw null; } }
+        public Microsoft.Build.Execution.BuildManager BuildManager { get { throw null; } }
+        public Microsoft.Build.Execution.GraphBuildResult BuildResult { get { throw null; } }
+        public bool IsCompleted { get { throw null; } }
+        public int SubmissionId { get { throw null; } }
+        public System.Threading.WaitHandle WaitHandle { get { throw null; } }
+        public Microsoft.Build.Execution.GraphBuildResult Execute() { throw null; }
+        public void ExecuteAsync(Microsoft.Build.Execution.GraphBuildSubmissionCompleteCallback callback, object context) { }
+    }
+    public delegate void GraphBuildSubmissionCompleteCallback(Microsoft.Build.Execution.GraphBuildSubmission submission);
     public partial class HostServices
     {
         public HostServices() { }
@@ -1427,7 +1472,7 @@ namespace Microsoft.Build.Graph
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(string[] entryProjectTargets) { throw null; }
+        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(System.Collections.Generic.ICollection<string> entryProjectTargets) { throw null; }
         public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -922,13 +922,16 @@ namespace Microsoft.Build.Execution
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildResult BuildRequest(Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public void CancelAllSubmissions() { }
         public void Dispose() { }
         public void EndBuild() { }
         ~BuildManager() { }
         public Microsoft.Build.Execution.ProjectInstance GetProjectInstanceForBuild(Microsoft.Build.Evaluation.Project project) { throw null; }
         public Microsoft.Build.Execution.BuildSubmission PendBuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
+        public Microsoft.Build.Execution.GraphBuildSubmission PendBuildRequest(Microsoft.Build.Execution.GraphBuildRequestData requestData) { throw null; }
         public void ResetCaches() { }
         public void ShutdownAllNodes() { }
     }
@@ -1037,6 +1040,48 @@ namespace Microsoft.Build.Execution
         public void ExecuteAsync(Microsoft.Build.Execution.BuildSubmissionCompleteCallback callback, object context) { }
     }
     public delegate void BuildSubmissionCompleteCallback(Microsoft.Build.Execution.BuildSubmission submission);
+    public sealed partial class GraphBuildRequestData
+    {
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraph projectGraph, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(Microsoft.Build.Graph.ProjectGraphEntryPoint projectGraphEntryPoint, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> projectGraphEntryPoints, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public GraphBuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices) { }
+        public GraphBuildRequestData(string projectFullPath, System.Collections.Generic.IDictionary<string, string> globalProperties, System.Collections.Generic.ICollection<string> targetsToBuild, Microsoft.Build.Execution.HostServices hostServices, Microsoft.Build.Execution.BuildRequestDataFlags flags) { }
+        public Microsoft.Build.Execution.BuildRequestDataFlags Flags { get { throw null; } }
+        public Microsoft.Build.Execution.HostServices HostServices { get { throw null; } }
+        public Microsoft.Build.Graph.ProjectGraph ProjectGraph { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<Microsoft.Build.Graph.ProjectGraphEntryPoint> ProjectGraphEntryPoints { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> TargetNames { get { throw null; } }
+    }
+    public sealed partial class GraphBuildResult
+    {
+        internal GraphBuildResult() { }
+        public bool CircularDependency { get { throw null; } }
+        public System.Exception Exception { get { throw null; } }
+        public Microsoft.Build.Execution.BuildResult this[Microsoft.Build.Graph.ProjectGraphNode node] { get { throw null; } }
+        public Microsoft.Build.Execution.BuildResultCode OverallResult { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, Microsoft.Build.Execution.BuildResult> ResultsByNode { get { throw null; } }
+        public int SubmissionId { get { throw null; } }
+    }
+    public partial class GraphBuildSubmission
+    {
+        internal GraphBuildSubmission() { }
+        public object AsyncContext { get { throw null; } }
+        public Microsoft.Build.Execution.BuildManager BuildManager { get { throw null; } }
+        public Microsoft.Build.Execution.GraphBuildResult BuildResult { get { throw null; } }
+        public bool IsCompleted { get { throw null; } }
+        public int SubmissionId { get { throw null; } }
+        public System.Threading.WaitHandle WaitHandle { get { throw null; } }
+        public Microsoft.Build.Execution.GraphBuildResult Execute() { throw null; }
+        public void ExecuteAsync(Microsoft.Build.Execution.GraphBuildSubmissionCompleteCallback callback, object context) { }
+    }
+    public delegate void GraphBuildSubmissionCompleteCallback(Microsoft.Build.Execution.GraphBuildSubmission submission);
     public partial class HostServices
     {
         public HostServices() { }
@@ -1422,7 +1467,7 @@ namespace Microsoft.Build.Graph
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(string[] entryProjectTargets) { throw null; }
+        public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(System.Collections.Generic.ICollection<string> entryProjectTargets) { throw null; }
         public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }
     [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -18,6 +18,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
@@ -133,6 +134,43 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.True(properties.TryGetValue("InitialProperty3", out propertyValue));
             Assert.True(String.Equals(propertyValue, "InitialProperty3", StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// A simple successful graph build.
+        /// </summary>
+        [Fact]
+        public void SimpleGraphBuild()
+        {
+            string contents = CleanupFileContents(@"
+<Project xmlns='msbuildnamespace' ToolsVersion='msbuilddefaulttoolsversion'>
+<PropertyGroup>
+       <InitialProperty1>InitialProperty1</InitialProperty1>
+       <InitialProperty2>InitialProperty2</InitialProperty2>
+       <InitialProperty3>InitialProperty3</InitialProperty3>
+</PropertyGroup>
+ <Target Name='test'>
+    <Message Text='[success]'/>
+ </Target>
+</Project>
+");
+            GraphBuildRequestData data = GetGraphBuildRequestData(contents);
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+            _logger.AssertLogContains("[success]");
+            _logger.ProjectStartedEvents.Count.ShouldBe(1);
+
+            ProjectStartedEventArgs projectStartedEvent = _logger.ProjectStartedEvents[0];
+            Dictionary<string, string> properties = ExtractProjectStartedPropertyList(projectStartedEvent.Properties);
+
+            properties.TryGetValue("InitialProperty1", out string propertyValue).ShouldBeTrue();
+            propertyValue.ShouldBe("InitialProperty1", StringCompareShould.IgnoreCase);
+
+            properties.TryGetValue("InitialProperty2", out propertyValue).ShouldBeTrue();
+            propertyValue.ShouldBe("InitialProperty2", StringCompareShould.IgnoreCase);
+
+            properties.TryGetValue("InitialProperty3", out propertyValue).ShouldBeTrue();
+            propertyValue.ShouldBe("InitialProperty3", StringCompareShould.IgnoreCase);
         }
 
 #if FEATURE_CODETASKFACTORY
@@ -907,25 +945,38 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void BuildRequestWithoutBegin()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-                {
-                    BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
-                    _buildManager.BuildRequest(data);
-                }
-           );
+            BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
+            Should.Throw<InvalidOperationException>(() => _buildManager.BuildRequest(data));
         }
+
+        /// <summary>
+        /// Submitting a synchronous graph build request before calling BeginBuild yields an InvalidOperationException.
+        /// </summary>
+        [Fact]
+        public void GraphBuildRequestWithoutBegin()
+        {
+            GraphBuildRequestData data = new GraphBuildRequestData("foo", new Dictionary<string, string>(), new string[0], null);
+            Should.Throw<InvalidOperationException>(() => _buildManager.BuildRequest(data));
+        }
+
         /// <summary>
         /// Pending a build request before calling BeginBuild yields an InvalidOperationException.
         /// </summary>
         [Fact]
         public void PendBuildRequestWithoutBegin()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-                {
-                    BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
-                    _buildManager.PendBuildRequest(data);
-                }
-           );
+            BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
+            Should.Throw<InvalidOperationException>(() => _buildManager.PendBuildRequest(data));
+        }
+
+        /// <summary>
+        /// Pending a build request before calling BeginBuild yields an InvalidOperationException.
+        /// </summary>
+        [Fact]
+        public void PendGraphBuildRequestWithoutBegin()
+        {
+            GraphBuildRequestData data = new GraphBuildRequestData("foo", new Dictionary<string, string>(), new string[0], null);
+            Should.Throw<InvalidOperationException>(() => _buildManager.PendBuildRequest(data));
         }
 
         /// <summary>
@@ -1002,29 +1053,36 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void ExtraEnds()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                _buildManager.BeginBuild(new BuildParameters());
-                _buildManager.EndBuild();
-                _buildManager.EndBuild();
-            }
-           );
+            _buildManager.BeginBuild(new BuildParameters());
+            _buildManager.EndBuild();
+
+            Assert.Throws<InvalidOperationException>(() => _buildManager.EndBuild());
         }
+
         /// <summary>
         /// Pending a request after EndBuild has been called yields an InvalidOperationException.
         /// </summary>
         [Fact]
         public void PendBuildRequestAfterEnd()
         {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
-                _buildManager.BeginBuild(new BuildParameters());
-                _buildManager.EndBuild();
+            BuildRequestData data = new BuildRequestData("foo", new Dictionary<string, string>(), "2.0", new string[0], null);
+            _buildManager.BeginBuild(new BuildParameters());
+            _buildManager.EndBuild();
 
-                _buildManager.PendBuildRequest(data);
-            }
-           );
+            Should.Throw<InvalidOperationException>(() => _buildManager.PendBuildRequest(data));
+        }
+
+        /// <summary>
+        /// Pending a request after EndBuild has been called yields an InvalidOperationException.
+        /// </summary>
+        [Fact]
+        public void PendGraphBuildRequestAfterEnd()
+        {
+            GraphBuildRequestData data = new GraphBuildRequestData("foo", new Dictionary<string, string>(), new string[0], null);
+            _buildManager.BeginBuild(new BuildParameters());
+            _buildManager.EndBuild();
+
+            Should.Throw<InvalidOperationException>(() => _buildManager.PendBuildRequest(data));
         }
 
         /// <summary>
@@ -3292,22 +3350,24 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// Retrieves a BuildRequestData using the specified contents, default targets and an empty project collection.
         /// </summary>
-        private BuildRequestData GetBuildRequestData(string projectContents)
-        {
-            return GetBuildRequestData(projectContents, new string[] { });
-        }
+        private BuildRequestData GetBuildRequestData(string projectContents) => GetBuildRequestData(projectContents, Array.Empty<string>());
+
+        /// <summary>
+        /// Retrieves a GraphBuildRequestData using the specified contents, default targets and an empty project collection.
+        /// </summary>
+        private GraphBuildRequestData GetGraphBuildRequestData(string projectContents) => GetGraphBuildRequestData(projectContents, Array.Empty<string>());
 
         /// <summary>
         /// Retrieves a BuildRequestData using the specified contents, targets and project collection.
         /// </summary>
         private BuildRequestData GetBuildRequestData(string projectContents, string[] targets, string toolsVersion = null)
-        {
-            var data = new BuildRequestData(
-                CreateProjectInstance(projectContents, toolsVersion, _projectCollection, true), targets,
-                _projectCollection.HostServices);
+            => new BuildRequestData(CreateProjectInstance(projectContents, toolsVersion, _projectCollection, true), targets, _projectCollection.HostServices);
 
-            return data;
-        }
+        /// <summary>
+        /// Retrieves a GraphBuildRequestData using the specified contents, targets and project collection.
+        /// </summary>
+        private GraphBuildRequestData GetGraphBuildRequestData(string projectContents, string[] targets)
+            => new GraphBuildRequestData(CreateProjectGraph(projectContents, _projectCollection), targets, _projectCollection.HostServices);
 
         /// <summary>
         /// Retrieve a ProjectInstance evaluated with the specified contents using the specified projectCollection
@@ -3316,6 +3376,17 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Project project = CreateProject(contents, toolsVersion, projectCollection, deleteTempProject);
             return project.CreateProjectInstance();
+        }
+
+        /// <summary>
+        /// Retrieve a CreateProjectGraph evaluated with the specified contents using the specified projectCollection
+        /// </summary>
+        private ProjectGraph CreateProjectGraph(string contents, ProjectCollection projectCollection)
+        {
+            var projectFilePath = _env.CreateFile().Path;
+            File.WriteAllText(projectFilePath, contents);
+
+            return new ProjectGraph(projectFilePath, projectCollection);
         }
 
         /// <summary>
@@ -3877,6 +3948,155 @@ $@"<Project InitialTargets=`Sleep`>
                     manager.Dispose();
                 }
             }
+        }
+
+        [Fact]
+        public void GraphBuildValid()
+        {
+            string project1 = _env.CreateFile(".proj").Path;
+            string project2 = _env.CreateFile(".proj").Path;
+
+            File.WriteAllText(project1, CleanupFileContents($@"
+<Project>
+  <ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReference Include='{project2}' />
+  </ItemGroup>
+  <Target Name='Build'>
+    <MsBuild Projects='{project2}' Targets='Build' />
+  </Target>
+</Project>
+"));
+            File.WriteAllText(project2, CleanupFileContents(@"
+<Project>
+  <Target Name='Build' />
+</Project>
+"));
+
+            var graph = new ProjectGraph(project1);
+            graph.ProjectNodes.Count.ShouldBe(2);
+
+            var data = new GraphBuildRequestData(graph, Array.Empty<string>());
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+            var node1 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
+            result.ResultsByNode.ContainsKey(node1).ShouldBeTrue();
+            result.ResultsByNode[node1].OverallResult.ShouldBe(BuildResultCode.Success);
+
+            var node2 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
+            result.ResultsByNode.ContainsKey(node2).ShouldBeTrue();
+            result.ResultsByNode[node2].OverallResult.ShouldBe(BuildResultCode.Success);
+        }
+
+        [Fact]
+        public void GraphBuildInvalid()
+        {
+            string project1 = _env.CreateFile(".proj").Path;
+            string project2 = _env.CreateFile(".proj").Path;
+
+            File.WriteAllText(project1, CleanupFileContents($@"
+<Project>
+  <ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReference Include='{project2}' />
+  </ItemGroup>
+  <Target Name='Build'>
+    <MsBuild Projects='{project2}' Targets='Build' />
+  </Target>
+</Project>
+"));
+            File.WriteAllText(project2, CleanupFileContents(@"
+<Project>
+  <WellThisIsntValid>
+</Project>
+"));
+
+            var data = new GraphBuildRequestData(new ProjectGraphEntryPoint(project1), Array.Empty<string>());
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+            result.Exception.ShouldBeOfType<AggregateException>().InnerExceptions.Count.ShouldBe(1);
+            result.Exception.ShouldBeOfType<AggregateException>().InnerExceptions[0].ShouldBeOfType<InvalidProjectFileException>().ProjectFile.ShouldBe(project2);
+        }
+
+        [Fact]
+        public void GraphBuildFail()
+        {
+            string project1 = _env.CreateFile(".proj").Path;
+            string project2 = _env.CreateFile(".proj").Path;
+
+            File.WriteAllText(project1, CleanupFileContents($@"
+<Project>
+  <ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReference Include='{project2}' />
+  </ItemGroup>
+  <Target Name='Build'>
+    <MsBuild Projects='{project2}' Targets='Build' />
+  </Target>
+</Project>
+"));
+            File.WriteAllText(project2, CleanupFileContents(@"
+<Project>
+  <Target Name='Build'>
+    <Error Text='Fail!'/>
+  </Target>
+</Project>
+"));
+
+            var graph = new ProjectGraph(project1);
+            graph.ProjectNodes.Count.ShouldBe(2);
+
+            var data = new GraphBuildRequestData(graph, Array.Empty<string>());
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+
+            var node1 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project1, StringComparison.OrdinalIgnoreCase));
+            result.ResultsByNode.ContainsKey(node1).ShouldBeTrue();
+            result.ResultsByNode[node1].OverallResult.ShouldBe(BuildResultCode.Failure);
+
+            var node2 = graph.ProjectNodes.First(node => node.ProjectInstance.FullPath.Equals(project2, StringComparison.OrdinalIgnoreCase));
+            result.ResultsByNode.ContainsKey(node2).ShouldBeTrue();
+            result.ResultsByNode[node2].OverallResult.ShouldBe(BuildResultCode.Failure);
+        }
+
+        [Fact]
+        public void GraphBuildCircular()
+        {
+            string project1 = _env.CreateFile(".proj").Path;
+            string project2 = _env.CreateFile(".proj").Path;
+
+            File.WriteAllText(project1, CleanupFileContents($@"
+<Project>
+  <ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReference Include='{project2}' />
+  </ItemGroup>
+  <Target Name='Build'>
+    <MsBuild Projects='{project2}' Targets='Build' />
+  </Target>
+</Project>
+"));
+            File.WriteAllText(project2, CleanupFileContents($@"
+<Project>
+  <ItemGroup>
+    <ProjectReferenceTargets Include='Build' Targets='Build' />
+    <ProjectReference Include='{project1}' />
+  </ItemGroup>
+  <Target Name='Build'>
+    <MsBuild Projects='{project1}' Targets='Build' />
+  </Target>
+</Project>
+"));
+
+            var data = new GraphBuildRequestData(new ProjectGraphEntryPoint(project1), Array.Empty<string>());
+
+            GraphBuildResult result = _buildManager.Build(_parameters, data);
+            result.OverallResult.ShouldBe(BuildResultCode.Failure);
+            result.CircularDependency.ShouldBeTrue();
         }
     }
 }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -10,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
@@ -17,6 +20,7 @@ using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Logging;
 using Microsoft.Build.Shared;
@@ -137,6 +141,14 @@ namespace Microsoft.Build.Execution
         private readonly Dictionary<int, BuildSubmission> _buildSubmissions;
 
         /// <summary>
+        /// The current pending and active graph build submissions.
+        /// </summary>
+        /// <remarks>
+        /// { submissionId, GraphBuildSubmission }
+        /// </remarks>
+        private readonly Dictionary<int, GraphBuildSubmission> _graphBuildSubmissions;
+
+        /// <summary>
         /// Event signalled when all build submissions are complete.
         /// </summary>
         private AutoResetEvent _noActiveSubmissionsEvent;
@@ -204,6 +216,11 @@ namespace Microsoft.Build.Execution
         private ActionBlock<Action> _workQueue;
 
         /// <summary>
+        /// A cancellation token source used to cancel graph build scheduling
+        /// </summary>
+        private CancellationTokenSource _graphSchedulingCancellationSource;
+
+        /// <summary>
         /// Flag indicating we have disposed.
         /// </summary>
         private bool _disposed;
@@ -241,6 +258,7 @@ namespace Microsoft.Build.Execution
             _hostName = hostName;
             _buildManagerState = BuildManagerState.Idle;
             _buildSubmissions = new Dictionary<int, BuildSubmission>();
+            _graphBuildSubmissions = new Dictionary<int, GraphBuildSubmission>();
             _noActiveSubmissionsEvent = new AutoResetEvent(true);
             _activeNodes = new HashSet<NGen<int>>();
             _noNodesActiveEvent = new AutoResetEvent(true);
@@ -278,7 +296,7 @@ namespace Microsoft.Build.Execution
 
             /// <summary>
             /// This is the state the BuildManager is in after <see cref="BuildManager.BeginBuild"/> has been called but before <see cref="BuildManager.EndBuild"/> has been called.
-            /// <see cref="BuildManager.PendBuildRequest"/>, <see cref="BuildManager.BuildRequest"/> and <see cref="BuildManager.EndBuild"/> may be called in this state.
+            /// <see cref="BuildManager.PendBuildRequest(Microsoft.Build.Execution.BuildRequestData)"/>, <see cref="BuildManager.BuildRequest(Microsoft.Build.Execution.BuildRequestData)"/>, <see cref="BuildManager.PendBuildRequest(Microsoft.Build.Execution.GraphBuildRequestData)"/>, <see cref="BuildManager.BuildRequest(Microsoft.Build.Execution.GraphBuildRequestData)"/>, and <see cref="BuildManager.EndBuild"/> may be called in this state.
             /// </summary>
             Building,
 
@@ -473,6 +491,14 @@ namespace Microsoft.Build.Execution
                         }
                     }
 
+                    foreach (GraphBuildSubmission submission in _graphBuildSubmissions.Values)
+                    {
+                        if (submission.IsStarted)
+                        {
+                            submission.CompleteResults(new GraphBuildResult(submission.SubmissionId, new BuildAbortedException()));
+                        }
+                    }
+
                     ShutdownConnectedNodesAsync(true /* abort */);
                     CheckForActiveNodesAndCleanUpSubmissions();
                 }
@@ -544,6 +570,27 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Submits a graph build request to the current build but does not start it immediately.  Allows the user to
+        /// perform asynchronous execution or access the submission ID prior to executing the request.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if StartBuild has not been called or if EndBuild has been called.</exception>
+        public GraphBuildSubmission PendBuildRequest(GraphBuildRequestData requestData)
+        {
+            lock (_syncLock)
+            {
+                ErrorUtilities.VerifyThrowArgumentNull(requestData, nameof(requestData));
+                ErrorIfState(BuildManagerState.WaitingForBuildToComplete, "WaitingForEndOfBuild");
+                ErrorIfState(BuildManagerState.Idle, "NoBuildInProgress");
+                VerifyStateInternal(BuildManagerState.Building);
+
+                var newSubmission = new GraphBuildSubmission(this, GetNextSubmissionId(), requestData);
+                _graphBuildSubmissions.Add(newSubmission.SubmissionId, newSubmission);
+                _noActiveSubmissionsEvent.Reset();
+                return newSubmission;
+            }
+        }
+
+        /// <summary>
         /// Convenience method. Submits a build request and blocks until the results are available.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if StartBuild has not been called or if EndBuild has been called.</exception>
@@ -556,6 +603,12 @@ namespace Microsoft.Build.Execution
 
             return result;
         }
+
+        /// <summary>
+        /// Convenience method. Submits a graph build request and blocks until the results are available.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if StartBuild has not been called or if EndBuild has been called.</exception>
+        public GraphBuildResult BuildRequest(GraphBuildRequestData requestData) => PendBuildRequest(requestData).Execute();
 
         /// <summary>
         /// Signals that no more build requests are expected (or allowed) and the BuildManager may clean up.
@@ -579,6 +632,12 @@ namespace Microsoft.Build.Execution
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
 
+                var graphSubmissionsToCheck = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
+                foreach (GraphBuildSubmission submission in graphSubmissionsToCheck)
+                {
+                    CheckSubmissionCompletenessAndRemove(submission);
+                }
+
                 _buildManagerState = BuildManagerState.WaitingForBuildToComplete;
             }
 
@@ -595,7 +654,10 @@ namespace Microsoft.Build.Execution
                 // OnThreadException method in this class already.
                 _workQueue.Complete();
 
-                ErrorUtilities.VerifyThrow(_buildSubmissions.Count == 0, "All submissions not yet complete.");
+                // Stop the graph scheduling thread(s)
+                _graphSchedulingCancellationSource?.Cancel();
+
+                ErrorUtilities.VerifyThrow(_buildSubmissions.Count == 0 && _graphBuildSubmissions.Count == 0, "All submissions not yet complete.");
                 ErrorUtilities.VerifyThrow(_activeNodes.Count == 0, "All nodes not yet shut down.");
 
                 if (loggingService != null)
@@ -671,6 +733,31 @@ namespace Microsoft.Build.Execution
         public BuildResult Build(BuildParameters parameters, BuildRequestData requestData)
         {
             BuildResult result;
+            BeginBuild(parameters);
+            try
+            {
+                result = BuildRequest(requestData);
+                if (result.Exception == null && _threadException != null)
+                {
+                    result.Exception = _threadException;
+                    _threadException = null;
+                }
+            }
+            finally
+            {
+                EndBuild();
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Convenience method.  Submits a lone graph build request and blocks until results are available.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if a build is already in progress.</exception>
+        public GraphBuildResult Build(BuildParameters parameters, GraphBuildRequestData requestData)
+        {
+            GraphBuildResult result;
             BeginBuild(parameters);
             try
             {
@@ -864,24 +951,67 @@ namespace Microsoft.Build.Execution
                             submission.CompleteLogging(true);
                             CheckSubmissionCompletenessAndRemove(submission);
                         }
-                        catch (Exception ex)
+                        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
                         {
-                            if (ExceptionHandling.IsCriticalException(ex))
-                            {
-                                throw;
-                            }
-
                             HandleExecuteSubmissionException(submission, ex);
                         }
                     });
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
                 {
-                    if (ExceptionHandling.IsCriticalException(ex))
+                    HandleExecuteSubmissionException(submission, ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// This method adds the graph build request in the specified submission to the set of requests being handled by the scheduler.
+        /// </summary>
+        internal void ExecuteSubmission(GraphBuildSubmission submission)
+        {
+            lock (_syncLock)
+            {
+                VerifyStateInternal(BuildManagerState.Building);
+
+                try
+                {
+                    submission.IsStarted = true;
+
+                    if (_shuttingDown)
                     {
-                        throw;
+                        // We were already canceled!
+                        var result = new GraphBuildResult(submission.SubmissionId, new BuildAbortedException());
+                        submission.CompleteResults(result);
+                        CheckSubmissionCompletenessAndRemove(submission);
+                        return;
                     }
 
+                    // Lazily create a cancellation token source to be used for all graph scheduling tasks running from this build manager.
+                    if (_graphSchedulingCancellationSource == null)
+                    {
+                        _graphSchedulingCancellationSource = new CancellationTokenSource();
+                    }
+
+                    // Do the scheduling in a separate thread to unblock the calling thread
+                    Task.Factory.StartNew(
+                        () =>
+                        {
+                            try
+                            {
+                                ExecuteGraphBuildScheduler(submission);
+                            }
+                            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                            {
+                                HandleExecuteSubmissionException(submission, ex);
+                            }
+                        },
+                        _graphSchedulingCancellationSource.Token,
+                        TaskCreationOptions.LongRunning,
+                        TaskScheduler.Default);
+                }
+                catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+                {
                     HandleExecuteSubmissionException(submission, ex);
                     throw;
                 }
@@ -1072,6 +1202,30 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Deals with exceptions that may be thrown as a result of ExecuteSubmission.
+        /// </summary>
+        private void HandleExecuteSubmissionException(GraphBuildSubmission submission, Exception ex)
+        {
+            if (ex is InvalidProjectFileException projectException)
+            {
+                if (projectException.HasBeenLogged != true)
+                {
+                    BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                    ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(buildEventContext, projectException);
+                    projectException.HasBeenLogged = true;
+                }
+            }
+
+            if (submission.IsStarted)
+            {
+                submission.CompleteResults(new GraphBuildResult(submission.SubmissionId, ex));
+            }
+
+            _overallBuildSuccess = false;
+            CheckSubmissionCompletenessAndRemove(submission);
+        }
+
+        /// <summary>
         /// The submission is a top level build request entering the BuildManager.
         /// Sends the request to the scheduler with optional legacy threading semantics behavior.
         /// </summary>
@@ -1101,13 +1255,8 @@ namespace Microsoft.Build.Execution
                     HandleNewRequest(Scheduler.VirtualNode, blocker);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
             {
-                if (ExceptionHandling.IsCriticalException(ex))
-                {
-                    throw;
-                }
-
                 InvalidProjectFileException projectException = ex as InvalidProjectFileException;
                 if (projectException != null)
                 {
@@ -1136,6 +1285,164 @@ namespace Microsoft.Build.Execution
 
                 submission.CompleteLogging(true);
                 ReportResultsToSubmission(new BuildResult(submission.BuildRequest, ex));
+                _overallBuildSuccess = false;
+            }
+        }
+
+        private void ExecuteGraphBuildScheduler(GraphBuildSubmission submission)
+        {
+            try
+            {
+                if (_shuttingDown)
+                {
+                    throw new BuildAbortedException();
+                }
+
+                var projectGraph = submission.BuildRequestData.ProjectGraph;
+                if (projectGraph == null)
+                {
+                    projectGraph = new ProjectGraph(
+                        submission.BuildRequestData.ProjectGraphEntryPoints,
+                        ProjectCollection.GlobalProjectCollection,
+                        (path, properties, collection) =>
+                        {
+                            ProjectLoadSettings projectLoadSettings = _buildParameters.ProjectLoadSettings;
+                            if (submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.IgnoreMissingEmptyAndInvalidImports))
+                            {
+                                projectLoadSettings |= ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreEmptyImports;
+                            }
+
+                            return new ProjectInstance(
+                                path,
+                                properties,
+                                null,
+                                _buildParameters,
+                                ((IBuildComponentHost)this).LoggingService,
+                                new BuildEventContext(
+                                    submission.SubmissionId,
+                                    _buildParameters.NodeId,
+                                    BuildEventContext.InvalidEvaluationId,
+                                    BuildEventContext.InvalidProjectInstanceId,
+                                    BuildEventContext.InvalidProjectContextId,
+                                    BuildEventContext.InvalidTargetId,
+                                    BuildEventContext.InvalidTaskId),
+                                SdkResolverService,
+                                submission.SubmissionId,
+                                projectLoadSettings);
+                        });
+                }
+
+                IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetLists = projectGraph.GetTargetLists(submission.BuildRequestData.TargetNames);
+
+                var waitHandle = new AutoResetEvent(true);
+                var graphBuildStateLock = new object();
+
+                var blockedNodes = new HashSet<ProjectGraphNode>(projectGraph.ProjectNodes);
+                var finishedNodes = new HashSet<ProjectGraphNode>(projectGraph.ProjectNodes.Count);
+                var buildingNodes = new Dictionary<BuildSubmission, ProjectGraphNode>();
+                Dictionary<ProjectGraphNode, BuildResult> resultsPerNode = new Dictionary<ProjectGraphNode, BuildResult>(projectGraph.ProjectNodes.Count);
+                while (blockedNodes.Count > 0 || buildingNodes.Count > 0)
+                {
+                    waitHandle.WaitOne();
+
+                    lock (graphBuildStateLock)
+                    {
+                        var unblockedNodes = blockedNodes
+                            .Where(node => node.ProjectReferences.All(projectReference => finishedNodes.Contains(projectReference)))
+                            .ToList();
+                        foreach (var node in unblockedNodes)
+                        {
+                            var targetList = targetLists[node];
+                            if (targetList.Count == 0)
+                            {
+                                // An empty target list here means "no targets" instead of "default targets", so don't even build it.
+                                finishedNodes.Add(node);
+                                blockedNodes.Remove(node);
+
+                                waitHandle.Set();
+
+                                continue;
+                            }
+
+                            var request = new BuildRequestData(
+                                node.ProjectInstance,
+                                targetList.ToArray(),
+                                submission.BuildRequestData.HostServices,
+                                submission.BuildRequestData.Flags);
+
+                            // TODO Tack onto the existing submission instead of pending a whole new submission for every node
+                            // Among other things, this makes BuildParameters.DetailedSummary produce a summary for each node, which is not desirable.
+                            // We basically want to submit all requests to the scheduler all at once and describe dependencies by requests being blocked by other requests.
+                            // However today the scheduler only keeps track of MSBuild nodes being blocked by other MSBuild nodes, and MSBuild nodes haven't been assigned to the graph nodes yet.
+                            var innerBuildSubmission = PendBuildRequest(request);
+                            buildingNodes.Add(innerBuildSubmission, node);
+                            blockedNodes.Remove(node);
+                            innerBuildSubmission.ExecuteAsync(finishedBuildSubmission =>
+                            {
+                                lock (graphBuildStateLock)
+                                {
+                                    ProjectGraphNode finishedNode = buildingNodes[finishedBuildSubmission];
+
+                                    finishedNodes.Add(finishedNode);
+                                    buildingNodes.Remove(finishedBuildSubmission);
+
+                                    resultsPerNode.Add(finishedNode, finishedBuildSubmission.BuildResult);
+                                }
+
+                                waitHandle.Set();
+                            }, null);
+                        }
+                    }
+                }
+
+                // The overall submission is complete, so report it as complete
+                ReportResultsToSubmission(new GraphBuildResult(submission.SubmissionId, new ReadOnlyDictionary<ProjectGraphNode, BuildResult>(resultsPerNode)));
+            }
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+            {
+                GraphBuildResult result = null;
+
+                // ProjectGraph throws an aggregate exception with InvalidProjectFileException inside when evaluation fails
+                if (ex is AggregateException aggregateException && aggregateException.InnerExceptions.All(innerException => innerException is InvalidProjectFileException))
+                {
+                    // Log each InvalidProjectFileException encountered during ProjectGraph creation
+                    foreach (var innerException in aggregateException.InnerExceptions)
+                    {
+                        var projectException = (InvalidProjectFileException) innerException;
+                        if (projectException.HasBeenLogged != true)
+                        {
+                            BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                            ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, projectException);
+                            projectException.HasBeenLogged = true;
+                        }
+                    }
+                }
+                else if (ex is CircularDependencyException)
+                {
+                    result = new GraphBuildResult(submission.SubmissionId, true);
+
+                    BuildEventContext projectBuildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                    ((IBuildComponentHost)this).LoggingService.LogInvalidProjectFileError(projectBuildEventContext, new InvalidProjectFileException(ex.Message, ex));
+                }
+                else if (ex is BuildAbortedException || ExceptionHandling.NotExpectedException(ex))
+                {
+                    throw;
+                }
+                else
+                {
+                    // Arbitrarily just choose the first entry point project's path
+                    var projectFile = submission.BuildRequestData.ProjectGraph?.EntryPointNodes.First().ProjectInstance.FullPath
+                        ?? submission.BuildRequestData.ProjectGraphEntryPoints?.First().ProjectFile;
+                    BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, 1, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                    ((IBuildComponentHost)this).LoggingService.LogFatalBuildError(buildEventContext, ex, new BuildEventFileInfo(projectFile));
+                }
+
+                if (result == null)
+                {
+                    result = new GraphBuildResult(submission.SubmissionId, ex);
+                }
+
+                ReportResultsToSubmission(result);
                 _overallBuildSuccess = false;
             }
         }
@@ -1214,9 +1521,11 @@ namespace Microsoft.Build.Execution
             _shuttingDown = false;
             _nodeConfiguration = null;
             _buildSubmissions.Clear();
+            _graphBuildSubmissions.Clear();
             _scheduler.Reset();
             _scheduler = null;
             _workQueue = null;
+            _graphSchedulingCancellationSource = null;
             _acquiredProjectRootElementCacheFromProjectInstance = false;
 
             _unnamedProjectInstanceToNames.Clear();
@@ -1419,8 +1728,15 @@ namespace Microsoft.Build.Execution
                         string exception = ExceptionHandling.ReadAnyExceptionFromFile(_instantiationTimeUtc);
                         loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath, exception);
                     }
+
+                    foreach (GraphBuildSubmission submission in _graphBuildSubmissions.Values)
+                    {
+                        BuildEventContext buildEventContext = new BuildEventContext(submission.SubmissionId, BuildEventContext.InvalidNodeId, BuildEventContext.InvalidProjectInstanceId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidTaskId);
+                        string exception = ExceptionHandling.ReadAnyExceptionFromFile(_instantiationTimeUtc);
+                        loggingService.LogError(buildEventContext, new BuildEventFileInfo(String.Empty) /* no project file */, "ChildExitedPrematurely", node, ExceptionHandling.DebugDumpPath, exception);
+                    }
                 }
-                else if (shutdownPacket.Reason == NodeShutdownReason.Error && _buildSubmissions.Values.Count == 0)
+                else if (shutdownPacket.Reason == NodeShutdownReason.Error && _buildSubmissions.Values.Count == 0 && _graphBuildSubmissions.Values.Count == 0)
                 {
                     // We have no submissions to attach any exceptions to, lets just log it here.
                     if (shutdownPacket.Exception != null)
@@ -1483,6 +1799,20 @@ namespace Microsoft.Build.Execution
                     submission.CompleteLogging(waitForLoggingThread: false);
 
                     _overallBuildSuccess = _overallBuildSuccess && (submission.BuildResult.OverallResult == BuildResultCode.Success);
+                    CheckSubmissionCompletenessAndRemove(submission);
+                }
+
+                var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
+                foreach (GraphBuildSubmission submission in graphSubmissions)
+                {
+                    if (submission.IsStarted)
+                    {
+                        continue;
+                    }
+
+                    submission.CompleteResults(new GraphBuildResult(submission.SubmissionId, new BuildAbortedException()));
+
+                    _overallBuildSuccess &= submission.BuildResult.OverallResult == BuildResultCode.Success;
                     CheckSubmissionCompletenessAndRemove(submission);
                 }
 
@@ -1608,6 +1938,26 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Completes a submission using the specified overall results.
+        /// </summary>
+        private void ReportResultsToSubmission(GraphBuildResult result)
+        {
+            lock (_syncLock)
+            {
+                // The build submission has not already been completed.
+                if (_graphBuildSubmissions.ContainsKey(result.SubmissionId))
+                {
+                    GraphBuildSubmission submission = _graphBuildSubmissions[result.SubmissionId];
+                    submission.CompleteResults(result);
+
+                    _overallBuildSuccess &= submission.BuildResult.OverallResult == BuildResultCode.Success;
+
+                    CheckSubmissionCompletenessAndRemove(submission);
+                }
+            }
+        }
+
+        /// <summary>
         /// Determines if the submission is fully completed.
         /// </summary>
         private void CheckSubmissionCompletenessAndRemove(BuildSubmission submission)
@@ -1625,23 +1975,48 @@ namespace Microsoft.Build.Execution
                     SdkResolverService.ClearCache(submission.SubmissionId);
                 }
 
-                if (_buildSubmissions.Count == 0)
+                CheckAllSubmissionsComplete(submission.BuildRequestData?.Flags);
+            }
+        }
+
+        /// <summary>
+        /// Determines if the submission is fully completed.
+        /// </summary>
+        private void CheckSubmissionCompletenessAndRemove(GraphBuildSubmission submission)
+        {
+            lock (_syncLock)
+            {
+                // If the submission has completed or never started, remove it.
+                if (submission.IsCompleted || !submission.IsStarted)
                 {
-                    if (submission.BuildRequestData != null && submission.BuildRequestData.Flags.HasFlag(BuildRequestDataFlags.ClearCachesAfterBuild))
-                    {
-                        // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
-                        // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
-                        // part of the import graph.
-                        _buildParameters?.ProjectRootElementCache?.Clear();
+                    _graphBuildSubmissions.Remove(submission.SubmissionId);
 
-                        FileMatcher.ClearFileEnumerationsCache();
-#if !CLR2COMPATIBILITY
-                        FileUtilities.ClearFileExistenceCache();
-#endif
-                    }
-
-                    _noActiveSubmissionsEvent.Set();
+                    // Clear all cached SDKs for the submission
+                    SdkResolverService.ClearCache(submission.SubmissionId);
                 }
+
+                CheckAllSubmissionsComplete(submission.BuildRequestData?.Flags);
+            }
+        }
+
+        private void CheckAllSubmissionsComplete(BuildRequestDataFlags? flags)
+        {
+            if (_buildSubmissions.Count == 0 && _graphBuildSubmissions.Count == 0)
+            {
+                if (flags.HasValue && flags.Value.HasFlag(BuildRequestDataFlags.ClearCachesAfterBuild))
+                {
+                    // Reset the project root element cache if specified which ensures that projects will be re-loaded from disk.  We do not need to reset the
+                    // cache on child nodes because the OutOfProcNode class sets "autoReloadFromDisk" to "true" which handles the case when a restore modifies
+                    // part of the import graph.
+                    _buildParameters?.ProjectRootElementCache?.Clear();
+
+                    FileMatcher.ClearFileEnumerationsCache();
+#if !CLR2COMPATIBILITY
+                    FileUtilities.ClearFileExistenceCache();
+#endif
+                }
+
+                _noActiveSubmissionsEvent.Set();
             }
         }
 
@@ -1700,6 +2075,30 @@ namespace Microsoft.Build.Execution
                             if (submission.BuildResult == null)
                             {
                                 submission.BuildResult = new BuildResult(submission.BuildRequest, e);
+                            }
+                            else
+                            {
+                                submission.BuildResult.Exception = _threadException;
+                            }
+                        }
+
+                        CheckSubmissionCompletenessAndRemove(submission);
+                    }
+
+                    var graphSubmissions = new List<GraphBuildSubmission>(_graphBuildSubmissions.Values);
+                    foreach (GraphBuildSubmission submission in graphSubmissions)
+                    {
+                        if (!submission.IsStarted)
+                        {
+                            continue;
+                        }
+
+                        // Attach the exception to this submission if it does not already have an exception associated with it
+                        if (submission.BuildResult?.Exception == null)
+                        {
+                            if (submission.BuildResult == null)
+                            {
+                                submission.BuildResult = new GraphBuildResult(submission.SubmissionId, e);
                             }
                             else
                             {
@@ -1813,15 +2212,9 @@ namespace Microsoft.Build.Execution
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
             {
-                if (ExceptionHandling.IsCriticalException(ex))
-                {
-                    throw;
-                }
-
                 ShutdownLoggingService(loggingService);
-
                 throw;
             }
 
@@ -1907,6 +2300,12 @@ namespace Microsoft.Build.Execution
                         {
                             _workQueue.Complete();
                             _workQueue = null;
+                        }
+
+                        if (_graphSchedulingCancellationSource != null)
+                        {
+                            _graphSchedulingCancellationSource.Cancel();
+                            _graphSchedulingCancellationSource = null;
                         }
 
                         if (_noActiveSubmissionsEvent != null)

--- a/src/Build/BackEnd/BuildManager/GraphBuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/GraphBuildRequestData.cs
@@ -1,0 +1,191 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Build.Graph;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Execution
+{
+    /// <summary>
+    /// GraphBuildRequestData encapsulates all of the data needed to submit a graph build request.
+    /// </summary>
+    public sealed class GraphBuildRequestData
+    {
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph.
+        /// </summary>
+        /// <param name="projectGraph">The graph to build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        public GraphBuildRequestData(ProjectGraph projectGraph, ICollection<string> targetsToBuild)
+            : this(projectGraph, targetsToBuild, null, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph.
+        /// </summary>
+        /// <param name="projectGraph">The graph to build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        public GraphBuildRequestData(ProjectGraph projectGraph, ICollection<string> targetsToBuild, HostServices hostServices)
+            : this(projectGraph, targetsToBuild, hostServices, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph.
+        /// </summary>
+        /// <param name="projectGraph">The graph to build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        /// <param name="flags">Flags controlling this build request.</param>
+        public GraphBuildRequestData(ProjectGraph projectGraph, ICollection<string> targetsToBuild, HostServices hostServices, BuildRequestDataFlags flags)
+            : this(targetsToBuild, hostServices, flags)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(projectGraph, nameof(projectGraph));
+
+            ProjectGraph = projectGraph;
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on project files.
+        /// </summary>
+        /// <param name="projectFullPath">The full path to the project file.</param>
+        /// <param name="globalProperties">The global properties which should be used during evaluation of the project.  Cannot be null.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use.  May be null.</param>
+        public GraphBuildRequestData(string projectFullPath, IDictionary<string, string> globalProperties, ICollection<string> targetsToBuild, HostServices hostServices)
+            : this(new ProjectGraphEntryPoint(projectFullPath, globalProperties).AsEnumerable(), targetsToBuild, hostServices, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on project files.
+        /// </summary>
+        /// <param name="projectFullPath">The full path to the project file.</param>
+        /// <param name="globalProperties">The global properties which should be used during evaluation of the project.  Cannot be null.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use.  May be null.</param>
+        /// <param name="flags">The <see cref="BuildRequestDataFlags"/> to use.</param>
+        public GraphBuildRequestData(string projectFullPath, IDictionary<string, string> globalProperties, ICollection<string> targetsToBuild, HostServices hostServices, BuildRequestDataFlags flags)
+            : this(new ProjectGraphEntryPoint(projectFullPath, globalProperties).AsEnumerable(), targetsToBuild, hostServices, flags)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoint">The entry point to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        public GraphBuildRequestData(ProjectGraphEntryPoint projectGraphEntryPoint, ICollection<string> targetsToBuild)
+            : this(projectGraphEntryPoint.AsEnumerable(), targetsToBuild, null, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoint">The entry point to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        public GraphBuildRequestData(ProjectGraphEntryPoint projectGraphEntryPoint, ICollection<string> targetsToBuild, HostServices hostServices)
+            : this(projectGraphEntryPoint.AsEnumerable(), targetsToBuild, hostServices, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoint">The entry point to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        /// <param name="flags">Flags controlling this build request.</param>
+        public GraphBuildRequestData(ProjectGraphEntryPoint projectGraphEntryPoint, ICollection<string> targetsToBuild, HostServices hostServices, BuildRequestDataFlags flags)
+            : this(projectGraphEntryPoint.AsEnumerable(), targetsToBuild, hostServices, flags)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoints">The entry points to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        public GraphBuildRequestData(IEnumerable<ProjectGraphEntryPoint> projectGraphEntryPoints, ICollection<string> targetsToBuild)
+            : this(projectGraphEntryPoints, targetsToBuild, null, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoints">The entry points to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        public GraphBuildRequestData(IEnumerable<ProjectGraphEntryPoint> projectGraphEntryPoints, ICollection<string> targetsToBuild, HostServices hostServices)
+            : this(projectGraphEntryPoints, targetsToBuild, hostServices, BuildRequestDataFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a GraphBuildRequestData for build requests based on a project graph entry points.
+        /// </summary>
+        /// <param name="projectGraphEntryPoints">The entry points to use in the build.</param>
+        /// <param name="targetsToBuild">The targets to build.</param>
+        /// <param name="hostServices">The host services to use, if any.  May be null.</param>
+        /// <param name="flags">Flags controlling this build request.</param>
+        public GraphBuildRequestData(IEnumerable<ProjectGraphEntryPoint> projectGraphEntryPoints, ICollection<string> targetsToBuild, HostServices hostServices, BuildRequestDataFlags flags)
+            : this(targetsToBuild, hostServices, flags)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(projectGraphEntryPoints, nameof(projectGraphEntryPoints));
+
+            ProjectGraphEntryPoints = projectGraphEntryPoints;
+        }
+
+        /// <summary>
+        /// Common constructor.
+        /// </summary>
+        private GraphBuildRequestData(ICollection<string> targetsToBuild, HostServices hostServices, BuildRequestDataFlags flags)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(targetsToBuild, nameof(targetsToBuild));
+            foreach (string targetName in targetsToBuild)
+            {
+                ErrorUtilities.VerifyThrowArgumentNull(targetName, "target");
+            }
+
+            HostServices = hostServices;
+            TargetNames = new List<string>(targetsToBuild);
+            Flags = flags;
+        }
+
+        /// <summary>
+        /// The requested project graph to build.
+        /// May be null.
+        /// </summary>
+        /// <value>The project graph.</value>
+        public ProjectGraph ProjectGraph { get; }
+
+        /// <summary>
+        /// The project graph entry points.
+        /// May be null.
+        /// </summary>
+        /// <value>The project graph entry points.</value>
+        public IEnumerable<ProjectGraphEntryPoint> ProjectGraphEntryPoints { get; }
+
+        /// <summary>
+        /// The name of the targets to build.
+        /// </summary>
+        /// <value>An array of targets in the project to be built.</value>
+        public ICollection<string> TargetNames { get; }
+
+        /// <summary>
+        /// Extra flags for this BuildRequest.
+        /// </summary>
+        public BuildRequestDataFlags Flags { get; }
+
+        /// <summary>
+        /// Gets the HostServices object for this request.
+        /// </summary>
+        public HostServices HostServices { get; }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/GraphBuildResult.cs
+++ b/src/Build/BackEnd/BuildManager/GraphBuildResult.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Graph;
+
+namespace Microsoft.Build.Execution
+{
+    public sealed class GraphBuildResult
+    {
+        /// <summary>
+        /// Constructor creates a build result with results for each graph node.
+        /// </summary>
+        /// <param name="submissionId">The id of the build submission.</param>
+        /// <param name="resultsByNode">The set of results for each graph node.</param>
+        internal GraphBuildResult(int submissionId, IReadOnlyDictionary<ProjectGraphNode, BuildResult> resultsByNode)
+        {
+            SubmissionId = submissionId;
+            ResultsByNode = resultsByNode;
+        }
+
+        /// <summary>
+        /// Constructor creates a build result indicating a circular dependency was created.
+        /// </summary>
+        /// <param name="submissionId">The id of the build submission.</param>
+        /// <param name="circularDependency">Set to true if a circular dependency was detected.</param>
+        internal GraphBuildResult(int submissionId, bool circularDependency)
+        {
+            SubmissionId = submissionId;
+            CircularDependency = circularDependency;
+        }
+
+        /// <summary>
+        /// Constructs a graph build result with an exception
+        /// </summary>
+        /// <param name="submissionId">The id of the build submission.</param>
+        /// <param name="exception">The exception, if any.</param>
+        internal GraphBuildResult(int submissionId, Exception exception)
+        {
+            SubmissionId = submissionId;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Returns the submission id.
+        /// </summary>
+        public int SubmissionId { get; }
+
+        /// <summary>
+        /// Returns a flag indicating if a circular dependency was detected.
+        /// </summary>
+        public bool CircularDependency { get; }
+
+        /// <summary>
+        /// Returns the exception generated while this result was run, if any.
+        /// </summary>
+        public Exception Exception { get; internal set; }
+
+        /// <summary>
+        /// Returns the overall result for this result set.
+        /// </summary>
+        public BuildResultCode OverallResult
+        {
+            get
+            {
+                if (Exception != null || CircularDependency)
+                {
+                    return BuildResultCode.Failure;
+                }
+
+                foreach (KeyValuePair<ProjectGraphNode, BuildResult> result in ResultsByNode)
+                {
+                    if (result.Value.OverallResult == BuildResultCode.Failure)
+                    {
+                        return BuildResultCode.Failure;
+                    }
+                }
+
+                return BuildResultCode.Success;
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerator for all build results in this graph build result
+        /// </summary>
+        public IReadOnlyDictionary<ProjectGraphNode, BuildResult> ResultsByNode { get; }
+
+        /// <summary>
+        /// Indexer which sets or returns results for the specified node
+        /// </summary>
+        /// <param name="node">The node</param>
+        /// <returns>The results for the specified node</returns>
+        /// <exception>KeyNotFoundException is returned if the specified node doesn't exist when reading this property.</exception>
+        public BuildResult this[ProjectGraphNode node] => ResultsByNode[node];
+    }
+}

--- a/src/Build/BackEnd/BuildManager/GraphBuildSubmission.cs
+++ b/src/Build/BackEnd/BuildManager/GraphBuildSubmission.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Execution
+{
+    /// <summary>
+    /// A callback used to receive notification that a build has completed.
+    /// </summary>
+    /// <remarks>
+    /// When this delegate is invoked, the WaitHandle on the BuildSubmission will have been be signalled and the OverallBuildResult will be valid.
+    /// </remarks>
+    public delegate void GraphBuildSubmissionCompleteCallback(GraphBuildSubmission submission);
+
+    /// <summary>
+    /// A GraphBuildSubmission represents a graph build request which has been submitted to the BuildManager for processing.  It may be used to
+    /// execute synchronous or asynchronous graph build requests and provides access to the results upon completion.
+    /// </summary>
+    /// <remarks>
+    /// This class is thread-safe.
+    /// </remarks>
+    public class GraphBuildSubmission
+    {
+        /// <summary>
+        /// The callback to invoke when the submission is complete.
+        /// </summary>
+        private GraphBuildSubmissionCompleteCallback _completionCallback;
+
+        /// <summary>
+        /// The completion event.
+        /// </summary>
+        private readonly ManualResetEvent _completionEvent;
+
+        /// <summary>
+        /// True if it has been invoked
+        /// </summary>
+        private int _completionInvoked;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        internal GraphBuildSubmission(BuildManager buildManager, int submissionId, GraphBuildRequestData requestData)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(buildManager, nameof(buildManager));
+            ErrorUtilities.VerifyThrowArgumentNull(requestData, nameof(requestData));
+
+            BuildManager = buildManager;
+            SubmissionId = submissionId;
+            BuildRequestData = requestData;
+            _completionEvent = new ManualResetEvent(false);
+            _completionInvoked = 0;
+        }
+
+        /// <summary>
+        /// The BuildManager with which this submission is associated.
+        /// </summary>
+        public BuildManager BuildManager { get; }
+
+        /// <summary>
+        /// An ID uniquely identifying this request from among other submissions within the same build.
+        /// </summary>
+        public int SubmissionId { get; }
+
+        /// <summary>
+        /// The asynchronous context provided to <see cref="BuildSubmission.ExecuteAsync(BuildSubmissionCompleteCallback, object)"/>, if any.
+        /// </summary>
+        public Object AsyncContext { get; private set; }
+
+        /// <summary>
+        /// A <see cref="System.Threading.WaitHandle"/> which will be signalled when the build is complete.  Valid after <see cref="BuildSubmission.Execute()"/> or <see cref="BuildSubmission.ExecuteAsync(BuildSubmissionCompleteCallback, object)"/> returns, otherwise null.
+        /// </summary>
+        public WaitHandle WaitHandle => _completionEvent;
+
+        /// <summary>
+        /// Returns true if this submission is complete.
+        /// </summary>
+        public bool IsCompleted => WaitHandle.WaitOne(new TimeSpan(0));
+
+        /// <summary>
+        /// The results of the build per graph node.  Valid only after WaitHandle has become signalled.
+        /// </summary>
+        public GraphBuildResult BuildResult { get; internal set; }
+
+        /// <summary>
+        /// The BuildRequestData being used for this submission.
+        /// </summary>
+        internal GraphBuildRequestData BuildRequestData { get; }
+
+        /// <summary>
+        /// Whether the graph build has started.
+        /// </summary>
+        internal bool IsStarted { get; set; }
+
+        /// <summary>
+        /// Starts the request and blocks until results are available.
+        /// </summary>
+        /// <exception cref="System.InvalidOperationException">The request has already been started or is already complete.</exception>
+        public GraphBuildResult Execute()
+        {
+            ExecuteAsync(null, null);
+            WaitHandle.WaitOne();
+
+            return BuildResult;
+        }
+
+        /// <summary>
+        /// Starts the request asynchronously and immediately returns control to the caller.
+        /// </summary>
+        /// <exception cref="System.InvalidOperationException">The request has already been started or is already complete.</exception>
+        public void ExecuteAsync(GraphBuildSubmissionCompleteCallback callback, object context)
+        {
+            ErrorUtilities.VerifyThrowInvalidOperation(!IsCompleted, "SubmissionAlreadyComplete");
+            _completionCallback = callback;
+            AsyncContext = context;
+            BuildManager.ExecuteSubmission(this);
+        }
+
+        /// <summary>
+        /// Sets the event signaling that the build is complete.
+        /// </summary>
+        internal void CompleteResults(GraphBuildResult result)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(result, nameof(result));
+            ErrorUtilities.VerifyThrow(result.SubmissionId == SubmissionId, "GraphBuildResult's submission id doesn't match GraphBuildSubmission's");
+
+            bool hasCompleted = (Interlocked.Exchange(ref _completionInvoked, 1) == 1);
+            if (!hasCompleted)
+            {
+                BuildResult = result;
+                _completionEvent.Set();
+
+                if (_completionCallback != null)
+                {
+                    void Callback(object state)
+                    {
+                        _completionCallback(this);
+                    }
+
+                    ThreadPoolExtensions.QueueThreadPoolWorkItemWithCulture(Callback, CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture);
+                }
+            }
+        }
+    }
+}

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Build.Graph
         /// </remarks>
         /// <param name="entryProjectTargets">The target list for the entry project. May be null or empty, in which case the entry projects' default targets will be used.</param>
         /// <returns>A dictionary containing the target list for each node.</returns>
-        public IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> GetTargetLists(string[] entryProjectTargets)
+        public IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> GetTargetLists(ICollection<string> entryProjectTargets)
         {
             // Seed the dictionary with empty lists for every node. In this particular case though an empty list means "build nothing" rather than "default targets".
             Dictionary<ProjectGraphNode, ImmutableList<string>> targetLists = ProjectNodes.ToDictionary(node => node, node => ImmutableList<string>.Empty);
@@ -279,7 +279,7 @@ namespace Microsoft.Build.Graph
             // Initial state of the graph traversal.
             foreach (var entryPointNode in EntryPointNodes)
             {
-                ImmutableList<string> entryTargets = entryProjectTargets == null || entryProjectTargets.Length == 0
+                ImmutableList<string> entryTargets = entryProjectTargets == null || entryProjectTargets.Count == 0
                     ? ImmutableList.CreateRange(entryPointNode.ProjectInstance.DefaultTargets)
                     : ImmutableList.CreateRange(entryProjectTargets);
                 var entryEdge = new ProjectGraphBuildRequest(entryPointNode, entryTargets);

--- a/src/Build/Graph/ProjectGraphEntryPoint.cs
+++ b/src/Build/Graph/ProjectGraphEntryPoint.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Graph
 {
@@ -26,6 +27,8 @@ namespace Microsoft.Build.Graph
         /// <param name="globalProperties">The global properties to use for this entry point. May be null, in which case the global properties of the project collection provided to the project graph will be used.</param>
         public ProjectGraphEntryPoint(string projectFile, IDictionary<string, string> globalProperties)
         {
+            ErrorUtilities.VerifyThrowArgumentLength(projectFile, nameof(projectFile));
+
             ProjectFile = projectFile;
             GlobalProperties = globalProperties;
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -192,6 +192,9 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="BackEnd\BuildManager\BuildManager.cs" />
     <Compile Include="BackEnd\BuildManager\BuildParameters.cs" />
+    <Compile Include="BackEnd\BuildManager\GraphBuildResult.cs" />
+    <Compile Include="BackEnd\BuildManager\GraphBuildSubmission.cs" />
+    <Compile Include="BackEnd\BuildManager\GraphBuildRequestData.cs" />
     <Compile Include="BackEnd\BuildManager\BuildSubmission.cs" />
     <Compile Include="BackEnd\BuildManager\LegacyThreadingData.cs" />
     <Compile Include="BackEnd\BuildManager\RequestedProjectState.cs" />


### PR DESCRIPTION
This enables programatic graph builds by exposing a way to ask the BuildManager for a graph build instead of the logic being inside XMake.

This also fixes a couple bugs related to how graph builds were happening and gets the logic "closer" to where we want it to end up in the end (the scheduler).

Closes: #3840