### PR TITLE
Make TF normalization explicit

### DIFF
--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -38,8 +38,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
+      <!-- Make normalization explicit: Deduplicate by keeping first occurence case insensitive; Trim -->
+      <_TargetFrameworkNormalized Include="@(_TargetFramework->Distinct()->Trim())" />
       <_InnerBuildProjects Include="$(MSBuildProjectFile)">
-        <AdditionalProperties>TargetFramework=%(_TargetFramework.Identity)</AdditionalProperties>
+        <AdditionalProperties>TargetFramework=%(_TargetFrameworkNormalized.Identity)</AdditionalProperties>
       </_InnerBuildProjects>
     </ItemGroup>
   </Target>

--- a/src/Tasks/Microsoft.Common.CrossTargeting.targets
+++ b/src/Tasks/Microsoft.Common.CrossTargeting.targets
@@ -38,8 +38,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target Name="_ComputeTargetFrameworkItems" Returns="@(InnerOutput)">
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
-      <!-- Make normalization explicit: Deduplicate by keeping first occurence case insensitive; Trim -->
-      <_TargetFrameworkNormalized Include="@(_TargetFramework->Distinct()->Trim())" />
+      <!-- Make normalization explicit: Trim; Deduplicate by keeping first occurence, case insensitive -->
+      <_TargetFrameworkNormalized Include="@(_TargetFramework->Trim()->Distinct())" />
       <_InnerBuildProjects Include="$(MSBuildProjectFile)">
         <AdditionalProperties>TargetFramework=%(_TargetFrameworkNormalized.Identity)</AdditionalProperties>
       </_InnerBuildProjects>


### PR DESCRIPTION
Before this change, the `TargetFrameworks` property went through a series of implicit normalizations:
- `<_TargetFramework Include="$(TargetFrameworks)" />` would trim the semicolon delimited list of TFs
- the task batching triggered by `TargetFramework=%(_TargetFrameworkNormalized.Identity)` uses an OrdinalIgnoreCase dictionary which achieves a first one wins case agnostic deduplication 

Sadly the static graph won't see these changes because they happen at build time. I could move it to evaluation time, but that would be a breaking change to people that read `TargetFrameworks` after an explicit sdk import.

Since the change is superfluous, we could also just keep the comment and not the extra item operations. :)