### PR TITLE
Let ProjectStartedEventArgs.ParentProjectBuildEventContext.TaskId be …

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1127,7 +1127,7 @@ namespace Microsoft.Build.BackEnd
                         // we receive the configuration response before we enter the wait state.
                         newRequest = new BuildRequest(issuingEntry.Request.SubmissionId, GetNextBuildRequestId(),
                             request.Config.ConfigurationId, request.Targets, issuingEntry.Request.HostServices,
-                            issuingEntry.Request.BuildEventContext, issuingEntry.Request,
+                            issuingEntry.Request.CurrentMSBuildTask ?? issuingEntry.Request.BuildEventContext, issuingEntry.Request,
                             buildRequestDataFlags);
 
                         issuingEntry.WaitForResult(newRequest);

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -420,6 +420,11 @@ namespace Microsoft.Build.BackEnd
                     if (requirements != null)
                     {
                         TaskLoggingContext taskLoggingContext = _targetLoggingContext.LogTaskBatchStarted(_projectFullPath, _targetChildInstance);
+                        if (taskLoggingContext.TaskName == "MSBuild")
+                        {
+                            _buildRequestEntry.Request.CurrentMSBuildTask = taskLoggingContext.BuildEventContext;
+                        }
+
                         try
                         {
                             if (
@@ -461,6 +466,8 @@ namespace Microsoft.Build.BackEnd
                         }
                         finally
                         {
+                            _buildRequestEntry.Request.CurrentMSBuildTask = null;
+
                             // Flag the completion of the task.
                             taskLoggingContext.LogTaskBatchFinished(_projectFullPath, taskResult.ResultCode == WorkUnitResultCode.Success || taskResult.ResultCode == WorkUnitResultCode.Skipped);
 

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -267,6 +267,8 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        public BuildEventContext CurrentMSBuildTask { get; set; }
+
         /// <summary>
         /// The set of flags specified in the BuildRequestData for this request.
         /// </summary>


### PR DESCRIPTION
…the Id of the MSBuild task that spawned the current project build.

This PR is my attempt to address the issue described here - https://github.com/Microsoft/msbuild/issues/3939

I have tested it on a very simple set of targets files. Unfortunately, I have not idea if it breaks any tests or how to unit test it in the first place.
