### PR TITLE
VSIX dependency on NuGet.BuildTools

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -5,6 +5,10 @@ package name=Microsoft.Build
         vs.package.chip=neutral
         vs.package.language=neutral
 
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.NuGet.BuildTools
+                version=[15.0,17.0)
+
 folder InstallDir:\MSBuild\Current
   file source=$(X86BinPath)Microsoft.Common.props
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props


### PR DESCRIPTION
Fixes #3852 by ensuring that NuGet's tasks and targets are present
wherever MSBuild itself is, since common.targets now depends on NuGet.

Closes NuGet/Home#7390.

I did a private test build of 45c61c6e2 ([comparison view](https://github.com/Microsoft/msbuild/compare/vs16.0...exp/vsix-depend-on-nuget)), which is this commit + some build changes that shouldn't be relevant at all. DDRITs passed, Build Tools installs successfully, and the NuGet stuff is there in a C++-only Build Tools installation. Build and DDRIT results available here (Microsoft internal): https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/162986

@rrelyea, can you review or nominate another NuGet reviewer?

@DustinCampbell, this should help with bugs like https://github.com/OmniSharp/omnisharp-roslyn/issues/1311 (not completely; Build Tools could still be missing necessary C# workloads. But help some!)