### PR TITLE
Use the real submission ID in BuildEventContext.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.Build.BackEnd
                 _componentHost.BuildParameters,
                 _nodeLoggingContext.LoggingService,
                 new BuildEventContext(
-                    _requestEntry.Request.BuildEventContext.SubmissionId,
+                    _requestEntry.Request.SubmissionId,
                     _nodeLoggingContext.BuildEventContext.NodeId,
                     BuildEventContext.InvalidEvaluationId,
                     BuildEventContext.InvalidProjectInstanceId,


### PR DESCRIPTION
Fix https://github.com/Microsoft/msbuild/issues/4044. The symptom of the issue is that design-time build logs (such as those obtained from Project System Tools) do not have evaluation messages or imported projects/targets. This is because the MuxLogger used by Microsoft.VisualStudio.ProjectServices.dll drops all build messages where the submission ID is not equal to the current submission ID of the logger. All evaluation messages had the submission ID set to -1 and they were all dropped.

To fix this we need to propagate the submission Id from the build request so that all log events (including evaluation messages) have a proper submission Id set. The way it is right now the BuildEventContext is Invalid, so the Submission ID is set to -1.

With this change the Submission ID is set correctly and I've verified that the evaluation messages are not being discarded by the MuxLogger.