### PR TITLE
Adding a info message when a local property is not evaluated because of global property

### DIFF
--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1360,6 +1360,7 @@ namespace Microsoft.Build.Evaluation
                         !_data.GlobalPropertiesToTreatAsLocal.Contains(propertyElement.Name)
                     )
                 {
+                    _evaluationLoggingContext.LogComment(MessageImportance.Normal, "OM_GlobalProperty", propertyElement.Name);
                     return;
                 }
 


### PR DESCRIPTION
Adding a info message when a local property is not evaluated because there is a global property with the same name already. I re-used a can't override global property error message that we had already.

Fixes https://github.com/Microsoft/msbuild/issues/1196