### PR TITLE
Update Azure DevOps YAML element names

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -6,7 +6,7 @@ trigger:
 jobs:
 - job: FullOnWindows
   displayName: "Build and test on Windows using full MSBuild"
-  queue: 'Hosted VS2017'
+  pool: 'Hosted VS2017'
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -45,7 +45,7 @@ jobs:
 
 - job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Build and test on Windows using bootstrapped full MSBuild"
-  queue: 'Hosted VS2017'
+  pool: 'Hosted VS2017'
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -84,7 +84,7 @@ jobs:
 
 - job: BootstrapMSBuildOnCoreWindows
   displayName: "Build and test on Windows using bootstrapped core MSBuild"
-  queue: 'Hosted VS2017'
+  pool: 'Hosted VS2017'
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -124,7 +124,7 @@ jobs:
 
 - job: FullReleaseOnWindows
   displayName: "Build and test Release on Windows using full MSBuild"
-  queue: 'Hosted VS2017'
+  pool: 'Hosted VS2017'
   steps:
   - task: BatchScript@1
     displayName: cibuild.cmd
@@ -165,7 +165,7 @@ jobs:
 # Disabling the hostType CI for now: https://github.com/Microsoft/msbuild/issues/4001
 # - job: CoreOnWindows
 #   displayName: "Build and test on Windows using .NET Core MSBuild"
-#   queue: 'Hosted VS2017'
+#   pool: 'Hosted VS2017'
 #   steps:
 #   - task: BatchScript@1
 #     displayName: VsDevCmd
@@ -210,7 +210,7 @@ jobs:
 
 - job: CoreOnLinux
   displayName: "Build and test on Linux using .NET Core MSBuild"
-  queue: 'Hosted Ubuntu 1604'
+  pool: 'Hosted Ubuntu 1604'
   steps:
   - bash: . 'eng/common/cibuild.sh'
     displayName: CI Build
@@ -238,7 +238,7 @@ jobs:
 
 - job: CoreBootstrappedOnLinux
   displayName: "Build and test on Linux using bootstrapped .NET Core MSBuild"
-  queue: 'Hosted Ubuntu 1604'
+  pool: 'Hosted Ubuntu 1604'
   steps:
   - bash: . 'eng/cibuild_bootstrapped_msbuild.sh'
     displayName: CI Build
@@ -266,7 +266,7 @@ jobs:
 
 - job: CoreOnMac
   displayName: "Build and test on macOS using .NET Core MSBuild"
-  queue: 'Hosted macOS'
+  pool: 'Hosted macOS'
   steps:
   - bash: . 'eng/common/cibuild.sh'
     displayName: CI Build

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -3,8 +3,8 @@ trigger:
 - exp/*
 - vs*
 
-phases:
-- phase: FullOnWindows
+jobs:
+- job: FullOnWindows
   displayName: "Build and test on Windows using full MSBuild"
   queue: 'Hosted VS2017'
   steps:
@@ -43,7 +43,7 @@ phases:
       ArtifactName: 'FullOnWindows test logs'
     condition: succeededOrFailed()
 
-- phase: BootstrapMSBuildOnFullFrameworkWindows
+- job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Build and test on Windows using bootstrapped full MSBuild"
   queue: 'Hosted VS2017'
   steps:
@@ -82,7 +82,7 @@ phases:
       ArtifactName: 'FullOnWindows test logs'
     condition: succeededOrFailed()
 
-- phase: BootstrapMSBuildOnCoreWindows
+- job: BootstrapMSBuildOnCoreWindows
   displayName: "Build and test on Windows using bootstrapped core MSBuild"
   queue: 'Hosted VS2017'
   steps:
@@ -122,7 +122,7 @@ phases:
       ArtifactName: 'FullOnWindows test logs'
     condition: succeededOrFailed()
 
-- phase: FullReleaseOnWindows
+- job: FullReleaseOnWindows
   displayName: "Build and test Release on Windows using full MSBuild"
   queue: 'Hosted VS2017'
   steps:
@@ -163,7 +163,7 @@ phases:
     condition: succeededOrFailed()
 
 # Disabling the hostType CI for now: https://github.com/Microsoft/msbuild/issues/4001
-# - phase: CoreOnWindows
+# - job: CoreOnWindows
 #   displayName: "Build and test on Windows using .NET Core MSBuild"
 #   queue: 'Hosted VS2017'
 #   steps:
@@ -208,7 +208,7 @@ phases:
 #       ArtifactName: 'CoreOnWindows test logs'
 #     condition: succeededOrFailed()
 
-- phase: CoreOnLinux
+- job: CoreOnLinux
   displayName: "Build and test on Linux using .NET Core MSBuild"
   queue: 'Hosted Ubuntu 1604'
   steps:
@@ -236,7 +236,7 @@ phases:
       ArtifactName: 'CoreOnLinux test logs'
     condition: succeededOrFailed()
 
-- phase: CoreBootstrappedOnLinux
+- job: CoreBootstrappedOnLinux
   displayName: "Build and test on Linux using bootstrapped .NET Core MSBuild"
   queue: 'Hosted Ubuntu 1604'
   steps:
@@ -264,7 +264,7 @@ phases:
       ArtifactName: 'CoreOnLinux test logs'
     condition: succeededOrFailed()
 
-- phase: CoreOnMac
+- job: CoreOnMac
   displayName: "Build and test on macOS using .NET Core MSBuild"
   queue: 'Hosted macOS'
   steps:


### PR DESCRIPTION
This doesn't directly solve the problem I set out to solve (I think we're just waiting on a feature rollout for https://docs.microsoft.com/en-us/azure/devops/release-notes/2019/sprint-146-update#display-status-for-each-pipeline-job-in-github-checks), but it is consistent with the new names (see https://github.com/MicrosoftDocs/vsts-docs/commit/c16b2205df876ba1d083e2df2af62520efea9128 and https://github.com/MicrosoftDocs/vsts-docs/commit/d5c8e55899bcaaa079fe58a05e8dfeebf58e04be), so might as well go with it.