### PR TITLE
Move to non-Preview images in CI

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -95,7 +95,7 @@ phases:
 
 - phase: CoreOnLinux
   displayName: "Build and test on Linux using .NET Core MSBuild"
-  queue: Hosted Linux Preview
+  queue: 'Hosted Ubuntu 1604'
   steps:
   - bash: . 'build/cibuild.sh'
     displayName: CI Build
@@ -123,7 +123,7 @@ phases:
 
 - phase: CoreOnMac
   displayName: "Build and test on macOS using .NET Core MSBuild"
-  queue: 'Hosted macOS Preview'
+  queue: 'Hosted macOS'
   steps:
   - bash: . 'build/cibuild.sh'
     displayName: CI Build


### PR DESCRIPTION
The "Hosted Linux Preview" pool has been deprecated and will be removed
in a couple of weeks, so switch to the recommended replacement.

Also moved away from macOS Preview since there's a non-Preview version
of it now.

Details on the deprecation: https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=vsts&tabs=yaml#hosted-linux-preview-pool-deprecation