### PR TITLE
 Ignore case when hashing CoreCompile inputs

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -703,6 +703,7 @@ namespace Microsoft.Build.Tasks
         public Hash() { }
         [Microsoft.Build.Framework.OutputAttribute]
         public string HashResult { get { throw null; } set { } }
+        public bool IgnoreCase { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -436,6 +436,7 @@ namespace Microsoft.Build.Tasks
         public Hash() { }
         [Microsoft.Build.Framework.OutputAttribute]
         public string HashResult { get { throw null; } set { } }
+        public bool IgnoreCase { get { throw null; } set { } }
         [Microsoft.Build.Framework.RequiredAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ItemsToHash { get { throw null; } set { } }
         public override bool Execute() { throw null; }

--- a/src/Tasks.UnitTests/Hash_Tests.cs
+++ b/src/Tasks.UnitTests/Hash_Tests.cs
@@ -43,12 +43,45 @@ namespace Microsoft.Build.Tasks.UnitTests
             Assert.Null(zeroLengthItemsHash);
         }
 
-        private string ExecuteHashTask(ITaskItem[] items)
+        [Fact]
+        public void HashTaskIgnoreCaseTest()
+        {
+            var uppercaseHash =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("ITEM1"),
+                        new TaskItem("ITEM2"),
+                        new TaskItem("ITEM3")
+                    },
+                    true);
+            var mixedcaseHash =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("Item1"),
+                        new TaskItem("iTEm2"),
+                        new TaskItem("iteM3")
+                    },
+                    true);
+            var lowercaseHash =
+                ExecuteHashTask(new ITaskItem[]
+                    {
+                        new TaskItem("item1"),
+                        new TaskItem("item2"),
+                        new TaskItem("item3")
+                    },
+                    true);
+            Assert.Equal(uppercaseHash, lowercaseHash);
+            Assert.Equal(uppercaseHash, mixedcaseHash);
+            Assert.Equal(mixedcaseHash, lowercaseHash);
+        }
+
+        private string ExecuteHashTask(ITaskItem[] items, bool ignoreCase = false)
         {
             var hashTask = new Hash
             {
                 BuildEngine = new MockEngine(),
-                ItemsToHash = items
+                ItemsToHash = items,
+                IgnoreCase = ignoreCase
             };
 
             Assert.True(hashTask.Execute());

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -54,11 +54,8 @@ namespace Microsoft.Build.Tasks
                     {
                         foreach (var item in ItemsToHash)
                         {
-                            foreach (char c in item.ItemSpec)
-                            {
-                                stringBuilder.Append(IgnoreCase ? char.ToLower(c) : c);
-                            }
-
+                            string itemSpec = item.ItemSpec;
+                            stringBuilder.Append(IgnoreCase ? itemSpec.ToUpperInvariant() : itemSpec);
                             stringBuilder.Append(ItemSeparatorCharacter);
                         }
 

--- a/src/Tasks/Hash.cs
+++ b/src/Tasks/Hash.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Build.Tasks
         public ITaskItem[] ItemsToHash { get; set; }
 
         /// <summary>
+        /// When true, will generate a case-insensitive hash.
+        /// </summary>
+        public bool IgnoreCase { get; set; }
+
+        /// <summary>
         /// Hash of the ItemsToHash ItemSpec.
         /// </summary>
         [Output]
@@ -49,7 +54,11 @@ namespace Microsoft.Build.Tasks
                     {
                         foreach (var item in ItemsToHash)
                         {
-                            stringBuilder.Append(item.ItemSpec);
+                            foreach (char c in item.ItemSpec)
+                            {
+                                stringBuilder.Append(IgnoreCase ? char.ToLower(c) : c);
+                            }
+
                             stringBuilder.Append(ItemSeparatorCharacter);
                         }
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3429,7 +3429,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="$(DefineConstants)" />
     </ItemGroup>
 
-    <Hash ItemsToHash="@(CoreCompileCache)" IgnoreCase="true">
+    <Hash 
+      ItemsToHash="@(CoreCompileCache)" 
+      IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreCase)`, `true`))">
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3429,7 +3429,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="$(DefineConstants)" />
     </ItemGroup>
 
-    <Hash ItemsToHash="@(CoreCompileCache)">
+    <Hash ItemsToHash="@(CoreCompileCache)" IgnoreCase="true">
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>
 


### PR DESCRIPTION
Fixes #4023 

Seems safe to always make hashing before ```CoreCompile``` case-insensitive regardless of file system. On a case-insensitive file system, this fixes the tagged issue. On a case-sensitive file system, adding/removing inputs that only differ by casing will still result in a different hash since we're hashing more/less characters, and breaking it seems like a very rare case.