### PR TITLE
[Static Graph] Skipped results do not trigger cache miss enforcement

### DIFF
--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             result.AddResultsForTarget("testTarget2", BuildResultUtilities.GetEmptySucceedingTargetResult());
             cache.AddResult(result);
 
-            ResultsCacheResponse response = cache.SatisfyRequest(request, new List<string>(), new List<string>(new string[] { "testTarget2" }), new List<string>(new string[] { "testTarget" }), skippedResultsAreOK: false);
+            ResultsCacheResponse response = cache.SatisfyRequest(request, new List<string>(), new List<string>(new string[] { "testTarget2" }), new List<string>(new string[] { "testTarget" }), skippedResultsDoNotCauseCacheMiss: false);
 
             Assert.Equal(ResultsCacheResponseType.Satisfied, response.Type);
 

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -787,6 +787,8 @@ namespace Microsoft.Build.Execution
 
         internal bool UsesInputCaches() => InputResultsCacheFiles != null;
 
+        internal bool SkippedResultsDoNotCauseCacheMiss() => IsolateProjects;
+
         /// <summary>
         /// Implementation of the serialization mechanism.
         /// </summary>

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -512,7 +512,13 @@ namespace Microsoft.Build.BackEnd
                                 {
                                     // If we have results already in the cache for this request, give them to the
                                     // entry now.
-                                    ResultsCacheResponse cacheResponse = resultsCache.SatisfyRequest(request, config.ProjectInitialTargets, config.ProjectDefaultTargets, config.GetAfterTargetsForDefaultTargets(request), skippedResultsAreOK: false);
+                                    var cacheResponse = resultsCache.SatisfyRequest(
+                                        request: request,
+                                        configInitialTargets: config.ProjectInitialTargets,
+                                        configDefaultTargets: config.ProjectDefaultTargets,
+                                        additionalTargetsToCheckForOverallResult: config.GetAfterTargetsForDefaultTargets(request),
+                                        skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
+
                                     if (cacheResponse.Type == ResultsCacheResponseType.Satisfied)
                                     {
                                         // We have a result, give it back to this request.
@@ -1169,11 +1175,11 @@ namespace Microsoft.Build.BackEnd
                         IResultsCache resultsCache = (IResultsCache)_componentHost.GetComponent(BuildComponentType.ResultsCache);
 
                         var response = resultsCache.SatisfyRequest(
-                            newRequest,
-                            matchingConfig.ProjectInitialTargets,
-                            matchingConfig.ProjectDefaultTargets,
-                            matchingConfig.GetAfterTargetsForDefaultTargets(newRequest),
-                            skippedResultsAreOK: false);
+                            request: newRequest,
+                            configInitialTargets: matchingConfig.ProjectInitialTargets,
+                            configDefaultTargets: matchingConfig.ProjectDefaultTargets,
+                            additionalTargetsToCheckForOverallResult: matchingConfig.GetAfterTargetsForDefaultTargets(newRequest),
+                            skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
 
                         if (response.Type == ResultsCacheResponseType.Satisfied)
                         {

--- a/src/Build/BackEnd/Components/Caching/IResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/IResultsCache.cs
@@ -51,12 +51,12 @@ namespace Microsoft.Build.BackEnd
         /// <param name="configDefaultTargets">The default targets for the request's configuration.</param>
         /// <param name="additionalTargetsToCheckForOverallResult">Any additional targets that need to be checked to determine overall 
         /// pass or failure, but that are not included as actual results. (E.g. AfterTargets of an entrypoint target)</param>
-        /// <param name="skippedResultsAreOK">If false, a cached skipped target will cause this method to return "NotSatisfied".  
+        /// <param name="skippedResultsDoNotCauseCacheMiss">If false, a cached skipped target will cause this method to return "NotSatisfied".  
         /// If true, then as long as there is a result in the cache (regardless of whether it was skipped or not), this method 
         /// will return "Satisfied". In most cases this should be false, but it may be set to true in a situation where there is no 
         /// chance of re-execution (which is the usual response to missing / skipped targets), and the caller just needs the data.</param>
         /// <returns>A response indicating the results, if any, and the targets needing to be built, if any.</returns>
-        ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, List<string> additionalTargetsToCheckForOverallResult, bool skippedResultsAreOK);
+        ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, List<string> additionalTargetsToCheckForOverallResult, bool skippedResultsDoNotCauseCacheMiss);
 
         /// <summary>
         /// Clears the results for a specific configuration.

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
@@ -78,14 +78,14 @@ namespace Microsoft.Build.Execution
             List<string> configInitialTargets,
             List<string> configDefaultTargets,
             List<string> additionalTargetsToCheckForOverallResult,
-            bool skippedResultsAreOK)
+            bool skippedResultsDoNotCauseCacheMiss)
         {
             var overrideRequest = _override.SatisfyRequest(
                 request,
                 configInitialTargets,
                 configDefaultTargets,
                 additionalTargetsToCheckForOverallResult,
-                skippedResultsAreOK);
+                skippedResultsDoNotCauseCacheMiss);
 
             if (overrideRequest.Type == ResultsCacheResponseType.Satisfied)
             {
@@ -96,7 +96,7 @@ namespace Microsoft.Build.Execution
                         configInitialTargets,
                         configDefaultTargets,
                         additionalTargetsToCheckForOverallResult,
-                        skippedResultsAreOK)
+                        skippedResultsDoNotCauseCacheMiss)
                         .Type == ResultsCacheResponseType.NotSatisfied,
                     "caches should not overlap");
 #endif
@@ -108,7 +108,7 @@ namespace Microsoft.Build.Execution
                 configInitialTargets,
                 configDefaultTargets,
                 additionalTargetsToCheckForOverallResult,
-                skippedResultsAreOK);
+                skippedResultsDoNotCauseCacheMiss);
         }
 
         public void ClearResultsForConfiguration(int configurationId)

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1881,5 +1881,56 @@ namespace Microsoft.Build.UnitTests
                 return obj.Line.GetHashCode() ^ obj.Column.GetHashCode() ^ obj.File.GetHashCode();
             }
         }
+
+        internal class BuildManagerSession : IDisposable
+        {
+            private readonly TestEnvironment _env;
+            private readonly BuildManager _buildManager;
+
+            public MockLogger Logger { get; set; }
+
+
+            public BuildManagerSession(
+                TestEnvironment env,
+                BuildParameters buildParametersPrototype = null,
+                bool enableNodeReuse = false,
+                bool shutdownInProcNode = true)
+            {
+                _env = env;
+
+                Logger = new MockLogger(_env.Output);
+                var loggers = new[] {Logger};
+
+                var actualBuildParameters = buildParametersPrototype?.Clone() ?? new BuildParameters();
+
+                actualBuildParameters.Loggers = actualBuildParameters.Loggers == null
+                    ? loggers
+                    : actualBuildParameters.Loggers.Concat(loggers).ToArray();
+
+                actualBuildParameters.ShutdownInProcNodeOnBuildFinish = shutdownInProcNode;
+                actualBuildParameters.EnableNodeReuse = enableNodeReuse;
+
+                _buildManager = new BuildManager();
+                _buildManager.BeginBuild(actualBuildParameters);
+            }
+
+            public BuildResult BuildProjectFile(string projectFile, string[] entryTargets = null)
+            {
+                var buildResult = _buildManager.BuildRequest(
+                    new BuildRequestData(projectFile,
+                        new Dictionary<string, string>(),
+                        MSBuildConstants.CurrentToolsVersion,
+                        entryTargets ?? new string[0],
+                        null));
+
+                return buildResult;
+            }
+
+            public void Dispose()
+            {
+                _buildManager.EndBuild();
+                _buildManager.Dispose();
+            }
+        }
     }
 }

--- a/src/Shared/UnitTests/TestEnvironment.cs
+++ b/src/Shared/UnitTests/TestEnvironment.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         private readonly List<TransientTestState> _variants = new List<TransientTestState>();
 
-        private readonly ITestOutputHelper _output;
+        public ITestOutputHelper Output { get; }
 
         private readonly Lazy<TransientTestFolder> _defaultTestDirectory;
 
@@ -55,7 +55,7 @@ namespace Microsoft.Build.UnitTests
 
         private TestEnvironment(ITestOutputHelper output)
         {
-            _output = output;
+            Output = output;
             _defaultTestDirectory = new Lazy<TransientTestFolder>(() => CreateFolder());
             SetDefaultInvariant();
         }
@@ -86,7 +86,7 @@ namespace Microsoft.Build.UnitTests
 
                 // Assert invariants
                 foreach (var item in _invariants)
-                    item.AssertInvariant(_output);
+                    item.AssertInvariant(Output);
             }
         }
 
@@ -294,8 +294,8 @@ namespace Microsoft.Build.UnitTests
         /// Will not work for out of proc nodes since the output writer does not reach into those
         public TransientPrintLineDebugger CreatePrintLineDebuggerWithTestOutputHelper()
         {
-            ErrorUtilities.VerifyThrowInternalNull(_output, nameof(_output));
-            return WithTransientTestState(new TransientPrintLineDebugger(this, OutPutHelperWriter(_output)));
+            ErrorUtilities.VerifyThrowInternalNull(Output, nameof(Output));
+            return WithTransientTestState(new TransientPrintLineDebugger(this, OutPutHelperWriter(Output)));
 
             CommonWriterType OutPutHelperWriter(ITestOutputHelper output)
             {


### PR DESCRIPTION
Closes #4343

PR is based on #4379, review that one first.

If a project has skipped targets, subsequent requests for those targets trigger the re-execution of the targets. This erroneously causes the static graph constraint of no cache misses. To fix it, `BuildParameters.IsolateProjects` will cause the `ResultsCache` to not issue a cache miss on skipped targets. This seems quite reasonable because in an isolated graph build, a project is visited only once.