### PR TITLE
Collect optprof profiles from d16.2stg

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -27,7 +27,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 16
   - name: VisualStudio.ChannelName
-    value: 'int.d16.1stg'
+    value: 'int.d16.2stg'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
This should fix the profile collection that was failing in https://dev.azure.com/devdiv/DevDiv/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?releaseId=326116&environmentId=1498239&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab&_a=release-environment-extension