### PR TITLE
Remove unnecessary AppContextSwitchOverrides from app.config

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -9,7 +9,6 @@
     <runtime>
       <DisableFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
-      <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -7,7 +7,6 @@
       <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
     </startup>
     <runtime>
-      <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <DisableFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
As of .NET 4.6.2, the default values for ```Switch.System.IO.UseLegacyPathHandling``` and ```Switch.System.IO.BlockLongPaths``` are ```false```. Since we now target .NET 4.7.2, these are no longer necessary.