### PR TITLE
Expect Roslyn tasks in Current

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -92,7 +92,7 @@
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
 
-        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\..\..\15.0\Bin\Roslyn" />
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 
         <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(MSBuildExtensionsPath32)\Microsoft\VC\v160\'))" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -88,7 +88,7 @@
         <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
         <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
 
-        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\..\..\15.0\Bin\Roslyn" />
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
 
         <!-- VC Specific Paths -->
         <property name="VCTargetsPath" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(MSBuildExtensionsPath32)\Microsoft\VC\v160\'))" />

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -974,7 +974,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
-    <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="..\..\15.0\Bin\Roslyn" />
     <Content Include="$(NuGetPackageRoot)microsoft.net.compilers\$(MicrosoftNetCompilersVersion)\tools\*" CopyToOutputDirectory="PreserveNewest" LinkBase="Roslyn" />
   </ItemGroup>
 


### PR DESCRIPTION
This completes the move from 15.0 to Current by consuming Roslyn
from the new directory. It is dependent on
https://github.com/dotnet/roslyn/pull/33114 which actually moves the
relevant files.

cc @jaredpar @tmat