### PR TITLE
Task Registry Now Uses Opportunistic Intern

### DIFF
--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Build.Execution
 
                 if (assemblyFile != null && !Path.IsPathRooted(assemblyFile))
                 {
-                    assemblyFile = Path.Combine(directoryOfImportingFile, assemblyFile);
+                    assemblyFile = OpportunisticIntern.InternStringIfPossible(Path.Combine(directoryOfImportingFile, assemblyFile));
                 }
 
                 if (String.Equals(taskFactory, RegisteredTaskRecord.CodeTaskFactory, StringComparison.OrdinalIgnoreCase) || String.Equals(taskFactory, RegisteredTaskRecord.XamlTaskFactory, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Significantly improves #4155 

Opening a solution of 810 projects yields reduced string duplication.

Example string that went from 9152 duplicates to 680:
![image](https://user-images.githubusercontent.com/4691428/56390575-32d70900-61e1-11e9-8c67-fe4721c45850.png)

![image](https://user-images.githubusercontent.com/4691428/56390596-3ec2cb00-61e1-11e9-9781-92896ebca3a4.png)

