### PR TITLE
Fixed Obsolete Marshal.PtrToStructure reference.

### DIFF
--- a/src/Tasks/ComReference.cs
+++ b/src/Tasks/ComReference.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.Tasks
 
             try
             {
-                typeLibAttr = (TYPELIBATTR)Marshal.PtrToStructure(pAttrs, typeof(TYPELIBATTR));
+                typeLibAttr = Marshal.PtrToStructure<TYPELIBATTR>(pAttrs);
             }
             finally
             {


### PR DESCRIPTION
Documentation for PtrToStructure shows the syntax PtrToStructure(IntPtr, Type) is now obsolete.   PtrToStructure<T>(IntPtr) is supported since .NET Framework 4.5.1

Documentation can be found at: https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostructure