### PR TITLE
Enumerate MSBuild from Current

### DIFF
--- a/scripts/EnumerateMSBuild.ps1
+++ b/scripts/EnumerateMSBuild.ps1
@@ -36,6 +36,7 @@ foreach ($instance in $vsInstances)
     
     # Look at each dll/exe in the MSBuild bin folder and get their ProductVersion
     ls -File -Recurse -Include ('*.dll', '*.exe') -Path "$instancePath\MSBuild\15.0\Bin" | % VersionInfo | Format-Table -AutoSize InternalName, ProductVersion, FileName | Out-File $logFile -Width 1000 -Append unicode
+    ls -File -Recurse -Include ('*.dll', '*.exe') -Path "$instancePath\MSBuild\Current\Bin" | % VersionInfo | Format-Table -AutoSize InternalName, ProductVersion, FileName | Out-File $logFile -Width 1000 -Append unicode
     Write-Log "********************" -LogToConsole $False
 }
 


### PR DESCRIPTION
The script hadn't been updated since the 15.0->Current move. Adding both
options to keep it working everywhere.