### PR TITLE
Minimize Path.GetDirectoryName Calls in GetItemSpecModifier

### DIFF
--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Build.Shared
         {
             return pattern.Length == 3 &&
                     StartsWithDrivePattern(pattern) &&
-                    pattern[2] == _forwardSlash || pattern[2] == _backSlash;
+                    (pattern[2] == _forwardSlash || pattern[2] == _backSlash);
         }
 
         /// <summary>
@@ -56,6 +56,23 @@ namespace Microsoft.Build.Shared
             return pattern.Length >= 2 &&
                 ((pattern[0] >= 'A' && pattern[0] <= 'Z') || (pattern[0] >= 'a' && pattern[0] <= 'z')) &&
                 pattern[1] == ':';
+        }
+
+        /// <summary>
+        /// Indicates whether the specified string starts with the drive pattern: "<drive letter>:/" or "<drive letter>:\".
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <returns></returns>
+        internal static bool StartsWithDrivePatternWithSlash(string pattern)
+        {
+            // Format dictates a length of at least 3,
+            // first character must be a letter,
+            // second character must be a ":"
+            // third character must be a slash.
+            return pattern.Length >= 3 &&
+                ((pattern[0] >= 'A' && pattern[0] <= 'Z') || (pattern[0] >= 'a' && pattern[0] <= 'z')) &&
+                pattern[1] == ':' &&
+                (pattern[2] == '\\' || pattern[2] == '/');
         }
 
         /// <summary>

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Build.Shared
         internal static bool IsDrivePatternWithSlash(string pattern)
         {
             return pattern.Length == 3 &&
-                    StartsWithDrivePattern(pattern) &&
-                    (pattern[2] == _forwardSlash || pattern[2] == _backSlash);
+                    StartsWithDrivePatternWithSlash(pattern);
         }
 
         /// <summary>
@@ -70,8 +69,7 @@ namespace Microsoft.Build.Shared
             // second character must be a ":"
             // third character must be a slash.
             return pattern.Length >= 3 &&
-                ((pattern[0] >= 'A' && pattern[0] <= 'Z') || (pattern[0] >= 'a' && pattern[0] <= 'z')) &&
-                pattern[1] == ':' &&
+                StartsWithDrivePattern(pattern) &&
                 (pattern[2] == '\\' || pattern[2] == '/');
         }
 

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Shared
             // third character must be a slash.
             return pattern.Length >= 3 &&
                 StartsWithDrivePattern(pattern) &&
-                (pattern[2] == '\\' || pattern[2] == '/');
+                (pattern[2] == _backSlash || pattern[2] == _forwardSlash);
         }
 
         /// <summary>

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -151,50 +151,6 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
-        /// Indicates whether the given path is a UNC or drive pattern root.
-        /// <para>Note: This function mimics the behavior of checking if Path.GetDirectoryName(path) == null.</para>
-        /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        internal static bool IsRootPath(string path)
-        {
-            // Eliminate all non-rooted paths
-            if (!Path.IsPathRooted(path))
-            {
-                return false;
-            }
-
-            int uncMatchLength = FileUtilitiesRegex.StartsWithUncPatternMatchLength(path);
-
-            // Determine if the given path is a standard drive/unc pattern root
-            if (FileUtilitiesRegex.IsDrivePattern(path) ||
-                FileUtilitiesRegex.IsDrivePatternWithSlash(path) ||
-                uncMatchLength == path.Length)
-            {
-                return true;
-            }
-
-            // Eliminate all non-root unc paths.
-            if (uncMatchLength != -1)
-            {
-                return false;
-            }
-
-            // Eliminate any drive patterns that don't have a slash after the colon or where the 4th character is a non-slash
-            // A non-slash at [3] is specifically checked here because Path.GetDirectoryName considers "C:///" a valid root.
-            if (FileUtilitiesRegex.StartsWithDrivePattern(path) &&
-                ((path.Length >= 3 && path[2] != _backSlash && path[2] != _forwardSlash) ||
-                (path.Length >= 4 && path[3] != _backSlash && path[3] != _forwardSlash)))
-            {
-                return false;
-            }
-
-            // There are some edge cases that can get to this point.
-            // After eliminating valid / invalid roots, fall back on original behavior.
-            return Path.GetDirectoryName(path) == null;
-        }
-
-        /// <summary>
         /// Indicates whether or not the file-spec meets the minimum requirements of a UNC pattern.
         /// UNC pattern requires a minimum length of 5 and first two characters must be a slash.
         /// </summary>

--- a/src/Shared/FileUtilitiesRegex.cs
+++ b/src/Shared/FileUtilitiesRegex.cs
@@ -32,6 +32,18 @@ namespace Microsoft.Build.Shared
         }
 
         /// <summary>
+        /// Indicates whether the specified string follows the pattern drive pattern: "<drive letter>:/" or "<drive letter>:\"
+        /// </summary>
+        /// <param name="pattern"></param>
+        /// <returns></returns>
+        internal static bool IsDrivePatternWithSlash(string pattern)
+        {
+            return pattern.Length == 3 &&
+                    StartsWithDrivePattern(pattern) &&
+                    pattern[2] == _forwardSlash || pattern[2] == _backSlash;
+        }
+
+        /// <summary>
         /// Indicates whether the specified string starts with the drive pattern: "<drive letter>:".
         /// </summary>
         /// <param name="pattern"></param>

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Build.Shared
                     else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Filename, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no filename
-                        if (Path.IsPathRooted(itemSpec) && Path.GetDirectoryName(itemSpec) == null)
+                        if (IsRootDirectory(itemSpec))
                         {
                             // NOTE: this is to prevent Path.GetFileNameWithoutExtension() from treating server and share elements
                             // in a UNC file-spec as filenames e.g. \\server, \\server\share
@@ -448,7 +448,7 @@ namespace Microsoft.Build.Shared
                     else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no extension
-                        if (Path.IsPathRooted(itemSpec) && Path.GetDirectoryName(itemSpec) == null)
+                        if (IsRootDirectory(itemSpec))
                         {
                             // NOTE: this is to prevent Path.GetExtension() from treating server and share elements in a UNC
                             // file-spec as filenames e.g. \\server.ext, \\server\share.ext
@@ -613,6 +613,51 @@ namespace Microsoft.Build.Shared
                 }
 
                 return modifiedItemSpec;
+            }
+
+            /// <summary>
+            /// Indicates whether the given path is a UNC or drive pattern root directory.
+            /// <para>Note: This function mimics the behavior of checking if Path.GetDirectoryName(path) == null.</para>
+            /// </summary>
+            /// <param name="path"></param>
+            /// <returns></returns>
+            private static bool IsRootDirectory(string path)
+            {
+                // Eliminate all non-rooted paths
+                if (!Path.IsPathRooted(path))
+                {
+                    return false;
+                }
+
+                int uncMatchLength = FileUtilitiesRegex.StartsWithUncPatternMatchLength(path);
+
+                // Determine if the given path is a standard drive/unc pattern root
+                if (FileUtilitiesRegex.IsDrivePattern(path) ||
+                    FileUtilitiesRegex.IsDrivePatternWithSlash(path) ||
+                    uncMatchLength == path.Length)
+                {
+                    return true;
+                }
+
+                // Eliminate all non-root unc paths.
+                if (uncMatchLength != -1)
+                {
+                    return false;
+                }
+
+                // Eliminate any drive patterns that don't have a slash after the colon or where the 4th character is a non-slash
+                // A non-slash at [3] is specifically checked here because Path.GetDirectoryName
+                // considers "C:///" a valid root.
+                if (FileUtilitiesRegex.StartsWithDrivePattern(path) &&
+                    ((path.Length >= 3 && path[2] != '\\' && path[2] != '/') ||
+                    (path.Length >= 4 && path[3] != '\\' && path[3] != '/')))
+                {
+                    return false;
+                }
+
+                // There are some edge cases that can get to this point.
+                // After eliminating valid / invalid roots, fall back on original behavior.
+                return Path.GetDirectoryName(path) == null;
             }
 
             /// <summary>

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Build.Shared
 
                 try
                 {
-                    if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.FullPath, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.FullPath, StringComparison.OrdinalIgnoreCase))
                     {
                         if (fullPath != null)
                         {
@@ -414,7 +414,7 @@ namespace Microsoft.Build.Shared
 
                         ThrowForUrl(modifiedItemSpec, itemSpec, currentDirectory);
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.RootDir, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.RootDir, StringComparison.OrdinalIgnoreCase))
                     {
                         GetItemSpecModifier(currentDirectory, itemSpec, definingProjectEscaped, ItemSpecModifiers.FullPath, ref fullPath);
 
@@ -430,7 +430,7 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec += Path.DirectorySeparatorChar;
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Filename, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Filename, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no filename
                         if (Path.GetDirectoryName(itemSpec) == null)
@@ -445,7 +445,7 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec = Path.GetFileNameWithoutExtension(FixFilePath(itemSpec));
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no extension
                         if (Path.GetDirectoryName(itemSpec) == null)
@@ -459,11 +459,11 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec = Path.GetExtension(itemSpec);
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.RelativeDir, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.RelativeDir, StringComparison.OrdinalIgnoreCase))
                     {
                         modifiedItemSpec = GetDirectory(itemSpec);
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Directory, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Directory, StringComparison.OrdinalIgnoreCase))
                     {
                         GetItemSpecModifier(currentDirectory, itemSpec, definingProjectEscaped, ItemSpecModifiers.FullPath, ref fullPath);
 
@@ -500,16 +500,16 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec = modifiedItemSpec.Substring(1);
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.RecursiveDir, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.RecursiveDir, StringComparison.OrdinalIgnoreCase))
                     {
                         // only the BuildItem class can compute this modifier -- so leave empty
                         modifiedItemSpec = String.Empty;
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.Identity, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Identity, StringComparison.OrdinalIgnoreCase))
                     {
                         modifiedItemSpec = itemSpec;
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.ModifiedTime, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.ModifiedTime, StringComparison.OrdinalIgnoreCase))
                     {
                         // About to go out to the filesystem.  This means data is leaving the engine, so need
                         // to unescape first.
@@ -527,7 +527,7 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec = String.Empty;
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.CreatedTime, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.CreatedTime, StringComparison.OrdinalIgnoreCase))
                     {
                         // About to go out to the filesystem.  This means data is leaving the engine, so need
                         // to unescape first.
@@ -543,7 +543,7 @@ namespace Microsoft.Build.Shared
                             modifiedItemSpec = String.Empty;
                         }
                     }
-                    else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.AccessedTime, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.AccessedTime, StringComparison.OrdinalIgnoreCase))
                     {
                         // About to go out to the filesystem.  This means data is leaving the engine, so need
                         // to unescape first.
@@ -568,7 +568,7 @@ namespace Microsoft.Build.Shared
                         }
                         else
                         {
-                            if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectDirectory, StringComparison.OrdinalIgnoreCase) == 0)
+                            if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectDirectory, StringComparison.OrdinalIgnoreCase))
                             {
                                 // ItemSpecModifiers.Directory does not contain the root directory
                                 modifiedItemSpec = Path.Combine
@@ -581,15 +581,15 @@ namespace Microsoft.Build.Shared
                             {
                                 string additionalModifier = null;
 
-                                if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectFullPath, StringComparison.OrdinalIgnoreCase) == 0)
+                                if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectFullPath, StringComparison.OrdinalIgnoreCase))
                                 {
                                     additionalModifier = ItemSpecModifiers.FullPath;
                                 }
-                                else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectName, StringComparison.OrdinalIgnoreCase) == 0)
+                                else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectName, StringComparison.OrdinalIgnoreCase))
                                 {
                                     additionalModifier = ItemSpecModifiers.Filename;
                                 }
-                                else if (String.Compare(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectExtension, StringComparison.OrdinalIgnoreCase) == 0)
+                                else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.DefiningProjectExtension, StringComparison.OrdinalIgnoreCase))
                                 {
                                     additionalModifier = ItemSpecModifiers.Extension;
                                 }

--- a/src/Shared/Modifiers.cs
+++ b/src/Shared/Modifiers.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Build.Shared
                     else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Filename, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no filename
-                        if (Path.GetDirectoryName(itemSpec) == null)
+                        if (Path.IsPathRooted(itemSpec) && Path.GetDirectoryName(itemSpec) == null)
                         {
                             // NOTE: this is to prevent Path.GetFileNameWithoutExtension() from treating server and share elements
                             // in a UNC file-spec as filenames e.g. \\server, \\server\share
@@ -448,7 +448,7 @@ namespace Microsoft.Build.Shared
                     else if (string.Equals(modifier, FileUtilities.ItemSpecModifiers.Extension, StringComparison.OrdinalIgnoreCase))
                     {
                         // if the item-spec is a root directory, it can have no extension
-                        if (Path.GetDirectoryName(itemSpec) == null)
+                        if (Path.IsPathRooted(itemSpec) && Path.GetDirectoryName(itemSpec) == null)
                         {
                             // NOTE: this is to prevent Path.GetExtension() from treating server and share elements in a UNC
                             // file-spec as filenames e.g. \\server.ext, \\server\share.ext


### PR DESCRIPTION
Fixes #2435 

Now performing basic in-place checks to determine a root from a non-root directory before calling `Path.GetDirectoryName`. This should eliminate the vast majority of times `Path.GetDirectoryName` is called within `GetItemSpecModifier`. Scenarios where it will still be called is when the current item spec is an invalid root such as:
```
C:///
\\\\\\server\\\share
```


Also swapped all uses of `string.compare(s1, s2) == 0` to `string.equals(s1, s2)` as string.equals does a length check before comparing characters.