### PR TITLE
Implementing tracking of environment variables

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -973,6 +973,7 @@ namespace Microsoft.Build.Execution
         public bool ShutdownInProcNodeOnBuildFinish { get { throw null; } set { } }
         public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetDefinitionLocations { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
+        public bool TrackReadsOnEnvironmentVariables { get { throw null; } set { } }
         public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
         public bool UseSynchronousLogging { get { throw null; } set { } }
         public System.Collections.Generic.ISet<string> WarningsAsErrors { get { throw null; } set { } }
@@ -1095,6 +1096,7 @@ namespace Microsoft.Build.Execution
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> EnvironmentVariableReads { get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { get { throw null; } }
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
@@ -1109,6 +1111,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectTargetInstance> Targets { get { throw null; } }
         public string ToolsVersion { get { throw null; } }
         public bool TranslateEntireState { get { throw null; } set { } }
+        public System.Collections.Generic.ICollection<string> UninitializedPropertyReads { get { throw null; } }
         public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude) { throw null; }
         public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
         public bool Build() { throw null; }
@@ -1425,9 +1428,11 @@ namespace Microsoft.Build.Experimental.Graph
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> EnvironmentVariableReads { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodesTopologicallySorted { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> UninitializedPropertyReads { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Experimental.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(System.Collections.Generic.ICollection<string> entryProjectTargets) { throw null; }
         public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -973,7 +973,6 @@ namespace Microsoft.Build.Execution
         public bool ShutdownInProcNodeOnBuildFinish { get { throw null; } set { } }
         public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetDefinitionLocations { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
-        public bool TrackReadsOnEnvironmentVariables { get { throw null; } set { } }
         public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
         public bool UseSynchronousLogging { get { throw null; } set { } }
         public System.Collections.Generic.ISet<string> WarningsAsErrors { get { throw null; } set { } }
@@ -1429,6 +1428,7 @@ namespace Microsoft.Build.Experimental.Graph
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> EnvironmentVariableReads { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> EnvironmentVariablesImpactingBuild { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodesTopologicallySorted { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -968,7 +968,6 @@ namespace Microsoft.Build.Execution
         public bool ShutdownInProcNodeOnBuildFinish { get { throw null; } set { } }
         public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetDefinitionLocations { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
-        public bool TrackReadsOnEnvironmentVariables { get { throw null; } set { } }
         public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
         public bool UseSynchronousLogging { get { throw null; } set { } }
         public System.Collections.Generic.ISet<string> WarningsAsErrors { get { throw null; } set { } }
@@ -1423,6 +1422,7 @@ namespace Microsoft.Build.Experimental.Graph
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> EnvironmentVariableReads { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> EnvironmentVariablesImpactingBuild { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodesTopologicallySorted { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -968,6 +968,7 @@ namespace Microsoft.Build.Execution
         public bool ShutdownInProcNodeOnBuildFinish { get { throw null; } set { } }
         public Microsoft.Build.Evaluation.ToolsetDefinitionLocations ToolsetDefinitionLocations { get { throw null; } set { } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Evaluation.Toolset> Toolsets { get { throw null; } }
+        public bool TrackReadsOnEnvironmentVariables { get { throw null; } set { } }
         public System.Globalization.CultureInfo UICulture { get { throw null; } set { } }
         public bool UseSynchronousLogging { get { throw null; } set { } }
         public System.Collections.Generic.ISet<string> WarningsAsErrors { get { throw null; } set { } }
@@ -1089,6 +1090,7 @@ namespace Microsoft.Build.Execution
         public ProjectInstance(string projectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, string toolsVersion, string subToolsetVersion, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.List<string> DefaultTargets { get { throw null; } }
         public string Directory { get { throw null; } }
+        public System.Collections.Generic.ICollection<string> EnvironmentVariableReads { get { throw null; } }
         public System.Collections.Generic.List<Microsoft.Build.Construction.ProjectItemElement> EvaluatedItemElements { get { throw null; } }
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
@@ -1103,6 +1105,7 @@ namespace Microsoft.Build.Execution
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectTargetInstance> Targets { get { throw null; } }
         public string ToolsVersion { get { throw null; } }
         public bool TranslateEntireState { get { throw null; } set { } }
+        public System.Collections.Generic.ICollection<string> UninitializedPropertyReads { get { throw null; } }
         public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude) { throw null; }
         public Microsoft.Build.Execution.ProjectItemInstance AddItem(string itemType, string evaluatedInclude, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> metadata) { throw null; }
         public bool Build() { throw null; }
@@ -1419,9 +1422,11 @@ namespace Microsoft.Build.Experimental.Graph
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties) { }
         public ProjectGraph(string entryProjectFile, System.Collections.Generic.IDictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection) { }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> EntryPointNodes { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> EnvironmentVariableReads { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> GraphRoots { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodes { get { throw null; } }
         public System.Collections.Generic.IReadOnlyCollection<Microsoft.Build.Experimental.Graph.ProjectGraphNode> ProjectNodesTopologicallySorted { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<string> UninitializedPropertyReads { get { throw null; } }
         public System.Collections.Generic.IReadOnlyDictionary<Microsoft.Build.Experimental.Graph.ProjectGraphNode, System.Collections.Immutable.ImmutableList<string>> GetTargetLists(System.Collections.Generic.ICollection<string> entryProjectTargets) { throw null; }
         public delegate Microsoft.Build.Execution.ProjectInstance ProjectInstanceFactoryFunc(string projectPath, System.Collections.Generic.Dictionary<string, string> globalProperties, Microsoft.Build.Evaluation.ProjectCollection projectCollection);
     }

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1957,7 +1957,7 @@ $@"
                 <Project>
                   <PropertyGroup>
                     <NotAnEnvVar>$(Path)</NotAnEnvVar>
-                    <Property2>$(SomeTestEnvVar)</Property>
+                    <Property2>$(SomeTestEnvVar)</Property2>
                     <CompName>$(ComputerName)</CompName>
                   </PropertyGroup>
                 </Project>");
@@ -1968,7 +1968,10 @@ $@"
                 var first = graph.ProjectNodes.First();
                 first.ProjectInstance.ShouldNotBeNull();
                 first.ProjectInstance.EnvironmentVariableReads.ShouldNotBeNull();
-                first.ProjectInstance.EnvironmentVariableReads.Count.ShouldBe(3);
+
+                string readEnvVars = string.Join(", ", first.ProjectInstance.EnvironmentVariableReads);
+                string allEnvVars = string.Join(", ", first.ProjectInstance.TestEnvironmentalProperties.Select(p => p.Name));
+                first.ProjectInstance.EnvironmentVariableReads.Count.ShouldBe(3, $"All: {allEnvVars} | Read: {readEnvVars}");
             }
         }
 

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1951,13 +1951,11 @@ $@"
             using (var env = TestEnvironment.Create())
             {
                 env.SetEnvironmentVariable("MSBUILDTRACKENVVARREADS", "1");
-                env.SetEnvironmentVariable("SomeTestEnvVar", "SomeValue");
 
                 var projFile = env.CreateFile($"{Guid.NewGuid()}.proj", @"
                 <Project>
                   <PropertyGroup>
                     <NotAnEnvVar>$(Path)</NotAnEnvVar>
-                    <Property2>$(SomeTestEnvVar)</Property2>
                     <CompName>$(ComputerName)</CompName>
                   </PropertyGroup>
                 </Project>");
@@ -1971,7 +1969,7 @@ $@"
 
                 string readEnvVars = string.Join(", ", first.ProjectInstance.EnvironmentVariableReads);
                 string allEnvVars = string.Join(", ", first.ProjectInstance.TestEnvironmentalProperties.Select(p => p.Name));
-                first.ProjectInstance.EnvironmentVariableReads.Count.ShouldBe(3, $"All: {allEnvVars} | Read: {readEnvVars}");
+                first.ProjectInstance.EnvironmentVariableReads.Count.ShouldBe(2, $"All: {allEnvVars} | Read: {readEnvVars}");
             }
         }
 

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1956,7 +1956,7 @@ $@"
                 <Project>
                   <PropertyGroup>
                     <NotAnEnvVar>$(Path)</NotAnEnvVar>
-                    <CompName>$(ComputerName)</CompName>
+                    <AlsoNotAnEnvVar>$(LocalAppData)</AlsoNotAnEnvVar>
                   </PropertyGroup>
                 </Project>");
 

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Build.Execution
         private static string s_msbuildExeKnownToExistAt;
 
         /// <summary>
+        /// Specifies whether or not MSBuild will track environment variable reads
+        /// </summary>
+        private static bool? s_trackReadsOnEnvironmentVariables;
+
+        /// <summary>
         /// The build id
         /// </summary>
         private int _buildId;
@@ -761,6 +766,15 @@ namespace Microsoft.Build.Execution
         {
             get => _outputResultsCacheFile;
             set => _outputResultsCacheFile = value;
+        }
+
+        /// <summary>
+        /// Track the environment variables actually read and used.
+        /// </summary>
+        public bool TrackReadsOnEnvironmentVariables
+        {
+            get => GetStaticBoolVariableOrDefault("MSBUILDTRACKENVVARREADS", ref s_trackReadsOnEnvironmentVariables, false);
+            set => s_trackReadsOnEnvironmentVariables = value;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -97,11 +97,6 @@ namespace Microsoft.Build.Execution
         private static string s_msbuildExeKnownToExistAt;
 
         /// <summary>
-        /// Specifies whether or not MSBuild will track environment variable reads
-        /// </summary>
-        private static bool? s_trackReadsOnEnvironmentVariables;
-
-        /// <summary>
         /// The build id
         /// </summary>
         private int _buildId;
@@ -766,15 +761,6 @@ namespace Microsoft.Build.Execution
         {
             get => _outputResultsCacheFile;
             set => _outputResultsCacheFile = value;
-        }
-
-        /// <summary>
-        /// Track the environment variables actually read and used.
-        /// </summary>
-        public bool TrackReadsOnEnvironmentVariables
-        {
-            get => GetStaticBoolVariableOrDefault("MSBUILDTRACKENVVARREADS", ref s_trackReadsOnEnvironmentVariables, false);
-            set => s_trackReadsOnEnvironmentVariables = value;
         }
 
         /// <summary>

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3371,7 +3371,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Sets a property which is not derived from Xml.
             /// </summary>
-            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvVar = false)
             {
                 ProjectProperty property = ProjectProperty.Create(Project, name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
                 Properties.Set(property);

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1256,7 +1256,7 @@ namespace Microsoft.Build.Evaluation
 
             foreach (ProjectPropertyInstance environmentProperty in _environmentProperties)
             {
-                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, false /* NOT global property */, false /* may NOT be a reserved name */);
+                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, false /* NOT global property */, false /* may NOT be a reserved name */, true /* IS environment variable. */);
                 environmentPropertiesList.Add(property);
             }
 

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Sets a property which does not come from the Xml.
         /// </summary>
-        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved);
+        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvVar = false);
 
         /// <summary>
         /// Sets a property which comes from the Xml.

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Sets a property which does not come from the Xml.
         /// </summary>
-        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvVar = false);
+        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false);
 
         /// <summary>
         /// Sets a property which comes from the Xml.

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Build.Evaluation
                 return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped, predecessor);
             }
 
-            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvVar = false)
             {
                 return _wrappedData.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
             }

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -74,6 +75,16 @@ namespace Microsoft.Build.Experimental.Graph
         public IReadOnlyCollection<ProjectGraphNode> ProjectNodesTopologicallySorted => _projectNodesTopologicallySorted.Value;
 
         public IReadOnlyCollection<ProjectGraphNode> GraphRoots { get; }
+
+        /// <summary>
+        ///     Gets a distinct enumeration of all of the environment variables reads during evaluation.
+        /// </summary>
+        public IEnumerable<string> EnvironmentVariableReads => _projectNodesTopologicallySorted?.Value.Select(p => p.ProjectInstance).SelectMany(pi => pi.EnvironmentVariableReads).Distinct();
+
+        /// <summary>
+        ///     Get a distinct enumeration of all the uninitialized property reads during evaluation.
+        /// </summary>
+        public IEnumerable<string> UninitializedPropertyReads => _projectNodesTopologicallySorted?.Value.Select(p => p.ProjectInstance).SelectMany(pi => pi.UninitializedPropertyReads).Distinct();
 
         /// <summary>
         ///     Constructs a graph starting from the given project file, evaluating with the global project collection and no

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -94,10 +94,7 @@ namespace Microsoft.Build.Experimental.Graph
                 {
                     foreach (string environmentVariableRead in projectNode.ProjectInstance.EnvironmentVariableReads)
                     {
-                        if (!distinctReads.Contains(environmentVariableRead))
-                        {
-                            distinctReads.Add(environmentVariableRead);
-                        }
+                        distinctReads.Add(environmentVariableRead);
                     }
                 }
 
@@ -123,10 +120,7 @@ namespace Microsoft.Build.Experimental.Graph
                 {
                     foreach (string uninitializedPropertyRead in projectNode.ProjectInstance.UninitializedPropertyReads)
                     {
-                        if (!distinctUninitializedProperties.Contains(uninitializedPropertyRead))
-                        {
-                            distinctUninitializedProperties.Add(uninitializedPropertyRead);
-                        }
+                        distinctUninitializedProperties.Add(uninitializedPropertyRead);
                     }
                 }
 

--- a/src/Build/Graph/ProjectGraph.cs
+++ b/src/Build/Graph/ProjectGraph.cs
@@ -79,12 +79,65 @@ namespace Microsoft.Build.Experimental.Graph
         /// <summary>
         ///     Gets a distinct enumeration of all of the environment variables reads during evaluation.
         /// </summary>
-        public IEnumerable<string> EnvironmentVariableReads => _projectNodesTopologicallySorted?.Value.Select(p => p.ProjectInstance).SelectMany(pi => pi.EnvironmentVariableReads).Distinct();
+        public IEnumerable<string> EnvironmentVariableReads
+        {
+            get
+            {
+                if (!ProjectNodes.Any())
+                {
+                    return Enumerable.Empty<string>();
+                }
+
+                var distinctReads = new HashSet<string>();
+
+                foreach (ProjectGraphNode projectNode in ProjectNodes)
+                {
+                    foreach (string environmentVariableRead in projectNode.ProjectInstance.EnvironmentVariableReads)
+                    {
+                        if (!distinctReads.Contains(environmentVariableRead))
+                        {
+                            distinctReads.Add(environmentVariableRead);
+                        }
+                    }
+                }
+
+                return distinctReads;
+            }
+        }
 
         /// <summary>
         ///     Get a distinct enumeration of all the uninitialized property reads during evaluation.
         /// </summary>
-        public IEnumerable<string> UninitializedPropertyReads => _projectNodesTopologicallySorted?.Value.Select(p => p.ProjectInstance).SelectMany(pi => pi.UninitializedPropertyReads).Distinct();
+        public IEnumerable<string> UninitializedPropertyReads
+        {
+            get
+            {
+                if (!ProjectNodes.Any())
+                {
+                    return Enumerable.Empty<string>();
+                }
+
+                var distinctUninitializedProperties = new HashSet<string>();
+
+                foreach (ProjectGraphNode projectNode in ProjectNodes)
+                {
+                    foreach (string uninitializedPropertyRead in projectNode.ProjectInstance.UninitializedPropertyReads)
+                    {
+                        if (!distinctUninitializedProperties.Contains(uninitializedPropertyRead))
+                        {
+                            distinctUninitializedProperties.Add(uninitializedPropertyRead);
+                        }
+                    }
+                }
+
+                return distinctUninitializedProperties;
+            }
+        }
+
+        /// <summary>
+        ///     A list of all potentially impactful environment variables.
+        /// </summary>
+        public IEnumerable<string> EnvironmentVariablesImpactingBuild => UninitializedPropertyReads.Concat(EnvironmentVariableReads);
 
         /// <summary>
         ///     Constructs a graph starting from the given project file, evaluating with the global project collection and no

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1339,11 +1339,8 @@ namespace Microsoft.Build.Execution
             {
                 if (isEnvironmentVariable)
                 {
-                    if (!_environmentVariables.Contains(name))
-                    {
-                        // If it's a new env var, track it.
-                        _environmentVariables.Add(name);
-                    }
+                    // If it's an env var, track it.
+                    _environmentVariables.Add(name);
                 }
                 else if (_environmentVariables.Contains(name))
                 {

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1342,7 +1342,7 @@ namespace Microsoft.Build.Execution
                     // If it's an env var, track it.
                     _environmentVariables.Add(name);
                 }
-                else if (_environmentVariables.Contains(name))
+                else
                 {
                     // If it's NOT an env var but the property has the same name,
                     // then we're not dependent on the env var any more: remove it.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -77,6 +77,11 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool LogPropertyFunctionsRequiringReflection = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection"));
 
+        /// <summary>
+        /// Track the environment variables actually read and used.
+        /// </summary>
+        public readonly bool TrackReadsOnEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDTRACKENVVARREADS"));
+
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {
             return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Track the environment variables actually read and used.
         /// </summary>
-        public readonly bool TrackReadsOnEnvironmentVariables = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDTRACKENVVARREADS"));
+        public readonly bool TrackReadsOnEnvironmentVariables = Environment.GetEnvironmentVariable("MSBUILDTRACKENVVARREADS") == "1";
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {


### PR DESCRIPTION
Implements tracking of environment variables (and uninitialized properties) for graph evaluation.

This allows users of ProjectGraph to better understand what parts of the environment will actually affect the build. This can help reduce the set of environment variables tracked and can potentially reduce unnecessary rebuilds due to environment changes.

* This is an opt-IN feature, set with a new build parameter: MSBUILDTRACKENVVARREADS

Resolves #3432 
Related to #2713 
