### PR TITLE
[Static graph] Add 64bit binaries to the bootstrap directory

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -88,11 +88,13 @@
 
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.dll" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.exe" />
+      <FreshlyBuiltBinariesx64 Include="$(MSBuildTaskHostX64BinPath)**\*.exe" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.tlb" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.pdb" />
+      <FreshlyBuiltBinariesx64 Include="$(MSBuildTaskHostX64BinPath)**\*.pdb" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.exe.config" />
+      <FreshlyBuiltBinariesx64 Include="$(MSBuildTaskHostX64BinPath)**\*.exe.config" />
       <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.dll.config" />
-
 
       <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.Common.props" />
       <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.VisualStudioVersion.*.Common.props" />

--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -56,7 +56,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BootstrapFull" DependsOnTargets="CleanBootstrapFolder;GatherNuGetDependencies">
+  <Target Name="BootstrapFull" DependsOnTargets="CleanBootstrapFolder;SetBinPaths;GatherNuGetDependencies">
     <ItemGroup>
       <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.targets" />
       <InstalledVersionedExtensions Include="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\**\*.props" />
@@ -85,6 +85,14 @@
       <FreshlyBuiltBinaries Include="$(OutputPath)**\*.pdb" />
       <FreshlyBuiltBinaries Include="$(OutputPath)**\*.exe.config" />
       <FreshlyBuiltBinaries Include="$(OutputPath)**\*.dll.config" />
+
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.dll" />
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.exe" />
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.tlb" />
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.pdb" />
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.exe.config" />
+      <FreshlyBuiltBinariesx64 Include="$(X64BinPath)**\*.dll.config" />
+
 
       <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.Common.props" />
       <FreshlyBuiltRootProjects Include="$(OutputPath)Microsoft.VisualStudioVersion.*.Common.props" />
@@ -131,6 +139,11 @@
           DestinationFiles="@(FreshlyBuiltBinaries -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(RoslynBinaries)"
           DestinationFiles="@(RoslynBinaries -> '$(BootstrapDestination)15.0\Bin\Roslyn\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- Copy our binaries to the x64 location. -->
+     <Copy SourceFiles="@(FreshlyBuiltBinariesx64)"
+          DestinationFiles="@(FreshlyBuiltBinariesx64 -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\Bin\amd64\%(RecursiveDir)%(Filename)%(Extension)')" />
+    
     <!-- Copy our freshly-built props and targets, overwriting anything we copied from the machine -->
     <Copy SourceFiles="@(FreshlyBuiltRootProjects)"
           DestinationFiles="@(FreshlyBuiltRootProjects -> '$(BootstrapDestination)$(TargetMSBuildToolsVersion)\%(Filename)%(Extension)')" />

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -48,10 +48,6 @@
     <Copy SourceFiles="$(PublishDir)$(AssemblyName).deps.json" DestinationFiles="$(PublishDir)MSBuild.deps.json" />
   </Target>
 
-  <PropertyGroup>
-    <IgnoreMSBuildTaskHost>true</IgnoreMSBuildTaskHost>
-  </PropertyGroup>
-
   <Import Project="..\Package\GetBinPaths.targets" Condition="$(TargetFramework.StartsWith('net4'))"/>
 
   <Import Project="$(RepoRoot)eng\BootStrapMSBuild.targets" />

--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -48,6 +48,12 @@
     <Copy SourceFiles="$(PublishDir)$(AssemblyName).deps.json" DestinationFiles="$(PublishDir)MSBuild.deps.json" />
   </Target>
 
+  <PropertyGroup>
+    <IgnoreMSBuildTaskHost>true</IgnoreMSBuildTaskHost>
+  </PropertyGroup>
+
+  <Import Project="..\Package\GetBinPaths.targets" Condition="$(TargetFramework.StartsWith('net4'))"/>
+
   <Import Project="$(RepoRoot)eng\BootStrapMSBuild.targets" />
 
 </Project>

--- a/src/Package/GetBinPaths.targets
+++ b/src/Package/GetBinPaths.targets
@@ -12,8 +12,7 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
                       Private="false"
                       ReferenceOutputAssembly="false"
-                      OutputItemType="MSBuildTaskHostResolvedProjectReferencePath" 
-                      Condition="'$(IgnoreMSBuildTaskHost)' != 'true'"/>
+                      OutputItemType="MSBuildTaskHostResolvedProjectReferencePath" />
 
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Deprecated\Conversion\Microsoft.Build.Conversion.csproj"
                       Private="false"
@@ -31,7 +30,7 @@
     <X64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
                          SetPlatform="Platform=x64"
                          OutputItemType="MSBuildTaskHostX64ResolvedProjectReferencePath"
-                         Condition="'$(IgnoreMSBuildTaskHost)' != 'true'" />
+                         GlobalPropertiesToRemove="TargetFramework" />
 
   </ItemGroup>
 

--- a/src/Package/GetBinPaths.targets
+++ b/src/Package/GetBinPaths.targets
@@ -3,17 +3,35 @@
   <ItemGroup>
     <!-- Reference projects whose outputs are used in the package.  Use OutputItemType to get the path to the output assembly,
          from which we will later derive the path to the output folder, which is passed as a variable to the .swr file. -->
-    <ProjectReference Include="..\..\MSBuild\MSBuild.csproj" Private="false" ReferenceOutputAssembly="false" OutputItemType="MSBuildResolvedProjectReferencePath"
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuild\MSBuild.csproj"
+                      Private="false"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="MSBuildResolvedProjectReferencePath"
                       SetTargetFramework="TargetFramework=$(TargetFramework)"/>
-    <ProjectReference Include="..\..\MSBuildTaskHost\MSBuildTaskHost.csproj" Private="false" ReferenceOutputAssembly="false" OutputItemType="MSBuildTaskHostResolvedProjectReferencePath" />
-    <ProjectReference Include="..\..\Deprecated\Conversion\Microsoft.Build.Conversion.csproj" Private="false" ReferenceOutputAssembly="false" OutputItemType="MSBuildConversionResolvedProjectReferencePath" />
+
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
+                      Private="false"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="MSBuildTaskHostResolvedProjectReferencePath" 
+                      Condition="'$(IgnoreMSBuildTaskHost)' != 'true'"/>
+
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Deprecated\Conversion\Microsoft.Build.Conversion.csproj"
+                      Private="false"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="MSBuildConversionResolvedProjectReferencePath" />
 
     <!-- Set up items to build projects where the Platform is set to x64, when we need the x64 versions of the files.
          We have to treat these separately from normal project references, as the AssignProjectConfiguration task would overwrite
          the SetPlatform item metadata if they were ProjectReferences.
     -->
-    <X64ProjectReference SetPlatform="Platform=x64" SetTargetFramework="TargetFramework=$(FullFrameworkTFM)" Include="..\..\MSBuild\MSBuild.csproj" OutputItemType="MSBuildX64ResolvedProjectReferencePath" />
-    <X64ProjectReference SetPlatform="Platform=x64" Include="..\..\MSBuildTaskHost\MSBuildTaskHost.csproj" OutputItemType="MSBuildTaskHostX64ResolvedProjectReferencePath" />
+    <X64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuild\MSBuild.csproj"
+                         SetPlatform="Platform=x64"
+                         SetTargetFramework="TargetFramework=$(FullFrameworkTFM)"
+                         OutputItemType="MSBuildX64ResolvedProjectReferencePath" />
+    <X64ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
+                         SetPlatform="Platform=x64"
+                         OutputItemType="MSBuildTaskHostX64ResolvedProjectReferencePath"
+                         Condition="'$(IgnoreMSBuildTaskHost)' != 'true'" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Building cloudbuild with static graph requires the 64 bit msbuild.

This PR depends on #4327, review only the latest commit.