### PR TITLE
Reduce ExtractPropertyFunction Allocations

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -28,6 +28,7 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
+    <PackageReference Update="System.Memory" Version="4.5.2" />
     <PackageReference Update="System.Net.Http" Version="4.3.0" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4456,7 +4456,7 @@ namespace Microsoft.Build.Evaluation
                 string[] functionArguments;
 
                 // The name of the function that will be invoked
-                string functionName;
+                ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
                 string remainder = String.Empty;
@@ -4474,9 +4474,8 @@ namespace Microsoft.Build.Evaluation
                     string argumentsContent;
 
                     // separate the function and the arguments
-                    functionName = spanSubstring.Trim().ToString();
+                    functionName = spanSubstring.Trim();
                     //functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
-
 
                     // Skip the '('
                     argumentStartIndex++;
@@ -4534,10 +4533,11 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expressionFunction.Substring(nextMethodIndex).Trim();
+                        remainder = expFuncAsSpan.Slice(nextMethodIndex).Trim().ToString();
                     }
 
-                    string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
+                    ReadOnlySpan<char> netPropertyName = expFuncAsSpan.Slice(methodStartIndex, methodLength).Trim();
+                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4550,7 +4550,7 @@ namespace Microsoft.Build.Evaluation
                 // either there are no functions left or what we have is another function or an indexer
                 if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
                 {
-                    functionBuilder.Name = functionName;
+                    functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
                     functionBuilder.Remainder = remainder;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4459,8 +4459,7 @@ namespace Microsoft.Build.Evaluation
                 ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
-                string remainder = String.Empty;
-                ReadOnlySpan<char> remainder2 = ReadOnlySpan<char>.Empty;
+                ReadOnlySpan<char> remainder = ReadOnlySpan<char>.Empty;
 
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
@@ -4512,9 +4511,8 @@ namespace Microsoft.Build.Evaluation
                             // We will keep empty entries so that we can treat them as null
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
-
-                        remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim().ToString();
-                        remainder2 = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
+                        
+                        remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }
                 else
@@ -4534,12 +4532,10 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim().ToString();
-                        remainder2 = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim();
+                        remainder = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim();
                     }
 
                     ReadOnlySpan<char> netPropertyName = expressionFunctionAsSpan.Slice(methodStartIndex, methodLength).Trim();
-                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4550,12 +4546,12 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // either there are no functions left or what we have is another function or an indexer
-                if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
+                if (remainder.IsEmpty || remainder[0] == '.' || remainder[0] == '[')
                 {
                     functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
-                    functionBuilder.Remainder = remainder2.ToString();
+                    functionBuilder.Remainder = remainder.ToString();
                 }
                 else
                 {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4464,13 +4464,19 @@ namespace Microsoft.Build.Evaluation
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
 
+                ReadOnlySpan<char> expFuncAsSpan = expressionFunction.AsSpan();
+
+                ReadOnlySpan<char> spanSubstring = expFuncAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex);
+
                 // There are arguments that need to be passed to the function
-                if (argumentStartIndex > -1 && !expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Contains("."))
+                if (argumentStartIndex > -1 && !spanSubstring.Contains(".".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     string argumentsContent;
 
                     // separate the function and the arguments
-                    functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
+                    functionName = spanSubstring.Trim().ToString();
+                    //functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
+
 
                     // Skip the '('
                     argumentStartIndex++;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3204,7 +3204,7 @@ namespace Microsoft.Build.Evaluation
                     var rootEndIndex = expressionRoot.IndexOf('.');
 
                     // If this is an instance function rather than a static, then we'll capture the name of the property referenced
-                    var functionReceiver = expressionRoot.Substring(0, rootEndIndex).Trim();
+                    var functionReceiver = expressionRoot.AsSpan().Slice(0, rootEndIndex).Trim().ToString();
 
                     // If propertyValue is null (we're not recursing), then we're expecting a valid property name
                     if (propertyValue == null && !IsValidPropertyName(functionReceiver))

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4511,7 +4511,7 @@ namespace Microsoft.Build.Evaluation
                             // We will keep empty entries so that we can treat them as null
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
-                        
+
                         remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4459,22 +4459,23 @@ namespace Microsoft.Build.Evaluation
                 ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
-                ReadOnlySpan<char> remainder = ReadOnlySpan<char>.Empty;
+                string remainder = String.Empty;
+                ReadOnlySpan<char> remainder2 = ReadOnlySpan<char>.Empty;
 
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
 
-                ReadOnlySpan<char> expressionFuncAsSpan = expressionFunction.AsSpan();
-
-                ReadOnlySpan<char> spanSubstring = expressionFuncAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex);
+                ReadOnlySpan<char> expressionFunctionAsSpan = expressionFunction.AsSpan();
+                
+                ReadOnlySpan<char> expressionSubstringAsSpan = argumentStartIndex > -1 ? expressionFunctionAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex) : ReadOnlySpan<char>.Empty;
 
                 // There are arguments that need to be passed to the function
-                if (argumentStartIndex > -1 && !spanSubstring.Contains(".".AsSpan(), StringComparison.OrdinalIgnoreCase))
+                if (argumentStartIndex > -1 && !expressionSubstringAsSpan.Contains(".".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     string argumentsContent;
 
                     // separate the function and the arguments
-                    functionName = spanSubstring.Trim();
+                    functionName = expressionSubstringAsSpan.Trim();
 
                     // Skip the '('
                     argumentStartIndex++;
@@ -4512,7 +4513,8 @@ namespace Microsoft.Build.Evaluation
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
 
-                        remainder = expressionFuncAsSpan.Slice(argumentsEndIndex + 1).Trim();
+                        remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim().ToString();
+                        remainder2 = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }
                 else
@@ -4532,10 +4534,12 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expressionFuncAsSpan.Slice(nextMethodIndex).Trim();
+                        remainder = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim().ToString();
+                        remainder2 = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim();
                     }
 
-                    ReadOnlySpan<char> netPropertyName = expressionFuncAsSpan.Slice(methodStartIndex, methodLength).Trim();
+                    ReadOnlySpan<char> netPropertyName = expressionFunctionAsSpan.Slice(methodStartIndex, methodLength).Trim();
+                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4546,12 +4550,12 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // either there are no functions left or what we have is another function or an indexer
-                if (remainder.IsEmpty || remainder[0] == '.' || remainder[0] == '[')
+                if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
                 {
                     functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
-                    functionBuilder.Remainder = remainder.ToString();
+                    functionBuilder.Remainder = remainder2.ToString();
                 }
                 else
                 {

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -33,6 +33,7 @@
 
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
+    <PackageReference Include="System.Memory" />
 
     <PackageReference Include="System.Reflection.Metadata" Condition="'$(MonoBuild)' == 'true'" />
   </ItemGroup>

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -28,6 +28,8 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/MSBuild" />
@@ -69,6 +71,8 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/amd64/MSBuild" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -26,6 +26,8 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
+  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
@@ -161,6 +163,8 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets


### PR DESCRIPTION
Meant to fix #4085 but can't seem to repro & prove the fix works.

Reduced allocations by making use of ReadOnlySpan<char>. Previous functionality saw lots of .Substring() and .Trim() calls on strings. Now they're being called on ReadOnlySpan and aren't turned into strings until needed at the end of the function.