### PR TITLE
Shorter node utilization histogram bars

### DIFF
--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2229,7 +2229,7 @@ namespace Microsoft.Build.BackEnd
                 scale = 1000;
             }
 
-            string durationBar = new String(barSegment, durationElementCount / scale);
+            string durationBar = new string(barSegment, durationElementCount / scale);
             if (scale > 1)
             {
                 durationBar = String.Format ("{0} (scale 1:{1})", durationBar, scale);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2206,7 +2206,34 @@ namespace Microsoft.Build.BackEnd
                 accumulatedDuration += duration;
             }
 
-            string durationBar = new String('#', (int)(duration / 0.05));
+            // Limit the number of histogram bar segments. For long runs the number of segments can be counted in
+            // hundreds of thousands (for instance a build which took 8061.7s would generate a line 161,235 characters
+            // long) which is a bit excessive. The scales implemented below limit the generated line length to
+            // manageable proportions even for very long runs.
+            int durationElementCount = (int)(duration / 0.05);
+            int scale;
+            char barSegment;
+            if (durationElementCount <= 100)
+            {
+                barSegment = '.';
+                scale = 1;
+            }
+            else if (durationElementCount <= 1000)
+            {
+                barSegment = '+';
+                scale = 100;
+            }
+            else
+            {
+                barSegment = '#';
+                scale = 1000;
+            }
+
+            string durationBar = new String(barSegment, durationElementCount / scale);
+            if (scale > 1)
+            {
+                durationBar = String.Format ("{0} (scale 1:{1})", durationBar, scale);
+            }
             if (haveNonIdleNode)
             {
                 loggingService.LogComment(context, MessageImportance.Normal, "NodeUtilizationEntry", stringBuilder, duration, accumulatedDuration, durationBar);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -2232,7 +2232,7 @@ namespace Microsoft.Build.BackEnd
             string durationBar = new string(barSegment, durationElementCount / scale);
             if (scale > 1)
             {
-                durationBar = String.Format ("{0} (scale 1:{1})", durationBar, scale);
+                durationBar = $"{durationBar} (scale 1:{scale})";
             }
             if (haveNonIdleNode)
             {


### PR DESCRIPTION
Limit the number of histogram bar segments. For long runs the number of segments
can be counted in hundreds of thousands (for instance a build which took 8061.7s
would generate a single line line 161,235 characters long) which is a bit
excessive and makes viewing text logs with histograms quite painful at times.

This commit implements a scaled approach in which the number of bar elements
calculated with the original formula is subdivided as follows:

 * <= 100 segments remains as-is, scale 1:1, character used: `.`
 * &gt; 100 <= 1000 segments, scale 1:100, character used: `+`
 * &gt; 1000 segments, scale 1:1000, character used: `#`

Additionaly, scale is printed after the histogram bar if it's different than `1:1`