### PR TITLE
Reduce rate of taking all Monitor locks in string interning

### DIFF
--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -520,7 +520,12 @@ namespace Microsoft.Build
             private readonly bool _useSimpleConcurrency;
 
 #if !CLR2COMPATIBILITY
-            private readonly ConcurrentDictionary<string, string> _internedStrings = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+            // ConcurrentDictionary starts with capacity 31 but we're usually adding far more than that. Make a better first capacity guess to reduce
+            // ConcurrentDictionary having to take all internal locks to upgrade its bucket list. Note that the number should be prime per the
+            // comments on the code at https://referencesource.microsoft.com/#mscorlib/system/Collections/Concurrent/ConcurrentDictionary.cs,122
+            // Also note default lock count is Environment.ProcessorCount from the same code.
+            private const int InitialCapacity = 2053;
+            private readonly ConcurrentDictionary<string, string> _internedStrings = new ConcurrentDictionary<string, string>(Environment.ProcessorCount, InitialCapacity, StringComparer.Ordinal);
 #endif
 
             #region Statistics

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Build
 #if !CLR2COMPATIBILITY
             // ConcurrentDictionary starts with capacity 31 but we're usually adding far more than that. Make a better first capacity guess to reduce
             // ConcurrentDictionary having to take all internal locks to upgrade its bucket list. Note that the number should be prime per the
-            // comments on the code at https://referencesource.microsoft.com/#mscorlib/system/Collections/Concurrent/ConcurrentDictionary.cs,122
+            // comments on the code at https://referencesource.microsoft.com/#mscorlib/system/Collections/Concurrent/ConcurrentDictionary.cs,122 
             // Also note default lock count is Environment.ProcessorCount from the same code.
             private const int InitialCapacity = 2053;
             private readonly ConcurrentDictionary<string, string> _internedStrings = new ConcurrentDictionary<string, string>(Environment.ProcessorCount, InitialCapacity, StringComparer.Ordinal);


### PR DESCRIPTION
Reduce rate of taking numProcessors or even more Monitor locks in string interning by increasing initial size of the string interning dictionary.

Increases from 31 to 2048.NextPrime() initial capacity. In medium-sized codebases (3K proj files) we see 200K of these; for 500 projects, 48K.

Intended to also reduce the rate of exceptions we see parsing large repos in QuickBuild:

```
System.UnauthorizedAccessException: Access is denied. (Exception from HRESULT: 0x80070005 (E_ACCESSDENIED))
   at System.Threading.Monitor.Enter(Object obj)
   at System.Collections.Concurrent.ConcurrentDictionary`2.AcquireLocks(Int32 fromInclusive, Int32 toExclusive, Int32& locksAcquired)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GrowTable(Tables tables, IEqualityComparer`1 newComparer, Boolean regenerateHashKeys, Int32 rehashCount)
   at System.Collections.Concurrent.ConcurrentDictionary`2.TryAddInternal(TKey key, TValue value, Boolean updateIfExists, Boolean acquireLock, TValue& resultingValue)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, TValue value)
   at Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.TryIntern(IInternable candidate, String& interned)
   at Microsoft.Build.OpportunisticIntern.BucketedPrioritizedStringList.InterningToString(IInternable candidate)
   at Microsoft.Build.Evaluation.Expander`2.PropertyExpander`1.ExpandPropertiesLeaveTypedAndEscaped(String expression, IPropertyProvider`1 properties, ExpanderOptions options, IElementLocation elementLocation, UsedUninitializedProperties usedUninitializedProperties)
...
```