### PR TITLE
Turn off caching distinct relative globs

### DIFF
--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1798,10 +1798,11 @@ namespace Microsoft.Build.Shared
                 filespecUnescaped = Path.Combine(projectDirectoryUnescaped, filespecUnescaped);
 
                 // increase the chance of cache hits when multiple relative globs refer to the same base directory
-                if (FileUtilities.ContainsRelativePathSegments(filespecUnescaped))
-                {
-                    filespecUnescaped = FileUtilities.GetFullPathNoThrow(filespecUnescaped);
-                }
+                // todo https://github.com/Microsoft/msbuild/issues/3889
+                //if (FileUtilities.ContainsRelativePathSegments(filespecUnescaped))
+                //{
+                //    filespecUnescaped = FileUtilities.GetFullPathNoThrow(filespecUnescaped);
+                //}
             }
             catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
             {

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -1013,6 +1013,8 @@ namespace Microsoft.Build.UnitTests
         [InlineData(@".\", true)]
         [InlineData(@"\..", true)]
         [InlineData(@"\.", true)]
+        [InlineData(@"..\..\a", true)]
+        [InlineData(@"..\..\..\a", true)]
         [InlineData(@"b..\", false)]
         [InlineData(@"b.\", false)]
         [InlineData(@"\b..", false)]

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -245,23 +245,29 @@ namespace Microsoft.Build.UnitTests
 
         public static void AssertItems(string[] expectedItems, IList<TestItem> items, Dictionary<string, string>[] expectedDirectMetadataPerItem, bool normalizeSlashes = false)
         {
-            Assert.Equal(expectedItems.Length, items.Count);
+            if (items.Count != 0 || expectedDirectMetadataPerItem.Length != 0)
+            {
+                expectedItems.ShouldNotBeEmpty();
+            }
 
-            Assert.Equal(expectedItems.Length, expectedDirectMetadataPerItem.Length);
-
-            for (int i = 0; i < expectedItems.Length; i++)
+            for (var i = 0; i < expectedItems.Length; i++)
             {
                 if (!normalizeSlashes)
                 {
-                    Assert.Equal(expectedItems[i], items[i].EvaluatedInclude);
+                    expectedItems[i].ShouldBe(items[i].EvaluatedInclude);
                 }
                 else
                 {
-                    Assert.Equal(NormalizeSlashes(expectedItems[i]), items[i].EvaluatedInclude);
+                    var normalizedItem = NormalizeSlashes(expectedItems[i]);
+                    normalizedItem.ShouldBe(items[i].EvaluatedInclude);
                 }
 
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);
             }
+
+            expectedItems.Length.ShouldBe(items.Count);
+
+            expectedItems.Length.ShouldBe(expectedDirectMetadataPerItem.Length);
         }
 
         /// <summary>


### PR DESCRIPTION
Because MSBuild globs preserve the fixed directory from the project file instead of returning fully qualified paths, it is harder than previously thought to cache distinct relative globs pointing to the same file, as the cached glob expansions would need to be rebased to multiple fixed directory parts.