### PR TITLE
Get Roslyn from 15.0 folder in amd64 MSBuild, too

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -92,7 +92,7 @@
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
 
-        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\..\..\15.0\Bin\Roslyn" />
 
         <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(MSBuildExtensionsPath32)\Microsoft\VC\v160\'))" />


### PR DESCRIPTION
This ports the change from 7b279c8ad to apply to 64-bit MSBuild as well
as 32-bit.