### PR TITLE
Distribute ResolveAssemblyReference cache

### DIFF
--- a/src/Tasks/SystemState.cs
+++ b/src/Tasks/SystemState.cs
@@ -386,17 +386,10 @@ namespace Microsoft.Build.Tasks
             bool isCachedInInstance = cachedInstanceFileState != null;
             bool isCachedInProcess =
                 s_processWideFileStateCache.TryGetValue(path, out FileState cachedProcessFileState);
-
-            bool isInstanceFileStateLatest = isCachedInInstance
-                                             && isCachedInProcess
-                                             && cachedInstanceFileState.LastModified > cachedProcessFileState.LastModified;
+            
             bool isInstanceFileStateUpToDate = isCachedInInstance && lastModified == cachedInstanceFileState.LastModified;
             bool isProcessFileStateUpToDate = isCachedInProcess && lastModified == cachedProcessFileState.LastModified;
 
-            if (isInstanceFileStateUpToDate && (!isCachedInProcess || isInstanceFileStateLatest))
-            {
-                return s_processWideFileStateCache[path] = cachedInstanceFileState;
-            }
             if (isProcessFileStateUpToDate)
             {
                 if (isCachedInInstance)
@@ -406,6 +399,10 @@ namespace Microsoft.Build.Tasks
                 }
 
                 return cachedProcessFileState;
+            }
+            if (isInstanceFileStateUpToDate)
+            {
+                return s_processWideFileStateCache[path] = cachedInstanceFileState;
             }
 
             return InitializeFileState(path, lastModified);


### PR DESCRIPTION
Currently, each instance of the ```SystemState``` cache copies _all_ ```FileState``` objects accessed and serializes them onto disk for each project. As pointed out in https://github.com/Microsoft/msbuild/issues/2015#issuecomment-443340515, this results in large amounts of identical data written to disk and deserialized into memory.

This adds some bookkeeping to each ```SystemState``` instance to ensure that ```FileState``` objects aren't duplicated from the process-wide cache if another instance is already responsible for serializing that object. This results in some additional IO on multi-proc builds since RAR execution order may change around and result in some cache misses, but it seems to be outweighed by the huge savings in memory and RAR times.

In both of these traces, this results in a nearly **_30% reduction in time spent on RAR_**

### WebLarge
<img width="1205" alt="rarcacheweblarge" src="https://user-images.githubusercontent.com/32187633/49556054-01574400-f8b7-11e8-9d22-a8ab9d9b3c70.PNG">

### OrchardCore
<img width="1193" alt="rarcacheorchardcore" src="https://user-images.githubusercontent.com/32187633/49556055-04523480-f8b7-11e8-84b9-3e7076bf1f33.PNG">

These are from ```/clp:PerformanceSummary /m``` so the task timings are cumulative, but this gives an idea of overall effect on build times.

**Master**
```
Target Performance Summary:
     6763 ms  Build                                    133 calls

Task Performance Summary:
    10663 ms  ResolveAssemblyReference                 132 calls
```

**Distributed cache**
```
Target Performance Summary:
     5513 ms  Build                                    133 calls

Task Performance Summary:
     7414 ms  ResolveAssemblyReference                 132 calls
```