### PR TITLE
Opt into DeferFXClosureWalk

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -8,6 +8,7 @@
     </startup>
     <runtime>
       <DisableFXClosureWalk enabled="true" />
+      <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
       <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -9,6 +9,7 @@
     <runtime>
       <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <DisableFXClosureWalk enabled="true" />
+      <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>


### PR DESCRIPTION
This is a new, not-to-be-used-unless-specifically-okayed-by-the-.NET
team feature that is expected to resolve some of the stability issues
caused by `DisableFXClosureWalk`. If present, it supersedes the older
flag, so we should opt into both to get performance on both 4.8+ and
older frameworks.

⚠ Note to everyone: **you shouldn't use this**. It exists only for very specific scenarios.