### PR TITLE
Add a new intrinsic item function

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3890,7 +3890,6 @@ $(
             ProjectInstance projectInstance = project.CreateProjectInstance();
             ICollection<ProjectItemInstance> squiggleItems = projectInstance.GetItems("Squiggle");
 
-            Assert.Equal(expected: 2, actual: squiggleItems.Count);
             Assert.Collection(squiggleItems,
                               item => StringComparer.OrdinalIgnoreCase.Compare(item.EvaluatedInclude, tempSquiggleFilePath),
                               item => StringComparer.OrdinalIgnoreCase.Compare(item.EvaluatedInclude, betaSquiggleFilePath));

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3885,9 +3885,8 @@ $(
 </Project>";
 
             File.WriteAllText(projectLocation.File, projectFileContents);
-            Project project = new Project(projectLocation.File);
 
-            ProjectInstance projectInstance = project.CreateProjectInstance();
+            ProjectInstance projectInstance = new ProjectInstance(projectLocation.File);
             ICollection<ProjectItemInstance> squiggleItems = projectInstance.GetItems("Squiggle");
 
             Assert.Collection(squiggleItems,

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2201,6 +2201,82 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 /// <summary>
+                /// Intrinsic function that returns all files of a given name that are in the same or ancestor directories of the given items.
+                /// </summary>
+                internal static IEnumerable<Pair<string, S>> GetPathsOfAllFilesAbove(Expander<P, I> expander, IElementLocation elementLocation, bool includeNellEntries, string functionName, IEnumerable<Pair<string, S>> itemsOfType, string[] arguments)
+                {
+                    ProjectErrorUtilities.VerifyThrowInvalidProject(arguments != null && arguments.Length == 1, elementLocation, "InvalidItemFunctionSyntax", functionName, (arguments == null ? 0 : arguments.Length));
+
+                    string fileName = arguments[0];
+
+                    // Phase 1: find all the applicable directories.
+
+                    SortedSet<string> directories = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (Pair<string, S> item in itemsOfType)
+                    {
+                        if (String.IsNullOrEmpty(item.Key))
+                        {
+                            continue;
+                        }
+
+                        string directoryName = null;
+
+                        // Unescape as we are passing to the file system
+                        string unescapedPath = EscapingUtilities.UnescapeAll(item.Key);
+
+                        try
+                        {
+                            string rootedPath;
+
+                            // If we're a projectitem instance then we need to get
+                            // the project directory and be relative to that
+                            if (Path.IsPathRooted(unescapedPath))
+                            {
+                                rootedPath = unescapedPath;
+                            }
+                            else
+                            {
+                                // If we're not a ProjectItem or ProjectItemInstance, then ProjectDirectory will be null.
+                                // In that case, we're safe to get the current directory as we'll be running on TaskItems which
+                                // only exist within a target where we can trust the current directory
+                                string baseDirectoryToUse = item.Value.ProjectDirectory ?? String.Empty;
+                                rootedPath = Path.Combine(baseDirectoryToUse, unescapedPath);
+                            }
+
+                            directoryName = Path.GetDirectoryName(rootedPath);
+                        }
+                        catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))
+                        {
+                            ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidItemFunctionExpression", functionName, item.Key, e.Message);
+                        }
+
+                        while (!String.IsNullOrEmpty(directoryName))
+                        {
+                            if (directories.Contains(directoryName))
+                            {
+                                // We've already got this directory (and all its ancestors) in the set.
+                                break;
+                            }
+
+                            directories.Add(directoryName);
+                            directoryName = Path.GetDirectoryName(directoryName);
+                        }
+                    }
+
+                    // Phase 2: Go through the directories and look for the specified file.
+
+                    foreach (string directoryPath in directories)
+                    {
+                        string possibleFile = Path.Combine(directoryPath, fileName);
+                        if (File.Exists(possibleFile))
+                        {
+                            yield return new Pair<string, S>(EscapingUtilities.Escape(possibleFile), null);
+                        }
+                    }
+                }
+
+                /// <summary>
                 /// Intrinsic function that returns the DirectoryName of the items in itemsOfType
                 /// UNDONE: This can be removed in favor of a built-in %(DirectoryName) metadata in future.
                 /// </summary>


### PR DESCRIPTION
Add a new intrinsic item function, `GetPathsOfAllFilesAbove`, to get all the files of a given name that are in the same or ancestor directories of the given items. This is being done to support the ".editorconfig in compiler" scenario where we need to map from all the .cs/.vb files in the project to the applicable set of .editorconfig files. For various reasons we don't want to find the .editorconfig files using a target/task, so instead we are adding this intrinsic function to allow us to find them as part of project evaluation.

There are two phases to the implementation. First we build the set of directories that we will search. For each input item, we get the item's directory and see if it is already in the set. If it is we don't need to do anything further with that item. Otherwise we walk up from that directory to the root, adding each ancestor directory to the set (or bailing out early if it has already been added).

Second, we go through the set of directories looking for the specified file. If it is found we return it.

This way we only check for each potential file once, rather than once per input file under that directory.