### PR TITLE
VSIX dependency on NuGet.BuildTools

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -5,6 +5,10 @@ package name=Microsoft.Build
         vs.package.chip=neutral
         vs.package.language=neutral
 
+vs.dependencies
+  vs.dependency id=Microsoft.VisualStudio.NuGet.BuildTools
+                version=[15.0,17.0)
+
 folder InstallDir:\MSBuild\Current
   file source=$(X86BinPath)Microsoft.Common.props
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props


### PR DESCRIPTION
Fixes #3852 by ensuring that NuGet's tasks and targets are present
wherever MSBuild itself is, since common.targets now depends on NuGet.

Closes NuGet/Home#7390.