### PR TITLE
Disable `bin` upload

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -131,10 +131,10 @@ jobs:
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: bin'
+    displayName: 'Publish Artifact: symbols'
     inputs:
-      PathtoPublish: 'artifacts\bin'
-      ArtifactName: bin
+      PathtoPublish: 'artifacts\bin\**\*.pdb'
+      ArtifactName: symbols
     condition: succeededOrFailed()
 
   # Publishes setup VSIXes to a drop.

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -130,13 +130,6 @@ jobs:
       ArtifactName: logs
     condition: succeededOrFailed()
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: symbols'
-    inputs:
-      PathtoPublish: 'artifacts\bin\**\*.pdb'
-      ArtifactName: symbols
-    condition: succeededOrFailed()
-
   # Publishes setup VSIXes to a drop.
   # Note: The insertion tool looks for the display name of this task in the logs.
   - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1


### PR DESCRIPTION
This should speed up the official build considerably in addition to minimizing redundant uploads.