### PR TITLE
Devdiv 736904: Clickonce Publish error

### DIFF
--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -1470,7 +1470,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         }
                         else
                         {
-                            if (settings.ComponentsLocation != ComponentsLocation.HomeSite || !VerifyHomeSiteInformation(packageFileNode, builder, settings, _results))
+                            if (settings.ComponentsLocation == ComponentsLocation.Relative || !VerifyHomeSiteInformation(packageFileNode, builder, settings, _results))
                             {
                                 if (settings.CopyComponents)
                                 {


### PR DESCRIPTION
Clickonce publishing fails when a prerequisite component is set to run from a absolute location (for e.g. a network share) instead of the Home Site or Relative to the install folder. This is due to an incorrect check that needs to happen only when the prerequisite component is set to run from the Relative location. This check and the subsequent copy needs to only happen when the prerequisite component is set to run from a location relative to the installation folder.