### PR TITLE
Leave ProjectExtensionsElement if namespace is only diff

### DIFF
--- a/src/Build/Construction/ProjectExtensionsElement.cs
+++ b/src/Build/Construction/ProjectExtensionsElement.cs
@@ -108,7 +108,11 @@ namespace Microsoft.Build.Construction
                     XmlElement.AppendChild(idElement);
                 }
 
-                if (idElement.InnerXml != value)
+                // The actual InnerXml may have the MSBuild namespace but be otherwise identical
+                // to the setting, in which case the namespace was probably inherited from the
+                // document and should be ignored.
+                if (idElement.InnerXml != value &&
+                    idElement.InnerXml.Replace(ProjectRootElement.EmptyProjectFileXmlNamespace, string.Empty) != value)
                 {
                     if (value.Length == 0)
                     {

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Construction
         private const string EmptyProjectFileContent = "{0}<Project{1}{2}>\r\n</Project>";
         private const string EmptyProjectFileXmlDeclaration = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n";
         private const string EmptyProjectFileToolsVersion = " ToolsVersion=\"" + MSBuildConstants.CurrentToolsVersion + "\"";
-        private const string EmptyProjectFileXmlNamespace = " xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"";
+        internal const string EmptyProjectFileXmlNamespace = " xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"";
 
         /// <summary>
         /// The singleton delegate that loads projects into the ProjectRootElement


### PR DESCRIPTION
When setting a ProjectExtensionsElement value, MSBuild diffs the current
and desired XML and writes only in the case that they differ. But this
is producing false negatives because the InnerXml may have a namespace
inherited from the project that isn't represented in the "real" XML.

Allow the current to be equal to the desired _modulo_ that namespace.

Fixes #3904.