### PR TITLE
Reduce ExtractPropertyFunction Allocations

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4460,7 +4460,7 @@ namespace Microsoft.Build.Evaluation
                 string[] functionArguments;
 
                 // The name of the function that will be invoked
-                string functionName;
+                ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
                 string remainder = String.Empty;
@@ -4478,9 +4478,8 @@ namespace Microsoft.Build.Evaluation
                     string argumentsContent;
 
                     // separate the function and the arguments
-                    functionName = spanSubstring.Trim().ToString();
+                    functionName = spanSubstring.Trim();
                     //functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
-
 
                     // Skip the '('
                     argumentStartIndex++;
@@ -4538,10 +4537,11 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expressionFunction.Substring(nextMethodIndex).Trim();
+                        remainder = expFuncAsSpan.Slice(nextMethodIndex).Trim().ToString();
                     }
 
-                    string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
+                    ReadOnlySpan<char> netPropertyName = expFuncAsSpan.Slice(methodStartIndex, methodLength).Trim();
+                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4554,7 +4554,7 @@ namespace Microsoft.Build.Evaluation
                 // either there are no functions left or what we have is another function or an indexer
                 if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
                 {
-                    functionBuilder.Name = functionName;
+                    functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
                     functionBuilder.Remainder = remainder;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4463,8 +4463,7 @@ namespace Microsoft.Build.Evaluation
                 ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
-                string remainder = String.Empty;
-                ReadOnlySpan<char> remainder2 = ReadOnlySpan<char>.Empty;
+                ReadOnlySpan<char> remainder = ReadOnlySpan<char>.Empty;
 
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
@@ -4516,9 +4515,8 @@ namespace Microsoft.Build.Evaluation
                             // We will keep empty entries so that we can treat them as null
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
-
-                        remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim().ToString();
-                        remainder2 = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
+                        
+                        remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }
                 else
@@ -4538,12 +4536,10 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim().ToString();
-                        remainder2 = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim();
+                        remainder = expressionFunctionAsSpan.Slice(nextMethodIndex).Trim();
                     }
 
                     ReadOnlySpan<char> netPropertyName = expressionFunctionAsSpan.Slice(methodStartIndex, methodLength).Trim();
-                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4554,12 +4550,12 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // either there are no functions left or what we have is another function or an indexer
-                if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
+                if (remainder.IsEmpty || remainder[0] == '.' || remainder[0] == '[')
                 {
                     functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
-                    functionBuilder.Remainder = remainder2.ToString();
+                    functionBuilder.Remainder = remainder.ToString();
                 }
                 else
                 {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4463,14 +4463,14 @@ namespace Microsoft.Build.Evaluation
                 ReadOnlySpan<char> functionName;
 
                 // What's left of the expression once the function has been constructed
-                string remainder = String.Empty;
+                ReadOnlySpan<char> remainder = ReadOnlySpan<char>.Empty;
 
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
 
-                ReadOnlySpan<char> expFuncAsSpan = expressionFunction.AsSpan();
+                ReadOnlySpan<char> expressionFuncAsSpan = expressionFunction.AsSpan();
 
-                ReadOnlySpan<char> spanSubstring = expFuncAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex);
+                ReadOnlySpan<char> spanSubstring = expressionFuncAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex);
 
                 // There are arguments that need to be passed to the function
                 if (argumentStartIndex > -1 && !spanSubstring.Contains(".".AsSpan(), StringComparison.OrdinalIgnoreCase))
@@ -4479,7 +4479,6 @@ namespace Microsoft.Build.Evaluation
 
                     // separate the function and the arguments
                     functionName = spanSubstring.Trim();
-                    //functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
 
                     // Skip the '('
                     argumentStartIndex++;
@@ -4517,7 +4516,7 @@ namespace Microsoft.Build.Evaluation
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
 
-                        remainder = expressionFunction.Substring(argumentsEndIndex + 1).Trim();
+                        remainder = expressionFuncAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }
                 else
@@ -4537,11 +4536,10 @@ namespace Microsoft.Build.Evaluation
                     if (nextMethodIndex > 0)
                     {
                         methodLength = nextMethodIndex - methodStartIndex;
-                        remainder = expFuncAsSpan.Slice(nextMethodIndex).Trim().ToString();
+                        remainder = expressionFuncAsSpan.Slice(nextMethodIndex).Trim();
                     }
 
-                    ReadOnlySpan<char> netPropertyName = expFuncAsSpan.Slice(methodStartIndex, methodLength).Trim();
-                    //string netPropertyName = expressionFunction.Substring(methodStartIndex, methodLength).Trim();
+                    ReadOnlySpan<char> netPropertyName = expressionFuncAsSpan.Slice(methodStartIndex, methodLength).Trim();
 
                     ProjectErrorUtilities.VerifyThrowInvalidProject(netPropertyName.Length > 0, elementLocation, "InvalidFunctionPropertyExpression", expressionFunction, String.Empty);
 
@@ -4552,12 +4550,12 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // either there are no functions left or what we have is another function or an indexer
-                if (String.IsNullOrEmpty(remainder) || remainder[0] == '.' || remainder[0] == '[')
+                if (remainder.IsEmpty || remainder[0] == '.' || remainder[0] == '[')
                 {
                     functionBuilder.Name = functionName.ToString();
                     functionBuilder.Arguments = functionArguments;
                     functionBuilder.BindingFlags = defaultBindingFlags;
-                    functionBuilder.Remainder = remainder;
+                    functionBuilder.Remainder = remainder.ToString();
                 }
                 else
                 {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4468,13 +4468,19 @@ namespace Microsoft.Build.Evaluation
                 // The binding flags that we will use for this function's execution
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
 
+                ReadOnlySpan<char> expFuncAsSpan = expressionFunction.AsSpan();
+
+                ReadOnlySpan<char> spanSubstring = expFuncAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex);
+
                 // There are arguments that need to be passed to the function
-                if (argumentStartIndex > -1 && !expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Contains("."))
+                if (argumentStartIndex > -1 && !spanSubstring.Contains(".".AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     string argumentsContent;
 
                     // separate the function and the arguments
-                    functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
+                    functionName = spanSubstring.Trim().ToString();
+                    //functionName = expressionFunction.Substring(methodStartIndex, argumentStartIndex - methodStartIndex).Trim();
+
 
                     // Skip the '('
                     argumentStartIndex++;

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3208,7 +3208,7 @@ namespace Microsoft.Build.Evaluation
                     var rootEndIndex = expressionRoot.IndexOf('.');
 
                     // If this is an instance function rather than a static, then we'll capture the name of the property referenced
-                    var functionReceiver = expressionRoot.Substring(0, rootEndIndex).Trim();
+                    var functionReceiver = expressionRoot.AsSpan().Slice(0, rootEndIndex).Trim().ToString();
 
                     // If propertyValue is null (we're not recursing), then we're expecting a valid property name
                     if (propertyValue == null && !IsValidPropertyName(functionReceiver))

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4515,7 +4515,7 @@ namespace Microsoft.Build.Evaluation
                             // We will keep empty entries so that we can treat them as null
                             functionArguments = ExtractFunctionArguments(elementLocation, expressionFunction, argumentsContent);
                         }
-                        
+
                         remainder = expressionFunctionAsSpan.Slice(argumentsEndIndex + 1).Trim();
                     }
                 }


### PR DESCRIPTION
Meant to fix #4085 but can't seem to repro & prove the fix works.

Reduced allocations by making use of ReadOnlySpan. Previous functionality saw lots of .Substring() and .Trim() calls on strings. Now they're being called on ReadOnlySpan and aren't turned into strings until needed at the end of the function.