### PR TITLE
Fix the serialization of ProjectItemInstance

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1432,15 +1432,13 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _itemDefinitions, ProjectItemDefinitionInstance.FactoryForDeserialization);
                 translator.TranslateDictionary(ref _directMetadata, ProjectMetadataInstance.FactoryForDeserialization);
 
-                if (_itemDefinitions != null &&
-                    _itemDefinitions.Count == 0)
+                if (_itemDefinitions?.Count == 0)
                 {
                     // If there are no item definitions, toss the list.
                     _itemDefinitions = null;
                 }
 
-                if (_directMetadata != null &&
-                    _directMetadata.Count == 0)
+                if (_directMetadata?.Count == 0)
                 {
                     // If there is no metadata, toss the dictionary.
                     _directMetadata = null;

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1429,10 +1429,22 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref _isImmutable);
                 translator.Translate(ref _definingFileEscaped);
 
-                CopyOnWritePropertyDictionary<ProjectMetadataInstance> temp = (translator.Mode == TranslationDirection.WriteToStream) ? MetadataCollection : null;
-                translator.TranslateDictionary<CopyOnWritePropertyDictionary<ProjectMetadataInstance>, ProjectMetadataInstance>(ref temp, ProjectMetadataInstance.FactoryForDeserialization);
-                ErrorUtilities.VerifyThrow(translator.Mode == TranslationDirection.WriteToStream || _directMetadata == null, "Should be null");
-                _directMetadata = (temp.Count == 0) ? null : temp; // If the metadata was all removed, toss the dictionary
+                translator.Translate(ref _itemDefinitions, ProjectItemDefinitionInstance.FactoryForDeserialization);
+                translator.TranslateDictionary(ref _directMetadata, ProjectMetadataInstance.FactoryForDeserialization);
+
+                if (_itemDefinitions != null &&
+                    _itemDefinitions.Count == 0)
+                {
+                    // If there are no item definitions, toss the list.
+                    _itemDefinitions = null;
+                }
+
+                if (_directMetadata != null &&
+                    _directMetadata.Count == 0)
+                {
+                    // If there is no metadata, toss the dictionary.
+                    _directMetadata = null;
+                }
             }
 
             #endregion


### PR DESCRIPTION
Fixes [Bug 68841](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/688412)/[Feedback 678764](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/678764).

Fix the serialization of `ProjectItemInstance` such that `_itemDefinitions` (a `List<ProjectItemDefinitionInstance`) and `_directMetadata` (a `CopyOnWritePropertyDictionary<ProjectMetadataInstance>`) are serialized separately.

Currently, when serializing a `ProjectItemInstance` we collapse the metadata in both `_directMetadata` and `_itemDefinitions` into a single dictionary via the `MetadataCollection` property (when deserializing these fields will be null and/or empty collections at this point, of course). Then, when serializing _or_ deserializing we set `_directMetadata` to this new dictionary.

That means that if you start with a `ProjectItemInstance` with non-empty collections for `_itemDefinitions` and `_directMetadata` then after the serialization it will have the same `_itemDefinitions` but the `_directMetadata` will contain all the items that were previously in both `_itemDefinitions` _and_ `_directMetadata`. After deserialization you'll end up with a `ProjectItemInstance` with a null/empty `_itemDefinitions`, and `_directMetadata` will have the combined items.

As best I can tell this is simply wrong. Problems can crop up because direct metadata is already evaluated, while the metadata from item definitions is not. So after one of these serialization/deserialization cycles we will have items in `_directMetadata` that we assume are evaluated, but are not.

This manifests in various ways, from unexpanded/unevaluated text showing in MSBuild messages, to generating files with names like "%(BaseFileName)PerfCounters.g.cs".

The fix here is to keep `_itemDefinitions` and `_directMetadata` separate during the serialization/deserialization process.