### PR TITLE
Allow WriteLinesToFile to create empty files

### DIFF
--- a/src/Tasks/FileIO/WriteLinesToFile.cs
+++ b/src/Tasks/FileIO/WriteLinesToFile.cs
@@ -127,11 +127,8 @@ namespace Microsoft.Build.Tasks
                     }
                     else
                     {
-                        if (buffer.Length > 0)
-                        {
-                            Directory.CreateDirectory(directoryPath);
-                            System.IO.File.AppendAllText(File.ItemSpec, buffer.ToString(), encoding);
-                        }
+                        Directory.CreateDirectory(directoryPath);
+                        System.IO.File.AppendAllText(File.ItemSpec, buffer.ToString(), encoding);
                     }
                 }
                 catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))


### PR DESCRIPTION
A change intended as a performance optimization in #4067 caused a
backward-compatibility regression: `WriteLinesToFile` became unable to
create empty files. `Touch` would be more appropriate for that case, but
`WriteLinesToFile` is used in that way in the Framework-delivered
`GenerateCompiledExpressionsTempFile` target, which we can't change
easily.

Removes the condition that caused us to avoid calling `AppendAllText`
with an empty buffer.

Adds regression tests (inverting the ones that ensured deletion).