### PR TITLE
Opt out of semver2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,6 +18,9 @@
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
+
+    <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
+    <SemanticVersioningV1>true</SemanticVersioningV1>
   </PropertyGroup>
   <!-- Repo Toolset Features -->
   <PropertyGroup>


### PR DESCRIPTION
Works around https://github.com/dotnet/roslyn/issues/35793 which sets a
win32 resource to a bad value when there are too many dots in
`AssemblyInformationalVersion`.

Medium term, I'd rather see us on semver2, since it's a nicer overall
experience.