### PR TITLE
Allow numeric comparison of $(MSBuildToolsVersion)

### DIFF
--- a/src/Build.UnitTests/EndToEndCondition_Tests.cs
+++ b/src/Build.UnitTests/EndToEndCondition_Tests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("'15.0' &lt; '$(MSBuildToolsVersion)'")]
         [InlineData("'14.0.0.0' &lt; '$(MSBuildToolsVersion)'")]
         [InlineData("'15.0' &lt;= '$(MSBuildToolsVersion)'")]
+        [InlineData("'$(MSBuildToolsVersion)' == '$(VisualStudioVersion)'")]
         public void TrueComparisonsInvolvingMSBuildToolsVersion(string condition)
         {
             MockLogger logger = new MockLogger(_output, profileEvaluation: false, printEventsToStdout: false);
@@ -55,6 +56,7 @@ namespace Microsoft.Build.UnitTests
         [InlineData("'$(MSBuildToolsVersion)' == ''")]
         [InlineData("'$(MSBuildToolsVersion)' == 'Incorrect'")]
         [InlineData("'14.3' &gt; '$(MSBuildToolsVersion)'")]
+        [InlineData("'Current' == '$(VisualStudioVersion)'")] // comparing the string representation of MSBuildToolsVersion directly doesn't match
         public void FalseComparisonsInvolvingMSBuildToolsVersion(string condition)
         {
             MockLogger logger = new MockLogger(_output, profileEvaluation: false, printEventsToStdout: false);

--- a/src/Build.UnitTests/EndToEndCondition_Tests.cs
+++ b/src/Build.UnitTests/EndToEndCondition_Tests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.Build.Execution;
+using Microsoft.Build.UnitTests;
+
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class EndToEndCondition_Tests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public EndToEndCondition_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory]
+        [InlineData("'$(MSBuildToolsVersion)' == 'Current'")] // shim doesn't apply to string-equal
+        [InlineData("'$(MSBuildToolsVersion)' &gt;= '15.0'")]
+        [InlineData("'$(MSBuildToolsVersion)' &gt;= '14.0.0.0'")]
+        [InlineData("'$(MSBuildToolsVersion)' &gt; '15.0'")]
+        [InlineData("'15.0' &lt; '$(MSBuildToolsVersion)'")]
+        [InlineData("'14.0.0.0' &lt; '$(MSBuildToolsVersion)'")]
+        [InlineData("'15.0' &lt;= '$(MSBuildToolsVersion)'")]
+        public void TrueComparisonsInvolvingMSBuildToolsVersion(string condition)
+        {
+            MockLogger logger = new MockLogger(_output, profileEvaluation: false, printEventsToStdout: false);
+            BuildResult result = Helpers.BuildProjectContentUsingBuildManager($@"<Project>
+ <Target Name=""Print"">
+  <Message Importance=""High""
+           Text=""Condition evaluated true: '{condition}'""
+           Condition=""{condition}"" />
+ </Target>
+</Project>", logger);
+
+            logger.AssertLogContains("Condition evaluated true");
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+        }
+
+        [Theory]
+        [InlineData(" '$(MSBuildToolsVersion)' == '' OR '$(MSBuildToolsVersion)' &lt; '4.0' ")] // WiX check
+        [InlineData("$(MSBuildToolsVersion) &gt; 20")]
+        [InlineData("'$(MSBuildToolsVersion)' == ''")]
+        [InlineData("'$(MSBuildToolsVersion)' == 'Incorrect'")]
+        [InlineData("'14.3' &gt; '$(MSBuildToolsVersion)'")]
+        public void FalseComparisonsInvolvingMSBuildToolsVersion(string condition)
+        {
+            MockLogger logger = new MockLogger(_output, profileEvaluation: false, printEventsToStdout: false);
+            BuildResult result = Helpers.BuildProjectContentUsingBuildManager($@"<Project>
+ <Target Name=""Print"">
+  <Message Importance=""High""
+           Text=""Condition evaluated false: '{condition}'""
+           Condition=""!({condition})"" />
+ </Target>
+</Project>", logger);
+
+            logger.AssertLogContains("Condition evaluated false");
+
+            result.OverallResult.ShouldBe(BuildResultCode.Success);
+        }
+
+    }
+}

--- a/src/Build/Evaluation/Conditionals/StringExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/StringExpressionNode.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Build.Evaluation
         internal override void ResetState()
         {
             _cachedExpandedValue = null;
+            _shouldBeTreatedAsVisualStudioVersion = null;
         }
 
         private bool? _shouldBeTreatedAsVisualStudioVersion = null;


### PR DESCRIPTION
Some extension (for sure WiX, probably others) compare
$(MSBuildToolsVersion) against a known baseline like "4.0" to determine
further behavior. This is broken by the change of ToolsVersion to
"Current":

```
A numeric comparison was attempted on "$(MSBuildToolsVersion)" that evaluates to "Current" instead of a number, in condition " '$(MSBuildToolsVersion)' == '' OR '$(MSBuildToolsVersion)' < '4.0' ".
```

Allow these comparisons again by treating expansion of that property
specially and as equivalent to CurrentVisualStudioVersion. Those two
values matched for MSBuild 12 to 15, so there shouldn't be too much user
confusion around the change.

Fixes #4150.