### PR TITLE
Log an error when ToolTask.ValidateParameters fails

### DIFF
--- a/src/Utilities/Resources/Strings.resx
+++ b/src/Utilities/Resources/Strings.resx
@@ -172,6 +172,10 @@
   <data name="ToolTask.EnvironmentVariableHeader">
     <value>Environment Variables passed to tool:</value>
   </data>
+  <data name="ToolTask.ValidateParametersFailed">
+    <value>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</value>
+    <comment>{StrBegin="MSB6011: "}</comment>
+  </data>
   <!-- FileTracker strings -->
   <data name="Tracking_LogFilesNotAvailable">
     <value xml:space="preserve">Tracking logs are not available, minimal rebuild will be disabled.</value>
@@ -287,7 +291,7 @@
   <!--
         The Utilities message bucket is: MSB6001 - MSB6200
 
-        Next message code should be MSB6011
+        Next message code should be MSB6012
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Utilities/Resources/Strings.resx
+++ b/src/Utilities/Resources/Strings.resx
@@ -173,7 +173,7 @@
     <value>Environment Variables passed to tool:</value>
   </data>
   <data name="ToolTask.ValidateParametersFailed">
-    <value>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</value>
+    <value>MSB6011: Invalid parameters passed to the {0} task.</value>
     <comment>{StrBegin="MSB6011: "}</comment>
   </data>
   <!-- FileTracker strings -->

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: Zadané umístění spustitelného souboru úlohy {0} je neplatné.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Při čtení souboru seznamu redistribuce {0} došlo k chybě. {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.cs.xlf
+++ b/src/Utilities/Resources/xlf/Strings.cs.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: Der angegebene Speicherort der ausführbaren Datei der Aufgabe "{0}" ist ungültig.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Fehler beim Lesen der redist-Listendatei "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.de.xlf
+++ b/src/Utilities/Resources/xlf/Strings.de.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.en.xlf
+++ b/src/Utilities/Resources/xlf/Strings.en.xlf
@@ -67,6 +67,11 @@
         <target state="new">MSB6004: The specified task executable location "{0}" is invalid.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="new">There was an error reading the redist list file "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.en.xlf
+++ b/src/Utilities/Resources/xlf/Strings.en.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: La ubicación de la tarea ejecutable especificada "{0}" no es válida.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Error al leer el archivo de lista redist "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.es.xlf
+++ b/src/Utilities/Resources/xlf/Strings.es.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.fr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: L'emplacement de la tâche exécutable spécifiée "{0}" n'est pas valide.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Une erreur s'est produite lors de la lecture du fichier de liste de composants redistribuables "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.it.xlf
+++ b/src/Utilities/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: il percorso specificato del file eseguibile dell'attività "{0}" non è valido.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Errore durante la lettura del file dell'elenco redist "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: 指定された実行可能タスクの場所 "{0}" が無効です。</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">再頒布リスト ファイル "{0}" の読み取り中にエラーが発生しました。{1}</target>

--- a/src/Utilities/Resources/xlf/Strings.ja.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ja.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: 지정한 작업 실행 파일의 위치 "{0}"이(가) 잘못되었습니다.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">재배포 목록 파일 "{0}"을(를) 읽는 동안 오류가 발생했습니다. {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.ko.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ko.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: Określona lokalizacja pliku wykonywalnego zadania „{0}” jest nieprawidłowa.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Wystąpił błąd odczytu pliku listy redystrybucyjnej „{0}”. {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.pl.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pl.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: O local da tarefa executável especificada "{0}" é inválido.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">Erro ao ler o arquivo da lista redist "{0}". {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Utilities/Resources/xlf/Strings.pt-BR.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.ru.xlf
+++ b/src/Utilities/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: Указанное расположение исполняемого файла задачи "{0}" является недопустимым.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">При загрузке списка файлов распространяемого пакета "{0}" произошла ошибка. {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.tr.xlf
+++ b/src/Utilities/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: Belirtilen "{0}" görev yürütülebilir dosyası konumu geçersiz.</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">"{0}" yeniden dağıtım liste dosyası okunurken bir hata oluştu. {1}</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: 指定的任务可执行文件位置“{0}”无效。</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">读取 redist 列表文件“{0}”时出错。{1}</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB6004: 指定的工作可執行檔位置 "{0}" 無效。</target>
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
+      <trans-unit id="ToolTask.ValidateParametersFailed">
+        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
+        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <note>{StrBegin="MSB6011: "}</note>
+      </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">
         <source>There was an error reading the redist list file "{0}". {1}</source>
         <target state="translated">讀取可轉散發清單檔 "{0}" 時發生錯誤。{1}</target>

--- a/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Utilities/Resources/xlf/Strings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note>{StrBegin="MSB6004: "}</note>
       </trans-unit>
       <trans-unit id="ToolTask.ValidateParametersFailed">
-        <source>MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</source>
-        <target state="new">MSB6011: {0}.ValidateParameters() returned false, but did not log an error.</target>
+        <source>MSB6011: Invalid parameters passed to the {0} task.</source>
+        <target state="new">MSB6011: Invalid parameters passed to the {0} task.</target>
         <note>{StrBegin="MSB6011: "}</note>
       </trans-unit>
       <trans-unit id="ToolsLocationHelper.InvalidRedistFile">

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1279,10 +1279,15 @@ namespace Microsoft.Build.Utilities
         /// <returns>true, if task executes successfully</returns>
         public override bool Execute()
         {
-            // Let the tool validate its parameters. ToolTask is responsible for logging
-            // useful information about what was wrong with the parameters.
+            // Let the tool validate its parameters.
             if (!ValidateParameters())
             {
+                // The ToolTask is responsible for logging useful information about what was wrong with the
+                // parameters; if it didn't, at least emit a generic message.
+                if (!Log.HasLoggedErrors)
+                {
+                    LogPrivate.LogErrorWithCodeFromResources("ToolTask.ValidateParametersFailed", this.GetType().FullName);
+                }
                 return false;
             }
 


### PR DESCRIPTION
Fixes #3968.

Sample output:

```
Build started 11/29/2018 6:01:24 PM.
     1>Project "s:\msbuild\foo.proj" on node 1 (default targets).
     1>s:\msbuild\foo.proj(4,2): error MSB6011: ClassLibrary3.Class1.ValidateParameters() returned false, but did not l
       og an error.
     1>Done Building Project "s:\msbuild\foo.proj" (default targets) -- FAILED.

Build FAILED.
```