### PR TITLE
Remove YAML variable definitions

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -2,6 +2,13 @@ trigger:
 - master
 - vs*
 
+# If defined here, these values are not overrideable
+# Once they exist, we should define these as "runtime parameters"
+# https://github.com/Microsoft/azure-pipelines-yaml/pull/129
+# variables:
+#   SignType: real
+#   SkipApplyOptimizationData: false
+
 jobs:
 - job: Windows_NT
   pool: 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -2,10 +2,6 @@ trigger:
 - master
 - vs*
 
-variables:
-  SignType: real
-  SkipApplyOptimizationData: false
-
 jobs:
 - job: Windows_NT
   pool: 


### PR DESCRIPTION
YAML variable definitions override queue-time variables, so these must
not be set in this way.

Docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#allow-at-queue-time