### PR TITLE
Preserve bin in official build

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -78,10 +78,10 @@ phases:
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: symbols'
+    displayName: 'Publish Artifact: bin'
     inputs:
-      PathtoPublish: 'artifacts\SymStore'
-      ArtifactName: symbols
+      PathtoPublish: 'artifacts\bin'
+      ArtifactName: bin
     condition: succeededOrFailed()
 
   - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -35,6 +35,8 @@
     <IncludeSatelliteOutputInPack>false</IncludeSatelliteOutputInPack>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <AddAppConfigToBuildOutputs>false</AddAppConfigToBuildOutputs>
+
+    <DebugType Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MonoBuild)' == 'true'">

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -23,6 +23,8 @@
          out of memory problems on large trees -->
     <LargeAddressAware>true</LargeAddressAware>
     <ApplicationIcon>..\MSBuild\MSBuild.ico</ApplicationIcon>
+
+    <DebugType>full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
This is a hacky workaround for problems preserving .pdbs for x64 versions of our .exe projects. We'll have to manually extract/publish those, but with these changes it's possible.

Sample official build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=2309328. Note that it has https://dev.azure.com/devdiv/_apis/resources/Containers/2969610?itemPath=bin%2FMSBuild%2Fx64%2FRelease%2Fnet472%2FMSBuild.pdb and https://dev.azure.com/devdiv/_apis/resources/Containers/2969610?itemPath=bin%2FMSBuildTaskHost%2Fx64%2FRelease%2Fnet35%2FMSBuildTaskHost.pdb (all links internal-only).