### PR TITLE
Add shebang to cibuild_bootstrapped_msbuild.sh

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 configuration="debug"
 host_type="core"
 build_stage1=true


### PR DESCRIPTION
I wanted to run this on my own machine and was annoyed when zsh didn't like it.