### PR TITLE
MSBuild May "Salt" Node Handshake For Test Environments

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -550,8 +550,8 @@ namespace Microsoft.Build.BackEnd
                                         commandLineArgs,
                                         (int)hostContext,
                                         this,
-                                        CommunicationsUtilities.GetTaskHostHostHandshake(hostContext),
-                                        CommunicationsUtilities.GetTaskHostClientHandshake(hostContext),
+                                        CommunicationsUtilities.GetHostHandshake(hostContext),
+                                        CommunicationsUtilities.GetClientHandshake(hostContext),
                                         NodeContextTerminated
                                     );
 

--- a/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
+++ b/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetHostHandshake()
         {
-            long hostHandshake = CommunicationsUtilities.GetTaskHostHostHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
+            long hostHandshake = CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
             return hostHandshake;
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetClientHandshake()
         {
-            long clientHandshake = CommunicationsUtilities.GetTaskHostClientHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
+            long clientHandshake = CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
             return clientHandshake;
         }
     }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -652,21 +652,24 @@ namespace Microsoft.Build.Internal
         /// </summary>
         /// <param name="hostContext">TaskHostContext</param>
         /// <returns>Base Handshake</returns>
-        public static long GetBaseHandshakeForContext(TaskHostContext hostContext)
+        private static long GetBaseHandshakeForContext(TaskHostContext hostContext)
         {
-            string nodeHandShakeSalt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
+            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
 
-            long salt = 0;
+            long nodeHandshakeSalt = 0;
 
-            if (!string.IsNullOrEmpty(nodeHandShakeSalt))
+            if (!string.IsNullOrEmpty(salt))
             {
-                salt = GetHandshakeHashCode(nodeHandShakeSalt);
+                nodeHandshakeSalt = GetHandshakeHashCode(salt);
             }
 
-            //hostContext takes up 4 bits (value ranges from 0-4), shift it until just before the most significant byte
-            //the most significant byte gets zero'd out to avoid connecting to older builds.
-            //salt is shifted to after the fileversionhash (32 bits + 8 bits)
-            long baseHandshake = ((long)hostContext << 52) | (salt << 40) | ((long)FileVersionHash << 8);
+            //FileVersionHash (32 bits) is shifted 8 bits to avoid session ID collision
+            //hostContext (4 bits) is shifted just after the FileVersionHash
+            //nodeHandshakeSalt (32 bits) is shifted just after hostContext
+            //the most significant byte (leftmost 8 bits) will get zero'd out to avoid connecting to older builds.
+            //| masked out | nodeHandshakeSalt | hostContext |              fileVersionHash             | SessionID
+            //  0000 0000     0000 0000 0000        0000        0000 0000 0000 0000 0000 0000 0000 0000   0000 0000
+            long baseHandshake = (nodeHandshakeSalt << 44) | ((long)hostContext << 40) | ((long)FileVersionHash << 8);
             return baseHandshake;
         }
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -326,9 +326,9 @@ namespace Microsoft.Build.Internal
         /// Magic number sent by the host to the client during the handshake.
         /// Derived from the binary timestamp to avoid mixing binary versions.
         /// </summary>
-        internal static long GetTaskHostHostHandshake(TaskHostContext hostContext)
+        internal static long GetHostHandshake(TaskHostContext hostContext)
         {
-            long baseHandshake = GenerateHostHandshakeFromBase(GetBaseHandshakeForContext(hostContext), GetTaskHostClientHandshake(hostContext));
+            long baseHandshake = GenerateHostHandshakeFromBase(GetBaseHandshakeForContext(hostContext), GetClientHandshake(hostContext));
             return baseHandshake;
         }
 
@@ -336,7 +336,7 @@ namespace Microsoft.Build.Internal
         /// Magic number sent by the client to the host during the handshake.
         /// Munged version of the host handshake.
         /// </summary>
-        internal static long GetTaskHostClientHandshake(TaskHostContext hostContext)
+        internal static long GetClientHandshake(TaskHostContext hostContext)
         {
             // Mask out the first byte. That's because old
             // builds used a single, non zero initial byte,


### PR DESCRIPTION
Addresses #4308

An environment variable `MSBUILDNODEHANDSHAKESALT` may be defined in order to allow MSBuild only to connect to nodes that come from the same test environment.