### PR TITLE
Support longer relative paths in ResolveAssemblyReference HintPaths

### DIFF
--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Microsoft.Build.Shared;
 
@@ -53,7 +54,7 @@ namespace Microsoft.Build.Tasks
         {
             if (!string.IsNullOrEmpty(hintPath))
             {
-                if (ResolveAsFile(hintPath, assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))
+                if (ResolveAsFile(Path.GetFullPath(hintPath), assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))
                 {
                     userRequestedSpecificFile = true;
                     foundPath = hintPath;

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using Microsoft.Build.Shared;
 
@@ -54,7 +53,7 @@ namespace Microsoft.Build.Tasks
         {
             if (!string.IsNullOrEmpty(hintPath))
             {
-                if (ResolveAsFile(Path.GetFullPath(hintPath), assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))
+                if (ResolveAsFile(FileUtilities.NormalizePath(hintPath), assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))
                 {
                     userRequestedSpecificFile = true;
                     foundPath = hintPath;


### PR DESCRIPTION
This problem introduced in https://github.com/microsoft/msbuild/pull/3700. If hint path in reference plus current directory more than MAX_PATH then MSBuild couldn't resolve the reference. But file exists and the actual path less than MAX_PATH. The problem in function GetFileAttributesEx. This function just contacted hint path with the current directory, and it doesn't work when your current directory deep into file system but the library on the top of the hierarchy. I benchmarked this fix with BenchmarkDotNet and not found a statistically significant difference between the original code and my fix.