### PR TITLE
Use $(VsixVersion) to set VSIX version

### DIFF
--- a/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
+++ b/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
@@ -33,7 +33,7 @@
     DependsOnTargets="SetBinPaths"
     Condition="!$(ShouldSkipProject)">
     <ItemGroup>
-      <SwrProperty Include="Version=$(AssemblyVersion)" />
+      <SwrProperty Include="Version=$(VsixVersion)" />
       <SwrProperty Include="X86BinPath=$(X86BinPath)" />
       <SwrProperty Include="X64BinPath=$(X64BinPath)" />
       <SwrProperty Include="TaskHostBinPath=$(MSBuildTaskHostBinPath)" />


### PR DESCRIPTION
We need this and an Arcade update (https://github.com/dotnet/arcade/pull/2698) that will come in through #4297 before we can insert a 16.2 build into VS.