### PR TITLE
Fix related item output for WinMD native implementation file.

### DIFF
--- a/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/WinMDTests.cs
@@ -122,12 +122,19 @@ namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests
         /// When a project to project reference is passed in we want to verify that
         /// the winmd references get the correct metadata applied to them
         /// </summary>
-        [Fact]
-        public void VerifyP2PHaveCorrectMetadataWinMD()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void VerifyP2PHaveCorrectMetadataWinMD(bool setImplementationMetadata)
         {
             // Create the engine.
             MockEngine engine = new MockEngine(_output);
             TaskItem taskItem = new TaskItem(@"C:\WinMD\SampleWindowsRuntimeOnly.Winmd");
+
+            if (setImplementationMetadata)
+            {
+                taskItem.SetMetadata(ItemMetadataNames.winmdImplmentationFile, "SampleWindowsRuntimeOnly.dll");
+            }
 
             ITaskItem[] assemblyFiles = new TaskItem[]
             {

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -890,10 +890,19 @@ namespace Microsoft.Build.Tasks
             }
 
             // Native Winmd files may have a companion dll beside it.
-            // If this is not a primary reference or the implementation metadata is not set on the item we need to set the implmentation metadata.
-            if (reference.IsWinMDFile && (!reference.IsPrimary || String.IsNullOrEmpty(reference.PrimarySourceItem.GetMetadata(ItemMetadataNames.winmdImplmentationFile))) && !reference.IsManagedWinMDFile)
+            if (reference.IsWinMDFile && !reference.IsManagedWinMDFile)
             {
-                string companionFile = baseName + ".dll";
+                var companionFile = baseName + ".dll";
+
+                if (reference.IsPrimary)
+                {
+                    var implementationFile = reference.PrimarySourceItem.GetMetadata(ItemMetadataNames.winmdImplmentationFile);
+
+                    if (!String.IsNullOrEmpty(implementationFile))
+                    {
+                        companionFile = Path.Combine(Path.GetDirectoryName(baseName), implementationFile);
+                    }
+                }
 
                 if (_fileExists(companionFile))
                 {
@@ -2602,7 +2611,10 @@ namespace Microsoft.Build.Tasks
                 {
                     if (VerifyArchitectureOfImplementationDll(reference.ImplementationAssembly, reference.FullPath))
                     {
-                        referenceItem.SetMetadata(ItemMetadataNames.winmdImplmentationFile, Path.GetFileName(reference.ImplementationAssembly));
+                        if (string.IsNullOrEmpty(referenceItem.GetMetadata(ItemMetadataNames.winmdImplmentationFile)))
+                        {
+                            referenceItem.SetMetadata(ItemMetadataNames.winmdImplmentationFile, Path.GetFileName(reference.ImplementationAssembly));
+                        }
 
                         // Add the implementation item as a related file
                         ITaskItem item = new TaskItem(reference.ImplementationAssembly);


### PR DESCRIPTION
The ResolveAssemblyReference task outputs `RelatedFiles` that should contain
the native implementation file for "native" WinMD references. This is needed to
copy the implementation file locally for P2P references.

However, if the reference to the native WinMD file already has the
`Implementation` metadata set, the task does not output the implementation file
in the `RelatedFiles` output. In the case of C++ projects that output a WinMD
file, the `Implementation` metadata gets set and referencing projects fail to
copy local the implementation file.

This commit changes the behavior so that the task will output the
implementation file even if the `Implementation` metadata is set on the WinMD
reference.

Fixes #4399.