### PR TITLE
Improve ResolveAssemblyReference performance

### DIFF
--- a/src/Shared/AssemblyNameExtension.cs
+++ b/src/Shared/AssemblyNameExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -741,7 +741,7 @@ namespace Microsoft.Build.Shared
             }
 
             // Do the names match?
-            if (0 != string.Compare(Name, that.Name, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(Name, that.Name, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/Shared/ConversionUtilities.cs
+++ b/src/Shared/ConversionUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -69,12 +69,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static bool ValidBooleanTrue(string parameterValue)
         {
-            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+            return String.Equals(parameterValue, "true", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "on", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!no", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -83,12 +83,12 @@ namespace Microsoft.Build.Shared
         /// </summary>
         private static bool ValidBooleanFalse(string parameterValue)
         {
-            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+            return String.Equals(parameterValue, "false", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "off", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "no", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) ||
+                   String.Equals(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Shared
         private const string WINDOWS_FILE_SYSTEM_REGISTRY_KEY = @"SYSTEM\CurrentControlSet\Control\FileSystem";
         private const string WINDOWS_LONG_PATHS_ENABLED_VALUE_NAME = "LongPathsEnabled";
 
-        private static DateTime minFileDate = DateTime.FromFileTimeUtc(0);
+        internal static DateTime MinFileDate { get; } = DateTime.FromFileTimeUtc(0);
 
 #if FEATURE_HANDLEREF
         internal static HandleRef NullHandleRef = new HandleRef(null, IntPtr.Zero);
@@ -844,7 +844,7 @@ namespace Microsoft.Build.Shared
             }
 
             DateTime lastWriteTime = Directory.GetLastWriteTimeUtc(fullPath);
-            bool directoryExists = lastWriteTime != minFileDate;
+            bool directoryExists = lastWriteTime != MinFileDate;
 
             fileModifiedTimeUtc = directoryExists ? lastWriteTime : DateTime.MinValue;
             return directoryExists;
@@ -987,7 +987,7 @@ namespace Microsoft.Build.Shared
             else
             {
                 DateTime lastWriteTime = File.GetLastWriteTimeUtc(fullPath);
-                bool fileExists = lastWriteTime != minFileDate;
+                bool fileExists = lastWriteTime != MinFileDate;
 
                 fileModifiedTime = fileExists ? lastWriteTime : DateTime.MinValue;
             }

--- a/src/Tasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyNameReferenceAscendingVersionComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -12,6 +12,8 @@ namespace Microsoft.Build.Tasks
     internal sealed class AssemblyNameReferenceAscendingVersionComparer : IComparer<AssemblyNameReference>
     {
         internal static readonly IComparer<AssemblyNameReference> comparer = new AssemblyNameReferenceAscendingVersionComparer();
+
+        private static Version DummyVersion { get; } = new Version(0, 0);
 
         /// <summary>
         /// Private construct so there's only one instance.
@@ -30,12 +32,12 @@ namespace Microsoft.Build.Tasks
 
             if (v1 == null)
             {
-                v1 = new Version(0, 0);
+                v1 = DummyVersion;
             }
 
             if (v2 == null)
             {
-                v2 = new Version(0, 0);
+                v2 = DummyVersion;
             }
 
             return v1.CompareTo(v2);

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -147,10 +147,11 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         internal void AddSourceItem(ITaskItem sourceItem)
         {
-            bool sourceItemAlreadyInList = _sourceItems.ContainsKey(sourceItem.ItemSpec);
+            string itemSpec = sourceItem.ItemSpec;
+            bool sourceItemAlreadyInList = _sourceItems.ContainsKey(itemSpec);
             if (!sourceItemAlreadyInList)
             {
-                _sourceItems[sourceItem.ItemSpec] = sourceItem;
+                _sourceItems[itemSpec] = sourceItem;
                 PropagateSourceItems(sourceItem);
             }
         }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -419,7 +419,15 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                if (_directoryExists(assemblyFileName))
+                if (_fileExists(assemblyFileName))
+                {
+                    assemblyName = _getAssemblyName(assemblyFileName);
+                    if (assemblyName != null)
+                    {
+                        reference.ResolvedSearchPath = assemblyFileName;
+                    }
+                }
+                else if (_directoryExists(assemblyFileName))
                 {
                     assemblyName = new AssemblyNameExtension("*directory*");
 
@@ -433,24 +441,13 @@ namespace Microsoft.Build.Tasks
                     );
                     reference.FullPath = String.Empty;
                 }
-                else
-                {
-                    if (_fileExists(assemblyFileName))
-                    {
-                        assemblyName = _getAssemblyName(assemblyFileName);
-                        if (assemblyName != null)
-                        {
-                            reference.ResolvedSearchPath = assemblyFileName;
-                        }
-                    }
 
-                    if (assemblyName == null)
-                    {
-                        reference.AddError
-                        (
-                            new DependencyResolutionException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("General.ExpectedFileMissing", reference.FullPath), null)
-                        );
-                    }
+                if (assemblyName == null)
+                {
+                    reference.AddError
+                    (
+                        new DependencyResolutionException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("General.ExpectedFileMissing", reference.FullPath), null)
+                    );
                 }
             }
             catch (BadImageFormatException e)

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -958,15 +958,6 @@ namespace Microsoft.Build.Tasks
             Reference reference
         )
         {
-            // If the directory doesn't exist (which is possible in the situation
-            // where we were passed in a pre-resolved reference from a P2P reference
-            // that hasn't actually been built yet), then GetDirectories will throw.
-            // Avoid that by just short-circuiting here.
-            if (!_directoryExists(reference.DirectoryName))
-            {
-                return;
-            }
-
             string serializationAssemblyFilename = reference.FileNameWithoutExtension + ".XmlSerializers.dll";
             string serializationAssemblyPath = Path.Combine(reference.DirectoryName, serializationAssemblyFilename);
             if (_fileExists(serializationAssemblyPath))

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1192,7 +1192,7 @@ namespace Microsoft.Build.Tasks
         /// <returns></returns>
         private static bool IsPseudoAssembly(string name)
         {
-            return String.Compare(name, "mscorlib", StringComparison.OrdinalIgnoreCase) == 0;
+            return string.Equals(name, "mscorlib", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -1470,7 +1470,7 @@ namespace Microsoft.Build.Tasks
                 if (assemblyReference.IsPrimary)
                 {
                     // Dont process yourself
-                    if (String.Compare(dependeeItemSpec, assemblyReference.PrimarySourceItem.ItemSpec, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(dependeeItemSpec, assemblyReference.PrimarySourceItem.ItemSpec, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }
@@ -1688,7 +1688,7 @@ namespace Microsoft.Build.Tasks
                             // frameworkPath is guaranteed to have a trailing slash, because 
                             // ResolveAssemblyReference.Execute takes care of adding it.
 
-                            if (String.Compare(referenceDirectoryName, frameworkPath, StringComparison.OrdinalIgnoreCase) == 0)
+                            if (string.Equals(referenceDirectoryName, frameworkPath, StringComparison.OrdinalIgnoreCase))
                             {
                                 hasFrameworkPath = true;
                             }
@@ -2403,7 +2403,7 @@ namespace Microsoft.Build.Tasks
                 return true;
             }
 
-            if (0 != String.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(a.Name, b.Name, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1785,23 +1785,23 @@ namespace Microsoft.Build.Tasks
             // since this is known to reveal bugs in at least one circumstance.
             assemblyReferences.Sort(AssemblyNameReferenceAscendingVersionComparer.comparer);
 
-            int leftIndex = 0;
-            int rightIndex = 1;
+            int currentWinnerIndex = 0;
+            int comparisonIndex = 1;
 
-            while (rightIndex < assemblyReferences.Count)
+            while (comparisonIndex < assemblyReferences.Count)
             {
                 bool isLeftVictim = ResolveAssemblyNameConflict
                 (
-                    assemblyReferences[leftIndex],
-                    assemblyReferences[rightIndex]
+                    assemblyReferences[currentWinnerIndex],
+                    assemblyReferences[comparisonIndex]
                 ) == 0;
 
                 if (isLeftVictim)
                 {
-                    leftIndex = rightIndex;
+                    currentWinnerIndex = comparisonIndex;
                 }
 
-                rightIndex++;
+                comparisonIndex++;
             }
         }
 
@@ -1832,9 +1832,8 @@ namespace Microsoft.Build.Tasks
             // First, resolve all conflicts between references.
             ResolveConflictsBetweenReferences(baseNameToReferences);
 
-            // Build two tables, one with a count and one with the corresponding references.
+            // Build a set of assembly names with conflicts and a table with the corresponding references.
             // Dependencies which differ only by version number need a suggested redirect.
-            // The count tells us whether there are two or more.
             var conflictingFullNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var fullNameToReference = new Dictionary<string, AssemblyNameReference>(References.Count, StringComparer.OrdinalIgnoreCase);
 
@@ -1894,7 +1893,7 @@ namespace Microsoft.Build.Tasks
 
             // Pass over the list of conflicting references and make a binding redirect for each.
             var idealRemappingsList = new List<DependentAssembly>(assemblyNamesList.Count);
-            var bindingRedirectVersion = new Version(0, 0, 0, 0);
+            var zeroVersion = new Version(0, 0, 0, 0);
 
             foreach (AssemblyNameReference assemblyNameReference in assemblyNamesList)
             {
@@ -1904,7 +1903,7 @@ namespace Microsoft.Build.Tasks
                 };
                 var bindingRedirect = new BindingRedirect
                 {
-                    OldVersionLow = bindingRedirectVersion,
+                    OldVersionLow = zeroVersion,
                     OldVersionHigh = assemblyNameReference.assemblyName.AssemblyName.Version,
                     NewVersion = assemblyNameReference.assemblyName.AssemblyName.Version
                 };

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -487,10 +487,10 @@ namespace Microsoft.Build.Tasks
                         (
                             Path.GetFileNameWithoutExtension(path)
                         );
+                    string filename = Path.GetFileName(path);
 
                     foreach (AssemblyEntry a in assemblyNames)
                     {
-                        string filename = Path.GetFileName(path);
                         string pathFromRedistList = Path.Combine(a.FrameworkDirectory, filename);
 
                         if (String.Equals(path, pathFromRedistList, StringComparison.OrdinalIgnoreCase))

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -480,7 +480,8 @@ namespace Microsoft.Build.Tasks
             if (redistList != null)
             {
                 string extension = Path.GetExtension(path);
-                if (String.Compare(extension, ".dll", StringComparison.OrdinalIgnoreCase) == 0)
+
+                if (string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase))
                 {
                     IEnumerable<AssemblyEntry> assemblyNames = redistList.FindAssemblyNameFromSimpleName
                         (

--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -630,7 +630,7 @@ namespace Microsoft.Build.Tasks
         private bool FileTimestampIndicatesFileExists(DateTime lastModified)
         {
             // TODO: Standardize LastWriteTime value for nonexistent files. See https://github.com/Microsoft/msbuild/issues/3699
-            return lastModified != DateTime.MinValue && lastModified != DateTime.FromFileTimeUtc(0);
+            return lastModified != DateTime.MinValue && lastModified != NativeMethodsShared.MinFileDate;
         }
 
         /// <summary>


### PR DESCRIPTION
Various hotspots in the core RAR logic that were showing up in profiles, and some easy allocation reductions. I'll break this up into separate commits with exact changes and clean up a bit, but here's a side-by-side perf trace I just ran on the changes in ```ReferenceTable``` when building OrchardCore. Notably ```ResolveConflicts()``` is basically free.

<img width="1388" alt="rarperf" src="https://user-images.githubusercontent.com/32187633/49320111-e5b5fd00-f4b4-11e8-857c-9f54a46e1e9d.PNG">

