### PR TITLE
Avoid emitting BOM to command script in Exec

### DIFF
--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -414,20 +414,24 @@ namespace Microsoft.Build.UnitTests
         /// Exec task will NOT use UTF8 when UTF8 Never is specified and non-ANSI characters are in the Command
         /// <remarks>Exec task will fail as the cmd processor will not be able to run the command.</remarks>
         /// </summary>
-        [Fact]
+        [Theory]
+        [InlineData("Never")]
+        [InlineData("System")]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public void ExecTaskUtf8NeverWithNonAnsi()
+        public void ExecTaskUtf8NeverWithNonAnsi(string useUtf8)
         {
-            RunExec(true, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, "Never", false);
+            RunExec(true, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, useUtf8, false);
         }
 
         /// <summary>
         /// Exec task will NOT use UTF8 when UTF8 Never is specified and only ANSI characters are in the Command
         /// </summary>
-        [Fact]
-        public void ExecTaskUtf8NeverWithAnsi()
+        [Theory]
+        [InlineData("Never")]
+        [InlineData("System")]
+        public void ExecTaskUtf8NeverWithAnsi(string useUtf8)
         {
-            RunExec(false, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, "Never");
+            RunExec(false, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, useUtf8);
         }
 
         [Theory]

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -377,11 +377,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Tests that Exec still executes properly when there's a non-ANSI character in the command
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/623")]
-#else
         [Fact]
-#endif
         public void ExecTaskUnicodeCharacterInCommand()
         {
             RunExec(true, new UTF8Encoding(false).EncodingName);
@@ -399,11 +395,7 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Exec task will use UTF8 when UTF8 Always is specified (with non-ANSI characters in the Command)
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/623")]
-#else
         [Fact]
-#endif
         public void ExecTaskUtf8AlwaysWithNonAnsi()
         {
             RunExec(true, new UTF8Encoding(false).EncodingName, "Always");
@@ -422,12 +414,8 @@ namespace Microsoft.Build.UnitTests
         /// Exec task will NOT use UTF8 when UTF8 Never is specified and non-ANSI characters are in the Command
         /// <remarks>Exec task will fail as the cmd processor will not be able to run the command.</remarks>
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/623")]
-#else
         [Fact]
-#endif
-        [Trait("Category", "mono-osx-failing")]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void ExecTaskUtf8NeverWithNonAnsi()
         {
             RunExec(true, EncodingUtilities.CurrentSystemOemEncoding.EncodingName, "Never", false);
@@ -835,12 +823,8 @@ namespace Microsoft.Build.UnitTests
         /// Test the CanEncode method with and without ANSI characters to determine if they can be encoded 
         /// in the current system encoding.
         /// </summary>
-#if RUNTIME_TYPE_NETCORE
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/623")]
-#else
         [Fact]
-        [Trait("Category", "mono-osx-failing")]
-#endif
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void CanEncodeTest()
         {
             var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Build.Tasks
         private const string UseUtf8Always = "ALWAYS";
         private const string UseUtf8Never = "NEVER";
         private const string UseUtf8Detect = "DETECT";
+        private const string UseUtf8System = "SYSTEM";
 
         // Are the encodings for StdErr and StdOut streams valid
         private bool _encodingParametersValid = true;
@@ -697,6 +698,7 @@ namespace Microsoft.Build.Tasks
                 case UseUtf8Always:
                     return s_utf8WithoutBom;
                 case UseUtf8Never:
+                case UseUtf8System:
                     return defaultEncoding;
                 default:
                     return CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -650,7 +650,7 @@ namespace Microsoft.Build.Tasks
 
         #endregion
 
-        private static readonly Encoding s_utf8WithoutBom = new UTF8Encoding(false);
+        private static readonly Encoding s_utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         /// <summary>
         /// Find the encoding for the batch file.
@@ -670,10 +670,20 @@ namespace Microsoft.Build.Tasks
             }
 
             var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+
+            // When Windows is configured to use UTF-8 by default, the above returns
+            // a UTF-8-with-BOM encoding, which cmd.exe can't interpret. Force the no-BOM
+            // encoding if the returned encoding would have emitted one (preamble is nonempty).
+            // See https://github.com/Microsoft/msbuild/issues/4268
+            if (defaultEncoding is UTF8Encoding e && e.GetPreamble().Length > 0)
+            {
+                defaultEncoding = s_utf8WithoutBom;
+            }
+
             string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? UseUtf8Detect : UseUtf8Encoding;
 
 #if FEATURE_OSVERSION
-            // UTF8 is only supposed in Windows 7 (6.1) or greater.
+            // UTF8 is only supported in Windows 7 (6.1) or greater.
             var windows7 = new Version(6, 1);
 
             if (Environment.OSVersion.Version < windows7)
@@ -687,7 +697,7 @@ namespace Microsoft.Build.Tasks
                 case UseUtf8Always:
                     return s_utf8WithoutBom;
                 case UseUtf8Never:
-                    return EncodingUtilities.CurrentSystemOemEncoding;
+                    return defaultEncoding;
                 default:
                     return CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)
                         ? defaultEncoding


### PR DESCRIPTION
When UTF-8 is the system default codepage, the encoding we get is
`Encoding.UTF8`, which uses a BOM. Unfortunately, `cmd.exe` emits an
error when trying to execute a file that starts with a BOM, so all Exec
tasks on an OS with that configuration are broken.

Instead, if the default encoding is a UTF-8 variant with a BOM, force it
to use UTF-8 with no BOM.

Marking as WIP while I consult with some internal Microsoft CMD experts to see if 

1. there's a better way
1. We should cross-link to an OS bug