### PR TITLE
Remove all .NET 1.1 collections from ResolveAssemblyReference

### DIFF
--- a/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
+++ b/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Build.Shared
         ///
         ///         This way we have a reverse sorted list of all of the version keys.
         /// </summary>
-        internal static List<ExtensionFoldersRegistryKey> GatherVersionStrings(string targetRuntimeVersion, IEnumerable versions)
+        internal static List<ExtensionFoldersRegistryKey> GatherVersionStrings(string targetRuntimeVersion, IEnumerable<string> versions)
         {
             List<string> additionalToleratedKeys = new List<string>();
             Version targetVersion = VersionUtilities.ConvertToVersion(targetRuntimeVersion);

--- a/src/Shared/AssemblyNameReverseVersionComparer.cs
+++ b/src/Shared/AssemblyNameReverseVersionComparer.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Reflection;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Shared

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -5873,7 +5873,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[0]);
             List<Exception> whiteListErrors = new List<Exception>();
             List<string> whiteListErrorFileNames = new List<string>();
-            Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[0], whiteListErrors, whiteListErrorFileNames);
+            Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[0], whiteListErrors, whiteListErrorFileNames);
             Assert.Null(blackList); // "Should return null if the AssemblyTableInfo is empty and the redist list is empty"
         }
 
@@ -5891,7 +5891,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[0], whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[0], whiteListErrors, whiteListErrorFileNames);
 
 
                 // Since there were no white list expect the black list to return null
@@ -5917,7 +5917,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
 
-                Hashtable blackList = redistList.GenerateBlackList(
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(
                                                                    new AssemblyTableInfo[]
                                                                                          {
                                                                                            new AssemblyTableInfo("c:\\RandomDirectory.xml", "TargetFrameworkDirectory"),
@@ -5960,7 +5960,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 Assert.Equal(0, blackList.Count); // "Expected to have no assemblies in the black list"
                 Assert.Equal(1, whiteListErrors.Count); // "Expected there to be an error in the whiteListErrors"
@@ -6007,7 +6007,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // If the names do not match then i expect there to be no black list items
                 Assert.Equal(0, blackList.Count); // "Expected to have no assembly in the black list"
@@ -6060,7 +6060,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // If the names do not match then i expect there to be no black list items
                 Assert.Equal(0, blackList.Count); // "Expected to have no assembly in the black list"
@@ -6107,7 +6107,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // If the names do not match then i expect there to be no black list items
                 Assert.Equal(0, blackList.Count); // "Expected to have no assembly in the black list"
@@ -6142,7 +6142,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // If the names do not match then i expect there to be no black list items
                 Assert.Equal(2, blackList.Count); // "Expected to have two assembly in the black list"
@@ -6151,7 +6151,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 ArrayList whiteListErrors2 = new ArrayList();
                 ArrayList whiteListErrorFileNames2 = new ArrayList();
-                Hashtable blackList2 = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList2 = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
                 Assert.Same(blackList, blackList2);
             }
             finally
@@ -6230,7 +6230,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 Assert.Equal(1, blackList.Count); // "Expected to have one assembly in the black list"
                 Assert.True(blackList.ContainsKey("System.Xml, Version=2.0.0.0, Culture=Neutral, PublicKeyToken=b03f5f7f11d50a3a")); // "Expected System.xml to be in the black list"
@@ -6246,7 +6246,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
         /// <summary>
         /// Test the case where we generate a black list based on a set of subset file paths, and then ask for
-        /// another black list using the same file paths. We expect to get the exact same Hashtable out
+        /// another black list using the same file paths. We expect to get the exact same Dictionary out
         /// as it should be pulled from the cache.
         /// </summary>
         [Fact]
@@ -6263,7 +6263,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // Since there were no white list expect the black list to return null
                 Assert.Equal(1, blackList.Count); // "Expected to have one assembly in the black list"
@@ -6273,7 +6273,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 List<Exception> whiteListErrors2 = new List<Exception>();
                 List<string> whiteListErrorFileNames2 = new List<string>();
-                Hashtable blackList2 = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors2, whiteListErrorFileNames2);
+                Dictionary<string, string> blackList2 = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors2, whiteListErrorFileNames2);
                 Assert.Same(blackList, blackList2);
             }
             finally
@@ -6308,7 +6308,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo, subsetListInfo2 }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo, subsetListInfo2 }, whiteListErrors, whiteListErrorFileNames);
                 // Since there were no white list expect the black list to return null
                 Assert.Equal(0, blackList.Count); // "Expected to have no assemblies in the black list"
                 Assert.Equal(0, whiteListErrors.Count); // "Expected there to be no error in the whiteListErrors"
@@ -6349,7 +6349,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // Since there were no white list expect the black list to return null
                 Assert.Equal(0, blackList.Count); // "Expected to have no assemblies in the black list"
@@ -6381,7 +6381,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFileNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFileNames);
 
                 // Since there were no white list expect the black list to return null
                 Assert.Equal(0, blackList.Count); // "Expected to have no assemblies in the black list"
@@ -6422,7 +6422,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 RedistList redistList = RedistList.GetRedistList(new AssemblyTableInfo[] { redistListInfo });
                 List<Exception> whiteListErrors = new List<Exception>();
                 List<string> whiteListErrorFilesNames = new List<string>();
-                Hashtable blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFilesNames);
+                Dictionary<string, string> blackList = redistList.GenerateBlackList(new AssemblyTableInfo[] { subsetListInfo }, whiteListErrors, whiteListErrorFilesNames);
 
                 // Since there were no white list expect the black list to return null
                 Assert.Equal(0, blackList.Count); // "Expected to have no assemblies in the black list"
@@ -6644,8 +6644,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             referenceTable.MarkReferencesForExclusion(null);
             referenceTable.RemoveReferencesMarkedForExclusion(false, String.Empty);
             Dictionary<AssemblyNameExtension, Reference> table2 = referenceTable.References;
-            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected hashtable to be a different instance"
-            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the hashtable"
+            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected Dictionary to be a different instance"
+            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the Dictionary"
             Assert.True(table2.ContainsKey(engineAssemblyName)); // "Expected to find the engineAssemblyName in the referenceList"
             Assert.True(table2.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
         }
@@ -6666,11 +6666,11 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             table.Add(engineAssemblyName, new Reference(isWinMDFile, fileExists, getRuntimeVersion));
             table.Add(xmlAssemblyName, new Reference(isWinMDFile, fileExists, getRuntimeVersion));
 
-            referenceTable.MarkReferencesForExclusion(new Hashtable());
+            referenceTable.MarkReferencesForExclusion(new Dictionary<string, string>());
             referenceTable.RemoveReferencesMarkedForExclusion(false, String.Empty);
             Dictionary<AssemblyNameExtension, Reference> table2 = referenceTable.References;
-            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected hashtable to be a different instance"
-            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the hashtable"
+            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected Dictionary to be a different instance"
+            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the Dictionary"
             Assert.True(table2.ContainsKey(engineAssemblyName)); // "Expected to find the engineAssemblyName in the referenceList"
             Assert.True(table2.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
         }
@@ -6697,7 +6697,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             table.Add(engineAssemblyName, reference);
             table.Add(xmlAssemblyName, new Reference(isWinMDFile, fileExists, getRuntimeVersion));
 
-            Hashtable blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var blackList = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             blackList[engineAssemblyName.FullName] = null;
             string[] targetFrameworks = new string[] { "Client", "Web" };
             string subSetName = ResolveAssemblyReference.GenerateSubSetName(targetFrameworks, null);
@@ -6737,7 +6737,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             table.Add(engineAssemblyName, reference);
             table.Add(xmlAssemblyName, new Reference(isWinMDFile, fileExists, getRuntimeVersion));
 
-            Hashtable blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var blackList = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             blackList[engineAssemblyName.FullName] = null;
             string[] targetFrameworks = new string[] { "Client", "Web" };
             string subSetName = ResolveAssemblyReference.GenerateSubSetName(targetFrameworks, null);
@@ -6814,7 +6814,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             table.Add(engineAssemblyName, reference);
             table.Add(xmlAssemblyName, new Reference(isWinMDFile, fileExists, getRuntimeVersion));
 
-            Hashtable blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            var blackList = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             blackList[engineAssemblyName.FullName] = null;
             referenceTable.MarkReferencesForExclusion(blackList);
             referenceTable.RemoveReferencesMarkedForExclusion(true, String.Empty);
@@ -6839,7 +6839,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -6883,7 +6883,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -6924,7 +6924,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension xmlAssemblyName = new AssemblyNameExtension("System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             Reference enginePrimaryReference = new Reference(isWinMDFile, fileExists, getRuntimeVersion);
@@ -6966,7 +6966,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension xmlAssemblyName = new AssemblyNameExtension("System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -7018,7 +7018,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -7069,7 +7069,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
                 null, null, null, new Version("4.0"), null, null, null, true, false, null, null, false, null, WarnOrErrorOnTargetArchitectureMismatchBehavior.None, false, false, null);
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -7117,7 +7117,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -7183,7 +7183,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             ReferenceTable referenceTable;
             MockEngine mockEngine;
             ResolveAssemblyReference rar;
-            Hashtable blackList;
+            Dictionary<string, string> blackList;
             AssemblyNameExtension engineAssemblyName = new AssemblyNameExtension("Microsoft.Build.Engine, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension dataAssemblyName = new AssemblyNameExtension("System.Data, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             AssemblyNameExtension sqlclientAssemblyName = new AssemblyNameExtension("System.SqlClient, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
@@ -7427,9 +7427,9 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// <summary>
         ///Initialize the black list and use it to remove references from the reference table
         /// </summary>
-        private void InitializeExclusionList(ReferenceTable referenceTable, AssemblyNameExtension[] assembliesForBlackList, out Hashtable blackList)
+        private void InitializeExclusionList(ReferenceTable referenceTable, AssemblyNameExtension[] assembliesForBlackList, out Dictionary<string, string> blackList)
         {
-            blackList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            blackList = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (AssemblyNameExtension assemblyName in assembliesForBlackList)
             {
                 blackList[assemblyName.FullName] = null;

--- a/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/Miscellaneous.cs
@@ -6707,8 +6707,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Dictionary<AssemblyNameExtension, Reference> table2 = referenceTable.References;
             string warningMessage = rar.Log.FormatResourceString("ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList", taskItem.ItemSpec, subSetName);
-            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected hashtable to be a different instance"
-            Assert.Equal(1, table2.Count); // "Expected there to be one elements in the hashtable"
+            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected dictionary to be a different instance"
+            Assert.Equal(1, table2.Count); // "Expected there to be one elements in the dictionary"
             Assert.False(table2.ContainsKey(engineAssemblyName)); // "Expected to not find the engineAssemblyName in the referenceList"
             Assert.True(table2.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
             mockEngine.AssertLogContains(warningMessage);
@@ -6746,8 +6746,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
 
             Dictionary<AssemblyNameExtension, Reference> table2 = referenceTable.References;
             string warningMessage = rar.Log.FormatResourceString("ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList", taskItem.ItemSpec, subSetName);
-            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected hashtable to be a different instance"
-            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the hashtable"
+            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected dictionary to be a different instance"
+            Assert.Equal(2, table2.Count); // "Expected there to be two elements in the dictionary"
             Assert.True(table2.ContainsKey(engineAssemblyName)); // "Expected to find the engineAssemblyName in the referenceList"
             Assert.True(table2.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
             mockEngine.AssertLogDoesntContain(warningMessage);
@@ -6822,8 +6822,8 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             Dictionary<AssemblyNameExtension, Reference> table2 = referenceTable.References;
             string subSetName = ResolveAssemblyReference.GenerateSubSetName(new string[] { }, null);
             string warningMessage = rar.Log.FormatResourceString("ResolveAssemblyReference.FailedToResolveReferenceBecausePrimaryAssemblyInExclusionList", taskItem.ItemSpec, subSetName);
-            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected hashtable to be a different instance"
-            Assert.Equal(1, table2.Count); // "Expected there to be one elements in the hashtable"
+            Assert.False(Object.ReferenceEquals(table, table2)); // "Expected dictionary to be a different instance"
+            Assert.Equal(1, table2.Count); // "Expected there to be one elements in the dictionary"
             Assert.False(table2.ContainsKey(engineAssemblyName)); // "Expected to not find the engineAssemblyName in the referenceList"
             Assert.True(table2.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
             Assert.True(String.IsNullOrEmpty(mockEngine.Log));
@@ -7153,7 +7153,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string warningMessage3 = rar.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", taskItem2.ItemSpec, dataAssemblyName.FullName, subsetName);
 
             Dictionary<AssemblyNameExtension, Reference> table = referenceTable.References;
-            Assert.Equal(0, table.Count); // "Expected there to be two elements in the hashtable"
+            Assert.Equal(0, table.Count); // "Expected there to be two elements in the dictionary"
             Assert.False(table.ContainsKey(sqlclientAssemblyName)); // "Expected to not find the sqlclientAssemblyName in the referenceList"
             Assert.False(table.ContainsKey(dataAssemblyName)); // "Expected to not to find the dataAssemblyName in the referenceList"
             Assert.False(table.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
@@ -7222,7 +7222,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
             string notExpectedwarningMessage2 = rar.Log.FormatResourceString("ResolveAssemblyReference.FailBecauseDependentAssemblyInExclusionList", taskItem.ItemSpec, sqlclientAssemblyName.FullName, subsetName);
 
             Dictionary<AssemblyNameExtension, Reference> table = referenceTable.References;
-            Assert.Equal(3, table.Count); // "Expected there to be three elements in the hashtable"
+            Assert.Equal(3, table.Count); // "Expected there to be three elements in the dictionary"
             Assert.True(table.ContainsKey(sqlclientAssemblyName)); // "Expected to find the sqlclientAssemblyName in the referenceList"
             Assert.True(table.ContainsKey(dataAssemblyName)); // "Expected to find the dataAssemblyName in the referenceList"
             Assert.False(table.ContainsKey(xmlAssemblyName)); // "Expected not to find the xmlssemblyName in the referenceList"
@@ -7257,7 +7257,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private static void VerifyReferenceTable(ReferenceTable referenceTable, MockEngine mockEngine, AssemblyNameExtension engineAssemblyName, AssemblyNameExtension dataAssemblyName, AssemblyNameExtension sqlclientAssemblyName, AssemblyNameExtension xmlAssemblyName, string[] warningMessages)
         {
             Dictionary<AssemblyNameExtension, Reference> table = referenceTable.References;
-            Assert.Equal(0, table.Count); // "Expected there to be zero elements in the hashtable"
+            Assert.Equal(0, table.Count); // "Expected there to be zero elements in the dictionary"
 
             if (warningMessages != null)
             {
@@ -7787,7 +7787,7 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         private static void VerifyReferenceTable(ReferenceTable referenceTable, MockEngine mockEngine, AssemblyNameExtension engineAssemblyName, AssemblyNameExtension dataAssemblyName, AssemblyNameExtension sqlclientAssemblyName, AssemblyNameExtension xmlAssemblyName, string warningMessage, string warningMessage2)
         {
             IDictionary<AssemblyNameExtension, Reference> table = referenceTable.References;
-            Assert.Equal(3, table.Count); // "Expected there to be three elements in the hashtable"
+            Assert.Equal(3, table.Count); // "Expected there to be three elements in the dictionary"
             Assert.False(table.ContainsKey(sqlclientAssemblyName)); // "Expected to not find the sqlclientAssemblyName in the referenceList"
             Assert.True(table.ContainsKey(xmlAssemblyName)); // "Expected to find the xmlssemblyName in the referenceList"
             Assert.True(table.ContainsKey(dataAssemblyName)); // "Expected to find the dataAssemblyName in the referenceList"

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -3,7 +3,6 @@
 #if FEATURE_WIN32_REGISTRY
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -208,7 +207,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersFromConfig/AssemblyFoldersFromConfigResolver.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
@@ -178,7 +175,7 @@ namespace Microsoft.Build.Tasks.AssemblyFoldersFromConfig
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersResolver.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Reflection;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Shared;
 
@@ -49,7 +47,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
 
             out string foundPath,
             out bool userRequestedSpecificFile

--- a/src/Tasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Tasks

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -52,7 +51,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string resolvedSearchPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
+++ b/src/Tasks/AssemblyDependency/CandidateAssemblyFilesResolver.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
-using System.Collections;
 using Microsoft.Build.Shared;
 using System.Diagnostics;
 
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/DirectoryResolver.cs
+++ b/src/Tasks/AssemblyDependency/DirectoryResolver.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/FrameworkPathResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Shared;
 
@@ -54,7 +53,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/GacResolver.cs
+++ b/src/Tasks/AssemblyDependency/GacResolver.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -58,7 +58,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
-using System.Collections;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
+++ b/src/Tasks/AssemblyDependency/RawFilenameResolver.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
-using System.Collections;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Add items that caused (possibly indirectly through a dependency chain) this Reference.
         /// </summary>
-        internal void AddSourceItems(ICollection<ITaskItem> sourceItemsToAdd)
+        internal void AddSourceItems(IEnumerable<ITaskItem> sourceItemsToAdd)
         {
             foreach (ITaskItem sourceItem in sourceItemsToAdd)
             {

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Tasks
     sealed internal class Reference
     {
         /// <summary>
-        /// Hashtable where ITaskItem.ItemSpec (a string) is the key and ITaskItem is the value.
+        /// dictionary where ITaskItem.ItemSpec (a string) is the key and ITaskItem is the value.
         /// A hash table is used to remove duplicates.
         /// All source items that inspired this reference (possibly indirectly through a dependency chain).
         /// </summary>

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Microsoft.Build.Shared;
@@ -160,7 +158,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Add items that caused (possibly indirectly through a dependency chain) this Reference.
         /// </summary>
-        internal void AddSourceItems(IEnumerable sourceItemsToAdd)
+        internal void AddSourceItems(ICollection<ITaskItem> sourceItemsToAdd)
         {
             foreach (ITaskItem sourceItem in sourceItemsToAdd)
             {
@@ -186,7 +184,7 @@ namespace Microsoft.Build.Tasks
         /// Get the source items for this reference.
         ///  This is collection of ITaskItems.
         /// </summary>
-        internal ICollection GetSourceItems()
+        internal ICollection<ITaskItem> GetSourceItems()
         {
             return _sourceItems.Values;
         }
@@ -220,7 +218,7 @@ namespace Microsoft.Build.Tasks
                 if (IsUnresolvable)
                 {
                     _errors = new List<Exception>();
-                    AssembliesConsideredAndRejected = new ArrayList();
+                    AssembliesConsideredAndRejected = new List<ResolutionSearchLocation>();
                 }
             }
         }
@@ -246,9 +244,9 @@ namespace Microsoft.Build.Tasks
         /// Get the dependee references for this reference.
         ///  This is collection of References.
         /// </summary>
-        internal ICollection GetDependees()
+        internal HashSet<Reference> GetDependees()
         {
-            return _dependees.ToList();
+            return _dependees;
         }
 
         /// <summary>
@@ -408,7 +406,7 @@ namespace Microsoft.Build.Tasks
         /// Return the list of dependency or resolution errors for this item.
         /// </summary>
         /// <returns>The collection of resolution errors.</returns>
-        internal ICollection GetErrors()
+        internal List<Exception> GetErrors()
         {
             return _errors;
         }
@@ -431,7 +429,7 @@ namespace Microsoft.Build.Tasks
         /// Return the list of related files for this item.
         /// </summary>
         /// <returns>The collection of related file extensions.</returns>
-        internal ICollection GetRelatedFileExtensions()
+        internal List<string> GetRelatedFileExtensions()
         {
             return _relatedFileExtensions;
         }
@@ -464,7 +462,7 @@ namespace Microsoft.Build.Tasks
         /// Return the list of satellite files for this item.
         /// </summary>
         /// <returns>The collection of satellit files.</returns>
-        internal ICollection GetSatelliteFiles()
+        internal List<string> GetSatelliteFiles()
         {
             return _satelliteFiles;
         }
@@ -473,7 +471,7 @@ namespace Microsoft.Build.Tasks
         /// Return the list of serialization assembly files for this item.
         /// </summary>
         /// <returns>The collection of serialization assembly files.</returns>
-        internal ICollection GetSerializationAssemblyFiles()
+        internal List<string> GetSerializationAssemblyFiles()
         {
             return _serializationAssemblyFiles;
         }
@@ -500,7 +498,7 @@ namespace Microsoft.Build.Tasks
                         _scatterFiles = Array.Empty<string>();
                         _satelliteFiles = new List<string>();
                         _serializationAssemblyFiles = new List<string>();
-                        AssembliesConsideredAndRejected = new ArrayList();
+                        AssembliesConsideredAndRejected = new List<ResolutionSearchLocation>();
                         ResolvedSearchPath = String.Empty;
                         _preUnificationVersions = new Dictionary<string, UnificationVersion>(StringComparer.OrdinalIgnoreCase);
                         IsBadImage = false;
@@ -804,7 +802,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Add some records to the table of assemblies that were considered and then rejected.
         /// </summary>
-        internal void AddAssembliesConsideredAndRejected(ArrayList assembliesConsideredAndRejectedToAdd)
+        internal void AddAssembliesConsideredAndRejected(List<ResolutionSearchLocation> assembliesConsideredAndRejectedToAdd)
         {
             AssembliesConsideredAndRejected.AddRange(assembliesConsideredAndRejectedToAdd);
         }
@@ -813,7 +811,7 @@ namespace Microsoft.Build.Tasks
         /// Returns a collection of strings. Each string is the full path to an assembly that was 
         /// considered for resolution but then rejected because it wasn't a complete match.
         /// </summary>
-        internal ArrayList AssembliesConsideredAndRejected { get; private set; } = new ArrayList();
+        internal List<ResolutionSearchLocation> AssembliesConsideredAndRejected { get; private set; } = new List<ResolutionSearchLocation>();
 
         /// <summary>
         /// The searchpath location that the reference was found at.

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -485,7 +484,7 @@ namespace Microsoft.Build.Tasks
         (
             ITaskItem[] referenceAssemblyFiles,
             ITaskItem[] referenceAssemblyNames,
-            ArrayList exceptions
+            List<Exception> exceptions
         )
         {
             // Loop over the referenceAssemblyFiles provided and add each one that doesn't exist.
@@ -1248,7 +1247,7 @@ namespace Microsoft.Build.Tasks
             bool userRequestedSpecificFile = false;
 
             // A list of assemblies that might have been matches but weren't
-            var assembliesConsideredAndRejected = new ArrayList();
+            var assembliesConsideredAndRejected = new List<ResolutionSearchLocation>();
 
             // First, look for the dependency in the parents' directories. Unless they are resolved from the GAC or assemblyFoldersEx then 
             // we should make sure we use the GAC and assemblyFolders resolvers themserves rather than a directory resolver to find the reference.
@@ -1391,7 +1390,7 @@ namespace Microsoft.Build.Tasks
 
                     // A Primary reference can also be dependency of other references. This means there may be other primary reference which depend on 
                     // the current primary reference and they need to be removed.
-                    ICollection dependees = assemblyReference.GetSourceItems();
+                    ICollection<ITaskItem> dependees = assemblyReference.GetSourceItems();
 
                     // Need to deal with dependencies, this can also include primary references who are dependencies themselves and are in the black list
                     if (!assemblyReference.IsPrimary || (assemblyReference.IsPrimary && isMarkedForExclusion && (dependees != null && dependees.Count > 1)))
@@ -1463,7 +1462,7 @@ namespace Microsoft.Build.Tasks
         {
             // For a dependency we would like to remove the primary references which caused this dependency to be found.
             // Source Items is the list of primary itemspecs which lead to the current reference being discovered. 
-            ICollection dependees = assemblyReference.GetSourceItems();
+            ICollection<ITaskItem> dependees = assemblyReference.GetSourceItems();
             foreach (ITaskItem dependee in dependees)
             {
                 string dependeeItemSpec = dependee.ItemSpec;
@@ -1594,7 +1593,7 @@ namespace Microsoft.Build.Tasks
             IEnumerable<DependentAssembly> remappedAssembliesValue,
             ITaskItem[] referenceAssemblyFiles,
             ITaskItem[] referenceAssemblyNames,
-            ArrayList exceptions
+            List<Exception> exceptions
         )
         {
 #if (!STANDALONEBUILD)
@@ -2518,7 +2517,7 @@ namespace Microsoft.Build.Tasks
             scatterFiles = scatterItems.ToArray();
 
             // Sort for stable outputs. (These came from a hashtable, which as undefined enumeration order.)
-            Array.Sort(primaryFiles, TaskItemSpecFilenameComparer.Comparer);
+            Array.Sort(primaryFiles, TaskItemSpecFilenameComparer.GenericComparer);
 
             // Find the copy-local items.
             FindCopyLocalItems(primaryFiles, copyLocalItems);
@@ -2641,7 +2640,7 @@ namespace Microsoft.Build.Tasks
                 bool hasWinMDFile = referenceItem.GetMetadata(ItemMetadataNames.winMDFile).Length > 0;
 
                 // If there were non-primary source items, then forward metadata from them.
-                ICollection sourceItems = reference.GetSourceItems();
+                ICollection<ITaskItem> sourceItems = reference.GetSourceItems();
                 foreach (ITaskItem sourceItem in sourceItems)
                 {
                     sourceItem.CopyMetadataTo(referenceItem);
@@ -2996,7 +2995,7 @@ namespace Microsoft.Build.Tasks
         /// Rather than have exclusion lists float around, we may as well just mark the reference themselves. This allows us to attach to a reference
         /// whether or not it is excluded and why.  This method will do a number of checks in a specific order and mark the reference as being excluded or not.
         /// </summary>
-        internal bool MarkReferencesForExclusion(Hashtable exclusionList)
+        internal bool MarkReferencesForExclusion(Dictionary<string, string> exclusionList)
         {
             bool anyMarkedReference = false;
             ListOfExcludedAssemblies = new List<string>();

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Text;
 using System.Diagnostics;
 using System.Reflection;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -876,7 +875,7 @@ namespace Microsoft.Build.Tasks
         /// <summary>
         /// Storage for names of all files writen to disk.
         /// </summary>
-        private ArrayList _filesWritten = new ArrayList();
+        private List<ITaskItem> _filesWritten = new List<ITaskItem>();
 
         /// <summary>
         /// The names of all files written to disk.
@@ -885,7 +884,7 @@ namespace Microsoft.Build.Tasks
         public ITaskItem[] FilesWritten
         {
             set { /*Do Nothing, Inputs not Allowed*/ }
-            get { return (ITaskItem[])_filesWritten.ToArray(typeof(ITaskItem)); }
+            get { return _filesWritten.ToArray(); }
         }
 
         /// <summary>
@@ -925,7 +924,7 @@ namespace Microsoft.Build.Tasks
             ReferenceTable dependencyTable,
             List<DependentAssembly> idealAssemblyRemappings,
             List<AssemblyNameReference> idealAssemblyRemappingsIdentities,
-            ArrayList generalResolutionExceptions
+            List<Exception> generalResolutionExceptions
         )
         {
             bool success = true;
@@ -1501,7 +1500,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="importance">The importance of the message.</param>
         private void LogReferenceErrors(Reference reference, MessageImportance importance)
         {
-            ICollection itemErrors = reference.GetErrors();
+            List<Exception> itemErrors = reference.GetErrors();
             foreach (Exception itemError in itemErrors)
             {
                 string message = String.Empty;
@@ -1663,7 +1662,7 @@ namespace Microsoft.Build.Tasks
         {
             if (!reference.IsPrimary)
             {
-                ICollection dependees = reference.GetSourceItems();
+                ICollection<ITaskItem> dependees = reference.GetSourceItems();
                 foreach (ITaskItem dependee in dependees)
                 {
                     Log.LogMessageFromResources(importance, "ResolveAssemblyReference.FourSpaceIndent", Log.FormatResourceString("ResolveAssemblyReference.RequiredBy", dependee.ItemSpec));
@@ -1976,7 +1975,7 @@ namespace Microsoft.Build.Tasks
                         redistList = RedistList.GetRedistList(installedAssemblyTableInfo);
                     }
 
-                    Hashtable blackList = null;
+                    Dictionary<string, string> blackList = null;
 
                     // The name of the subset if it is generated or the name of the profile. This will be used for error messages and logging.
                     string subsetOrProfileName = null;
@@ -2157,7 +2156,7 @@ namespace Microsoft.Build.Tasks
                     dependencyTable.FindDependenciesOfExternallyResolvedReferences = FindDependenciesOfExternallyResolvedReferences;
 
                     // If AutoUnify, then compute the set of assembly remappings.
-                    ArrayList generalResolutionExceptions = new ArrayList();
+                    var generalResolutionExceptions = new List<Exception>();
 
                     subsetOrProfileName = targetingSubset && String.IsNullOrEmpty(_targetedFrameworkMoniker) ? subsetOrProfileName : _targetedFrameworkMoniker;
                     bool excludedReferencesExist = false;
@@ -2494,7 +2493,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="installedAssemblyTableInfo">Installed assembly info of the profile redist lists</param>
         /// <param name="fullRedistAssemblyTableInfo">Installed assemblyInfo for the full framework redist lists</param>
         /// <param name="blackList">Generated exclusion list</param>
-        private void HandleProfile(AssemblyTableInfo[] installedAssemblyTableInfo, out AssemblyTableInfo[] fullRedistAssemblyTableInfo, out Hashtable blackList, out RedistList fullFrameworkRedistList)
+        private void HandleProfile(AssemblyTableInfo[] installedAssemblyTableInfo, out AssemblyTableInfo[] fullRedistAssemblyTableInfo, out Dictionary<string, string> blackList, out RedistList fullFrameworkRedistList)
         {
             // Redist list which will contain the full framework redist list.
             fullFrameworkRedistList = null;

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Reflection;
-using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Tasks
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         );
@@ -109,7 +109,7 @@ namespace Microsoft.Build.Tasks
             bool isPrimaryProjectReference,
             bool wantSpecificVersion,
             bool allowMismatchBetweenFusionNameAndFileName,
-            ArrayList assembliesConsideredAndRejected
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected
         )
         {
             ResolutionSearchLocation considered = null;
@@ -295,7 +295,7 @@ namespace Microsoft.Build.Tasks
             bool wantSpecificVersion,
             string[] executableExtensions,
             string directory,
-            ArrayList assembliesConsideredAndRejected
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected
         )
         {
             if (assemblyName == null)

--- a/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
+++ b/src/Tasks/AssemblyDependency/TaskItemSpecFilenameComparer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -12,9 +11,8 @@ namespace Microsoft.Build.Tasks
     /// <summary>
     /// Compare two ITaskItems by the file name in their ItemSpec.
     /// </summary>
-    internal sealed class TaskItemSpecFilenameComparer : IComparer, IComparer<ITaskItem>
+    internal sealed class TaskItemSpecFilenameComparer : IComparer<ITaskItem>
     {
-        internal static readonly IComparer Comparer = new TaskItemSpecFilenameComparer();
         internal static readonly IComparer<ITaskItem> GenericComparer = new TaskItemSpecFilenameComparer();
 
         /// <summary>

--- a/src/Tasks/InstalledSDKResolver.cs
+++ b/src/Tasks/InstalledSDKResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -42,7 +41,7 @@ namespace Microsoft.Build.Tasks
             string[] executableExtensions,
             string hintPath,
             string assemblyFolderKey,
-            ArrayList assembliesConsideredAndRejected,
+            List<ResolutionSearchLocation> assembliesConsideredAndRejected,
             out string foundPath,
             out bool userRequestedSpecificFile
         )

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Build.Tasks
         /// 
         /// </summary>
         /// <param name="whiteListAssemblyTableInfo">List of paths to white list xml files</param>
-        /// <returns>A hashtable containing the full assembly names of black listed assemblies as the key, and null as the value. 
+        /// <returns>A dictionary containing the full assembly names of black listed assemblies as the key, and null as the value. 
         ///          If there is no assemblies in the redist list null is returned.
         /// </returns> 
         internal Dictionary<string, string> GenerateBlackList(AssemblyTableInfo[] whiteListAssemblyTableInfo, List<Exception> whiteListErrors, List<string> whiteListErrorFileNames)
@@ -601,7 +601,7 @@ namespace Microsoft.Build.Tasks
                     blackList.Remove(whiteListEntry.FullName + "," + whiteListEntry.RedistName);
                 }
 
-                // The output hashtable needs to be just the full names and not the names + redist name
+                // The output dictionary needs to be just the full names and not the names + redist name
                 var blackListOfAssemblyNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (string name in blackList.Values)
                 {
@@ -771,7 +771,7 @@ namespace Microsoft.Build.Tasks
                             string hashIndex = String.Format(CultureInfo.InvariantCulture, "{0},{1}", newEntry.FullName, newEntry.IsRedistRoot == null ? "null" : newEntry.IsRedistRoot.ToString());
 
                             assemblyEntries.TryGetValue(hashIndex, out AssemblyEntry dictionaryEntry);
-                            // If the entry is not in the hashtable or the entry is in the hashtable but the new entry has the ingac flag true, make sure the hashtable contains the entry with the ingac true.
+                            // If the entry is not in the dictionary or the entry is in the dictionary but the new entry has the ingac flag true, make sure the dictionary contains the entry with the ingac true.
                             if (dictionaryEntry == null || newEntry.InGAC)
                             {
                                 assemblyEntries[hashIndex] = newEntry;

--- a/src/Tasks/RedistList.cs
+++ b/src/Tasks/RedistList.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Build.Tasks
         private readonly ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension> _remappingCache = new ConcurrentDictionary<AssemblyNameExtension, AssemblyNameExtension>(AssemblyNameComparer.GenericComparerConsiderRetargetable);
 
         // List of cached BlackList RedistList objects, the key is a semi-colon delimited list of data file paths
-        private readonly ConcurrentDictionary<string, Hashtable> _cachedBlackList = new ConcurrentDictionary<string, Hashtable>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, Dictionary<string, string>> _cachedBlackList = new ConcurrentDictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
         
         /***************Fields which are only set in the constructor and should not be modified by the class. **********************/
         // Array of errors encountered while reading files.
@@ -500,7 +500,7 @@ namespace Microsoft.Build.Tasks
         /// <returns>A hashtable containing the full assembly names of black listed assemblies as the key, and null as the value. 
         ///          If there is no assemblies in the redist list null is returned.
         /// </returns> 
-        internal Hashtable GenerateBlackList(AssemblyTableInfo[] whiteListAssemblyTableInfo, List<Exception> whiteListErrors, List<string> whiteListErrorFileNames)
+        internal Dictionary<string, string> GenerateBlackList(AssemblyTableInfo[] whiteListAssemblyTableInfo, List<Exception> whiteListErrors, List<string> whiteListErrorFileNames)
         {
             // Return null if there are no assemblies in the redist list.
             if (_assemblyList.Count == 0)
@@ -522,7 +522,7 @@ namespace Microsoft.Build.Tasks
 
             string key = keyBuilder.ToString();
 
-            if (!_cachedBlackList.TryGetValue(key, out Hashtable returnTable))
+            if (!_cachedBlackList.TryGetValue(key, out Dictionary<string, string> returnTable))
             {
                 var whiteListAssemblies = new List<AssemblyEntry>();
 
@@ -602,7 +602,7 @@ namespace Microsoft.Build.Tasks
                 }
 
                 // The output hashtable needs to be just the full names and not the names + redist name
-                var blackListOfAssemblyNames = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                var blackListOfAssemblyNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 foreach (string name in blackList.Values)
                 {
                     blackListOfAssemblyNames[name] = null;


### PR DESCRIPTION
Replaces all ```System.Collection``` usages with the equivalent collections from ```System.Collections.Generic``` in RAR. Seems safe and might help performance a little.