### PR TITLE
Disallow using Roslyn 1.0.0 targets in design-time builds

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -315,7 +315,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Target>
 
     <PropertyGroup>
-        <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == ''">$(RoslynTargetsPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
+        <!-- Design-time builds require a newer version than 1.0 to succeed, so ignore override in that case -->
+        <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(CSharpCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     </PropertyGroup>
 
     <Import Project="$(CSharpCoreTargetsPath)" />

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -315,7 +315,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Target>
 
     <PropertyGroup>
-        <!-- Design-time builds require a newer version than 1.0 to succeed, so ignore override in that case -->
+        <!-- Design-time builds require a newer version than 1.0 to succeed, so override back to inbox in that case -->
         <CSharpCoreTargetsPath Condition="'$(CSharpCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(CSharpCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     </PropertyGroup>
 

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -315,7 +315,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Target>
 
     <PropertyGroup>
-      <!-- Design-time builds require a newer version than 1.0 to succeed, so ignore override in that case -->
+      <!-- Design-time builds require a newer version than 1.0 to succeed, so override back to inbox in that case -->
       <VisualBasicCoreTargetsPath Condition="'$(VisualBasicCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(VisualBasicCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
     </PropertyGroup>
 

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -315,7 +315,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Target>
 
     <PropertyGroup>
-        <VisualBasicCoreTargetsPath Condition="'$(VisualBasicCoreTargetsPath)' == ''">$(RoslynTargetsPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
+      <!-- Design-time builds require a newer version than 1.0 to succeed, so ignore override in that case -->
+      <VisualBasicCoreTargetsPath Condition="'$(VisualBasicCoreTargetsPath)' == '' or ('$(DesignTimeBuild)' == 'true' and $(VisualBasicCoreTargetsPath.Contains('Microsoft.Net.Compilers.1.0.0')))">$(RoslynTargetsPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
     </PropertyGroup>
 
     <Import Project="$(VisualBasicCoreTargetsPath)" />


### PR DESCRIPTION
The Visual Studio IDE relies on "design-time" builds to determine what the contents of a project is. Prior to 16.0, the design-time build for .NET Framework projects utilized MSBuild host objects to determine what the command-line inputs would be to the compiler (i.e. csc.exe). In 16.0, we switched to a non-host object based method for extracting the command-line as it works better for Roslyn.

Unfortunately, the method we now use isn't supported on the very first version of the Roslyn compilers. So if a project opened in 16.0 explicitly references the Microsoft.Net.Compilers 1.0 package, then the design-time build will fail and Intellisense will be broken.

The fix is to ignore the compiler override if (and only if) we're doing a design-time build. This should be safe because a design-time build never actually runs the compiler, it only collects the command-line. And since the compilers are backwards compatible in terms of the command-line, everything should work.

We scope ignoring the override to ONLY the 1.0 version of the compilers so that we preserve the ability of the Roslyn team to test out new switches in pre-release versions of the compilers.