### PR TITLE
Use reference assemblies in the MSBuild repo

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,6 +13,8 @@
     <!-- Do not mangle paths for test assemblies, because Shoudly assertions want actual on-disk paths. -->
     <DeterministicSourcePaths Condition="'$(IsTestProject)' == 'true'">false</DeterministicSourcePaths>
 
+    <ProduceReferenceAssembly Condition="'$(IsTestProject)' != 'true'">true</ProduceReferenceAssembly>
+
     <!-- Set up BeforeCommon.targets -->
     <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.BeforeCommon.targets</CustomBeforeMicrosoftCommonTargets>
 


### PR DESCRIPTION
We couldn't do this when [support for reference assembly generation and
consumption lit up](https://github.com/Microsoft/msbuild/pull/2039), because we wanted to continue supporting older VS
builds. But now I think we've moved far enough forward in time that we
can require 15.3.