### PR TITLE
Improve the performance of SdkResolverManifest.Load

### DIFF
--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1751,6 +1751,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="ErrorWritingCacheFile" UESanitized="false" Visibility="Public">
     <value>MSB4258: Writing output result cache file in path "{0}" encountered an error: {1}</value>
   </data>
+  <data name="InvalidSdkResolverDocumentNode" UESanitized="false" Visibility="Public">
+    <value>MSB4259: Unable to find node {0} in the SDK Resolver XML document</value>
+  </data>
   <data name="UsingInputCaches" UESanitized="false" Visibility="Public">
     <value>Using input build results caches: {0}</value>
     <comment>
@@ -1769,7 +1772,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4259.
+        Next message code should be MSB4260.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojekt {0} byl vygenerován.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Das Metaprojekt "{0}" wurde generiert.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -82,6 +82,11 @@
         <target state="new">MSB4255: The following input result cache files do not exist: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="new">Metaproject "{0}" generated.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Se generó el metaproyecto "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Le métaprojet "{0}" a été généré.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Il metaprogetto "{0}" è stato generato.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">メタプロジェクト "{0}" が生成されました。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">메타프로젝트 "{0}"이(가) 생성되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Wygenerowano metaprojekt „{0}”.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -81,6 +81,11 @@
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojeto "{0}" gerado.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Создан метапроект "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">"{0}" meta projesi oluşturuldu.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已生成元项目“{0}”。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSdkResolverDocumentNode">
+        <source>MSB4259: Unable to find node {0} in the SDK Resolver XML document</source>
+        <target state="new">MSB4259: Unable to find node {0} in the SDK Resolver XML document</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已產生中繼專案 "{0}"。</target>


### PR DESCRIPTION
__Unit testing validation is still in progress, do not merge__

Along with the comments in #4025, this change removes the use of `DataContractSerializer` in favor of an `XmlDocument` in `SdkResolverManifest.Load`.

In a standalone app, where there aren't many assemblies to search for types:
- Before: **00:00:00.0196070**
- After: **00:00:00.0082989** ~~**00:00:00.0006201** invalid measure causef by the JIT~~

In the context of a larger assembly set, the deserialization was taking around 230ms to complete.