### PR TITLE
Enable initial build with Core in CI

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -91,7 +91,7 @@ jobs:
     displayName: cibuild.cmd
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
-      arguments: '-hostType core'
+      arguments: '-msbuildEngine dotnet'
   - task: PublishTestResults@2
     displayName: Publish .NET Framework Test Results
     inputs:
@@ -162,52 +162,6 @@ jobs:
       PathtoPublish: 'artifacts/TestResults'
       ArtifactName: 'FullOnWindows Release test logs'
     condition: succeededOrFailed()
-
-# Disabling the hostType CI for now: https://github.com/Microsoft/msbuild/issues/4001
-# - job: CoreOnWindows
-#   displayName: "Build and test on Windows using .NET Core MSBuild"
-#   pool: 'Hosted VS2017'
-#   steps:
-#   - task: BatchScript@1
-#     displayName: VsDevCmd
-#     inputs:
-#       filename: 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat'
-#       modifyEnvironment: true
-#   - task: BatchScript@1
-#     displayName: cibuild.cmd
-#     inputs:
-#       filename: 'eng/common/cibuild.cmd'
-#       arguments: '-hostType Core'
-#   - task: PublishTestResults@2
-#     displayName: Publish .NET Framework Test Results
-#     inputs:
-#       testRunTitle: 'Windows-on-core Full Framework'
-#       testRunner: XUnit
-#       testResultsFiles: 'artifacts/**/*UnitTests_net472*.xml'
-#       publishRunAttachments: true
-#       mergeTestResults: true
-#     condition: always()
-#   - task: PublishTestResults@2
-#     displayName: Publish .NET Core 2.1 Test Results
-#     inputs:
-#       testRunTitle: 'Windows-on-core .NET Core 2.1'
-#       testRunner: XUnit
-#       testResultsFiles: 'artifacts/**/*UnitTests_netcoreapp2.1*.xml'
-#       publishRunAttachments: true
-#       mergeTestResults: true
-#     condition: always()
-#   - task: PublishBuildArtifacts@1
-#     displayName: 'Publish Artifact: logs'
-#     inputs:
-#       PathtoPublish: 'artifacts/log/Debug'
-#       ArtifactName: 'CoreOnWindows build logs'
-#     condition: succeededOrFailed()
-#   - task: PublishBuildArtifacts@1
-#     displayName: 'Publish Artifact: logs/TestResults'
-#     inputs:
-#       PathtoPublish: 'artifacts/log/Debug/TestResults'
-#       ArtifactName: 'CoreOnWindows test logs'
-#     condition: succeededOrFailed()
 
 - job: CoreBootstrappedOnLinux
   displayName: "Build and test on Linux using bootstrapped .NET Core MSBuild"

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-  [string] $hostType,
+  [string] $msbuildEngine,
   [string] $configuration = "Debug",
   [switch] $prepareMachine,
   [bool] $buildStage1 = $True,
@@ -50,9 +50,9 @@ $ArtifactsDir = Join-Path $RepoRoot "artifacts"
 $Stage1Dir = Join-Path $RepoRoot "stage1"
 $Stage1BinDir = Join-Path $Stage1Dir "bin"
 
-if ($hostType -eq '')
+if ($msbuildEngine -eq '')
 {
-  $hostType = 'full'
+  $msbuildEngine = 'vs'
 }
 
 $msbuildToUse = "msbuild"
@@ -66,7 +66,7 @@ try {
 
   if ($buildStage1)
   {
-    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci /p:CreateBootstrap=true @properties
+    & $PSScriptRoot\Common\Build.ps1 -restore -build -ci -msbuildEngine $msbuildEngine /p:CreateBootstrap=true @properties
   }
 
   $bootstrapRoot = Join-Path $Stage1BinDir "bootstrap"
@@ -75,7 +75,7 @@ try {
   $dotnetToolPath = InitializeDotNetCli $true
   $dotnetExePath = Join-Path $dotnetToolPath "dotnet.exe"
 
-  if ($hostType -eq 'full')
+  if ($msbuildEngine -eq 'vs')
   {
     $buildToolPath = Join-Path $bootstrapRoot "net472\MSBuild\Current\Bin\MSBuild.exe"
     $buildToolCommand = "";


### PR DESCRIPTION
Fixes #4001 by switching the initial build of the bootstrapped-core job
to also be driven by core MSBuild.

Changes the `-hostType` parameter of `cibuild_bootstrapped_msbuild` to
`-msbuildEngine` to match the Arcade build option.