### PR TITLE
System.Net.Http 4.3.4

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -28,7 +28,7 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
-    <PackageReference Update="System.Net.Http" Version="4.3.0" />
+    <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Update="System.Resources.Writer" Version="4.0.0" />


### PR DESCRIPTION
Update to the latest System.Net.Http to avoid a warning our official build has been throwing about a stale reference.