### PR TITLE
Normalize newlines with negative lookbehind

### DIFF
--- a/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/WhiteSpacePreservation_Tests.cs
@@ -448,8 +448,8 @@ multi-line comment here
             // Each OS uses its own line endings. Using WSL on Windows leads to LF on Windows which messes up the tests. This happens due to git LF <-> CRLF conversions.
             if (NativeMethodsShared.IsWindows)
             {
-                projectContents = Regex.Replace(projectContents, @"[^\r]\n", "\r\n", RegexOptions.Multiline);
-                updatedProject = Regex.Replace(updatedProject, @"[^\r]\n", "\r\n", RegexOptions.Multiline);
+                projectContents = Regex.Replace(projectContents, @"(?<!\r)\n", "\r\n", RegexOptions.Multiline);
+                updatedProject = Regex.Replace(updatedProject, @"(?<!\r)\n", "\r\n", RegexOptions.Multiline);
             }
             else
             {


### PR DESCRIPTION
The previous iteration of this normalization mechanism ate the character
before a bare `\n` when run on Windows.

Noticed this while investigating bizarre local test failures in #4186.

fyi @cdmihai 