### PR TITLE
MSBuild.Bootstrap to place Microsoft.Common.props correctly

### DIFF
--- a/build/BootStrapMSBuild.targets
+++ b/build/BootStrapMSBuild.targets
@@ -85,7 +85,9 @@
       <FreshlyBuiltBinaries Include="$(OutputPath)**\*.exe.config" />
       <FreshlyBuiltBinaries Include="$(OutputPath)**\*.dll.config" />
 
-      <FreshlyBuiltProjects Include="$(OutputPath)**\*props" />
+      <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.Common.props" />
+      <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.VisualStudioVersion.*.Common.props" />
+      <FreshlyBuiltProjects Include="$(OutputPath)**\*props" Exclude="@(FreshlyBuiltRootProjects)" />
       <FreshlyBuiltProjects Include="$(OutputPath)**\*targets" />
       <FreshlyBuiltProjects Include="$(OutputPath)**\*tasks" />
       <FreshlyBuiltProjects Include="$(OutputPath)**\*xml" />
@@ -129,6 +131,8 @@
     <Copy SourceFiles="@(RoslynBinaries)"
           DestinationFiles="@(RoslynBinaries -> '$(BootstrapDestination)15.0\Bin\Roslyn\%(RecursiveDir)%(Filename)%(Extension)')" />
     <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
+    <Copy SourceFiles="@(FreshlyBuiltRootProjects)"
+          DestinationFiles="@(FreshlyBuiltRootProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(FreshlyBuiltProjects)"
           DestinationFiles="@(FreshlyBuiltProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>


### PR DESCRIPTION
Today Microsoft.Common.props (and Microsoft.VisualStudioVersion.v15.Common.props) are placed inside the Bin folder, which isn't where they exist in the VS directory. This leads to the current VS install's being used in the bootstrap instead of the one in the repo, making it cumbersome to test changes to Microsoft.Common.props