### PR TITLE
Disable tests with ActiveIssue attributes

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,6 +32,8 @@
 
     <XunitOptions Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(XunitOptions) -notrait category=nonnetcoreapptests</XunitOptions>
 
+    <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+
     <TestRunnerAdditionalArguments>$(XunitOptions)</TestRunnerAdditionalArguments>
     
     <PackageOutputPath Condition="'$(IsVisualStudioInsertionPackage)' == 'true'">$(DevDivPackagesDir)</PackageOutputPath>


### PR DESCRIPTION
I tried to disable a test with an `[ActiveIssue]` annotation and it didn't actually disable, because we weren't telling xunit to ignore known-failing tests.