### PR TITLE
MockLogger AssertLogDoesntContain Summary Described The Opposite Functionality

### DIFF
--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Assert that the log file contains the given string.
+        /// Assert that the log file does not contain the given string.
         /// </summary>
         /// <param name="contains"></param>
         internal void AssertLogDoesntContain(string contains)


### PR DESCRIPTION
`AssertLogDoesntContain`'s summary now properly describes its function.