### PR TITLE
Fix test on mono, failing because of difference in error string

### DIFF
--- a/src/Tasks.UnitTests/Unzip_Tests.cs
+++ b/src/Tasks.UnitTests/Unzip_Tests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
                 unzip.Execute().ShouldBeFalse(() => _mockEngine.Log);
 
-                _mockEngine.Log.ShouldContain("D6DFD219DACE48F8B86EFCDF98433333.txt' is denied", () => _mockEngine.Log);
+                _mockEngine.Log.ShouldContain($"D6DFD219DACE48F8B86EFCDF98433333.txt{ (NativeMethodsShared.IsMono ? "\"" : "'") } is denied", () => _mockEngine.Log);
             }
         }
 


### PR DESCRIPTION
 `Microsoft.Build.Tasks.UnitTests.Unzip_Tests.LogsErrorIfReadOnlyFileCannotBeOverwitten`