### PR TITLE
Add target to expose potential .editorconfig files

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -6019,6 +6019,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Returns="@(DesignerRuntimeImplementationProjectOutputGroupOutput)">
   </Target>
 
+  <!--
+    ============================================================
+                       .editorconfig support
+    ============================================================
+  -->
+  <!-- Expose the set of potential .editorconfig files so the project system can
+       retrieve them. -->
+  <Target Name="GetPotentialEditorConfigFiles" Returns="@(PotentialEditorConfigFiles)" />
+  
   <PropertyGroup>
     <CodeAnalysisTargets Condition="'$(CodeAnalysisTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeAnalysis\Microsoft.CodeAnalysis.targets</CodeAnalysisTargets>
   </PropertyGroup>


### PR DESCRIPTION
Add a `GetPotentialEditorConfigFiles` target so design-time builds can
harvest these items and pass them to the project system.