### PR TITLE
Normalize paths in GetPathsOfAllDirectoriesAbove

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3970,6 +3970,49 @@ $(
         }
 
         [Fact]
+        public void ExpandItemVectorFunctions_GetPathsOfAllDirectoriesAbove_ReturnCanonicalPaths()
+        {
+            // Directory structure:
+            // <temp>\
+            //    alpha\
+            //        .proj
+            //        One.cs
+            //        beta\
+            //            Two.cs
+            //    gamma\
+            //        Three.cs
+            using (var env = TestEnvironment.Create())
+            {
+                var root = env.CreateFolder();
+
+                var alpha = root.CreateDirectory("alpha");
+                var projectFile = env.CreateFile(alpha, ".proj",
+                    @"<Project>
+  <ItemGroup>
+    <Compile Include=""One.cs"" />
+    <Compile Include=""beta\Two.cs"" />
+    <Compile Include=""..\gamma\Three.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <MyDirectories Include=""@(Compile->GetPathsOfAllDirectoriesAbove())"" />
+  </ItemGroup>
+</Project>");
+
+                var beta = alpha.CreateDirectory("beta");
+                var gamma = root.CreateDirectory("gamma");
+
+                ProjectInstance projectInstance = new ProjectInstance(projectFile.Path);
+                ICollection<ProjectItemInstance> myDirectories = projectInstance.GetItems("MyDirectories");
+
+                var includes = myDirectories.Select(i => i.EvaluatedInclude);
+                includes.ShouldContain(root.Path);
+                includes.ShouldContain(alpha.Path);
+                includes.ShouldContain(beta.Path);
+                includes.ShouldContain(gamma.Path);
+            }
+        }
+
+        [Fact]
         public void ExpandItemVectorFunctions_Combine()
         {
             using (var env = TestEnvironment.Create())

--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3962,6 +3962,7 @@ $(
                 ICollection<ProjectItemInstance> myDirectories = projectInstance.GetItems("MyDirectories");
 
                 var includes = myDirectories.Select(i => i.EvaluatedInclude);
+                includes.ShouldBeUnique();
                 includes.ShouldContain(root.Path);
                 includes.ShouldContain(alpha.Path);
                 includes.ShouldContain(beta.Path);
@@ -4005,6 +4006,7 @@ $(
                 ICollection<ProjectItemInstance> myDirectories = projectInstance.GetItems("MyDirectories");
 
                 var includes = myDirectories.Select(i => i.EvaluatedInclude);
+                includes.ShouldBeUnique();
                 includes.ShouldContain(root.Path);
                 includes.ShouldContain(alpha.Path);
                 includes.ShouldContain(beta.Path);

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2313,6 +2313,10 @@ namespace Microsoft.Build.Evaluation
                                 rootedPath = Path.Combine(baseDirectoryToUse, unescapedPath);
                             }
 
+                            // Normalize the path to remove elements like "..".
+                            // Otherwise we run the risk of returning two or more different paths that represent the
+                            // same directory.
+                            rootedPath = FileUtilities.NormalizePath(rootedPath);
                             directoryName = Path.GetDirectoryName(rootedPath);
                         }
                         catch (Exception e) when (ExceptionHandling.IsIoRelatedException(e))

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -289,7 +289,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\Resolver.cs">
-      <SubType>Code</SubType>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyDependency\ResolveAssemblyReference.cs">


### PR DESCRIPTION
The `GetPathsOfAllDirectoriesAbove` item intrinsic takes a set of items and is supposed to return the set of directories above those items--one item per directory. However, it doesn't properly handle some forms of relative paths. For example, if you start with these items:

* C:\alpha\beta\Class1.cs
* C:\alpha\beta\..\Class2.cs

Then you'll get the following output:

* C:\
* C:\alpha
* C:\alpha\beta
* C:\alpha\beta\..

Which means we end up with two different paths that logically represent the same "alpha" directory.

To fix this we first run the item paths through `Path.GetFullPath(...)` which reduces it to a normalized form without ".." and such.

Fixes #4392.