### PR TITLE
Set debugger-launch parameter as string in CI script

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -110,7 +110,7 @@ try {
   $env:UseSharedCompilation="true"
 
   # Ensure that debug bits fail fast, rather than hanging waiting for a debugger attach.
-  $env:MSBUILDDONOTLAUNCHDEBUGGER=true
+  $env:MSBUILDDONOTLAUNCHDEBUGGER="true"
 
   # When using bootstrapped MSBuild:
   # - Turn off node reuse (so that bootstrapped MSBuild processes don't stay running and lock files)


### PR DESCRIPTION
Avoids an error like

```
The term 'true' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
System.Management.Automation.CommandNotFoundException: The term 'true' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
at <ScriptBlock>, S:\msbuild\eng\cibuild_bootstrapped_msbuild.ps1: line 113
at <ScriptBlock>, <No file>: line 1
```

It isn't clear to me why this happened on my machine just now, but worked fine in Azure Pipelines (and also presumably when I added this line). Different PowerShell versions?