### PR TITLE
C++ CodeAnalysis assemblies to v16

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -59,15 +59,15 @@
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>
           <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\FxCopTask.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+          <codeBase version="16.0.0.0" href="..\..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -55,15 +55,15 @@
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>
           <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\FxCopTask.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+          <codeBase version="16.0.0.0" href="..\..\Microsoft\VisualStudio\v16.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
         </dependentAssembly>
       </assemblyBinding>
     </runtime>


### PR DESCRIPTION
These assemblies have moved and versioned in dev16.

Update of the workaround for #1675 in #1699.

Fixes #4137.