### PR TITLE
Create the build request before the first build invocation

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1163,6 +1163,25 @@ namespace Microsoft.Build.CommandLine
                             // Determine if the user specified /Target:Restore which means we should only execute a restore in the fancy way that /restore is executed
                             bool restoreOnly = targets.Length == 1 && String.Equals(targets[0], MSBuildConstants.RestoreTargetName, StringComparison.OrdinalIgnoreCase);
 
+                            // Execute restore below changes the current working directory and does not change back. Therefore, if we try to create the request after
+                            // the restore call we end up with incorrect normalize paths to the project. To avoid that, we are preparing the request before the first
+                            // build (restore) request.
+                            // PS: We couldn't find a straight forward way to make the restore invocation clean up after itself, so we should this ugly but less risky
+                            // approach.
+                            GraphBuildRequestData graphBuildRequest = null;
+                            BuildRequestData buildRequest = null;
+                            if (!restoreOnly)
+                            {
+                                if (graphBuild)
+                                {
+                                    graphBuildRequest = new GraphBuildRequestData(new ProjectGraphEntryPoint(projectFile, globalProperties), targets, null);
+                                }
+                                else
+                                {
+                                    buildRequest = new BuildRequestData(projectFile, globalProperties, toolsVersion, targets, null);
+                                }
+                            }
+
                             if (enableRestore || restoreOnly)
                             {
                                 (result, exception) = ExecuteRestore(projectFile, toolsVersion, buildManager, restoreProperties.Count > 0 ? restoreProperties : globalProperties);
@@ -1177,13 +1196,11 @@ namespace Microsoft.Build.CommandLine
                             {
                                 if (graphBuild)
                                 {
-                                    var request = new GraphBuildRequestData(new ProjectGraphEntryPoint(projectFile, globalProperties), targets, null);
-                                    (result, exception) = ExecuteGraphBuild(buildManager, request);
+                                    (result, exception) = ExecuteGraphBuild(buildManager, graphBuildRequest);
                                 }
                                 else
                                 {
-                                    var request = new BuildRequestData(projectFile, globalProperties, toolsVersion, targets, null);
-                                    (result, exception) = ExecuteBuild(buildManager, request);
+                                    (result, exception) = ExecuteBuild(buildManager, buildRequest);
                                 }
                             }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -1163,8 +1163,8 @@ namespace Microsoft.Build.CommandLine
                             // Determine if the user specified /Target:Restore which means we should only execute a restore in the fancy way that /restore is executed
                             bool restoreOnly = targets.Length == 1 && String.Equals(targets[0], MSBuildConstants.RestoreTargetName, StringComparison.OrdinalIgnoreCase);
 
-                            // Execute restore below changes the current working directory and does not change back. Therefore, if we try to create the request after
-                            // the restore call we end up with incorrect normalize paths to the project. To avoid that, we are preparing the request before the first
+                            // ExecuteRestore below changes the current working directory and does not change back. Therefore, if we try to create the request after
+                            // the restore call we end up with incorrectly normalized paths to the project. To avoid that, we are preparing the request before the first
                             // build (restore) request.
                             // PS: We couldn't find a straight forward way to make the restore invocation clean up after itself, so we should this ugly but less risky
                             // approach.


### PR DESCRIPTION
Create the build request before the first build invocation to avoid changes to the current working directory to lead to the wrong request being created in regards to normalized paths to the projects.

This was the less risky change we could come up with for now.