### PR TITLE
Add DesignerRuntimeImplementationProjectOutputGroup

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6010,7 +6010,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <!--
     ============================================================
-                              DesignerOutputGroup
+         DesignerRuntimeImplementationProjectOutputGroup
 
     Exposes build items to be used by designer. The default is empty, but
     SDKs can override it as appropriate. The empty stub is required so that
@@ -6019,16 +6019,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
-    <DesignerOutputGroupDependsOn>
-      $(DesignerOutputGroupDependsOn);
+    <DesignerRuntimeImplementationProjectOutputGroupDependsOn>
+      $(DesignerRuntimeImplementationProjectOutputGroupDependsOn);
       $(CommonOutputGroupsDependsOn)
-    </DesignerOutputGroupDependsOn>
+    </DesignerRuntimeImplementationProjectOutputGroupDependsOn>
   </PropertyGroup>
 
   <Target
-      Name="DesignerOutputGroup"
-      DependsOnTargets="$(DesignerOutputGroupDependsOn)"
-      Returns="@(DesignerOutputGroup)">
+      Name="DesignerRuntimeImplementationProjectOutputGroup"
+      DependsOnTargets="$(DesignerRuntimeImplementationProjectOutputGroupDependsOn)"
+      Returns="@(DesignerRuntimeImplementationProjectOutputGroupOutput)">
   </Target>
 
   <PropertyGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6008,6 +6008,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   </Target>
 
+  <!--
+    ============================================================
+                              DesignerOutputGroup
+
+    Exposes build items to be used by designer. The default is empty, but
+    SDKs can override it as appropriate. The empty stub is required so that
+    the project system can always rely on calling it even if it is not
+    overridden.
+    ============================================================
+    -->
+  <PropertyGroup>
+    <DesignerOutputGroupDependsOn>
+      $(DesignerOutputGroupDependsOn);
+      $(CommonOutputGroupsDependsOn)
+    </DesignerOutputGroupDependsOn>
+  </PropertyGroup>
+
+  <Target
+      Name="DesignerOutputGroup"
+      DependsOnTargets="$(DesignerOutputGroupDependsOn)"
+      Returns="@(DesignerOutputGroup)">
+  </Target>
+
   <PropertyGroup>
     <CodeAnalysisTargets Condition="'$(CodeAnalysisTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeAnalysis\Microsoft.CodeAnalysis.targets</CodeAnalysisTargets>
   </PropertyGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/issues/2707

This adds a stub target for the new output group to common targets, which the SDK will override.

@davkean Is this the correct pattern to follow here?

FYI, @chabiss