### PR TITLE
Avoid Microsoft.IO.Redist

### DIFF
--- a/build/Packages.props
+++ b/build/Packages.props
@@ -14,7 +14,6 @@
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />
     <PackageReference Update="Microsoft.DotNet.BuildTools.GenAPI" Version="2.1.0-prerelease-02404-02" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <!-- Update binding redirect in app.config and app.amd64.config when changing this -->
     <PackageReference Update="Microsoft.IO.Redist" Version="4.6.0-preview1-26822-04" />
     <PackageReference Update="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
     <PackageReference Update="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" />
@@ -28,7 +27,6 @@
     <PackageReference Update="SourceLink.Create.CommandLine" Version="2.1.2" />
     <PackageReference Update="System.CodeDom" Version="4.4.0" />
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
-    <!-- Update binding redirect in app.config and app.amd64.config when changing this -->
     <PackageReference Update="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Update="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
@@ -45,7 +43,6 @@
     <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
 
-    <!-- Update binding redirect in app.config and app.amd64.config when changing this -->
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.5.24.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.6.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
 

--- a/build/Packages.props
+++ b/build/Packages.props
@@ -14,7 +14,6 @@
     <PackageReference Update="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />
     <PackageReference Update="Microsoft.DotNet.BuildTools.GenAPI" Version="2.1.0-prerelease-02404-02" />
     <PackageReference Update="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
-    <PackageReference Update="Microsoft.IO.Redist" Version="4.6.0-preview1-26822-04" />
     <PackageReference Update="Microsoft.Net.Compilers" Version="$(MicrosoftNetCompilersVersion)" />
     <PackageReference Update="Microsoft.NETCore.Compilers" Version="$(MicrosoftNetCoreCompilersVersion)" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.15" />
@@ -32,7 +31,6 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
-    <PackageReference Update="System.Memory" Version="4.5.1" />
     <PackageReference Update="System.Net.Http" Version="4.3.0" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
@@ -42,7 +40,7 @@
     <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
-
+    
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.5.24.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.6.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
 

--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -49,7 +49,6 @@
         "mscorlib.dll",
         "netstandard.dll",
         "System.Collections.Immutable.dll",
-        "System.Threading.Tasks.Dataflow.dll",
-        "Microsoft.IO.Redist.dll"
+        "System.Threading.Tasks.Dataflow.dll"
       ]
 }

--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -48,10 +48,7 @@
     "exclude": [
         "mscorlib.dll",
         "netstandard.dll",
-        "System.Buffers.dll",
         "System.Collections.Immutable.dll",
-        "System.Numerics.Vectors.dll",
-        "System.Memory.dll",
         "System.Threading.Tasks.Dataflow.dll",
         "Microsoft.IO.Redist.dll"
       ]

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -12,8 +12,7 @@
         https://dotnet.myget.org/F/roslyn/api/v3/index.json;
         https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
         https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-        https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json;
-        https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+        https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
     </RestoreSources>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1496,7 +1496,7 @@ namespace Microsoft.Build.Construction
 
                     _encoding = saveEncoding;
 
-                    var fileInfo = FileUtilities.GetFileInfoNoThrow(_projectFileLocation.File);
+                    FileInfo fileInfo = FileUtilities.GetFileInfoNoThrow(_projectFileLocation.File);
 
                     // If the file was deleted by a race with someone else immediately after it was written above
                     // then we obviously can't read the write time. In this obscure case, we'll retain the 

--- a/src/Build/Evaluation/ProjectRootElementCache.cs
+++ b/src/Build/Evaluation/ProjectRootElementCache.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Build.Evaluation
 
                 if (projectRootElement != null && _autoReloadFromDisk)
                 {
-                    var fileInfo = FileUtilities.GetFileInfoNoThrow(projectFile);
+                    FileInfo fileInfo = FileUtilities.GetFileInfoNoThrow(projectFile);
 
                     // If the file doesn't exist on disk, go ahead and use the cached version.
                     // It's an in-memory project that hasn't been saved yet.

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -31,16 +31,13 @@
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
 
     <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
-    <PackageReference Include="System.Reflection.Metadata" Condition="'$(MonoBuild)' == 'true'" />
 
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(MonoBuild)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(MonoBuild)' != 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
-
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
   </ItemGroup>

--- a/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -12,16 +12,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(MonoBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -46,20 +46,6 @@
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
 
-        <!-- Redirects for dlls redistributed by msbuild. Tasks depending on these will fail if they target older versions without msbuild redirecting them -->
-        <dependentAssembly>
-          <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="System.Threading.Tasks.Dataflow" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-4.5.24.0" newVersion="4.5.24.0" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-        </dependentAssembly>
-
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -40,22 +40,6 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
         </dependentAssembly>
 
-        <!-- Redirects for dlls redistributed by msbuild. Tasks depending on these will fail if they target older versions without msbuild redirecting them.
-             If devenv.exe's app.config also redirects these dlls, then the redirected versions in our app.config need to match devenv's
-        -->
-        <dependentAssembly>
-          <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="System.Threading.Tasks.Dataflow" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-4.5.24.0" newVersion="4.5.24.0" />
-        </dependentAssembly>
-        <dependentAssembly>
-          <assemblyIdentity name="Microsoft.IO.Redist" culture="neutral" publicKeyToken="b77a5c561934e089" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-        </dependentAssembly>
-
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -29,9 +29,7 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.IO.Redist.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/System.Buffers.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/MSBuild" />
@@ -72,9 +70,7 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.IO.Redist.dll" target="v15.0/bin/amd64" />
-    <file src="$X86BinPath$/System.Buffers.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin/amd64" />
-    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/amd64/MSBuild" />

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -28,7 +28,6 @@
     <file src="$X86BinPath$/Microsoft.Build.Framework.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
-    <file src="$X86BinPath$/Microsoft.IO.Redist.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
 
@@ -69,7 +68,6 @@
     <file src="$X86BinPath$/Microsoft.Build.Framework.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
-    <file src="$X86BinPath$/Microsoft.IO.Redist.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
 

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -23,10 +23,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks
@@ -161,10 +158,7 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -17,7 +17,6 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
@@ -156,7 +155,6 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.IO.Redist.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -512,7 +512,7 @@ namespace Microsoft.Build.Shared
                         // to unescape first.
                         string unescapedItemSpec = EscapingUtilities.UnescapeAll(itemSpec);
 
-                        var info = FileUtilities.GetFileInfoNoThrow(unescapedItemSpec);
+                        FileInfo info = FileUtilities.GetFileInfoNoThrow(unescapedItemSpec);
 
                         if (info != null)
                         {

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Build.UnitTests
             try
             {
                 file = FileUtilities.GetTemporaryFile();
-                var info = FileUtilities.GetFileInfoNoThrow(file);
+                FileInfo info = FileUtilities.GetFileInfoNoThrow(file);
                 Assert.Equal(info.LastWriteTime, new FileInfo(file).LastWriteTime);
             }
             finally
@@ -181,7 +181,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void GetFileInfoNoThrowNonexistent()
         {
-            var info = FileUtilities.GetFileInfoNoThrow("this_file_is_nonexistent");
+            FileInfo info = FileUtilities.GetFileInfoNoThrow("this_file_is_nonexistent");
             Assert.Null(info);
         }
 

--- a/src/Tasks/DependencyFile.cs
+++ b/src/Tasks/DependencyFile.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         internal bool HasFileChanged()
         {
-            var info = FileUtilities.GetFileInfoNoThrow(filename);
+            FileInfo info = FileUtilities.GetFileInfoNoThrow(filename);
 
             // Obviously if the file no longer exists then we are not up to date.
             if (info == null || !info.Exists)

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -956,7 +956,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <!-- Tasks need to mimic redistributing the compilers, so add references to both full framework and .net core -->
@@ -971,7 +970,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(MonoBuild)' != 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -18,9 +18,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" />
-
+    
     <PackageReference Include="System.Collections.Immutable" />
-    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETStandard'">
@@ -31,10 +30,6 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <PackageReference Include="System.Text.Encoding.CodePages" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.IO.Redist" Condition="'$(MonoBuild)' != 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">


### PR DESCRIPTION
We're not currently using any of the new functionality (right @cdmihai?) and we have a [VS bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/722326) that there are related ngen failures.

This is _almost_ straight reverts; a couple had merge conflicts.