### PR TITLE
Adding tracking of properties with relevant events.

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -408,6 +408,14 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+        public string PropertySource { get { throw null; } set { } }
+        public string PropertyValue { get { throw null; } set { } }
+    }
     public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public PropertyReassignmentEventArgs() { }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
-    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public EnvironmentVariableReadEventArgs() { }
-        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null) { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string EnvironmentVariableName { get { throw null; } set { } }
     }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
@@ -408,10 +408,10 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
-    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public PropertyReassignmentEventArgs() { }
-        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null) { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string Location { get { throw null; } set { } }
         public string NewValue { get { throw null; } set { } }
         public string PreviousValue { get { throw null; } set { } }
@@ -577,10 +577,10 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
-    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public UninitializedPropertyReadEventArgs() { }
-        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null) { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string PropertyName { get { throw null; } set { } }
     }
 }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
-    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public EnvironmentVariableReadEventArgs() { }
-        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null) { }
         public string EnvironmentVariableName { get { throw null; } set { } }
     }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
@@ -408,10 +408,10 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
-    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public PropertyReassignmentEventArgs() { }
-        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null) { }
         public string Location { get { throw null; } set { } }
         public string NewValue { get { throw null; } set { } }
         public string PreviousValue { get { throw null; } set { } }
@@ -577,10 +577,10 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
-    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public UninitializedPropertyReadEventArgs() { }
-        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null) { }
         public string PropertyName { get { throw null; } set { } }
     }
 }

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
     {
         protected ExternalProjectFinishedEventArgs() { }
@@ -402,6 +408,15 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string Location { get { throw null; } set { } }
+        public string NewValue { get { throw null; } set { } }
+        public string PreviousValue { get { throw null; } set { } }
+        public string PropertyName { get { throw null; } set { } }
+    }
     public enum RegisteredTaskObjectLifetime
     {
         AppDomain = 1,
@@ -562,6 +577,12 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+    }
 }
 namespace Microsoft.Build.Framework.Profiler
 {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -407,6 +407,14 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+        public string PropertySource { get { throw null; } set { } }
+        public string PropertyValue { get { throw null; } set { } }
+    }
     public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public PropertyReassignmentEventArgs() { }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
     {
         protected ExternalProjectFinishedEventArgs() { }
@@ -401,6 +407,15 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string Location { get { throw null; } set { } }
+        public string NewValue { get { throw null; } set { } }
+        public string PreviousValue { get { throw null; } set { } }
+        public string PropertyName { get { throw null; } set { } }
+    }
     public enum RegisteredTaskObjectLifetime
     {
         AppDomain = 1,
@@ -561,6 +576,12 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+    }
 }
 namespace Microsoft.Build.Framework.Profiler
 {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
-    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public EnvironmentVariableReadEventArgs() { }
-        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null) { }
         public string EnvironmentVariableName { get { throw null; } set { } }
     }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
@@ -407,10 +407,10 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
-    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public PropertyReassignmentEventArgs() { }
-        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null) { }
         public string Location { get { throw null; } set { } }
         public string NewValue { get { throw null; } set { } }
         public string PreviousValue { get { throw null; } set { } }
@@ -576,10 +576,10 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
-    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
     {
         public UninitializedPropertyReadEventArgs() { }
-        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null) { }
         public string PropertyName { get { throw null; } set { } }
     }
 }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
-    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public EnvironmentVariableReadEventArgs() { }
-        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null) { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string EnvironmentVariableName { get { throw null; } set { } }
     }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
@@ -407,10 +407,10 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
-    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public PropertyReassignmentEventArgs() { }
-        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null) { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string Location { get { throw null; } set { } }
         public string NewValue { get { throw null; } set { } }
         public string PreviousValue { get { throw null; } set { } }
@@ -576,10 +576,10 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
-    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildStatusEventArgs
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
     {
         public UninitializedPropertyReadEventArgs() { }
-        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null) { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
         public string PropertyName { get { throw null; } set { } }
     }
 }

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -473,6 +473,25 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void PropertyInitialValueEventArgs()
+        {
+            var args = new PropertyInitialValueSetEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                propertyValue: Guid.NewGuid().ToString(),
+                propertySource: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.PropertyValue,
+                e => e.PropertySource,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+        [Fact]
         public void ReadingCorruptedStreamThrows()
         {
             var memoryStream = new MemoryStream();

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -419,6 +419,60 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void RoundTripEnvironmentVariableReadEventArgs()
+        {
+            var args = new EnvironmentVariableReadEventArgs(
+                environmentVariableName: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.EnvironmentVariableName,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
+        public void RoundTripPropertyReassignmentEventArgs()
+        {
+            var args = new PropertyReassignmentEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                previousValue: Guid.NewGuid().ToString(),
+                newValue: Guid.NewGuid().ToString(),
+                location: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.PreviousValue,
+                e => e.NewValue,
+                e => e.Location,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
+        public void UninitializedPropertyReadEventArgs()
+        {
+            var args = new UninitializedPropertyReadEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
         public void ReadingCorruptedStreamThrows()
         {
             var memoryStream = new MemoryStream();

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4540,7 +4540,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 pc.RegisterLogger(logger);
                 Project project = pc.LoadProject(tempPath.Path);
 
-                bool result = project.Build();
+                project.Build().ShouldBeTrue();
                 Assert.True(result);
 
                 logger

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4541,7 +4541,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 Project project = pc.LoadProject(tempPath.Path);
 
                 project.Build().ShouldBeTrue();
-                Assert.True(result);
 
                 logger
                     .AllBuildEvents

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4528,7 +4528,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             {
                 env.SetEnvironmentVariable("MsBuildLogPropertyTracking", "1");
                 env.SetEnvironmentVariable("DEFINED_ENVIRONMENT_VARIABLE", "It's Defined!");
-                env.SetEnvironmentVariable("DEFINED_ENVIRONMENT_VARIABLE2", "It's Defined!");
+                env.SetEnvironmentVariable("DEFINED_ENVIRONMENT_VARIABLE2", "It's also Defined!");
 
                 var tempPath = env.CreateFile(Guid.NewGuid().ToString(), testTargets);
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4562,6 +4562,32 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     .AllBuildEvents
                     .OfType<PropertyReassignmentEventArgs>()
                     .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
+
+                IDictionary<string, PropertyInitialValueSetEventArgs> propertyInitialValueMap = logger
+                    .AllBuildEvents
+                    .OfType<PropertyInitialValueSetEventArgs>()
+                    .ToDictionary(piv => piv.PropertyName);
+
+                // Verify logging of property initial values.
+                propertyInitialValueMap.ShouldContainKey("Prop");
+                propertyInitialValueMap["Prop"].PropertySource.ShouldBe("Xml");
+                propertyInitialValueMap["Prop"].PropertyValue.ShouldBe(string.Empty);
+
+                propertyInitialValueMap.ShouldContainKey("EnvVar");
+                propertyInitialValueMap["EnvVar"].PropertySource.ShouldBe("Xml");
+                propertyInitialValueMap["EnvVar"].PropertyValue.ShouldBe("It's Defined!");
+
+                propertyInitialValueMap.ShouldContainKey("DEFINED_ENVIRONMENT_VARIABLE");
+                propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertySource.ShouldBe("EnvironmentVariable");
+                propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertyValue.ShouldBe("It's Defined!");
+
+                propertyInitialValueMap.ShouldContainKey("NotEnvVarRead");
+                propertyInitialValueMap["NotEnvVarRead"].PropertySource.ShouldBe("Xml");
+                propertyInitialValueMap["NotEnvVarRead"].PropertyValue.ShouldBe("Overwritten!");
+
+                propertyInitialValueMap.ShouldContainKey("Prop2");
+                propertyInitialValueMap["Prop2"].PropertySource.ShouldBe("Xml");
+                propertyInitialValueMap["Prop2"].PropertyValue.ShouldBe("Value1");
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -506,9 +506,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string testTargetPath = Path.Combine(targetDirectory, "test.proj");
 
             string originalValue = Environment.GetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY");
+            bool originalValue2 = BuildParameters.WarnOnUninitializedProperty;
+
             try
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", null);
+                BuildParameters.WarnOnUninitializedProperty = false;
                 Directory.CreateDirectory(targetDirectory);
                 File.WriteAllText(testTargetPath, testtargets);
 
@@ -524,6 +527,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
+                BuildParameters.WarnOnUninitializedProperty = originalValue2;
                 FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4546,26 +4546,22 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 logger
                     .AllBuildEvents
                     .OfType<UninitializedPropertyReadEventArgs>()
-                    .Any(p => p.PropertyName == "DOES_NOT_EXIST")
-                    .ShouldBeTrue();
+                    .ShouldContain(p => p.PropertyName == "DOES_NOT_EXIST");
 
                 logger
                     .AllBuildEvents
                     .OfType<EnvironmentVariableReadEventArgs>()
-                    .Any(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE2")
-                    .ShouldBeTrue();
+                    .ShouldContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE2");
 
                 logger
                     .AllBuildEvents
                     .OfType<EnvironmentVariableReadEventArgs>()
-                    .Any(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE")
-                    .ShouldBeFalse();
+                    .ShouldNotContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE");
 
                 logger
                     .AllBuildEvents
                     .OfType<PropertyReassignmentEventArgs>()
-                    .Any(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2")
-                    .ShouldBeTrue();
+                    .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4574,7 +4574,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
                 propertyInitialValueMap.ShouldContainKey("EnvVar");
                 propertyInitialValueMap["EnvVar"].PropertySource.ShouldBe("Xml");
-                propertyInitialValueMap["EnvVar"].PropertyValue.ShouldBe("It's Defined!");
+                propertyInitialValueMap["EnvVar"].PropertyValue.ShouldBe("It's also Defined!");
 
                 propertyInitialValueMap.ShouldContainKey("DEFINED_ENVIRONMENT_VARIABLE");
                 propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertySource.ShouldBe("EnvironmentVariable");

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4543,7 +4543,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingPropertyReassignment()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "PropertyReassignment",
+                "1",
                 logger =>
                 {
                     logger
@@ -4573,7 +4573,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingNone()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "None",
+                "0",
                 logger =>
                 {
                     logger
@@ -4602,7 +4602,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingPropertyInitialValue()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "PropertyInitialValueSet",
+                "2",
                 logger =>
                 {
                     logger
@@ -4652,7 +4652,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingEnvironmentVariableRead()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "EnvironmentVariableRead",
+                "4",
                 logger =>
                 {
                     logger
@@ -4686,7 +4686,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingUninitializedPropertyRead()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "UninitializedPropertyRead",
+                "8",
                 logger =>
                 {
                     logger
@@ -4715,7 +4715,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         public void VerifyPropertyTrackingLoggingAll()
         {
             this.VerifyPropertyTrackingLoggingScenario(
-                "All",
+                "15",
                 logger =>
                 {
                     logger

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception
         /// </summary>
-        /// <param name="exception">The exception wich is to be logged</param>
+        /// <param name="exception">The exception which is to be logged</param>
         /// <param name="file">The file in which the error occurred</param>
         internal void LogFatalBuildError(Exception exception, BuildEventFileInfo file)
         {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2998,6 +2998,11 @@ namespace Microsoft.Build.Evaluation
             public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary { get; }
 
             /// <summary>
+            /// A dictionary of all of the environment variable properties.
+            /// </summary>
+            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => this.Project.ProjectCollection.EnvironmentProperties;
+
+            /// <summary>
             /// List of names of the properties that, while global, are still treated as overridable 
             /// </summary>
             public ISet<string> GlobalPropertiesToTreatAsLocal => _globalPropertiesToTreatAsLocal ?? (_globalPropertiesToTreatAsLocal =

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2998,7 +2998,7 @@ namespace Microsoft.Build.Evaluation
             public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary { get; }
 
             /// <summary>
-            /// A dictionary of all of the environment variable properties.
+            /// A dictionary of all of the properties read from environment variables during evaluation.
             /// </summary>
             public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => this.Project.ProjectCollection.EnvironmentProperties;
 

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3371,7 +3371,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Sets a property which is not derived from Xml.
             /// </summary>
-            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
             {
                 ProjectProperty property = ProjectProperty.Create(Project, name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
                 Properties.Set(property);

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3383,13 +3383,10 @@ namespace Microsoft.Build.Evaluation
 
             /// <summary>
             /// Sets a property derived from Xml.
-            /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
-            /// This would include all properties with the same name that lie above in the logical
-            /// project file, and whose conditions evaluated to true.
-            /// If there are none above this is null.
             /// </summary>
-            public ProjectProperty SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, ProjectProperty predecessor)
+            public ProjectProperty SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
             {
+                ProjectProperty predecessor = GetProperty(propertyElement.Name);
                 ProjectProperty property = ProjectProperty.Create(Project, propertyElement, evaluatedValueEscaped, predecessor);
                 Properties.Set(property);
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1276,7 +1276,7 @@ namespace Microsoft.Build.Evaluation
 
             foreach (ProjectPropertyInstance environmentProperty in _environmentProperties)
             {
-                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, false /* NOT global property */, false /* may NOT be a reserved name */, true /* IS an environment variable.*/);
+                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, isGlobalProperty: false, mayBeReserved: false, isEnvironmentVariable: true);
                 environmentPropertiesList.Add(property);
             }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -622,6 +622,7 @@ namespace Microsoft.Build.Evaluation
             using (_evaluationProfiler.TrackPass(EvaluationPass.TotalEvaluation))
             {
                 ErrorUtilities.VerifyThrow(_data.EvaluationId == BuildEventContext.InvalidEvaluationId, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
+                _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
 
                 _logProjectImportedEvents = Traits.Instance.EscapeHatches.LogProjectImports;
 
@@ -645,8 +646,6 @@ namespace Microsoft.Build.Evaluation
 #if (!STANDALONEBUILD)
             CodeMarkers.Instance.CodeMarker(CodeMarkerEvent.perfMSBuildProjectEvaluatePass0End);
 #endif
-                _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
-
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
 
                 ErrorUtilities.VerifyThrow(_data.EvaluationId != BuildEventContext.InvalidEvaluationId, "Evaluation should produce an evaluation ID");

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -210,12 +210,8 @@ namespace Microsoft.Build.Evaluation
                 buildEventContext,
                 string.IsNullOrEmpty(projectRootElement.ProjectFileLocation.File) ? "(null)" : projectRootElement.ProjectFileLocation.File);
 
-            if (Traits.Instance.LogPropertyTracking)
-            {
-                // Wrap the IEvaluatorData<> object passed in.
-                data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext);
-            }
-
+            // Wrap the IEvaluatorData<> object passed in.
+            data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext, Traits.Instance.LogPropertyTracking);
             _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
             // Create containers for the evaluation results

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1401,11 +1401,7 @@ namespace Microsoft.Build.Evaluation
 
                 _expander.UsedUninitializedProperties.CurrentlyEvaluatingPropertyElementName = null;
 
-                P property = _data.SetProperty(
-                    propertyElement,
-                    evaluatedValue,
-                    // If we're tracking property usage, don't first do a get here. The tracker will give false "uninitialized property read" events.
-                    Traits.Instance.LogPropertyTracking ? null : _data.GetProperty(propertyElement.Name));
+                _data.SetProperty(propertyElement, evaluatedValue);
             }
         }
 

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -206,6 +206,11 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// A dictionary of all of the environment variable properties.
+        /// </summary>
+        PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary { get; }
+
+        /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>
         void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem);

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -267,12 +267,8 @@ namespace Microsoft.Build.Evaluation
 
         /// <summary>
         /// Sets a property which comes from the Xml.
-        /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
-        /// This would include all properties with the same name that lie above in the logical
-        /// project file, and whose conditions evaluated to true.
-        /// If there are none above this is null.
         /// </summary>
-        P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor);
+        P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped);
 
         /// <summary>
         /// Retrieves an existing target, if any.

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Sets a property which does not come from the Xml.
         /// </summary>
-        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved);
+        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false);
 
         /// <summary>
         /// Sets a property which comes from the Xml.

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -124,6 +124,14 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary
+            {
+                get
+                {
+                    return _wrappedData.EnvironmentVariablePropertiesDictionary;
+                }
+            }
+
             public ISet<string> GlobalPropertiesToTreatAsLocal
             {
                 get

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -292,9 +292,9 @@ namespace Microsoft.Build.Evaluation
                 _wrappedData.RecordImportWithDuplicates(importElement, import, versionEvaluated);
             }
 
-            public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor)
+            public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
             {
-                return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped, predecessor);
+                return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped);
             }
 
             public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Build.Evaluation
                 return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped, predecessor);
             }
 
-            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
             {
                 return _wrappedData.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
             }

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared.FileSystem;
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.BackEnd.Components.Logging;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Wraps an existing <see cref="IEvaluatorData{P,I,M,D}"/> allowing the property usage to be tracked.
+    /// </summary>
+    /// <typeparam name="P">The type of properties to be produced.</typeparam>
+    /// <typeparam name="I">The type of items to be produced.</typeparam>
+    /// <typeparam name="M">The type of metadata on those items.</typeparam>
+    /// <typeparam name="D">The type of item definitions to be produced.</typeparam>
+    internal class PropertyTrackingEvaluatorDataWrapper<P, I, M, D> : IEvaluatorData<P, I, M, D>
+        where P : class, IProperty, IEquatable<P>, IValued
+        where I : class, IItem
+        where M : class, IMetadatum
+        where D : class, IItemDefinition<M>
+    {
+        private readonly IEvaluatorData<P, I, M, D> _wrapped;
+        private readonly HashSet<string> _environmentVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly EvaluationLoggingContext _evaluationLoggingContext;
+
+        /// <summary>
+        /// Creates an instance of the PropertyTrackingEvaluatorDataWrapper class.
+        /// </summary>
+        /// <param name="dataToWrap">The underlying <see cref="IEvaluatorData{P,I,M,D}"/> to wrap for property tracking.</param>
+        /// <param name="evaluationLoggingContext">The <see cref="EvaluationLoggingContext"/> used to log relevant events.</param>
+        public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext)
+        {
+            _wrapped = dataToWrap ?? throw new ArgumentNullException(nameof(dataToWrap));
+            _evaluationLoggingContext = evaluationLoggingContext ?? throw new ArgumentNullException(nameof(evaluationLoggingContext));
+        }
+
+        #region IEvaluatorData<> members with tracking-related code in them.
+
+        /// <summary>
+        /// Returns a property with the specified name, or null if it was not found.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The property.</returns>
+        public P GetProperty(string name)
+        {
+            P prop = _wrapped.GetProperty(name);
+            this.TrackPropertyRead(name, prop);
+            return prop;
+        }
+
+        /// <summary>
+        /// Returns a property with the specified name, or null if it was not found.
+        /// Name is the segment of the provided string with the provided start and end indexes.
+        /// </summary>
+        public P GetProperty(string name, int startIndex, int endIndex)
+        {
+            P prop = _wrapped.GetProperty(name, startIndex, endIndex);
+            this.TrackPropertyRead(name.Substring(startIndex, endIndex - startIndex + 1), prop);
+            return prop;
+        }
+
+        /// <summary>
+        /// Sets a property which does not come from the Xml.
+        /// </summary>
+        public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
+        {
+            P originalProperty = _wrapped.GetProperty(name);
+            P newProperty = _wrapped.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved, isEnvironmentVariable);
+
+            this.TrackPropertyReassignment(originalProperty, newProperty, string.Empty);
+
+            // If it's an environment variable, add it to our list.
+            // If not, make sure it's removed.
+            if (isEnvironmentVariable)
+            {
+                _environmentVariables.Add(name);
+            }
+            else
+            {
+                // If setting a property overwrites a previous environment variable property
+                // we won't track reads of it ANY MORE. However, if reads happened prior to
+                // when it was overwritten, those reads ARE captured.
+                _environmentVariables.Remove(name);
+            }
+
+            return newProperty;
+        }
+
+        /// <summary>
+        /// Sets a property which comes from the Xml.
+        /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
+        /// This would include all properties with the same name that lie above in the logical
+        /// project file, and whose conditions evaluated to true.
+        /// If there are none above this is null.
+        /// </summary>
+        public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor)
+        {
+            P originalProperty = predecessor ?? _wrapped.GetProperty(propertyElement.Name);
+            P newProperty = _wrapped.SetProperty(propertyElement, evaluatedValueEscaped, originalProperty);
+
+            this.TrackPropertyReassignment(originalProperty, newProperty, propertyElement.Location.LocationString);
+
+            _environmentVariables.Remove(newProperty.Name);
+            return newProperty;
+        }
+        #endregion
+
+        #region IEvaluatorData<> members that are forwarded directly to wrapped object.
+        public ICollection<I> GetItems(string itemType) => _wrapped.GetItems(itemType);
+        public int EvaluationId { get => _wrapped.EvaluationId; set => _wrapped.EvaluationId = value; }
+        public string Directory => _wrapped.Directory;
+        public TaskRegistry TaskRegistry { get => _wrapped.TaskRegistry; set => _wrapped.TaskRegistry = value; }
+        public Toolset Toolset => _wrapped.Toolset;
+        public string SubToolsetVersion => _wrapped.SubToolsetVersion;
+        public string ExplicitToolsVersion => _wrapped.ExplicitToolsVersion;
+        public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary => _wrapped.GlobalPropertiesDictionary;
+        public ISet<string> GlobalPropertiesToTreatAsLocal => _wrapped.GlobalPropertiesToTreatAsLocal;
+        public List<string> InitialTargets { get => _wrapped.InitialTargets; set => _wrapped.InitialTargets = value; }
+        public List<string> DefaultTargets { get => _wrapped.DefaultTargets; set => _wrapped.DefaultTargets = value; }
+        public IDictionary<string, List<TargetSpecification>> BeforeTargets { get => _wrapped.BeforeTargets; set => _wrapped.BeforeTargets = value; }
+        public IDictionary<string, List<TargetSpecification>> AfterTargets { get => _wrapped.AfterTargets; set => _wrapped.AfterTargets = value; }
+        public Dictionary<string, List<string>> ConditionedProperties => _wrapped.ConditionedProperties;
+        public bool ShouldEvaluateForDesignTime => _wrapped.ShouldEvaluateForDesignTime;
+        public bool CanEvaluateElementsWithFalseConditions => _wrapped.CanEvaluateElementsWithFalseConditions;
+        public PropertyDictionary<P> Properties => _wrapped.Properties;
+        public IEnumerable<D> ItemDefinitionsEnumerable => _wrapped.ItemDefinitionsEnumerable;
+        public ItemDictionary<I> Items => _wrapped.Items;
+        public List<ProjectItemElement> EvaluatedItemElements => _wrapped.EvaluatedItemElements;
+        public void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem) => _wrapped.InitializeForEvaluation(toolsetProvider, fileSystem);
+        public void FinishEvaluation() => _wrapped.FinishEvaluation();
+        public void AddItem(I item) => _wrapped.AddItem(item);
+        public void AddItemIgnoringCondition(I item) => _wrapped.AddItem(item);
+        public IItemDefinition<M> AddItemDefinition(string itemType) => _wrapped.AddItemDefinition(itemType);
+        public void AddToAllEvaluatedPropertiesList(P property) => _wrapped.AddToAllEvaluatedPropertiesList(property);
+        public void AddToAllEvaluatedItemDefinitionMetadataList(M itemDefinitionMetadatum) => _wrapped.AddToAllEvaluatedItemDefinitionMetadataList(itemDefinitionMetadatum);
+        public void AddToAllEvaluatedItemsList(I item) => _wrapped.AddToAllEvaluatedItemsList(item);
+        public IItemDefinition<M> GetItemDefinition(string itemType) => _wrapped.GetItemDefinition(itemType);
+        public ProjectTargetInstance GetTarget(string targetName) => _wrapped.GetTarget(targetName);
+        public void AddTarget(ProjectTargetInstance target) => _wrapped.AddTarget(target);
+        public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult) => _wrapped.RecordImport(importElement, import, versionEvaluated, sdkResult);
+        public void RecordImportWithDuplicates(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated) => _wrapped.RecordImportWithDuplicates(importElement, import, versionEvaluated);
+        public string ExpandString(string unexpandedValue) => _wrapped.ExpandString(unexpandedValue);
+        public bool EvaluateCondition(string condition) => _wrapped.EvaluateCondition(condition);
+        #endregion
+
+        #region Private Methods...
+        /// <summary>
+        /// Logic containing what to do when a property is read.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="property">The value of the property that was read (null if there is no value).</param>
+        private void TrackPropertyRead(string name, P property)
+        {
+            // MSBuild looks up a property called "InnerBuildProperty". If that isn't present,
+            // an empty string is returned and it then attempts to look up the value for that property
+            // (which is an empty string). Thus this check.
+            if (string.IsNullOrEmpty(name)) return;
+
+            if (_environmentVariables.Contains(name))
+            {
+                this.TrackEnvironmentVariableRead(name);
+            }
+            else if (property == null)
+            {
+                this.TrackUninitializedPropertyRead(name);
+            }
+        }
+
+        /// <summary>
+        /// Logs an EnvironmentVariableRead event.
+        /// </summary>
+        /// <param name="name">The name of the environment variable read.</param>
+        private void TrackEnvironmentVariableRead(string name)
+        {
+            var args = new EnvironmentVariableReadEventArgs(
+                name,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("EnvironmentVariableRead", name));
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        /// <summary>
+        /// Logs an UninitializedPropertyRead event.
+        /// </summary>
+        /// <param name="name">The name of the uninitialized property read.</param>
+        private void TrackUninitializedPropertyRead(string name)
+        {
+            var args = new UninitializedPropertyReadEventArgs(
+                name,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("UninitializedPropertyRead", name));
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        /// <summary>
+        /// If the property's value has changed, it logs a PropertyReassignment event.
+        /// </summary>
+        /// <param name="predecessor">The property's preceding state. Null if none.</param>
+        /// <param name="property">The property's current state.</param>
+        /// <param name="location">The location of this property's reassignment.</param>
+        private void TrackPropertyReassignment(P predecessor, P property, string location)
+        {
+            if (predecessor == null) return;
+
+            string newValue = property.EvaluatedValue;
+            string oldValue = predecessor.EvaluatedValue;
+            if (newValue == oldValue) return;
+
+            var args = new PropertyReassignmentEventArgs(
+                property.Name,
+                oldValue,
+                newValue,
+                location,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyReassignment", property.Name, newValue, oldValue, location));
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        #endregion
+    }
+}

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -39,8 +39,11 @@ namespace Microsoft.Build.Evaluation
         /// <param name="evaluationLoggingContext">The <see cref="EvaluationLoggingContext"/> used to log relevant events.</param>
         public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext)
         {
-            _wrapped = dataToWrap ?? throw new ArgumentNullException(nameof(dataToWrap));
-            _evaluationLoggingContext = evaluationLoggingContext ?? throw new ArgumentNullException(nameof(evaluationLoggingContext));
+            ErrorUtilities.VerifyThrowInternalNull(dataToWrap, nameof(dataToWrap));
+            ErrorUtilities.VerifyThrowInternalNull(evaluationLoggingContext, nameof(evaluationLoggingContext));
+
+            _wrapped = dataToWrap;
+            _evaluationLoggingContext = evaluationLoggingContext;
         }
 
         #region IEvaluatorData<> members with tracking-related code in them.

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Build.Evaluation
         public void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem) => _wrapped.InitializeForEvaluation(toolsetProvider, fileSystem);
         public void FinishEvaluation() => _wrapped.FinishEvaluation();
         public void AddItem(I item) => _wrapped.AddItem(item);
-        public void AddItemIgnoringCondition(I item) => _wrapped.AddItem(item);
+        public void AddItemIgnoringCondition(I item) => _wrapped.AddItemIgnoringCondition(item);
         public IItemDefinition<M> AddItemDefinition(string itemType) => _wrapped.AddItemDefinition(itemType);
         public void AddToAllEvaluatedPropertiesList(P property) => _wrapped.AddToAllEvaluatedPropertiesList(property);
         public void AddToAllEvaluatedItemDefinitionMetadataList(M itemDefinitionMetadatum) => _wrapped.AddToAllEvaluatedItemDefinitionMetadataList(itemDefinitionMetadatum);

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -105,10 +105,10 @@ namespace Microsoft.Build.Evaluation
         /// project file, and whose conditions evaluated to true.
         /// If there are none above this is null.
         /// </summary>
-        public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor)
+        public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
         {
-            P originalProperty = predecessor ?? _wrapped.GetProperty(propertyElement.Name);
-            P newProperty = _wrapped.SetProperty(propertyElement, evaluatedValueEscaped, originalProperty);
+            P originalProperty = _wrapped.GetProperty(propertyElement.Name);
+            P newProperty = _wrapped.SetProperty(propertyElement, evaluatedValueEscaped);
 
             this.TrackPropertyReassignment(originalProperty, newProperty, propertyElement.Location.LocationString);
 

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -38,14 +38,14 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="dataToWrap">The underlying <see cref="IEvaluatorData{P,I,M,D}"/> to wrap for property tracking.</param>
         /// <param name="evaluationLoggingContext">The <see cref="EvaluationLoggingContext"/> used to log relevant events.</param>
-        public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext, string settingString)
+        public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext, int settingValue)
         {
             ErrorUtilities.VerifyThrowInternalNull(dataToWrap, nameof(dataToWrap));
             ErrorUtilities.VerifyThrowInternalNull(evaluationLoggingContext, nameof(evaluationLoggingContext));
 
             _wrapped = dataToWrap;
             _evaluationLoggingContext = evaluationLoggingContext;
-            _settings = ParsePropertyTrackingSettings(settingString);
+            _settings = (PropertyTrackingSetting)settingValue;
         }
 
         #region IEvaluatorData<> members with tracking-related code in them.
@@ -291,20 +291,6 @@ namespace Microsoft.Build.Evaluation
             }
 
             return mayBeReserved ? PropertySource.BuiltIn : PropertySource.Toolset;
-        }
-
-        private static PropertyTrackingSetting ParsePropertyTrackingSettings(string settingString)
-        {
-            // If the environment is NOT defined, or there is a parsing error,
-            // default this to the current functionality: property reassignments are logged.
-            if (
-                string.IsNullOrEmpty(settingString) ||
-                !Enum.TryParse(settingString, true, out PropertyTrackingSetting settings))
-            {
-                return PropertyTrackingSetting.PropertyReassignment;
-            }
-
-            return settings;
         }
 
         #endregion

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Build.Evaluation
             var args = new EnvironmentVariableReadEventArgs(
                 name,
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("EnvironmentVariableRead", name));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
 
             _evaluationLoggingContext.LogBuildEvent(args);
         }
@@ -200,6 +201,7 @@ namespace Microsoft.Build.Evaluation
             var args = new UninitializedPropertyReadEventArgs(
                 name,
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("UninitializedPropertyRead", name));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
 
             _evaluationLoggingContext.LogBuildEvent(args);
         }
@@ -224,6 +226,7 @@ namespace Microsoft.Build.Evaluation
                 newValue,
                 location,
                 ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyReassignment", property.Name, newValue, oldValue, location));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
 
             _evaluationLoggingContext.LogBuildEvent(args);
         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -877,6 +877,11 @@ namespace Microsoft.Build.Execution
             { return _globalProperties; }
         }
 
+        PropertyDictionary<ProjectPropertyInstance> IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.EnvironmentVariablePropertiesDictionary
+        {
+            get => _environmentVariableProperties;
+        }
+
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable 
         /// </summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1314,7 +1314,7 @@ namespace Microsoft.Build.Execution
         /// immutable if we are immutable.
         /// Only called during evaluation, so does not check for immutability.
         /// </summary>
-        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable)
         {
             // Mutability not verified as this is being populated during evaluation
             ProjectPropertyInstance property = ProjectPropertyInstance.Create(name, evaluatedValueEscaped, mayBeReserved, _isImmutable);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1327,7 +1327,7 @@ namespace Microsoft.Build.Execution
         /// Predecessor is discarded as it is a design time only artefact.
         /// Only called during evaluation, so does not check for immutability.
         /// </summary>
-        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, ProjectPropertyInstance predecessor)
+        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
         {
             // Mutability not verified as this is being populated during evaluation
             ProjectPropertyInstance property = ProjectPropertyInstance.Create(propertyElement.Name, evaluatedValueEscaped, false /* may not be reserved */, _isImmutable);

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -24,6 +24,6 @@
         PropertyReassignment,
         UninitializedPropertyRead,
         EnvironmentVariableRead,
-        PropertyInitialValueSet
+        PropertyInitialValueSet,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -20,6 +20,9 @@
         ProjectEvaluationFinished,
         ProjectImported,
         ProjectImportArchive,
-        TargetSkipped
+        TargetSkipped,
+        PropertyReassignment,
+        UninitializedPropertyRead,
+        EnvironmentVariableRead
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -23,6 +23,7 @@
         TargetSkipped,
         PropertyReassignment,
         UninitializedPropertyRead,
-        EnvironmentVariableRead
+        EnvironmentVariableRead,
+        PropertyInitialValueSet
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Build.Logging
         private ProjectImportsCollector projectImportsCollector;
         private string _initialTargetOutputLogging;
         private string _initialLogImports;
-        private string _initialTrackProperties;
 
         /// <summary>
         /// Describes whether to collect the project files (including imported project files) used during the build.
@@ -90,11 +89,9 @@ namespace Microsoft.Build.Logging
         {
             _initialTargetOutputLogging = Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING");
             _initialLogImports = Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS");
-            _initialTrackProperties = Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking");
 
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
-            Environment.SetEnvironmentVariable("MsBuildLogPropertyTracking", "1");
 
             ProcessParameters();
 
@@ -152,7 +149,6 @@ namespace Microsoft.Build.Logging
         {
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", _initialTargetOutputLogging);
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", _initialLogImports);
-            Environment.SetEnvironmentVariable("MsBuildLogPropertyTracking", _initialTrackProperties);
 
             if (projectImportsCollector != null)
             {

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -28,10 +28,12 @@ namespace Microsoft.Build.Logging
         // version 5:
         //   - new EvaluationFinished.ProfilerResult
         // version 6:
-        //   -  Ids and parent ids for the evaluation locations
+        //   - Ids and parent ids for the evaluation locations
         // version 7:
-        //   -  Include ProjectStartedEventArgs.GlobalProperties
-        internal const int FileFormatVersion = 7;
+        //   - Include ProjectStartedEventArgs.GlobalProperties
+        // version 8:
+        //   - new record kinds: EnvironmentVariableRead, PropertyReassignment, UninitializedPropertyRead
+        internal const int FileFormatVersion = 8;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Build.Logging
         private ProjectImportsCollector projectImportsCollector;
         private string _initialTargetOutputLogging;
         private string _initialLogImports;
+        private string _initialTrackProperties;
 
         /// <summary>
         /// Describes whether to collect the project files (including imported project files) used during the build.
@@ -89,9 +90,11 @@ namespace Microsoft.Build.Logging
         {
             _initialTargetOutputLogging = Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING");
             _initialLogImports = Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS");
+            _initialTrackProperties = Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking");
 
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
+            Environment.SetEnvironmentVariable("MsBuildLogPropertyTracking", "1");
 
             ProcessParameters();
 
@@ -149,6 +152,7 @@ namespace Microsoft.Build.Logging
         {
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", _initialTargetOutputLogging);
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", _initialLogImports);
+            Environment.SetEnvironmentVariable("MsBuildLogPropertyTracking", _initialTrackProperties);
 
             if (projectImportsCollector != null)
             {

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -121,6 +121,9 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.UninitializedPropertyRead:
                     result = ReadUninitializedPropertyReadEventArgs();
                     break;
+                case BinaryLogRecordKind.PropertyInitialValueSet:
+                    result = ReadPropertyInitialValueSetEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -566,6 +569,27 @@ namespace Microsoft.Build.Logging
 
             var e = new UninitializedPropertyReadEventArgs(
                 propertyName,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyInitialValueSetEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+            string propertyValue = ReadString();
+            string propertySource = ReadString();
+
+            var e = new PropertyInitialValueSetEventArgs(
+                propertyName,
+                propertyValue,
+                propertySource,
                 fields.Message,
                 fields.HelpKeyword,
                 fields.SenderName,

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -112,6 +112,15 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.TargetSkipped:
                     result = ReadTargetSkippedEventArgs();
                     break;
+                case BinaryLogRecordKind.EnvironmentVariableRead:
+                    result = ReadEnvironmentVariableReadEventArgs();
+                    break;
+                case BinaryLogRecordKind.PropertyReassignment:
+                    result = ReadPropertyReassignmentEventArgs();
+                    break;
+                case BinaryLogRecordKind.UninitializedPropertyRead:
+                    result = ReadUninitializedPropertyReadEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -505,6 +514,57 @@ namespace Microsoft.Build.Logging
                 fields.Timestamp);
             e.BuildEventContext = fields.BuildEventContext;
             e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadEnvironmentVariableReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var environmentVariableName = ReadString();
+
+            var e = new EnvironmentVariableReadEventArgs(
+                environmentVariableName,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyReassignmentEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            string propertyName = ReadString();
+            string previousValue = ReadString();
+            string newValue = ReadString();
+            string location = ReadString();
+
+            var e = new PropertyReassignmentEventArgs(
+                propertyName,
+                previousValue,
+                newValue,
+                location,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadUninitializedPropertyReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            string propertyName = ReadString();
+
+            var e = new UninitializedPropertyReadEventArgs(
+                propertyName,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName);
+            SetCommonFields(e, fields);
+
             return e;
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -520,13 +520,16 @@ namespace Microsoft.Build.Logging
         private BuildEventArgs ReadEnvironmentVariableReadEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+
             var environmentVariableName = ReadString();
 
             var e = new EnvironmentVariableReadEventArgs(
                 environmentVariableName,
                 fields.Message,
                 fields.HelpKeyword,
-                fields.SenderName);
+                fields.SenderName,
+                importance);
             SetCommonFields(e, fields);
 
             return e;
@@ -535,6 +538,7 @@ namespace Microsoft.Build.Logging
         private BuildEventArgs ReadPropertyReassignmentEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
             string propertyName = ReadString();
             string previousValue = ReadString();
             string newValue = ReadString();
@@ -547,7 +551,8 @@ namespace Microsoft.Build.Logging
                 location,
                 fields.Message,
                 fields.HelpKeyword,
-                fields.SenderName);
+                fields.SenderName,
+                importance);
             SetCommonFields(e, fields);
 
             return e;
@@ -556,13 +561,15 @@ namespace Microsoft.Build.Logging
         private BuildEventArgs ReadUninitializedPropertyReadEventArgs()
         {
             var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
             string propertyName = ReadString();
 
             var e = new UninitializedPropertyReadEventArgs(
                 propertyName,
                 fields.Message,
                 fields.HelpKeyword,
-                fields.SenderName);
+                fields.SenderName,
+                importance);
             SetCommonFields(e, fields);
 
             return e;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -304,6 +304,12 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
+            if (e is PropertyInitialValueSetEventArgs)
+            {
+                Write((PropertyInitialValueSetEventArgs)e);
+                return;
+            }
+
             Write(BinaryLogRecordKind.Message);
             WriteMessageFields(e);
         }
@@ -348,6 +354,15 @@ namespace Microsoft.Build.Logging
             Write(BinaryLogRecordKind.UninitializedPropertyRead);
             WriteMessageFields(e);
             Write(e.PropertyName);
+        }
+
+        private void Write(PropertyInitialValueSetEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyInitialValueSet);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PropertyValue);
+            Write(e.PropertySource);
         }
 
         private void Write(EnvironmentVariableReadEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -84,18 +84,6 @@ namespace Microsoft.Build.Logging
             {
                 Write((ProjectEvaluationFinishedEventArgs)e);
             }
-            else if (e is PropertyReassignmentEventArgs)
-            {
-                Write((PropertyReassignmentEventArgs)e);
-            }
-            else if (e is UninitializedPropertyReadEventArgs)
-            {
-                Write((UninitializedPropertyReadEventArgs)e);
-            }
-            else if (e is EnvironmentVariableReadEventArgs)
-            {
-                Write((EnvironmentVariableReadEventArgs)e);
-            }
             else
             {
                 // convert all unrecognized objects to message
@@ -298,6 +286,24 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
+            if (e is PropertyReassignmentEventArgs)
+            {
+                Write((PropertyReassignmentEventArgs)e);
+                return;
+            }
+
+            if (e is UninitializedPropertyReadEventArgs)
+            {
+                Write((UninitializedPropertyReadEventArgs)e);
+                return;
+            }
+
+            if (e is EnvironmentVariableReadEventArgs)
+            {
+                Write((EnvironmentVariableReadEventArgs)e);
+                return;
+            }
+
             Write(BinaryLogRecordKind.Message);
             WriteMessageFields(e);
         }
@@ -330,7 +336,7 @@ namespace Microsoft.Build.Logging
         private void Write(PropertyReassignmentEventArgs e)
         {
             Write(BinaryLogRecordKind.PropertyReassignment);
-            WriteBuildEventArgsFields(e);
+            WriteMessageFields(e);
             Write(e.PropertyName);
             Write(e.PreviousValue);
             Write(e.NewValue);
@@ -340,14 +346,14 @@ namespace Microsoft.Build.Logging
         private void Write(UninitializedPropertyReadEventArgs e)
         {
             Write(BinaryLogRecordKind.UninitializedPropertyRead);
-            WriteBuildEventArgsFields(e);
+            WriteMessageFields(e);
             Write(e.PropertyName);
         }
 
         private void Write(EnvironmentVariableReadEventArgs e)
         {
             Write(BinaryLogRecordKind.EnvironmentVariableRead);
-            WriteBuildEventArgsFields(e);
+            WriteMessageFields(e);
             Write(e.EnvironmentVariableName);
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -84,6 +84,18 @@ namespace Microsoft.Build.Logging
             {
                 Write((ProjectEvaluationFinishedEventArgs)e);
             }
+            else if (e is PropertyReassignmentEventArgs)
+            {
+                Write((PropertyReassignmentEventArgs)e);
+            }
+            else if (e is UninitializedPropertyReadEventArgs)
+            {
+                Write((UninitializedPropertyReadEventArgs)e);
+            }
+            else if (e is EnvironmentVariableReadEventArgs)
+            {
+                Write((EnvironmentVariableReadEventArgs)e);
+            }
             else
             {
                 // convert all unrecognized objects to message
@@ -313,6 +325,30 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.CriticalBuildMessage);
             WriteMessageFields(e);
+        }
+
+        private void Write(PropertyReassignmentEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyReassignment);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PreviousValue);
+            Write(e.NewValue);
+            Write(e.Location);
+        }
+
+        private void Write(UninitializedPropertyReadEventArgs e)
+        {
+             Write(BinaryLogRecordKind.UninitializedPropertyRead);
+             WriteMessageFields(e);
+             Write(e.PropertyName);
+        }
+
+        private void Write(EnvironmentVariableReadEventArgs e)
+        {
+            Write(BinaryLogRecordKind.EnvironmentVariableRead);
+            WriteMessageFields(e);
+            Write(e.EnvironmentVariableName);
         }
 
         private void Write(TaskCommandLineEventArgs e)

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Build.Logging
         private void Write(PropertyReassignmentEventArgs e)
         {
             Write(BinaryLogRecordKind.PropertyReassignment);
-            WriteMessageFields(e);
+            WriteBuildEventArgsFields(e);
             Write(e.PropertyName);
             Write(e.PreviousValue);
             Write(e.NewValue);
@@ -339,15 +339,15 @@ namespace Microsoft.Build.Logging
 
         private void Write(UninitializedPropertyReadEventArgs e)
         {
-             Write(BinaryLogRecordKind.UninitializedPropertyRead);
-             WriteMessageFields(e);
-             Write(e.PropertyName);
+            Write(BinaryLogRecordKind.UninitializedPropertyRead);
+            WriteBuildEventArgsFields(e);
+            Write(e.PropertyName);
         }
 
         private void Write(EnvironmentVariableReadEventArgs e)
         {
             Write(BinaryLogRecordKind.EnvironmentVariableRead);
-            WriteMessageFields(e);
+            WriteBuildEventArgsFields(e);
             Write(e.EnvironmentVariableName);
         }
 

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -161,6 +161,7 @@
     <Compile Include="BackEnd\BuildManager\CacheAggregator.cs" />
     <Compile Include="BackEnd\Components\Caching\ConfigCacheWithOverride.cs" />
     <Compile Include="BackEnd\Components\Caching\ResultsCacheWithOverride.cs" />
+    <Compile Include="Evaluation\PropertyTrackingEvaluatorDataWrapper.cs" />
     <Compile Include="Graph\GraphBuilder.cs" />
     <Compile Include="Graph\ParallelWorkSet.cs" />
     <Compile Include="Graph\ProjectInterpretation.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -745,7 +745,7 @@
   </data>
   <data name="PropertyNameInRegistryHasZeroLength" UESanitized="false" Visibility="Public">
     <value>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</value>
-    <comment>{StrBegin="MSB4148: "}</comment>
+    <comment>{StrBegin="MSB4148: "}</comment> 
   </data>
   <data name="PropertyReassignment" UESanitized="false" Visibility="Public">
     <value>Property reassignment: $({0})="{1}" (previous value: "{2}") at {3}</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -745,7 +745,7 @@
   </data>
   <data name="PropertyNameInRegistryHasZeroLength" UESanitized="false" Visibility="Public">
     <value>MSB4148: The name of a property stored under the registry key "{0}" has zero length.</value>
-    <comment>{StrBegin="MSB4148: "}</comment> 
+    <comment>{StrBegin="MSB4148: "}</comment>
   </data>
   <data name="PropertyReassignment" UESanitized="false" Visibility="Public">
     <value>Property reassignment: $({0})="{1}" (previous value: "{2}") at {3}</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1793,17 +1793,17 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     </comment>
   </data>
   <data name="UninitializedPropertyRead" UESanitized="false" Visibility="Public">
-    <value>MSB4261: Read uninitialized property "{0}"</value>
+    <value>Read uninitialized property "{0}"</value>
     <comment>
     </comment>
   </data>
   <data name="EnvironmentVariableRead" UESanitized="false" Visibility="Public">
-    <value>MSB4262: Read environment variable "{0}"</value>
+    <value>Read environment variable "{0}"</value>
     <comment>
     </comment>
   </data>
   <data name="PropertyAssignment" UESanitized="false" Visibility="Public">
-    <value>MSB4263: Property initial value: $({0})="{1}" Source: {2}</value>
+    <value>Property initial value: $({0})="{1}" Source: {2}</value>
     <comment>
     </comment>
   </data>
@@ -1813,7 +1813,7 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
         MSB4128 is being used in FileLogger.cs (can't be added here yet as strings are currently frozen)
         MSB4129 is used by Shared\XmlUtilities.cs (can't be added here yet as strings are currently frozen)
 
-        Next message code should be MSB4264.
+        Next message code should be MSB4261.
 
         Some unused codes which can also be reused (because their messages were deleted, and UE hasn't indexed the codes yet):
             <none>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1792,6 +1792,16 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} and {1} are file paths
     </comment>
   </data>
+  <data name="UninitializedPropertyRead" UESanitized="false" Visibility="Public">
+    <value>MSB4261: Read uninitialized property "{0}"</value>
+    <comment>
+    </comment>
+  </data>
+  <data name="EnvironmentVariableRead" UESanitized="false" Visibility="Public">
+    <value>MSB4262: Read environment variable "{0}"</value>
+    <comment>
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1802,6 +1802,11 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
     <comment>
     </comment>
   </data>
+  <data name="PropertyAssignment" UESanitized="false" Visibility="Public">
+    <value>MSB4263: Property initial value: $({0})="{1}" Source: {2}</value>
+    <comment>
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Projekt {0} přeskočil omezení izolace grafu v odkazovaném projektu {1}.</target>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Zadaný výstupní soubor mezipaměti pro výsledky je prázdný.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Při čtení vstupních souborů mezipaměti pro výsledky z cesty {0} byla zjištěna chyba: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Die angegebene Cachedatei für Ausgabeergebnisse ist leer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Beim Lesen der Cachedateien für Eingabeergebnisse aus dem Pfad "{0}" wurde ein Fehler festgestellt: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Das Projekt "{0}" hat Graphisolationseinschränkungen für das referenzierte Projekt "{1}" übersprungen.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -67,6 +67,11 @@
         <target state="new">MSB4257: The specified output result cache file is empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="new">MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: El proyecto "{0}" ha omitido las restricciones de aislamiento de gráficos en el proyecto "{1}" al que se hace referencia.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: El archivo de caché de resultados de salida especificado está vacío.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Error al leer los archivos de caché de resultados de entrada en la ruta de acceso "{0}": {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: le projet "{0}" a ignoré les contraintes d'isolement de graphe dans le projet référencé "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Le fichier cache des résultats de sortie spécifié est vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: La lecture des fichiers cache des résultats d'entrée à partir du chemin "{0}" a rencontré une erreur : {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: il file della cache dei risultati di output specificato è vuoto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: durante la lettura dei file della cache dei risultati di input dal percorso "{0}" è stato rilevato un errore: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: il progetto "{0}" ha ignorato i vincoli di isolamento del grafico nel progetto di riferimento "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: プロジェクト "{0}" は、参照先のプロジェクト "{1}" で、グラフの分離制約をスキップしました</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定された出力結果キャッシュ ファイルは空です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: パス "{0}" から入力結果キャッシュ ファイルを読み取る処理でエラーが発生しました: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 지정한 출력 결과 캐시 파일이 비어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: "{0}" 경로에서 입력 결과 캐시 파일을 읽는 중 오류가 발생했습니다. {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 프로젝트 "{0}"에서 참조된 프로젝트 "{1}"의 그래프 격리 제약 조건을 건너뛰었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: W przypadku projektu „{0}” pominięto ograniczenia izolacji grafu dla przywoływanego projektu „{1}”</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Określony plik wyjściowej pamięci podręcznej wyników jest pusty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Podczas odczytywania plików wejściowej pamięci podręcznej wyników ze ścieżki „{0}” wystąpił błąd: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -66,6 +66,11 @@
         <target state="translated">MSB4257: o arquivo de cache do resultado de saída especificado está vazio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: a leitura dos arquivos de cache do resultado de entrada do caminho "{0}" encontrou um erro: {1}</target>
@@ -150,6 +155,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -67,8 +67,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -113,8 +113,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -162,8 +162,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -112,6 +112,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: o projeto "{0}" ignorou as restrições de isolamento do gráfico no projeto referenciado "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: указанный выходной файл кэша результатов пустой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: произошла ошибка при чтении входных файлов кэша результатов из пути "{0}": {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: проект "{0}" пропустил ограничения изоляции графа в проекте "{1}", на который указывает ссылка.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: "{0}" projesi, başvurulan "{1}" projesindeki graf yalıtımı kısıtlamalarını atladı</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Belirtilen çıkış sonucu önbellek dosyası boş.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: "{0}" yolundan giriş sonucu önbellek dosyaları okunurken bir hatayla karşılaşıldı: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 项目“{0}”已跳过所引用的项目“{1}”上的图形隔离约束</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定的输出结果缓存文件为空。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: 从路径“{0}”读取输入结果缓存文件时遇到错误: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentVariableRead">
-        <source>MSB4262: Read environment variable "{0}"</source>
-        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
@@ -114,8 +114,8 @@
     </note>
       </trans-unit>
       <trans-unit id="PropertyAssignment">
-        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
-        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
@@ -163,8 +163,8 @@
     </note>
       </trans-unit>
       <trans-unit id="UninitializedPropertyRead">
-        <source>MSB4261: Read uninitialized property "{0}"</source>
-        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
         <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定的輸出結果快取檔案是空的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>MSB4262: Read environment variable "{0}"</source>
+        <target state="new">MSB4262: Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: 從路徑 "{0}" 讀取輸入結果快取檔案發生錯誤: {1}</target>
@@ -151,6 +156,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>MSB4261: Read uninitialized property "{0}"</source>
+        <target state="new">MSB4261: Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -113,6 +113,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>MSB4263: Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">MSB4263: Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 專案 "{0}" 已跳過參考專案 "{1}" 上的圖形隔離條件約束</target>

--- a/src/Framework/EnvironmentVariableReadEventArgs.cs
+++ b/src/Framework/EnvironmentVariableReadEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for the environment variable read event.
+    /// </summary>
+    [Serializable]
+    public class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+        public EnvironmentVariableReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+        /// <param name="environmentVariableName">The name of the environment variable that was read.</param>
+        public EnvironmentVariableReadEventArgs(
+            string environmentVariableName,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.EnvironmentVariableName = environmentVariableName;
+        }
+
+        /// <summary>
+        /// The name of the environment variable that was read.
+        /// </summary>
+        public string EnvironmentVariableName { get; set; }
+    }
+}

--- a/src/Framework/EnvironmentVariableReadEventArgs.cs
+++ b/src/Framework/EnvironmentVariableReadEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// Arguments for the environment variable read event.
     /// </summary>
     [Serializable]
-    public class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    public class EnvironmentVariableReadEventArgs : BuildStatusEventArgs
     {
         /// <summary>
         /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
@@ -26,8 +26,7 @@ namespace Microsoft.Build.Framework
             string environmentVariableName,
             string message,
             string helpKeyword = null,
-            string senderName = null,
-            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+            string senderName = null) : base(message, helpKeyword, senderName)
         {
             this.EnvironmentVariableName = environmentVariableName;
         }

--- a/src/Framework/EnvironmentVariableReadEventArgs.cs
+++ b/src/Framework/EnvironmentVariableReadEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// Arguments for the environment variable read event.
     /// </summary>
     [Serializable]
-    public class EnvironmentVariableReadEventArgs : BuildStatusEventArgs
+    public class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
     {
         /// <summary>
         /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
@@ -26,7 +26,8 @@ namespace Microsoft.Build.Framework
             string environmentVariableName,
             string message,
             string helpKeyword = null,
-            string senderName = null) : base(message, helpKeyword, senderName)
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
         {
             this.EnvironmentVariableName = environmentVariableName;
         }

--- a/src/Framework/PropertyInitialValueSetEventArgs.cs
+++ b/src/Framework/PropertyInitialValueSetEventArgs.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The argument for a property initial value set event.
+    /// </summary>
+    public class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Creates an instance of the <see cref="PropertyInitialValueSetEventArgs"/> class.
+        /// </summary>
+        public PropertyInitialValueSetEventArgs() { }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="PropertyInitialValueSetEventArgs"/> class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="propertyValue">The value of the property.</param>
+        /// <param name="propertySource">The source of the property.</param>
+        public PropertyInitialValueSetEventArgs(
+            string propertyName,
+            string propertyValue,
+            string propertySource,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PropertyValue = propertyValue;
+            this.PropertySource = propertySource;
+        }
+
+        /// <summary>
+        /// The name of the property.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// The value of the property.
+        /// </summary>
+        public string PropertyValue { get; set; }
+
+        /// <summary>
+        /// The source of the property.
+        /// </summary>
+        public string PropertySource { get; set; }
+    }
+}

--- a/src/Framework/PropertyInitialValueSetEventArgs.cs
+++ b/src/Framework/PropertyInitialValueSetEventArgs.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Build.Framework
     /// <summary>
     /// The argument for a property initial value set event.
     /// </summary>
+    [Serializable]
     public class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
     {
         /// <summary>

--- a/src/Framework/PropertyReassignmentEventArgs.cs
+++ b/src/Framework/PropertyReassignmentEventArgs.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The argument for a property reassignment event.
+    /// </summary>
+    [Serializable]
+    public class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Creates an instance of the PropertyReassignmentEventArgs class.
+        /// </summary>
+        public PropertyReassignmentEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the PropertyReassignmentEventArgs class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property whose value was reassigned.</param>
+        /// <param name="previousValue">The previous value of the reassigned property.</param>
+        /// <param name="newValue">The new value of the reassigned property.</param>
+        /// <param name="location">The location of the reassignment.</param>
+        public PropertyReassignmentEventArgs(
+            string propertyName,
+            string previousValue,
+            string newValue,
+            string location,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PreviousValue = previousValue;
+            this.NewValue = newValue;
+            this.Location = location;
+        }
+
+        /// <summary>
+        /// The name of the property whose value was reassigned.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// The previous value of the reassigned property.
+        /// </summary>
+        public string PreviousValue { get; set; }
+
+        /// <summary>
+        /// The new value of the reassigned property.
+        /// </summary>
+        public string NewValue { get; set; }
+
+        /// <summary>
+        /// The location of the reassignment.
+        /// </summary>
+        public string Location { get; set; }
+    }
+}

--- a/src/Framework/PropertyReassignmentEventArgs.cs
+++ b/src/Framework/PropertyReassignmentEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// The argument for a property reassignment event.
     /// </summary>
     [Serializable]
-    public class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    public class PropertyReassignmentEventArgs : BuildStatusEventArgs
     {
         /// <summary>
         /// Creates an instance of the PropertyReassignmentEventArgs class.
@@ -32,8 +32,7 @@ namespace Microsoft.Build.Framework
             string location,
             string message,
             string helpKeyword = null,
-            string senderName = null,
-            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+            string senderName = null) : base(message, helpKeyword, senderName)
         {
             this.PropertyName = propertyName;
             this.PreviousValue = previousValue;

--- a/src/Framework/PropertyReassignmentEventArgs.cs
+++ b/src/Framework/PropertyReassignmentEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// The argument for a property reassignment event.
     /// </summary>
     [Serializable]
-    public class PropertyReassignmentEventArgs : BuildStatusEventArgs
+    public class PropertyReassignmentEventArgs : BuildMessageEventArgs
     {
         /// <summary>
         /// Creates an instance of the PropertyReassignmentEventArgs class.
@@ -32,7 +32,8 @@ namespace Microsoft.Build.Framework
             string location,
             string message,
             string helpKeyword = null,
-            string senderName = null) : base(message, helpKeyword, senderName)
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
         {
             this.PropertyName = propertyName;
             this.PreviousValue = previousValue;

--- a/src/Framework/UninitializedPropertyReadEventArgs.cs
+++ b/src/Framework/UninitializedPropertyReadEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The arguments for an uninitialized property read event.
+    /// </summary>
+    [Serializable]
+    public class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// UninitializedPropertyReadEventArgs
+        /// </summary>
+        public UninitializedPropertyReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the UninitializedPropertyReadEventArgs class
+        /// </summary>
+        /// <param name="propertyName">The name of the uninitialized property that was read.</param>
+        public UninitializedPropertyReadEventArgs(
+            string propertyName,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+        }
+
+        /// <summary>
+        /// The name of the uninitialized property that was read.
+        /// </summary>
+        public string PropertyName { get; set; }
+    }
+}

--- a/src/Framework/UninitializedPropertyReadEventArgs.cs
+++ b/src/Framework/UninitializedPropertyReadEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// The arguments for an uninitialized property read event.
     /// </summary>
     [Serializable]
-    public class UninitializedPropertyReadEventArgs : BuildStatusEventArgs
+    public class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
     {
         /// <summary>
         /// UninitializedPropertyReadEventArgs
@@ -26,7 +26,8 @@ namespace Microsoft.Build.Framework
             string propertyName,
             string message,
             string helpKeyword = null,
-            string senderName = null) : base(message, helpKeyword, senderName)
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
         {
             this.PropertyName = propertyName;
         }

--- a/src/Framework/UninitializedPropertyReadEventArgs.cs
+++ b/src/Framework/UninitializedPropertyReadEventArgs.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Framework
     /// The arguments for an uninitialized property read event.
     /// </summary>
     [Serializable]
-    public class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    public class UninitializedPropertyReadEventArgs : BuildStatusEventArgs
     {
         /// <summary>
         /// UninitializedPropertyReadEventArgs
@@ -26,8 +26,7 @@ namespace Microsoft.Build.Framework
             string propertyName,
             string message,
             string helpKeyword = null,
-            string senderName = null,
-            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+            string senderName = null) : base(message, helpKeyword, senderName)
         {
             this.PropertyName = propertyName;
         }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Log property tracking information.
         /// </summary>
-        public string LogPropertyTracking => Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking");
+        public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 1); // Default to logging only property reassignments.
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool LogPropertyFunctionsRequiringReflection = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection"));
 
+        /// <summary>
+        /// Log property tracking information.
+        /// </summary>
+        public bool LogPropertyTracking => Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking") == "1";
+
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {
             return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Log property tracking information.
         /// </summary>
-        public bool LogPropertyTracking => Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking") == "1";
+        public string LogPropertyTracking => Environment.GetEnvironmentVariable("MsBuildLogPropertyTracking");
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {


### PR DESCRIPTION
### Description
This change introduces opt-in functionality that will track property usage and generate three events:
1. Environment Variables Read  (new)
2. Uninitialized Properties Read (new)
3. Property Reassigned (already exists)

Opt-in is via the environment variable, `MSBuildLogPropertyTracking=1`.

It's implemented via a new class named PropertyTrackingEvaluatorDataWraper that implements IEvaluatorData<> and wraps the Evaluator's instance of IEvaluatorData<> to intercept get and set property calls.

Resolves #3432 
Related to #2713

### Customer Impact

BuildXL needs to know what environment variables took part in a build to correctly generate a graph.  Without this functionality, environment variables that modify the graph will not be properly detected which will produce incorrect cache hits.

### Regression?

No

### Risk

Low risk, net new functionality which is opt-in.  Performance testing shows no impact with these changes.

### Test changes in this PR

New unit tests
