### PR TITLE
Adding a bind redirect for Microsoft.Build.CPPTasks.Common to 16.1

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -45,6 +45,11 @@
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
           <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="16.0.0.0-16.1.0.0" newVersion="16.1.0.0" />
+          <codeBase version="16.1.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+        </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->
         <dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -51,6 +51,11 @@
           <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
           <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="16.0.0.0-16.1.0.0" newVersion="16.1.0.0" />
+          <codeBase version="16.1.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+        </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
         <dependentAssembly>


### PR DESCRIPTION
Adding a bind redirect for Microsoft.Build.CPPTasks.Common to 16.1 from 16.0-16.1. This will allow task dlls that depend on this assembly to target 16.0 and for it to work on 16.0 and higher versions of VS.