### PR TITLE
[Static graph] Ability to skip isolation constraints certain references

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -1274,7 +1274,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             /// <summary>
             /// Not Implemented
             /// </summary>
-            private void MockIRequestBuilderCallback_OnBuildRequestBlocked(BuildRequestEntry sourceEntry, int blockingGlobalRequestId, string blockingTarget, IBuildResults partialBuildResult = null)
+            private void MockIRequestBuilderCallback_OnBuildRequestBlocked(BuildRequestEntry issuingEntry, int blockingGlobalRequestId, string blockingTarget, IBuildResults partialBuildResult = null)
             {
                 throw new NotImplementedException();
             }
@@ -1290,7 +1290,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             /// <summary>
             /// Not Implemented
             /// </summary>
-            private void MockIRequestBuilderCallback_OnNewBuildRequests(BuildRequestEntry sourceEntry, FullyQualifiedBuildRequest[] requests)
+            private void MockIRequestBuilderCallback_OnNewBuildRequests(BuildRequestEntry issuingEntry, FullyQualifiedBuildRequest[] requests)
             {
                 throw new NotImplementedException();
             }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -947,15 +947,15 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Raised when the active request needs to build new requests.
         /// </summary>
-        /// <param name="sourceEntry">The request issuing the requests.</param>
+        /// <param name="issuingEntry">The request issuing the requests.</param>
         /// <param name="newRequests">The requests being issued.</param>
         /// <remarks>Called by the RequestBuilder (implicitly through an event).  Non-overlapping with other RequestBuilders.</remarks>
-        private void Builder_OnNewBuildRequests(BuildRequestEntry sourceEntry, FullyQualifiedBuildRequest[] newRequests)
+        private void Builder_OnNewBuildRequests(BuildRequestEntry issuingEntry, FullyQualifiedBuildRequest[] newRequests)
         {
             QueueAction(
                 () =>
                 {
-                    _unsubmittedRequests.Enqueue(new PendingUnsubmittedBuildRequests(sourceEntry, newRequests));
+                    _unsubmittedRequests.Enqueue(new PendingUnsubmittedBuildRequests(issuingEntry, newRequests));
                     IssueUnsubmittedRequests();
                     EvaluateRequestStates();
                 },
@@ -967,12 +967,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <remarks>
         /// Called by the RequestBuilder (implicitly through an event).  Non-overlapping with other RequestBuilders.</remarks>
-        private void Builder_OnBlockedRequest(BuildRequestEntry sourceEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult = null)
+        private void Builder_OnBlockedRequest(BuildRequestEntry issuingEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult = null)
         {
             QueueAction(
                 () =>
                 {
-                    _unsubmittedRequests.Enqueue(new PendingUnsubmittedBuildRequests(sourceEntry, blockingGlobalRequestId, blockingTarget, partialBuildResult));
+                    _unsubmittedRequests.Enqueue(new PendingUnsubmittedBuildRequests(issuingEntry, blockingGlobalRequestId, blockingTarget, partialBuildResult));
                     IssueUnsubmittedRequests();
                     EvaluateRequestStates();
                 },
@@ -995,23 +995,23 @@ namespace Microsoft.Build.BackEnd
             {
                 PendingUnsubmittedBuildRequests unsubmittedRequest = _unsubmittedRequests.Dequeue();
 
-                BuildRequestEntry sourceEntry = unsubmittedRequest.SourceEntry;
+                BuildRequestEntry issuingEntry = unsubmittedRequest.IssuingEntry;
 
-                if (unsubmittedRequest.BlockingGlobalRequestId == sourceEntry.Request.GlobalRequestId)
+                if (unsubmittedRequest.BlockingGlobalRequestId == issuingEntry.Request.GlobalRequestId)
                 {
                     if (unsubmittedRequest.BlockingTarget == null)
                     {
                         // We are yielding
-                        IssueBuildRequest(new BuildRequestBlocker(sourceEntry.Request.GlobalRequestId, sourceEntry.GetActiveTargets(), YieldAction.Yield));
-                        lock (sourceEntry.GlobalLock)
+                        IssueBuildRequest(new BuildRequestBlocker(issuingEntry.Request.GlobalRequestId, issuingEntry.GetActiveTargets(), YieldAction.Yield));
+                        lock (issuingEntry.GlobalLock)
                         {
-                            sourceEntry.WaitForBlockingRequest(sourceEntry.Request.GlobalRequestId);
+                            issuingEntry.WaitForBlockingRequest(issuingEntry.Request.GlobalRequestId);
                         }
                     }
                     else
                     {
                         // We are ready to continue
-                        IssueBuildRequest(new BuildRequestBlocker(sourceEntry.Request.GlobalRequestId, sourceEntry.GetActiveTargets(), YieldAction.Reacquire));
+                        IssueBuildRequest(new BuildRequestBlocker(issuingEntry.Request.GlobalRequestId, issuingEntry.GetActiveTargets(), YieldAction.Reacquire));
                     }
                 }
                 else if (unsubmittedRequest.BlockingGlobalRequestId == BuildRequest.InvalidGlobalRequestId)
@@ -1019,28 +1019,28 @@ namespace Microsoft.Build.BackEnd
                     if (unsubmittedRequest.NewRequests != null)
                     {
                         // We aren't blocked on another request, we are blocked on new requests
-                        IssueBuildRequests(sourceEntry, unsubmittedRequest.NewRequests);
+                        IssueBuildRequests(issuingEntry, unsubmittedRequest.NewRequests);
                     }
                     else
                     {
                         // We are blocked waiting for our results to transfer
-                        lock (sourceEntry.GlobalLock)
+                        lock (issuingEntry.GlobalLock)
                         {
-                            sourceEntry.WaitForBlockingRequest(sourceEntry.Request.GlobalRequestId);
+                            issuingEntry.WaitForBlockingRequest(issuingEntry.Request.GlobalRequestId);
                         }
 
-                        IssueBuildRequest(new BuildRequestBlocker(sourceEntry.Request.GlobalRequestId));
+                        IssueBuildRequest(new BuildRequestBlocker(issuingEntry.Request.GlobalRequestId));
                     }
                 }
                 else
                 {
                     // We are blocked on an existing build request.
-                    lock (sourceEntry.GlobalLock)
+                    lock (issuingEntry.GlobalLock)
                     {
-                        sourceEntry.WaitForBlockingRequest(unsubmittedRequest.BlockingGlobalRequestId);
+                        issuingEntry.WaitForBlockingRequest(unsubmittedRequest.BlockingGlobalRequestId);
                     }
 
-                    IssueBuildRequest(new BuildRequestBlocker(sourceEntry.Request.GlobalRequestId, sourceEntry.GetActiveTargets(), unsubmittedRequest.BlockingGlobalRequestId, unsubmittedRequest.BlockingTarget, unsubmittedRequest.PartialBuildResult));
+                    IssueBuildRequest(new BuildRequestBlocker(issuingEntry.Request.GlobalRequestId, issuingEntry.GetActiveTargets(), unsubmittedRequest.BlockingGlobalRequestId, unsubmittedRequest.BlockingTarget, unsubmittedRequest.PartialBuildResult));
                 }
 
                 countToSubmit--;
@@ -1389,7 +1389,7 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// The issuing request
             /// </summary>
-            public readonly BuildRequestEntry SourceEntry;
+            public readonly BuildRequestEntry IssuingEntry;
 
             /// <summary>
             /// The new requests to issue
@@ -1399,11 +1399,11 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Create a new unsubmitted request entry
             /// </summary>
-            /// <param name="sourceEntry">The build request originating these requests.</param>
+            /// <param name="issuingEntry">The build request originating these requests.</param>
             /// <param name="newRequests">The new requests to be issued.</param>
-            public PendingUnsubmittedBuildRequests(BuildRequestEntry sourceEntry, FullyQualifiedBuildRequest[] newRequests)
+            public PendingUnsubmittedBuildRequests(BuildRequestEntry issuingEntry, FullyQualifiedBuildRequest[] newRequests)
             {
-                SourceEntry = sourceEntry;
+                IssuingEntry = issuingEntry;
                 NewRequests = newRequests;
                 BlockingGlobalRequestId = BuildRequest.InvalidGlobalRequestId;
                 BlockingTarget = null;
@@ -1413,20 +1413,20 @@ namespace Microsoft.Build.BackEnd
             /// <summary>
             /// Create a new unsubmitted request entry
             /// </summary>
-            /// <param name="sourceEntry">The build request originating these requests.</param>
+            /// <param name="issuingEntry">The build request originating these requests.</param>
             /// <param name="blockingGlobalRequestId">The request on which we are blocked.</param>
             /// <param name="blockingTarget">The target on which we are blocked.</param>
-            private PendingUnsubmittedBuildRequests(BuildRequestEntry sourceEntry, int blockingGlobalRequestId, string blockingTarget)
+            private PendingUnsubmittedBuildRequests(BuildRequestEntry issuingEntry, int blockingGlobalRequestId, string blockingTarget)
             {
-                SourceEntry = sourceEntry;
+                IssuingEntry = issuingEntry;
                 NewRequests = null;
                 BlockingGlobalRequestId = blockingGlobalRequestId;
                 BlockingTarget = blockingTarget;
                 PartialBuildResult = null;
             }
 
-            public PendingUnsubmittedBuildRequests(BuildRequestEntry sourceEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult)
-                : this(sourceEntry, blockingGlobalRequestId, blockingTarget)
+            public PendingUnsubmittedBuildRequests(BuildRequestEntry issuingEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult)
+                : this(issuingEntry, blockingGlobalRequestId, blockingTarget)
             {
                 PartialBuildResult = partialBuildResult;
             }

--- a/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/FullyQualifiedBuildRequest.cs
@@ -25,7 +25,13 @@ namespace Microsoft.Build.BackEnd
         /// <param name="targets">The set of targets to build.</param>
         /// <param name="resultsNeeded">Whether or not to wait for the results of this request.</param>
         /// <param name="flags">Flags specified for the build request.</param>
-        public FullyQualifiedBuildRequest(BuildRequestConfiguration config, string[] targets, bool resultsNeeded, BuildRequestDataFlags flags = BuildRequestDataFlags.None)
+        public FullyQualifiedBuildRequest(
+            BuildRequestConfiguration config,
+            string[] targets,
+            bool resultsNeeded,
+            bool skipStaticGraphIsolationConstraints = false,
+            BuildRequestDataFlags flags = BuildRequestDataFlags.None
+            )
         {
             ErrorUtilities.VerifyThrowArgumentNull(config, nameof(config));
             ErrorUtilities.VerifyThrowArgumentNull(targets, nameof(targets));
@@ -33,6 +39,7 @@ namespace Microsoft.Build.BackEnd
             Config = config;
             Targets = targets;
             ResultsNeeded = resultsNeeded;
+            SkipStaticGraphIsolationConstraints = skipStaticGraphIsolationConstraints;
             BuildRequestDataFlags = flags;
         }
 
@@ -55,6 +62,8 @@ namespace Microsoft.Build.BackEnd
         /// The set of flags specified in the BuildRequestData for this request.
         /// </summary>
         public BuildRequestDataFlags BuildRequestDataFlags { get; set; }
+
+        public bool SkipStaticGraphIsolationConstraints { get; }
 
         /// <summary>
         /// Implementation of the equality operator.

--- a/src/Build/BackEnd/Components/RequestBuilder/IRequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IRequestBuilder.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Build.BackEnd
     /// <summary>
     /// Delegate for event raised when a new build request needs to be issued.
     /// </summary>
-    /// <param name="sourceEntry">The entry issuing the request.</param>
+    /// <param name="issuingEntry">The entry issuing the request.</param>
     /// <param name="requests">The request to be issued.</param>
-    internal delegate void NewBuildRequestsDelegate(BuildRequestEntry sourceEntry, FullyQualifiedBuildRequest[] requests);
+    internal delegate void NewBuildRequestsDelegate(BuildRequestEntry issuingEntry, FullyQualifiedBuildRequest[] requests);
 
     /// <summary>
     /// Delegate for event raised when a build request has completed.
@@ -25,10 +25,10 @@ namespace Microsoft.Build.BackEnd
     /// <summary>
     /// Delegate for event raised when a build request is blocked on another request which is in progress.
     /// </summary>
-    /// <param name="sourceEntry">The build request entry which is being blocked.</param>
+    /// <param name="issuingEntry">The build request entry which is being blocked.</param>
     /// <param name="blockingGlobalRequestId">The request on which we are blocked.</param>
     /// <param name="blockingTarget">The target on which we are blocked.</param>
-    internal delegate void BuildRequestBlockedDelegate(BuildRequestEntry sourceEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult);
+    internal delegate void BuildRequestBlockedDelegate(BuildRequestEntry issuingEntry, int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult);
 
     /// <summary>
     /// Represents a class which is capable of building BuildRequestEntries.

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -355,8 +355,14 @@ namespace Microsoft.Build.BackEnd
 
                 BuildRequestConfiguration config = new BuildRequestConfiguration(data, _componentHost.BuildParameters.DefaultToolsVersion);
 
-                requests[i] = new FullyQualifiedBuildRequest(config, targets, waitForResults,
-                    flags: skipNonexistentTargets ? BuildRequestDataFlags.SkipNonexistentTargets : BuildRequestDataFlags.None);
+                requests[i] = new FullyQualifiedBuildRequest(
+                    config: config,
+                    targets: targets,
+                    resultsNeeded: waitForResults,
+                    skipStaticGraphIsolationConstraints: _componentHost.BuildParameters.IsolateProjects && _requestEntry.RequestConfiguration.ShouldSkipIsolationConstraintsForReference(config.ProjectFullPath),
+                    flags: skipNonexistentTargets
+                        ? BuildRequestDataFlags.SkipNonexistentTargets
+                        : BuildRequestDataFlags.None);
             }
 
             // Send the requests off

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -990,7 +990,7 @@ namespace Microsoft.Build.BackEnd
                 return null;
             }
 
-            var projectReferenceItems = _taskExecutionHost.ProjectInstance.GetItems(ItemTypeNames.ProjectReference);
+            var projectReferenceItems = _buildRequestEntry.RequestConfiguration.Project.GetItems(ItemTypeNames.ProjectReference);
 
             var declaredProjects = new HashSet<string>(projectReferenceItems.Count);
 
@@ -1008,7 +1008,9 @@ namespace Microsoft.Build.BackEnd
             {
                 var normalizedMSBuildProject = FileUtilities.NormalizePath(msbuildProject.ItemSpec);
 
-                if (!declaredProjects.Contains(normalizedMSBuildProject))
+                if (
+                    !(declaredProjects.Contains(normalizedMSBuildProject)
+                      || _buildRequestEntry.RequestConfiguration.ShouldSkipIsolationConstraintsForReference(normalizedMSBuildProject)))
                 {
                     if (undeclaredProjects == null)
                     {

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Build.BackEnd
 
             // If the caller supplies an array to put the target outputs in, it must have the same length as the array of project file names they provided, too.
             // "MSB3094: "{2}" refers to {0} item(s), and "{3}" refers to {1} item(s). They must have the same number of items."
-            ErrorUtilities.VerifyThrowArgument((targetOutputsPerProject == null) || (projectFileNames.Length == targetOutputsPerProject.Length), "General.TwoVectorsMustHaveSameLength", projectFileNames.Length, targetOutputsPerProject.Length, "projectFileNames", "targetOutputsPerProject");
+            ErrorUtilities.VerifyThrowArgument((targetOutputsPerProject == null) || (projectFileNames.Length == targetOutputsPerProject.Length), "General.TwoVectorsMustHaveSameLength", projectFileNames.Length, targetOutputsPerProject?.Length ?? 0, "projectFileNames", "targetOutputsPerProject");
 
             BuildEngineResult result = BuildProjectFilesInParallel(projectFileNames, targetNames, globalProperties, new List<String>[projectFileNames.Length], toolsVersion, includeTargetOutputs);
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1582,8 +1582,10 @@ namespace Microsoft.Build.BackEnd
                         abortRequestBatch = true;
                     }
                 }
-                else if (CheckIfCacheMissesAreAllowed(nodeForResults, request, responses))
+                else if (CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request, responses, out var emitNonErrorLogs))
                 {
+                    emitNonErrorLogs(_componentHost.LoggingService);
+
                     // Ensure there is no affinity mismatch between this request and a previous request of the same configuration.
                     NodeAffinity requestAffinity = GetNodeAffinityForRequest(request);
                     NodeAffinity existingRequestAffinity = NodeAffinity.Any;
@@ -1730,7 +1732,7 @@ namespace Microsoft.Build.BackEnd
             }
             else
             {
-                CheckIfCacheMissesAreAllowed(nodeForResults, request.BuildRequest, responses);
+                CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(nodeForResults, request.BuildRequest, responses, out _);
             }
         }
 
@@ -1786,72 +1788,95 @@ namespace Microsoft.Build.BackEnd
             return null;
         }
 
-        private bool CheckIfCacheMissesAreAllowed(int nodeForResults, BuildRequest request, List<ScheduleResponse> responses)
+        /// <returns>True if caches misses are allowed, false otherwise</returns>
+        private bool CheckIfCacheMissOnReferencedProjectIsAllowedAndErrorIfNot(int nodeForResults, BuildRequest request, List<ScheduleResponse> responses, out Action<ILoggingService> emitNonErrorLogs)
         {
+            emitNonErrorLogs = _ => { };
+
             var isIsolatedBuild = _componentHost.BuildParameters.IsolateProjects;
+            var configCache = (IConfigCache) _componentHost.GetComponent(BuildComponentType.ConfigCache);
 
             // do not check root requests as nothing depends on them
-            if (!request.IsRootRequest && isIsolatedBuild)
+            if (!isIsolatedBuild || request.IsRootRequest || request.SkipStaticGraphIsolationConstraints)
             {
-                var configCache = (IConfigCache) _componentHost.GetComponent(BuildComponentType.ConfigCache);
-                var requestConfig = configCache[request.ConfigurationId];
-
-                // Need the parent request. But the parent / child relationship is sometimes formed after the cache is queried, so get creative
-                var parentRequest = _schedulingData.BlockedRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId);
-                if (parentRequest == null)
+                if (isIsolatedBuild && request.SkipStaticGraphIsolationConstraints)
                 {
-                    // the parent might still be in executing requests because the scheduler might not have had a chance to mark it as blocked yet
-                    parentRequest = _schedulingData.ExecutingRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId);
+                    // retrieving the configs is not quite free, so avoid computing them eagerly
+                    var configs = GetConfigurations();
+
+                    emitNonErrorLogs = ls => ls.LogComment(
+                            NewBuildEventContext(),
+                            MessageImportance.Normal,
+                            "SkippedConstraintsOnRequest",
+                            configs.parentConfig.ProjectFullPath,
+                            configs.requestConfig.ProjectFullPath);
                 }
+
+                return true;
+            }
+
+            var (requestConfig, parentConfig) = GetConfigurations();
+
+            // allow self references (project calling the msbuild task on itself, potentially with different global properties)
+            if (parentConfig.ProjectFullPath.Equals(requestConfig.ProjectFullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var errorMessage = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
+                "CacheMissesNotAllowedInIsolatedGraphBuilds",
+                parentConfig.ProjectFullPath,
+                requestConfig.ProjectFullPath,
+                request.Targets.Count == 0
+                    ? "default"
+                    : string.Join(";", request.Targets));
+
+            // Issue a failed build result to have the msbuild task marked as failed and thus stop the build
+            BuildResult result = new BuildResult(request, new InvalidOperationException(errorMessage));
+            result.SetOverallResult(false);
+
+            var response = GetResponseForResult(nodeForResults, request, result);
+            responses.Add(response);
+
+            // Log an error to have something displayed to the user and to avoid having a failed build with 0 errors
+            // todo Search if there's a way to have the error automagically logged in response to the failed build result
+            _componentHost.LoggingService.LogErrorFromText(
+                NewBuildEventContext(),
+                null,
+                null,
+                null,
+                new BuildEventFileInfo(requestConfig.ProjectFullPath),
+                errorMessage);
+
+            return false;
+
+            BuildEventContext NewBuildEventContext()
+            {
+                return new BuildEventContext(
+                    request.SubmissionId,
+                    1,
+                    BuildEventContext.InvalidProjectInstanceId,
+                    BuildEventContext.InvalidProjectContextId,
+                    BuildEventContext.InvalidTargetId,
+                    BuildEventContext.InvalidTaskId);
+            }
+
+            (BuildRequestConfiguration requestConfig, BuildRequestConfiguration parentConfig) GetConfigurations()
+            {
+                var buildRequestConfiguration = configCache[request.ConfigurationId];
+
+                // Need the parent request. It might be blocked or executing; check both.
+                var parentRequest = _schedulingData.BlockedRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId)
+                                    ?? _schedulingData.ExecutingRequests.FirstOrDefault(r => r.BuildRequest.GlobalRequestId == request.ParentGlobalRequestId);
 
                 ErrorUtilities.VerifyThrowInternalNull(parentRequest, nameof(parentRequest));
                 ErrorUtilities.VerifyThrow(
                     configCache.HasConfiguration(parentRequest.BuildRequest.ConfigurationId),
                     "All non root requests should have a parent with a loaded configuration");
 
-                var parentConfig = configCache[parentRequest.BuildRequest.ConfigurationId];
-
-                // allow self references (project calling the msbuild task on itself, potentially with different global properties)
-                if (parentConfig.ProjectFullPath.Equals(requestConfig.ProjectFullPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-
-                var errorMessage = ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword(
-                    "CacheMissesNotAllowedInIsolatedGraphBuilds",
-                    parentConfig.ProjectFullPath,
-                    requestConfig.ProjectFullPath,
-                    request.Targets.Count == 0
-                        ? "default"
-                        : string.Join(";", request.Targets));
-
-                // Issue a failed build result to have the msbuild task marked as failed and thus stop the build
-                BuildResult result = new BuildResult(request, new InvalidOperationException(errorMessage));
-                result.SetOverallResult(false);
-
-                var response = GetResponseForResult(nodeForResults, request, result);
-                responses.Add(response);
-
-                // Log an error to have something displayed to the user and to avoid having a failed build with 0 errors
-                // todo Search if there's a way to have the error automagically logged in response to the failed build result
-                _componentHost.LoggingService.LogErrorFromText(
-                    new BuildEventContext(
-                        request.SubmissionId,
-                        1,
-                        BuildEventContext.InvalidProjectInstanceId,
-                        BuildEventContext.InvalidProjectContextId,
-                        BuildEventContext.InvalidTargetId,
-                        BuildEventContext.InvalidTaskId),
-                    null,
-                    null,
-                    null,
-                    new BuildEventFileInfo(requestConfig.ProjectFullPath),
-                    errorMessage);
-
-                return false;
+                var parentConfiguration = configCache[parentRequest.BuildRequest.ConfigurationId];
+                return (buildRequestConfiguration, parentConfiguration);
             }
-
-            return true;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -80,10 +80,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private RequestedProjectState _requestedProjectState;
 
-        /// <summary>
-        /// If set, skip targets that are not defined in the projects to be built.
-        /// </summary>
-        private bool _skipNonexistentTargets;
+        private bool _skipStaticGraphIsolationConstraints;
 
         /// <summary>
         /// Constructor for serialization.
@@ -102,6 +99,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="hostServices">Host services if any. May be null.</param>
         /// <param name="parentBuildEventContext">The build event context of the parent project.</param>
         /// <param name="parentRequest">The parent build request, if any.</param>
+        /// <param name="skipStaticGraphIsolationConstraints"></param>
         /// <param name="buildRequestDataFlags">Additional flags for the request.</param>
         /// <param name="requestedProjectState">Filter for desired build results.</param>
         public BuildRequest(
@@ -113,7 +111,8 @@ namespace Microsoft.Build.BackEnd
             BuildEventContext parentBuildEventContext,
             BuildRequest parentRequest,
             BuildRequestDataFlags buildRequestDataFlags = BuildRequestDataFlags.None,
-            RequestedProjectState requestedProjectState = null)
+            RequestedProjectState requestedProjectState = null,
+            bool skipStaticGraphIsolationConstraints = false)
         {
             ErrorUtilities.VerifyThrowArgumentNull(escapedTargets, "targets");
             ErrorUtilities.VerifyThrowArgumentNull(parentBuildEventContext, "parentBuildEventContext");
@@ -137,6 +136,8 @@ namespace Microsoft.Build.BackEnd
             _nodeRequestId = nodeRequestId;
             _buildRequestDataFlags = buildRequestDataFlags;
             _requestedProjectState = requestedProjectState;
+
+            _skipStaticGraphIsolationConstraints = skipStaticGraphIsolationConstraints;
         }
 
         /// <summary>
@@ -309,13 +310,9 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// If set, skip targets that are not defined in the projects to be built.
+        /// Whether static graph isolation constraints should be skipped for this request
         /// </summary>
-        internal bool SkipNonexistentTargets
-        {
-            get => _skipNonexistentTargets;
-            set => _skipNonexistentTargets = value;
-        }
+        internal bool SkipStaticGraphIsolationConstraints => _skipStaticGraphIsolationConstraints;
 
         /// <summary>
         /// Sets the configuration id to a resolved id.
@@ -344,7 +341,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _parentBuildEventContext);
             translator.Translate(ref _buildEventContext);
             translator.TranslateEnum(ref _buildRequestDataFlags, (int)_buildRequestDataFlags);
-            translator.Translate(ref _skipNonexistentTargets);
+            translator.Translate(ref _skipStaticGraphIsolationConstraints);
             translator.Translate(ref _requestedProjectState);
             translator.Translate(ref _hostServices);
 

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Build.Globbing
 
         /// <summary>
         ///     See <see cref="Parse(string,string)" />.
-        ///     The glob root will be the current working directory.
+        ///     The glob root, if the glob is not fully qualified, will be the current working directory.
         /// </summary>
         /// <param name="fileSpec"></param>
         /// <returns></returns>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1733,7 +1733,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
   <data name="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds" UESanitized="false" Visibility="Public">
-    <value>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</value>
+    <value>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</value>
     <comment>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
@@ -1763,13 +1763,19 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} is a file path
     </comment>
   </data>
+  <data name="SkippedConstraintsOnRequest" UESanitized="false" Visibility="Public">
+    <value>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</value>
+    <comment>
+      LOCALIZATION: {0} and {1} are file paths
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4259.
+        Next message code should be MSB4260.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: Úloha MSBuild sestavuje projekty {0}, které nejsou zadané v položce ProjectReference. V izolovaných sestaveních to pravděpodobně znamená, že tyto odkazy nejsou v {1} explicitně zadané jako položka ProjectReference.</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: Úloha MSBuild sestavuje projekty {0}, které nejsou zadané v položce ProjectReference. V izolovaných sestaveních to pravděpodobně znamená, že tyto odkazy nejsou v {1} explicitně zadané jako položka ProjectReference.</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: Mit der MSBuild-Aufgabe werden die Projekte "{0}" erstellt, die nicht im ProjectReference-Element angegeben wurden. In isolierten Builds bedeutet dies wahrscheinlich, dass der Verweis nicht explizit als ProjectReference-Element in "{1}" angegeben wurde.</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: Mit der MSBuild-Aufgabe werden die Projekte "{0}" erstellt, die nicht im ProjectReference-Element angegeben wurden. In isolierten Builds bedeutet dies wahrscheinlich, dass der Verweis nicht explizit als ProjectReference-Element in "{1}" angegeben wurde.</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="new">MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="new">MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: La tarea MSBuild está compilando proyectos {0} que no se especifican en el elemento ProjectReference. En compilaciones aisladas, esto significa probablemente que las referencias no se especifican explícitamente como un elemento ProjectReference en "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: La tarea MSBuild está compilando proyectos {0} que no se especifican en el elemento ProjectReference. En compilaciones aisladas, esto significa probablemente que las referencias no se especifican explícitamente como un elemento ProjectReference en "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: La tâche MSBuild génère un ou des projets {0} qui ne sont pas spécifiés dans l'élément ProjectReference. Dans les builds isolées, cela signifie probablement que les références ne sont pas explicitement spécifiées en tant qu'élément ProjectReference dans "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: La tâche MSBuild génère un ou des projets {0} qui ne sont pas spécifiés dans l'élément ProjectReference. Dans les builds isolées, cela signifie probablement que les références ne sont pas explicitement spécifiées en tant qu'élément ProjectReference dans "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: il task MSBuild compila progetti {0} che non sono specificati nell'elemento ProjectReference. Nelle compilazioni isolate questa condizione indica probabilmente che i riferimenti non sono specificati in modo esplicito come elemento ProjectReference in "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: il task MSBuild compila progetti {0} che non sono specificati nell'elemento ProjectReference. Nelle compilazioni isolate questa condizione indica probabilmente che i riferimenti non sono specificati in modo esplicito come elemento ProjectReference in "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: ProjectReference 項目で指定されていないプロジェクト {0} が MSBuild タスクによってビルドされています。分離されたビルドでは、これは多くの場合、参照が "{1}" で ProjectReference 項目として明示的に指定されていないことを意味します</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: ProjectReference 項目で指定されていないプロジェクト {0} が MSBuild タスクによってビルドされています。分離されたビルドでは、これは多くの場合、参照が "{1}" で ProjectReference 項目として明示的に指定されていないことを意味します</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: MSBuild 작업이 ProjectReference 항목에 지정되지 않은 {0} 프로젝트를 빌드하고 있습니다. 격리된 빌드에서 이는 참조가 "{1}"에서 ProjectReference 항목으로 명시적으로 지정되지 않았음을 의미할 수 있습니다.</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: MSBuild 작업이 ProjectReference 항목에 지정되지 않은 {0} 프로젝트를 빌드하고 있습니다. 격리된 빌드에서 이는 참조가 "{1}"에서 ProjectReference 항목으로 명시적으로 지정되지 않았음을 의미할 수 있습니다.</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: Zadanie programu MSBuild kompiluje projekty {0}, które nie są określone w elemencie ProjectReference. W przypadku kompilacji izolowanych prawdopodobnie oznacza to, że odwołania nie zostały jawnie określone jako element ProjectReference w pliku „{1}”</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: Zadanie programu MSBuild kompiluje projekty {0}, które nie są określone w elemencie ProjectReference. W przypadku kompilacji izolowanych prawdopodobnie oznacza to, że odwołania nie zostały jawnie określone jako element ProjectReference w pliku „{1}”</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -107,9 +107,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: A tarefa MSBuild está compilando projetos {0} que não estão especificados no item ProjectReference. Em builds isolados, isso provavelmente significa que as referências não são especificadas de forma explícita como um item de ProjectReference em "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: A tarefa MSBuild está compilando projetos {0} que não estão especificados no item ProjectReference. Em builds isolados, isso provavelmente significa que as referências não são especificadas de forma explícita como um item de ProjectReference em "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: задача MSBuild собирает проект(ы) {0}, которые не указаны в элементе ProjectReference. В изолированных сборках это может означать, что ссылки явно не указаны как элемент ProjectReference в "{1}"</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: задача MSBuild собирает проект(ы) {0}, которые не указаны в элементе ProjectReference. В изолированных сборках это может означать, что ссылки явно не указаны как элемент ProjectReference в "{1}"</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: MSBuild görevi, ProjectReference öğesinde belirtilmeyen {0} projesini derliyor. Yalıtılmış derlemelerde bu genellikle başvuruların "{1}" içinde açıkça ProjectReference öğesi olarak belirtilmediği anlamına gelir</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: MSBuild görevi, ProjectReference öğesinde belirtilmeyen {0} projesini derliyor. Yalıtılmış derlemelerde bu genellikle başvuruların "{1}" içinde açıkça ProjectReference öğesi olarak belirtilmediği anlamına gelir</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: MSBuild 任务正在生成未在 ProjectReference 项中指定的 {0} 项目。在独立生成中，这可能表示未将引用显式地指定为“{1}”中的 ProjectReference 项</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: MSBuild 任务正在生成未在 ProjectReference 项中指定的 {0} 项目。在独立生成中，这可能表示未将引用显式地指定为“{1}”中的 ProjectReference 项</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -108,9 +108,16 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="SkippedConstraintsOnRequest">
+        <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
+        <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
+        <note>
+      LOCALIZATION: {0} and {1} are file paths
+    </note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
-        <source>MSB4254: The MSBuild task is building project(s) {0} which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
-        <target state="translated">MSB4254: MSBuild 工作建置的專案 {0} 未在 ProjectReference 項目中指定。在隔離式組建中，這可能代表未在 "{1}" 中將該參考明確指定為 ProjectReference 項目</target>
+        <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
+        <target state="needs-review-translation">MSB4254: MSBuild 工作建置的專案 {0} 未在 ProjectReference 項目中指定。在隔離式組建中，這可能代表未在 "{1}" 中將該參考明確指定為 ProjectReference 項目</target>
         <note>
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -78,8 +78,8 @@ namespace Microsoft.Build.Shared
         /// Current version of this MSBuild Engine assembly in the form, e.g, "12.0"
         /// </summary>
         internal const string CurrentProductVersion = "16.0";
-		
-		/// <summary>
+        
+        /// <summary>
         /// Symbol used in ProjectReferenceTarget items to represent default targets
         /// </summary>
         internal const string DefaultTargetsMarker = ".default";
@@ -89,8 +89,8 @@ namespace Microsoft.Build.Shared
         /// with fallback to default targets if the ProjectReference item has no targets specified.
         /// </summary>
         internal const string ProjectReferenceTargetsOrDefaultTargetsMarker = ".projectReferenceTargetsOrDefaultTargets";
-		
-		// One-time allocations to avoid implicit allocations for Split(), Trim().
+        
+        // One-time allocations to avoid implicit allocations for Split(), Trim().
         internal static readonly char[] SemicolonChar = { ';' };
         internal static readonly char[] SpaceChar = { ' ' };
         internal static readonly char[] SingleQuoteChar = { '\'' };
@@ -133,6 +133,8 @@ namespace Microsoft.Build.Shared
         /// Statically specifies what targets a project calls on its references
         /// </summary>
         internal const string ProjectReferenceTargets = nameof(ProjectReferenceTargets);
+
+        internal const string GraphIsolationExemptReference = nameof(GraphIsolationExemptReference);
     }
 
     /// <summary>

--- a/src/Shared/UnitTests/MockLogger.cs
+++ b/src/Shared/UnitTests/MockLogger.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Reflection;
 using System.Resources;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;
 using Shouldly;
 using Xunit;
@@ -472,5 +473,11 @@ namespace Microsoft.Build.UnitTests
         /// Assert that no warnings were logged
         /// </summary>
         internal void AssertNoWarnings() => Assert.Equal(0, WarningCount);
+
+        internal void AssertMessageCount(string message, int expectedCount)
+        {
+            var matches = Regex.Matches(FullLog, message);
+            matches.Count.ShouldBe(expectedCount);
+        }
     }
 }

--- a/src/Tasks/Microsoft.Managed.targets
+++ b/src/Tasks/Microsoft.Managed.targets
@@ -35,6 +35,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <DisableTransitiveProjectReferences Condition="'$(BuildProjectReferences)' != 'false' and '$(DisableTransitiveProjectReferences)' == ''">true</DisableTransitiveProjectReferences>
    </PropertyGroup>
 
+   <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
+      <!-- WPF projects generate a project with a random name at build time and then build the project via the IBuildEngine callbacks.
+           Detect WPF, and exclude the generated project from static graph isolation constraint checking.
+           Escape the item to avoid eager evaluation of the wildcards.
+      -->
+      <GraphIsolationExemptReference
+         Condition="'$(UseWPF)' == 'true' or '@(Page)' != '' or '@(ApplicationDefinition)' != '' or '@(XamlPage)' != '' or '@(XamlAppDef)' != ''"
+         Include="$([MSBuild]::Escape('$(MSBuildProjectDirectory)\$(MSBuildProjectName)*_wpftmp$(MSBuildProjectExtension)'))" />
+   </ItemGroup>
+
   <!--
     Properties for extension of ProjectReferenceTargets.
     Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.


### PR DESCRIPTION
Projects can now skip static graph constraint checks on certain references by declaring an item, `ReferencesToSkipGraphIsolationConstraintsOn`, which contains wildcards matching the full path of the references they want excluded. This allows static graph to build WPF projects, which generate and build an undeclared project with a random name at build time.

This PR is based on #4327. Relevant commits start with 91db31c