### PR TITLE
Switching OptProf tests to the same we used in OptProf v1

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -9,6 +9,13 @@
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild",
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc"
           ]
+        },
+        {
+          "container": "VSPE",
+          "testCases": [
+            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vc_auto7",
+            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment"
+          ]
         }
       ]
     }

--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -9,13 +9,6 @@
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild",
             "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc"
           ]
-        },
-        {
-          "container": "VSPE",
-          "testCases": [
-            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vc_auto7",
-            "VSPE.OptProfTests.vs_perf_designtime_solution_build_vb_australiangovernment"
-          ]
         }
       ]
     }

--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -4,9 +4,10 @@
       "name": "Microsoft.Build.vsix",
       "tests": [
         {
-          "container": "TeamEng",
+          "container": "MSBuild",
           "testCases": [
-            "TeamEng.OptProfTest.vs_debugger_interop_managedclient"
+            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild",
+            "MSBuild.Managed.vs_perf_designtime_commandline_msbuild_cs_mstv_fullbuild_4proc"
           ]
         }
       ]


### PR DESCRIPTION
Some of the tests msbuild used in OptProf V1 have been ported to OptProfV2. Switching to using them now that they are available.

Removed the old test because it should not be necessary anymore and because it was flaky.