### PR TITLE
Mark a test relevant only on full framework as WindowsOnly

### DIFF
--- a/src/Tasks.UnitTests/Move_Tests.cs
+++ b/src/Tasks.UnitTests/Move_Tests.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Build.UnitTests
         /// Moving a locked file will fail
         /// </summary>
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)] // "File names under Unix are case-sensitive and this test is not useful"
+        [PlatformSpecific(TestPlatforms.Windows)] // "File locking Unix differs significantly from Windows"
         public void MoveLockedFile()
         {
             string file = null;

--- a/src/Tasks.UnitTests/Move_Tests.cs
+++ b/src/Tasks.UnitTests/Move_Tests.cs
@@ -461,8 +461,7 @@ namespace Microsoft.Build.UnitTests
         /// Moving a locked file will fail
         /// </summary>
         [Fact]
-        [Trait("Category", "netcore-osx-failing")]
-        [Trait("Category", "netcore-linux-failing")]
+        [PlatformSpecific(TestPlatforms.Windows)] // "File names under Unix are case-sensitive and this test is not useful"
         public void MoveLockedFile()
         {
             string file = null;


### PR DESCRIPTION
    `Microsoft.Build.UnitTests.Move_Tests.MoveLockedFile`

- this was marked as failing on netcore
- It expects to fail trying to move a "locked"(open for writing) file
- But on dotnet and mono, the behavior is to not fail in that operation

- Thus, marking this test as Windows/full framework only.