### PR TITLE
Release package versioning for 16.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "16.0-preview",
+  "version": "16.0",
   "assemblyVersion": "15.1",
   "buildNumberOffset": "135"
 }


### PR DESCRIPTION
Drop the `-preview` from our versions.

This will require another insertion to VS.

(Note to observers: this doesn't mean we're 100% done. Just that we think we're very close.)