### PR TITLE
Version bump to 16.3

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -27,7 +27,7 @@ jobs:
   - name: VisualStudio.MajorVersion
     value: 16
   - name: VisualStudio.ChannelName
-    value: 'int.d16.2stg'
+    value: 'int.master'
   - name: VisualStudio.DropName
     value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,13 @@ For more information on MSBuild, see the [MSBuild documentation](https://docs.mi
 
 ### Build Status
 
-The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.2.
+The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.3 and .NET Core SDK 3.0.100.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=master)
 
-We have forked for MSBuild 16.1 in the branch [`vs16.1`](https://github.com/Microsoft/msbuild/tree/vs16.1). Changes to that branch need special approval.
+We have forked for MSBuild 16.2 in the branch [`vs16.2`](https://github.com/Microsoft/msbuild/tree/vs16.2). Changes to that branch need special approval.
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.1)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.1)
-
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.2)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.2)
 
 MSBuild 16.0 builds from the branch [`vs16.0`](https://github.com/Microsoft/msbuild/tree/vs16.0). Only high-priority bugfixes will be considered for servicing 16.0.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.2.0</VersionPrefix>
+    <VersionPrefix>16.3.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -47,8 +47,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.2.0.0" newVersion="16.2.0.0" />
-          <codeBase version="16.2.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.3.0.0" newVersion="16.3.0.0" />
+          <codeBase version="16.3.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -53,8 +53,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.2.0.0" newVersion="16.2.0.0" />
-          <codeBase version="16.2.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.3.0.0" newVersion="16.3.0.0" />
+          <codeBase version="16.3.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
Includes a VC++ binding redirect, so this can only be inserted to branches that have already moved to 16.3 version numbering.