### PR TITLE
FUTD fix

### DIFF
--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -736,7 +736,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Microsoft.Common.overridetasks">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="Microsoft.Common.props">


### PR DESCRIPTION
Mark all targets files in Tasks PreserveNewest.

This broke Visual Studio's fast-up-to-date check, causing slower-than-
necessary builds from inside the IDE.