### PR TITLE
Support multi-line Exec Commands

### DIFF
--- a/src/Build/Xml/XmlReaderExtension.cs
+++ b/src/Build/Xml/XmlReaderExtension.cs
@@ -80,21 +80,10 @@ namespace Microsoft.Build.Internal
 
             XmlReader reader;
 
-            if (loadAsReadOnly)
-            {
-                XmlReaderSettings xrs = new XmlReaderSettings
-                {
-                    DtdProcessing = DtdProcessing.Ignore,
-                    IgnoreComments = true,
-                    IgnoreWhitespace = true,
-                };
-                reader = XmlReader.Create(input, xrs, uri);
-            }
-            else
-            {
-                reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
-            }
-
+            // Ignore loadAsReadOnly for now; using XmlReader.Create results in whitespace changes
+            // of attribute text, specifically newline removal.
+            // https://github.com/Microsoft/msbuild/issues/4210
+            reader = new XmlTextReader(uri, input) { DtdProcessing = DtdProcessing.Ignore };
 
             reader.Read();
             encoding = input.CurrentEncoding;

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -5,13 +5,14 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Text;
-using Microsoft.Build.UnitTests;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
@@ -20,9 +21,16 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class Exec_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public Exec_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         private Exec PrepareExec(string command)
         {
-            IBuildEngine2 mockEngine = new MockEngine(true);
+            IBuildEngine2 mockEngine = new MockEngine(_output);
             Exec exec = new Exec();
             exec.BuildEngine = mockEngine;
             exec.Command = command;
@@ -31,7 +39,7 @@ namespace Microsoft.Build.UnitTests
 
         private ExecWrapper PrepareExecWrapper(string command)
         {
-            IBuildEngine2 mockEngine = new MockEngine(true);
+            IBuildEngine2 mockEngine = new MockEngine(_output);
             ExecWrapper exec = new ExecWrapper();
             exec.BuildEngine = mockEngine;
             exec.Command = command;


### PR DESCRIPTION
Fixes #4210 by reverting to the old behavior of always using `XmlTextReader`. I didn't just revert #3584 because that would be a public API change, and it seems better to avoid that churn this close to release. With this PR, the read-only option is ignored.