### PR TITLE
Don't block explicitly referencing MSBuild 15.0

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Build.Shared
 
             return msBuildExePath == null
                 ? null
-                : TryFromMSBuildAssemblyUnderVisualStudio(msBuildExePath, msBuildExePath) ?? TryFromStandaloneMSBuildExe(msBuildExePath);
+                : TryFromMSBuildAssemblyUnderVisualStudio(msBuildExePath, msBuildExePath, true) ?? TryFromStandaloneMSBuildExe(msBuildExePath);
         }
 
         private static BuildEnvironment TryFromVisualStudioProcess()
@@ -210,10 +210,14 @@ namespace Microsoft.Build.Shared
 
         }
 
-        private static BuildEnvironment TryFromMSBuildAssemblyUnderVisualStudio(string msbuildAssembly, string msbuildExe)
+        private static BuildEnvironment TryFromMSBuildAssemblyUnderVisualStudio(string msbuildAssembly, string msbuildExe, bool allowLegacyToolsVersion = false)
         {
+            string msBuildPathPattern = allowLegacyToolsVersion
+                ? $@".*\\MSBuild\\({CurrentToolsVersion}|\d+\.0)\\Bin\\.*"
+                : $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*";
+
             if (NativeMethodsShared.IsWindows &&
-                Regex.IsMatch(msbuildAssembly, $@".*\\MSBuild\\{CurrentToolsVersion}\\Bin\\.*", RegexOptions.IgnoreCase))
+                Regex.IsMatch(msbuildAssembly, msBuildPathPattern, RegexOptions.IgnoreCase))
             {
                 // In a Visual Studio path we must have MSBuild.exe
                 if (FileSystems.Default.FileExists(msbuildExe))
@@ -318,7 +322,7 @@ namespace Microsoft.Build.Shared
         private static string GetVsRootFromMSBuildAssembly(string msBuildAssembly)
         {
             return FileUtilities.GetFolderAbove(msBuildAssembly,
-                Regex.IsMatch(msBuildAssembly, $@".\\MSBuild\\{CurrentToolsVersion}\\Bin\\Amd64\\MSBuild\.exe", RegexOptions.IgnoreCase)
+                Regex.IsMatch(msBuildAssembly, $@"\\Bin\\Amd64\\MSBuild\.exe", RegexOptions.IgnoreCase)
                     ? 5
                     : 4);
         }


### PR DESCRIPTION
* Added a test and associated fixes for pointing `MSBUILD_EXE_PATH` to a Dev15 VS install path.
* Added some regression tests on scenarios that shouldn't be supported.

Note that after discussing with @rainersigwald we both agreed that other scenarios shouldn't work. The scenario here is using `Microsoft.Build.dll` version 16.0+ to evaluate, and potentially build, a project when you only have MSBuild 15 installed. The engine should be backwards compatible so using older targets _should_ not be an issue. But if we add custom logic to allow this to work easily, many scenarios are going to be broken. For example multiproc builds will call MSBuild.exe to spawn workers which will fail because the versions will mismatch. However, if the environment variable is explicitly set MSBuild should honor that even if there is unexpected behavior.