### PR TITLE
Add stub ResolveFrameworkReferences target

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2764,6 +2764,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       DependsOnTargets="ResolveComReferences" />
 
   <!--
+    ============================================================
+                                      ResolveFrameworkReferences
+
+    Overrridden by Microsoft.NET.Sdk to return
+    ResolvedFrameworkReference items in order to populate the
+    Frameworks node of the Solution Explorer in the IDE.
+  -->
+  <Target Name="ResolveFrameworkReferences" />
+  
+  <!--
     ***********************************************************************************************
     ***********************************************************************************************
                                                                 PrepareResources Section


### PR DESCRIPTION
This will enable the VS project system to call this target to populate the Frameworks node in the solution explorer.  Microsoft.NET.Sdk will override this target (see https://github.com/dotnet/sdk/pull/3355) to provide ResolvedFrameworkReference items as appropriate.