### PR TITLE
Don't ship NuGet SDK resolver manifest for CoreXT

### DIFF
--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -16,7 +16,6 @@
     <file src="$X86BinPath$/Microsoft.Common.props" target="\Extensions\15.0" />
     <file src="$X86BinPath$/Microsoft.VisualStudioVersion.v15.Common.props" target="\Extensions\15.0" />
 
-    <file src="$repoRoot$\src\MSBuild\SdkResolvers\Standalone\Microsoft.Build.NuGetSdkResolver.xml" target="v15.0\bin\SdkResolvers\Microsoft.Build.NuGetSdkResolver" />
     <!-- x86 -->
 
     <file src="$X86BinPath$/MSBuild.exe" target="v15.0/bin" />


### PR DESCRIPTION
The presence of the XML manifest for the NuGet SDK resolver will cause
MSBuild to error when the actual assembly is not present (it is present
for VS installations from a NuGet VSIX, but it's not guaranteed in
CoreXT environments). Just remove it.

Internal bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/763317