### PR TITLE
Tolerate unexpandable metadata from definitions in logging

### DIFF
--- a/src/Build.UnitTests/BinaryLogger_Tests.cs
+++ b/src/Build.UnitTests/BinaryLogger_Tests.cs
@@ -69,6 +69,31 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.BuildProjectExpectSuccess(s_testProject, binaryLogger);
         }
 
+        [Fact]
+        public void BinaryLoggerShouldNotThrowWhenMetadataCannotBeExpanded()
+        {
+            var binaryLogger = new BinaryLogger
+            {
+                Parameters = $"LogFile={_logFile}"
+            };
+
+            const string project = @"
+<Project>
+<ItemDefinitionGroup>
+  <F>
+   <MetadataFileName>a\b\%(Filename).c</MetadataFileName>
+  </F>
+ </ItemDefinitionGroup>
+ <ItemGroup>
+  <F Include=""-in &quot;x\y\z&quot;"" />
+ </ItemGroup>
+ <Target Name=""X"" />
+</Project>";
+
+            ObjectModelHelpers.BuildProjectExpectSuccess(project, binaryLogger);
+        }
+
+
         public void Dispose()
         {
             _env.Dispose();

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -191,6 +191,29 @@ namespace Microsoft.Build.UnitTests
             sc.ToString().ShouldContain("XXX:");
         }
 
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp, "Minimal path validation in Core allows expanding path containing quoted slashes.")]
+        public void TestItemsWithUnexpandableMetadata()
+        {
+            SimulatedConsole sc = new SimulatedConsole();
+            ConsoleLogger logger = new ConsoleLogger(LoggerVerbosity.Diagnostic, sc.Write, null, null);
+            ObjectModelHelpers.BuildProjectExpectSuccess(@"
+<Project>
+<ItemDefinitionGroup>
+  <F>
+   <MetadataFileName>a\b\%(Filename).c</MetadataFileName>
+  </F>
+ </ItemDefinitionGroup>
+ <ItemGroup>
+  <F Include=""-in &quot;x\y\z&quot;"" />
+ </ItemGroup>
+ <Target Name=""X"" />
+</Project>", logger);
+
+            sc.ToString().ShouldContain("\"a\\b\\%(Filename).c\"");
+
+        }
+
         /// <summary>
         /// Verify that on minimal verbosity the console logger does not log the target names.
         /// </summary>

--- a/src/Build/Logging/BaseConsoleLogger.cs
+++ b/src/Build/Logging/BaseConsoleLogger.cs
@@ -14,6 +14,7 @@ using System.IO;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
+using Microsoft.Build.Exceptions;
 
 namespace Microsoft.Build.BackEnd.Logging
 {
@@ -659,9 +660,19 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 foreach (DictionaryEntry metadatum in metadata)
                 {
+                    string valueOrError;
+                    try
+                    {
+                        valueOrError = item.GetMetadata(metadatum.Key as string);
+                    }
+                    catch (InvalidProjectFileException e)
+                    {
+                        valueOrError = e.Message;
+                    }
+
                     // A metadatum's "value" is its escaped value, since that's how we represent them internally.
                     // So unescape before returning to the world at large.
-                    WriteLinePretty("        " + metadatum.Key + " = " + item.GetMetadata(metadatum.Key as string));
+                    WriteLinePretty("        " + metadatum.Key + " = " + valueOrError);
                 }
             }
             resetColor();

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Framework.Profiler;
 
@@ -544,7 +545,20 @@ namespace Microsoft.Build.Logging
             foreach (string metadataName in customMetadata.Keys)
             {
                 Write(metadataName);
-                Write(item.GetMetadata(metadataName));
+                string valueOrError;
+
+                try
+                {
+                    valueOrError = item.GetMetadata(metadataName);
+                }
+                catch (InvalidProjectFileException e)
+                {
+                    valueOrError = e.Message;
+                    //valueOrError = $"{{Error logging expanded metadata. Raw value: {customMetadata[metadataName]}}}";
+                    // valueOrError = (string)customMetadata[metadataName];
+                }
+
+                Write(valueOrError);
             }
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -554,8 +554,6 @@ namespace Microsoft.Build.Logging
                 catch (InvalidProjectFileException e)
                 {
                     valueOrError = e.Message;
-                    //valueOrError = $"{{Error logging expanded metadata. Raw value: {customMetadata[metadataName]}}}";
-                    // valueOrError = (string)customMetadata[metadataName];
                 }
 
                 Write(valueOrError);

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.Shared;
 using ColorSetter = Microsoft.Build.Logging.ColorSetter;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
 using WriteHandler = Microsoft.Build.Logging.WriteHandler;
+using Microsoft.Build.Exceptions;
 
 namespace Microsoft.Build.BackEnd.Logging
 {
@@ -727,7 +728,17 @@ namespace Microsoft.Build.BackEnd.Logging
 
                 foreach (DictionaryEntry metadatum in metadata)
                 {
-                    WriteMessageAligned(new String(' ', 4 * tabWidth) + metadatum.Key + " = " + item.GetMetadata(metadatum.Key as string), false);
+                    string valueOrError;
+                    try
+                    {
+                        valueOrError = item.GetMetadata(metadatum.Key as string);
+                    }
+                    catch (InvalidProjectFileException e)
+                    {
+                        valueOrError = e.Message;
+                    }
+
+                    WriteMessageAligned($"{new string(' ', 4 * tabWidth)}{metadatum.Key} = {valueOrError}", false);
                 }
             }
             resetColor();


### PR DESCRIPTION
Using `ItemDefinitionGroup` metadata definitions, it's possible to create an item with an unexpandable metadatum: the `Include` is not a path-like thing and the metadatum uses a filesystem intrinsic metadatum name like `%(FileName)`.

Metadata is recursively expanded when logging is sufficiently high, which can lead to #4181 when 

There are a couple of options for resolving this. I'm proposing option 1 in this PR, but would like to get some opinions before going forward.

1. Log an error in the expanded metadata (including the unexpanded value and the error itself)
```
Initial Items:
Foo
    -in "x\y\z"
        MetadataFileName = Cannot expand metadata in expression "a\b\%(Filename).c". The item metadata "%(Filename)" cannot be applied to the path "-in "x\y\z"". Illegal characters in path.
```
2. Switch to logging raw, unexpanded metadata
```
Foo
    -in "x\y\z"
        MetadataFileName = a\b\%(Filename).c
```

I slightly prefer the former because if the metadata is used later, causing a build-time error, it gives a bit more of a clue about what's going wrong, and it still has the unexpanded string. But a point in favor of "just log unexpanded metadata" is that that's what happens when a new item is created inside a target.