### PR TITLE
Removal of FEATURE_RESGENCACHE checks for .NET Core

### DIFF
--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -68,10 +68,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 Utilities.AssertLogContainsResource(t, "GenerateResource.ProcessingFile", resxFile, resourcesFile);
                 Utilities.AssertLogContainsResource(t, "GenerateResource.ReadResourceMessage", 1, resxFile);
@@ -156,10 +154,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 Utilities.AssertLogContainsResource(t, "GenerateResource.ProcessingFile", textFile, resourcesFile);
                 Utilities.AssertLogContainsResource(t, "GenerateResource.ReadResourceMessage", 4, textFile);
@@ -320,10 +316,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             Path.GetExtension(t.FilesWritten[0].ItemSpec).ShouldBe(".resources");
 
             Utilities.AssertLogContainsResource(t, "GenerateResource.OutputDoesntExist", t.OutputResources[0].ItemSpec);
-
-#if FEATURE_RESGENCACHE
+            
             Utilities.AssertStateFileWasWritten(t);
-#endif
 
             GenerateResource t2 = Utilities.CreateTask(_output);
             t2.StateFile = new TaskItem(t.StateFile);
@@ -392,10 +386,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Assert.Equal(".resources", Path.GetExtension(resourcesFile));
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 GenerateResource t2 = Utilities.CreateTask(_output);
                 t2.StateFile = new TaskItem(t.StateFile);
@@ -450,10 +442,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Path.GetExtension(resourcesFile).ShouldBe(".resources");
                 resourcesFile = t.FilesWritten[0].ItemSpec;
                 Path.GetExtension(resourcesFile).ShouldBe(".resources");
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 GenerateResource t2 = Utilities.CreateTask(_output);
                 t2.StateFile = new TaskItem(t.StateFile);
@@ -622,10 +612,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t.FilesWritten[0].ItemSpec, resourcesFile1);
                 Assert.Equal(t.OutputResources[1].ItemSpec, resourcesFile2);
                 Assert.Equal(t.FilesWritten[1].ItemSpec, resourcesFile2);
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 // Repeat, and it should do nothing as they are up to date
                 GenerateResource t2 = Utilities.CreateTask(_output);
@@ -643,10 +631,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t2.FilesWritten[0].ItemSpec, resourcesFile1);
                 Assert.Equal(t2.OutputResources[1].ItemSpec, resourcesFile2);
                 Assert.Equal(t2.FilesWritten[1].ItemSpec, resourcesFile2);
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t2);
-#endif
 
                 Assert.True(time.Equals(File.GetLastWriteTime(t2.OutputResources[0].ItemSpec)));
                 Assert.True(time2.Equals(File.GetLastWriteTime(t2.OutputResources[1].ItemSpec)));
@@ -1479,10 +1465,9 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 bool success = t.Execute();
                 // Task should have failed
                 Assert.False(success);
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
+
                 // Should not have created an output for the invalid resx
                 // Should have created the other file
                 Assert.False(File.Exists(resourcesFile1));
@@ -1533,10 +1518,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 bool success = t.Execute();
                 // Task should have failed
                 Assert.False(success);
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 // Should not have created an output for the invalid resx
                 // Should have created the other file
@@ -1894,10 +1877,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t.FilesWritten[i].ItemSpec, t.OutputResources[i].ItemSpec);
                 Assert.True(File.Exists(t.FilesWritten[i].ItemSpec));
             }
-
-#if FEATURE_RESGENCACHE
+            
             Utilities.AssertStateFileWasWritten(t);
-#endif
 
             // Done, so clean up.
             File.Delete(t.StateFile.ItemSpec);
@@ -1957,10 +1938,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 Assert.Equal(t.FilesWritten[0].ItemSpec, Path.ChangeExtension(t.Sources[0].ItemSpec, ".resources"));
                 Assert.Equal(t.FilesWritten[1].ItemSpec, Path.ChangeExtension(t.Sources[1].ItemSpec, ".resources"));
                 Assert.Equal(t.FilesWritten[2].ItemSpec, Path.ChangeExtension(t.Sources[3].ItemSpec, ".resources"));
-
-#if FEATURE_RESGENCACHE
+                
                 Utilities.AssertStateFileWasWritten(t);
-#endif
 
                 // Make sure there was an error on the second resource
                 // "unsupported square bracket keyword"
@@ -2188,11 +2167,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  Read-only StateFile yields message
         /// </summary>
-#if FEATURE_RESGENCACHE
         [Fact]
-#else
-        [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/297")]
-#endif
         [PlatformSpecific(TestPlatforms.Windows)]
         public void StateFileUnwritable()
         {

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 
@@ -2063,7 +2062,6 @@ namespace Microsoft.Build.Tasks
             }
         }
 
-
         /// <summary>
         /// Make sure that OutputResources has 1 file name for each name in Sources.
         /// </summary>
@@ -2743,7 +2741,7 @@ namespace Microsoft.Build.Tasks
                             && GetFormat(inFile) != Format.Assembly
                             // outFileOrDir is a directory when the input file is an assembly
                             && GetFormat(outFileOrDir) != Format.Assembly)
-                        // Never delete an assembly since we don't ever actually write to assemblies.
+                            // Never delete an assembly since we don't ever actually write to assemblies.
                         {
                             RemoveCorruptedFile(outFileOrDir);
                         }

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Tasks
 #endif
 
 
-        #region Fields
+#region Fields
         
         // This cache helps us track the linked resource files listed inside of a resx resource file
         private ResGenDependencies _cache;
@@ -169,9 +169,9 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private List<ITaskItem> _satelliteInputs;
 
-        #endregion  // fields
+#endregion  // fields
 
-        #region Properties
+#region Properties
 
         /// <summary>
         /// The names of the items to be converted. The extension must be one of the
@@ -530,7 +530,7 @@ namespace Microsoft.Build.Tasks
             set;
         }
 
-        #endregion // properties
+#endregion // properties
 
         /// <summary>
         /// Simple public constructor.
@@ -2244,7 +2244,7 @@ namespace Microsoft.Build.Tasks
         : MarshalByRefObject
 #endif
     {
-        #region fields
+#region fields
         /// <summary>
         /// List of readers used for input.
         /// </summary>
@@ -2409,7 +2409,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool _useSourcePath = false;
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Process all files.
@@ -2558,7 +2558,7 @@ namespace Microsoft.Build.Tasks
         }
 #endif
 
-        #region Code from ResGen.EXE
+#region Code from ResGen.EXE
 
         /// <summary>
         /// Read all resources from a file and write to a new file in the chosen format
@@ -2605,7 +2605,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (ae.InnerException is XmlException)
                 {
-                    XmlException xe = (XmlException)ae.InnerException;
+                    XmlException xe = (XmlException) ae.InnerException;
                     _logger.LogErrorWithCodeFromResources(null, FileUtilities.GetFullPathNoThrow(inFile), xe.LineNumber,
                         xe.LinePosition, 0, 0, "General.InvalidResxFile", xe.Message);
                 }
@@ -3890,7 +3890,7 @@ namespace Microsoft.Build.Tasks
             public string name;
             public object value;
         }
-        #endregion // Code from ResGen.EXE
+#endregion // Code from ResGen.EXE
     }
 
 #if FEATURE_ASSEMBLY_LOADFROM

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -12,10 +12,10 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-#if FEATURE_RESGENCACHE
+
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-#endif
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 #if FEATURE_COM_INTEROP
@@ -123,7 +123,7 @@ namespace Microsoft.Build.Tasks
 
         // Write time of newest uncorrelated input
         // DateTime.MinValue indicates "missing" iff _newestUncorrelatedInput != null
-        private DateTime _newestUncorrelatedInputWriteTime; 
+        private DateTime _newestUncorrelatedInputWriteTime;
 
         // The targets may pass in the path to the SDKToolsPath. If so this should be used to generate the commandline 
         // for logging purposes.  Also, when ExecuteAsTool is true, it determines where the system goes looking for resgen.exe
@@ -171,9 +171,9 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private List<ITaskItem> _satelliteInputs;
 
-#endregion  // fields
+        #endregion  // fields
 
-#region Properties
+        #region Properties
 
         /// <summary>
         /// The names of the items to be converted. The extension must be one of the
@@ -532,7 +532,7 @@ namespace Microsoft.Build.Tasks
             set;
         }
 
-#endregion // properties
+        #endregion // properties
 
         /// <summary>
         /// Simple public constructor.
@@ -1944,7 +1944,6 @@ namespace Microsoft.Build.Tasks
 
                         return true;
                     }
-#if FEATURE_RESGENCACHE
                     catch (SerializationException e)
                     {
                         Log.LogMessageFromResources
@@ -1959,7 +1958,6 @@ namespace Microsoft.Build.Tasks
 
                         return true;
                     }
-#endif
                     catch (Exception e)
                     {
                         // DDB#9819
@@ -2010,7 +2008,6 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool NeedSeparateAppDomainBasedOnSerializedType(XmlReader reader)
         {
-#if FEATURE_RESGENCACHE
             while (reader.Read())
             {
                 if (reader.NodeType == XmlNodeType.Element)
@@ -2034,12 +2031,10 @@ namespace Microsoft.Build.Tasks
 
             // We didn't find any element at all -- the .resx is malformed.
             // Return true to err on the side of caution. Error will appear later.
-#endif
             return true;
         }
 #endif
 
-#if FEATURE_RESGENCACHE
         /// <summary>
         /// Deserializes a base64 block from a resx in order to figure out if its type is in the GAC.
         /// Because we're not providing any assembly resolution callback, deserialization
@@ -2094,7 +2089,7 @@ namespace Microsoft.Build.Tasks
                 return Convert.FromBase64String(text);
             }
         }
-#endif // FEATURE_RESGENCACHE
+
 
         /// <summary>
         /// Make sure that OutputResources has 1 file name for each name in Sources.
@@ -2278,7 +2273,7 @@ namespace Microsoft.Build.Tasks
         : MarshalByRefObject
 #endif
     {
-#region fields
+        #region fields
         /// <summary>
         /// List of readers used for input.
         /// </summary>
@@ -2445,7 +2440,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private bool _useSourcePath = false;
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Process all files.
@@ -2596,7 +2591,7 @@ namespace Microsoft.Build.Tasks
         }
 #endif
 
-#region Code from ResGen.EXE
+        #region Code from ResGen.EXE
 
         /// <summary>
         /// Read all resources from a file and write to a new file in the chosen format
@@ -2643,7 +2638,7 @@ namespace Microsoft.Build.Tasks
             {
                 if (ae.InnerException is XmlException)
                 {
-                    XmlException xe = (XmlException) ae.InnerException;
+                    XmlException xe = (XmlException)ae.InnerException;
                     _logger.LogErrorWithCodeFromResources(null, FileUtilities.GetFullPathNoThrow(inFile), xe.LineNumber,
                         xe.LinePosition, 0, 0, "General.InvalidResxFile", xe.Message);
                 }
@@ -2668,9 +2663,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
             catch (Exception e) when (
-#if FEATURE_RESGENCACHE
                                       e is SerializationException ||
-#endif
                                       e is TargetInvocationException)
             {
                 // DDB #9819
@@ -2791,7 +2784,7 @@ namespace Microsoft.Build.Tasks
                             && GetFormat(inFile) != Format.Assembly
                             // outFileOrDir is a directory when the input file is an assembly
                             && GetFormat(outFileOrDir) != Format.Assembly)
-                            // Never delete an assembly since we don't ever actually write to assemblies.
+                        // Never delete an assembly since we don't ever actually write to assemblies.
                         {
                             RemoveCorruptedFile(outFileOrDir);
                         }
@@ -2812,7 +2805,7 @@ namespace Microsoft.Build.Tasks
                     if (FileSystems.Default.FileExists(currentOutputFile))
                     {
                         if (GetFormat(currentOutputFile) != Format.Assembly)
-                            // Never delete an assembly since we don't ever actually write to assemblies.
+                        // Never delete an assembly since we don't ever actually write to assemblies.
                         {
                             RemoveCorruptedFile(currentOutputFile);
                         }
@@ -2839,9 +2832,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
             catch (Exception e) when (
-#if FEATURE_RESGENCACHE
                                       e is SerializationException ||
-#endif
                                       e is TargetInvocationException)
             {
                 // DDB #9819
@@ -3894,7 +3885,6 @@ namespace Microsoft.Build.Tasks
             private int lineNumber;
             private int column;
 
-#if FEATURE_RESGENCACHE
             /// <summary>
             /// Fxcop want to have the correct basic exception constructors implemented
             /// </summary>
@@ -3902,7 +3892,6 @@ namespace Microsoft.Build.Tasks
                 : base(info, context)
             {
             }
-#endif
 
             internal TextFileException(String message, String fileName, int lineNumber, int linePosition)
                 : base(message)
@@ -3942,7 +3931,7 @@ namespace Microsoft.Build.Tasks
             public string name;
             public object value;
         }
-#endregion // Code from ResGen.EXE
+        #endregion // Code from ResGen.EXE
     }
 
 #if FEATURE_ASSEMBLY_LOADFROM

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -473,6 +473,7 @@
     <Compile Include="RemoveDir.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ResGenDependencies.cs" />
     <Compile Include="ResolveCodeAnalysisRuleSet.cs" />
     <Compile Include="ResolveKeySource.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
@@ -610,7 +611,7 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResGen.cs" />
-    <Compile Include="ResGenDependencies.cs" />
+
     <Compile Include="ResolveComReferenceCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -611,7 +611,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResGen.cs" />
-
     <Compile Include="ResolveComReferenceCache.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Build.Tasks
                 // Construct the return array
                 var retVal = new List<string>();
 
+#if FEATURE_RESX_RESOURCE_READER
                 using (var resxReader = new ResXResourceReader(filename))
                 {
                     // Tell the reader to return ResXDataNode's instead of the object type
@@ -252,6 +253,7 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
+#endif
 
                 return retVal.ToArray();
             }

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Tasks
                 // Construct the return array
                 var retVal = new List<string>();
 
-                //TODO: Write a .NET Core version of this implementation.
+                //TODO: .NET Core version of this https://github.com/microsoft/msbuild/issues/1247
 #if FEATURE_RESX_RESOURCE_READER
                 using (var resxReader = new ResXResourceReader(filename))
                 {

--- a/src/Tasks/ResGenDependencies.cs
+++ b/src/Tasks/ResGenDependencies.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Build.Tasks
                 // Construct the return array
                 var retVal = new List<string>();
 
+                //TODO: Write a .NET Core version of this implementation.
 #if FEATURE_RESX_RESOURCE_READER
                 using (var resxReader = new ResXResourceReader(filename))
                 {


### PR DESCRIPTION
A step towards more than just strings as embedded resources in .NET Core.

Removed all preprocessor conditions for FEATURE_RESGENCACHE, as @rainersigwald is working towards core resx parsing.

#### Work to be done
The function `GetLinkedFiles` needs a .NET Core code path. In its current state, it returns an empty array on core, while full framework will do traditional processing.



