### PR TITLE
Typo in ProjectStartedEventArgs.ProjectId doc comment

### DIFF
--- a/src/Framework/ProjectStartedEventArgs.cs
+++ b/src/Framework/ProjectStartedEventArgs.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Build.Framework
         private int projectId;
 
         /// <summary>
-        /// Gets the idenifier of the project.
+        /// Gets the identifier of the project.
         /// </summary>
         public int ProjectId
         {


### PR DESCRIPTION
Noticed this while working on something today.