### PR TITLE
Revert to Arcade 1.0.0-beta.19272.13

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19304.1">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19272.13">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>d2599acd9703ef747dfb4329ec3e3beff182e755</Sha>
+      <Sha>86e674361bdcefecbd8199ab62d0b1a6cb25703d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/global.json
+++ b/global.json
@@ -12,6 +12,6 @@
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.1",
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19304.1"
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19272.13"
   }
 }


### PR DESCRIPTION
Reverting to older Arcade version to work around
https://github.com/dotnet/arcade/issues/2944.