### PR TITLE
Use Microsoft.VisualStudio.PackageGroup.NuGet (16.0)

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -6,7 +6,7 @@ package name=Microsoft.Build
         vs.package.language=neutral
 
 vs.dependencies
-  vs.dependency id=Microsoft.VisualStudio.NuGet.BuildTools
+  vs.dependency id=Microsoft.VisualStudio.PackageGroup.NuGet
                 version=[15.0,17.0)
 
 folder InstallDir:\MSBuild\Current


### PR DESCRIPTION
Fixes #4307, depending on the new PackageGroup that comprises the
correct NuGet package for the current SKU.