### PR TITLE
Ignore IsReadOnlyAttribute in GenAPI

### DIFF
--- a/ref/ExcludeAttributeList.txt
+++ b/ref/ExcludeAttributeList.txt
@@ -2,3 +2,4 @@ T:System.Diagnostics.DebuggerBrowsableAttribute
 T:System.Diagnostics.DebuggerDisplayAttribute
 T:System.Diagnostics.DebuggerStepThroughAttribute
 T:System.Runtime.CompilerServices.CompilerGeneratedAttribute
+T:System.Runtime.CompilerServices.IsReadOnlyAttribute


### PR DESCRIPTION
This is emitted by newer Roslyn compilers, but is not a meaningful
contract change in our public API, so I'm setting it to be ignored.