### PR TITLE
Don't allocate RegEx Match objects in some cases

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -642,11 +642,8 @@ namespace Microsoft.Build.Shared
 
             if (NativeMethodsShared.IsWindows && !EndsWithSlash(fullPath))
             {
-                Match drive = FileUtilitiesRegex.DrivePattern.Match(fileSpec);
-                Match UNCShare = FileUtilitiesRegex.UNCPattern.Match(fullPath);
-
-                if ((drive.Success && (drive.Length == fileSpec.Length)) ||
-                    (UNCShare.Success && (UNCShare.Length == fullPath.Length)))
+                if (FileUtilitiesRegex.DrivePattern.IsMatch(fileSpec) ||
+                    FileUtilitiesRegex.UncPattern.IsMatch(fullPath))
                 {
                     // append trailing slash if Path.GetFullPath failed to (this happens with drive-specs and UNC shares)
                     fullPath += Path.DirectorySeparatorChar;

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -18,6 +18,9 @@ namespace Microsoft.Build.Shared
         // regular expression used to match file-specs comprising exactly "<drive letter>:" (with no trailing characters)
         internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:$", RegexOptions.Compiled);
 
+        // regular expression used to match file-specs beginning with "<drive letter>:"
+        internal static readonly Regex StartWithDrivePattern = new Regex(@"^[A-Za-z]:", RegexOptions.Compiled);
+
         private static readonly string s_baseUncPattern = string.Format(
             CultureInfo.InvariantCulture,
             @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+",

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
-using System.Security;
-using System.Collections;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -19,13 +15,21 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class FileUtilitiesRegex
     {
-        // regular expression used to match file-specs beginning with "<drive letter>:" 
-        internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:", RegexOptions.Compiled);
+        // regular expression used to match file-specs comprising exactly "<drive letter>:" (with no trailing characters)
+        internal static readonly Regex DrivePattern = new Regex(@"^[A-Za-z]:$", RegexOptions.Compiled);
+
+        private static readonly string s_baseUncPattern = string.Format(
+            CultureInfo.InvariantCulture,
+            @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+",
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
         // regular expression used to match UNC paths beginning with "\\<server>\<share>"
-        internal static readonly Regex UNCPattern =
+        internal static readonly Regex StartsWithUncPattern = new Regex(s_baseUncPattern, RegexOptions.Compiled);
+
+        // regular expression used to match UNC paths comprising exactly "\\<server>\<share>"
+        internal static readonly Regex UncPattern =
             new Regex(
-                string.Format(CultureInfo.InvariantCulture, @"^[\{0}\{1}][\{0}\{1}][^\{0}\{1}]+[\{0}\{1}][^\{0}\{1}]+",
-                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), RegexOptions.Compiled);
+                string.Format(CultureInfo.InvariantCulture, @"{0}$", s_baseUncPattern),
+                RegexOptions.Compiled);
     }
 }

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Build.Shared
                         if (NativeMethodsShared.IsWindows)
                         {
                             int length = -1;
-                            if (FileUtilitiesRegex.DrivePattern.IsMatch(modifiedItemSpec))
+                            if (FileUtilitiesRegex.StartWithDrivePattern.IsMatch(modifiedItemSpec))
                             {
                                 length = 2;
                             }

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Build.Shared
 
                         if (!EndsWithSlash(modifiedItemSpec))
                         {
-                            ErrorUtilities.VerifyThrow(FileUtilitiesRegex.UNCPattern.IsMatch(modifiedItemSpec),
+                            ErrorUtilities.VerifyThrow(FileUtilitiesRegex.StartsWithUncPattern.IsMatch(modifiedItemSpec),
                                 "Only UNC shares should be missing trailing slashes.");
 
                             // restore/append trailing slash if Path.GetPathRoot() has either removed it, or failed to add it
@@ -471,19 +471,26 @@ namespace Microsoft.Build.Shared
 
                         if (NativeMethodsShared.IsWindows)
                         {
-                            Match root = FileUtilitiesRegex.DrivePattern.Match(modifiedItemSpec);
-
-                            if (!root.Success)
+                            int length = -1;
+                            if (FileUtilitiesRegex.DrivePattern.IsMatch(modifiedItemSpec))
                             {
-                                root = FileUtilitiesRegex.UNCPattern.Match(modifiedItemSpec);
+                                length = 2;
+                            }
+                            else
+                            {
+                                var match = FileUtilitiesRegex.StartsWithUncPattern.Match(modifiedItemSpec);
+                                if (match.Success)
+                                {
+                                    length = match.Length;
+                                }
                             }
 
-                            if (root.Success)
+                            if (length != -1)
                             {
-                                ErrorUtilities.VerifyThrow((modifiedItemSpec.Length > root.Length) && IsSlash(modifiedItemSpec[root.Length]),
+                                ErrorUtilities.VerifyThrow((modifiedItemSpec.Length > length) && IsSlash(modifiedItemSpec[length]),
                                                            "Root directory must have a trailing slash.");
 
-                                modifiedItemSpec = modifiedItemSpec.Substring(root.Length + 1);
+                                modifiedItemSpec = modifiedItemSpec.Substring(length + 1);
                             }
                         }
                         else

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Build.Tasks
                 : Directory.GetCurrentDirectory();
 
             // check if the working directory we're going to use for the exec command is a UNC path
-            workingDirectoryIsUNC = FileUtilitiesRegex.UNCPattern.IsMatch(_workingDirectory);
+            workingDirectoryIsUNC = FileUtilitiesRegex.StartsWithUncPattern.IsMatch(_workingDirectory);
 
             // if the working directory is a UNC path, and all drive letters are mapped, bail out, because the pushd command
             // will not be able to auto-map to the UNC path


### PR DESCRIPTION
Prior code acquired a `Match` and checked the `Length` to assert the full string matched.

This change uses patterns that match end of string `$` in order to draw the same conclusion, allowing the non-allocating `IsMatch` method to be used.

---

Looking at an RPS trace for d16.0 on loading a large solution, this `FileUtilities.GetFullPath`'s usage of `Regex.Match` accounted for 1.5% of total allocations.

We are looking at ways to avoid these calls (dotnet/project-system#3548), but this is a win for MSBuild regardless.

![image](https://user-images.githubusercontent.com/350947/49254235-a211b380-f420-11e8-80cf-afdf663169a3.png)
