### PR TITLE
WIP: Trimmed NuGet Package Sources

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,10 +6,7 @@
     <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
     <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
         $(RestoreSources);
-        https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-        https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
         https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-        https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json
     </RestoreSources>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>


### PR DESCRIPTION
Fix #4426

Kept `roslyn-tools` due to `MicroBuild.Plugins.SwixBuild` dependency.