### PR TITLE
Set -diagnostics for xunit

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -32,7 +32,7 @@
 
     <XunitOptions Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(XunitOptions) -notrait category=nonnetcoreapptests</XunitOptions>
 
-    <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+    <XunitOptions>$(XunitOptions) -notrait category=failing -diagnostics</XunitOptions>
 
     <TestRunnerAdditionalArguments>$(XunitOptions)</TestRunnerAdditionalArguments>
     


### PR DESCRIPTION
Inserts test run markers in the test stdout, like: 


           

>  ...
>           Found satellite file "en\System.XML.resources.dll".
>            Found satellite file "en-GB\System.XML.resources.dll".
>            This reference is not "CopyLocal" because it's a prerequisite file.
>            The ImageRuntimeVersion for this reference is "v2.0.50727".
>    **_Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests.Miscellaneous.PrimaryFXAssemblyRefIsNotCopyLocal [PASS]_**
>      Output:
>     TargetFrameworkMoniker:    
>     TargetFrameworkMonikerDisplayName:
>     TargetedRuntimeVersion:
>  ...
            
