### PR TITLE
Add BeforeTargets and AfterTargets to ProjectTargetInstance

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1270,7 +1270,9 @@ namespace Microsoft.Build.Execution
     public sealed partial class ProjectTargetInstance
     {
         internal ProjectTargetInstance() { }
+        public string AfterTargets { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation AfterTargetsLocation { get { throw null; } }
+        public string BeforeTargets { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation BeforeTargetsLocation { get { throw null; } }
         public System.Collections.Generic.IList<Microsoft.Build.Execution.ProjectTargetInstanceChild> Children { get { throw null; } }
         public string Condition { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1264,7 +1264,9 @@ namespace Microsoft.Build.Execution
     public sealed partial class ProjectTargetInstance
     {
         internal ProjectTargetInstance() { }
+        public string AfterTargets { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation AfterTargetsLocation { get { throw null; } }
+        public string BeforeTargets { get { throw null; } }
         public Microsoft.Build.Construction.ElementLocation BeforeTargetsLocation { get { throw null; } }
         public System.Collections.Generic.IList<Microsoft.Build.Execution.ProjectTargetInstanceChild> Children { get { throw null; } }
         public string Condition { get { throw null; } }

--- a/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectTargetInstance_Tests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
@@ -30,6 +29,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             Assert.Equal("i", target.Inputs);
             Assert.Equal("o", target.Outputs);
             Assert.Equal("d", target.DependsOnTargets);
+            Assert.Equal("b", target.BeforeTargets);
+            Assert.Equal("a", target.AfterTargets);
             Assert.Equal("k", target.KeepDuplicateOutputs);
             Assert.Equal("r", target.Returns);
             Assert.Equal("t1", ((ProjectTaskInstance)target.Children[0]).Name);
@@ -133,7 +134,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         {
             string content = @"
                     <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
-                        <Target Name='t' Inputs='i' Outputs='o' Condition='c' DependsOnTargets='d' KeepDuplicateOutputs='k' Returns='r'>
+                        <Target Name='t' Inputs='i' Outputs='o' Condition='c' DependsOnTargets='d' BeforeTargets='b' AfterTargets='a' KeepDuplicateOutputs='k' Returns='r'>
                             <t1/>
                         </Target>
                     </Project>

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -749,6 +749,54 @@ namespace Microsoft.Build.UnitTests.OM.Instance
             }
         }
 
+        [Fact]
+        public void AddTargetAddsNewTarget()
+        {
+            string projectFileContent = @"
+                    <Project>
+                        <Target Name='a' />
+                    </Project>";
+            ProjectRootElement rootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)));
+            ProjectInstance projectInstance = new ProjectInstance(rootElement);
+
+            ProjectTargetInstance targetInstance = projectInstance.AddTarget("b", "1==1", "inputs", "outputs", "returns", "keepDuplicateOutputs", "dependsOnTargets", "beforeTargets", "afterTargets", true);
+
+            Assert.Equal(2, projectInstance.Targets.Count);
+            Assert.Equal(targetInstance, projectInstance.Targets["b"]);
+            Assert.Equal("b", targetInstance.Name);
+            Assert.Equal("1==1", targetInstance.Condition);
+            Assert.Equal("inputs", targetInstance.Inputs);
+            Assert.Equal("outputs", targetInstance.Outputs);
+            Assert.Equal("returns", targetInstance.Returns);
+            Assert.Equal("keepDuplicateOutputs", targetInstance.KeepDuplicateOutputs);
+            Assert.Equal("dependsOnTargets", targetInstance.DependsOnTargets);
+            Assert.Equal("beforeTargets", targetInstance.BeforeTargets);
+            Assert.Equal("afterTargets", targetInstance.AfterTargets);
+            Assert.Equal(projectInstance.ProjectFileLocation, targetInstance.Location);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.ConditionLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.InputsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.OutputsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.ReturnsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.KeepDuplicateOutputsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.DependsOnTargetsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.BeforeTargetsLocation);
+            Assert.Equal(ElementLocation.EmptyLocation, targetInstance.AfterTargetsLocation);
+            Assert.True(targetInstance.ParentProjectSupportsReturnsAttribute);
+        }
+
+        [Fact]
+        public void AddTargetThrowsWithExistingTarget()
+        {
+            string projectFileContent = @"
+                    <Project>
+                        <Target Name='a' />
+                    </Project>";
+            ProjectRootElement rootElement = ProjectRootElement.Create(XmlReader.Create(new StringReader(projectFileContent)));
+            ProjectInstance projectInstance = new ProjectInstance(rootElement);
+
+            Assert.Throws<InternalErrorException>(() => projectInstance.AddTarget("a", "1==1", "inputs", "outputs", "returns", "keepDuplicateOutputs", "dependsOnTargets", "beforeTargets", "afterTargets", true));
+        }
+
         /// <summary>
         /// Create a ProjectInstance from provided project content
         /// </summary>

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -1,22 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using Microsoft.Build.Execution;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Framework;
-using System.Collections;
 using System;
-using System.Diagnostics;
-using Microsoft.Build.Construction;
+using System.Collections.Generic;
 using System.IO;
-using System.Xml;
 using System.Linq;
+using System.Xml;
 using Microsoft.Build.BackEnd;
-using Microsoft.Build.Engine.UnitTests;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests.BackEnd;
-using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
+++ b/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
@@ -86,6 +86,8 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
                 Assert.Equal(x.Returns, y.Returns);
                 Assert.Equal(x.KeepDuplicateOutputs, y.KeepDuplicateOutputs);
                 Assert.Equal(x.DependsOnTargets, y.DependsOnTargets);
+                Assert.Equal(x.BeforeTargets, y.BeforeTargets);
+                Assert.Equal(x.AfterTargets, y.AfterTargets);
                 Assert.Equal(x.ParentProjectSupportsReturnsAttribute, y.ParentProjectSupportsReturnsAttribute);
                 Assert.Equal(x.Location, y.Location, new Helpers.ElementLocationComparerIgnoringType());
                 Assert.Equal(x.ConditionLocation, y.ConditionLocation, new Helpers.ElementLocationComparerIgnoringType());

--- a/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
+++ b/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
@@ -179,6 +179,8 @@ namespace Microsoft.Build.Engine.UnitTests.TestData
                 $"r{stringCounter}",
                 $"kdo{stringCounter}",
                 $"dot{stringCounter}",
+                $"bt{stringCounter}",
+                $"at{stringCounter}",
                 new MockElementLocation($"location{stringCounter}"),
                 new MockElementLocation($"conditionLocation{stringCounter}"),
                 new MockElementLocation($"inputsLocation{stringCounter}"),

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1233,7 +1233,7 @@ namespace Microsoft.Build.Construction
                 outputItemAsItem = "@(" + outputItem + ")";
             }
 
-            ProjectTargetInstance target = metaprojectInstance.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, false /* legacy target returns behaviour */);
+            ProjectTargetInstance target = metaprojectInstance.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, String.Empty, String.Empty, false /* legacy target returns behaviour */);
 
             AddReferencesBuildTask(target, targetName, null /* No need to capture output */);
 
@@ -1298,7 +1298,7 @@ namespace Microsoft.Build.Construction
             // Add a supporting target called "GetFrameworkPathAndRedistList".
             AddTargetForGetFrameworkPathAndRedistList(metaprojectInstance);
 
-            ProjectTargetInstance newTarget = metaprojectInstance.AddTarget(targetName ?? "Build", ComputeTargetConditionForWebProject(project), null, null, null, null, "GetFrameworkPathAndRedistList", false /* legacy target returns behaviour */);
+            ProjectTargetInstance newTarget = metaprojectInstance.AddTarget(targetName ?? "Build", ComputeTargetConditionForWebProject(project), null, null, null, null, "GetFrameworkPathAndRedistList", null, null, false /* legacy target returns behaviour */);
 
             // Build the references
             AddReferencesBuildTask(newTarget, targetName, null /* No need to capture output */);
@@ -1718,7 +1718,7 @@ namespace Microsoft.Build.Construction
                 return;
             }
 
-            ProjectTargetInstance frameworkPathAndRedistListTarget = metaprojectInstance.AddTarget("GetFrameworkPathAndRedistList", String.Empty, null, null, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance frameworkPathAndRedistListTarget = metaprojectInstance.AddTarget("GetFrameworkPathAndRedistList", String.Empty, null, null, null, null, null, null, null, false /* legacy target returns behaviour */);
 
             ProjectTaskInstance getFrameworkPathTask = frameworkPathAndRedistListTarget.AddTask("GetFrameworkPath", String.Empty, null);
 
@@ -1764,7 +1764,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private void AddMetaprojectTargetForUnknownProjectType(ProjectInstance traversalProject, ProjectInstance metaprojectInstance, ProjectInSolution project, string targetName, string unknownProjectTypeErrorMessage)
         {
-            ProjectTargetInstance newTarget = metaprojectInstance.AddTarget(targetName ?? "Build", "'$(CurrentSolutionConfigurationContents)' != ''", null, null, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance newTarget = metaprojectInstance.AddTarget(targetName ?? "Build", "'$(CurrentSolutionConfigurationContents)' != ''", null, null, null, null, null, null, null, false /* legacy target returns behaviour */);
 
             foreach (SolutionConfigurationInSolution solutionConfiguration in _solutionFile.SolutionConfigurations)
             {
@@ -1842,7 +1842,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private void AddValidateProjectsTarget(ProjectInstance traversalProject, List<ProjectInSolution> projects)
         {
-            ProjectTargetInstance newTarget = traversalProject.AddTarget("ValidateProjects", null, null, null, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance newTarget = traversalProject.AddTarget("ValidateProjects", null, null, null, null, null, null, null, null, false /* legacy target returns behaviour */);
 
             foreach (ProjectInSolution project in projects)
             {
@@ -1894,7 +1894,7 @@ namespace Microsoft.Build.Construction
                 outputItemAsItem = "@(" + outputItem + ")";
             }
 
-            ProjectTargetInstance target = traversalProject.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, false /* legacy target returns behaviour */);
+            ProjectTargetInstance target = traversalProject.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, String.Empty, String.Empty, false /* legacy target returns behaviour */);
             AddReferencesBuildTask(target, targetName, outputItem);
         }
 
@@ -1963,7 +1963,7 @@ namespace Microsoft.Build.Construction
                 outputItemAsItem = "@(" + outputItemName + ")";
             }
 
-            ProjectTargetInstance targetElement = traversalProject.AddTarget(actualTargetName, null, null, outputItemAsItem, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance targetElement = traversalProject.AddTarget(actualTargetName, null, null, outputItemAsItem, null, null, null, null, null, false /* legacy target returns behaviour */);
             if (canBuildDirectly)
             {
                 AddProjectBuildTask(traversalProject, projectConfiguration, targetElement, targetToBuild, "@(ProjectReference)", "'%(ProjectReference.Identity)' == '" + EscapingUtilities.Escape(project.AbsolutePath) + "'", outputItemName);
@@ -2275,7 +2275,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private void AddValidateSolutionConfigurationTarget(ProjectInstance traversalProject)
         {
-            ProjectTargetInstance initialTarget = traversalProject.AddTarget("ValidateSolutionConfiguration", null, null, null, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance initialTarget = traversalProject.AddTarget("ValidateSolutionConfiguration", null, null, null, null, null, null, null, null, false /* legacy target returns behaviour */);
 
             if (_solutionFile.SolutionConfigurations.Count > 0)
             {
@@ -2316,7 +2316,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private static void AddValidateToolsVersionsTarget(ProjectInstance traversalProject)
         {
-            ProjectTargetInstance validateToolsVersionsTarget = traversalProject.AddTarget("ValidateToolsVersions", null, null, null, null, null, null, false /* legacy target returns behaviour */);
+            ProjectTargetInstance validateToolsVersionsTarget = traversalProject.AddTarget("ValidateToolsVersions", null, null, null, null, null, null, null, null, false /* legacy target returns behaviour */);
             ProjectTaskInstance toolsVersionErrorTask = AddErrorWarningMessageInstance
                 (
                 validateToolsVersionsTarget,
@@ -2339,6 +2339,8 @@ namespace Microsoft.Build.Construction
                 returns: null,
                 keepDuplicateOutputs: null,
                 dependsOnTargets: null,
+                beforeTargets: null,
+                afterTargets: null,
                 parentProjectSupportsReturnsAttribute: false);
 
             var property = new ProjectPropertyGroupTaskPropertyInstance(

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -580,6 +580,8 @@ namespace Microsoft.Build.Evaluation
                 targetElement.Returns,
                 targetElement.KeepDuplicateOutputs,
                 targetElement.DependsOnTargets,
+                targetElement.BeforeTargets,
+                targetElement.AfterTargets,
                 targetElement.Location,
                 targetElement.ConditionLocation,
                 targetElement.InputsLocation,

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2214,7 +2214,17 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Adds the specified target to the instance.
         /// </summary>
-        internal ProjectTargetInstance AddTarget(string targetName, string condition, string inputs, string outputs, string returns, string keepDuplicateOutputs, string dependsOnTargets, bool parentProjectSupportsReturnsAttribute)
+        internal ProjectTargetInstance AddTarget(
+            string targetName,
+            string condition,
+            string inputs,
+            string outputs,
+            string returns,
+            string keepDuplicateOutputs,
+            string dependsOnTargets,
+            string beforeTargets,
+            string afterTargets,
+            bool parentProjectSupportsReturnsAttribute)
         {
             VerifyThrowNotImmutable();
 
@@ -2230,6 +2240,8 @@ namespace Microsoft.Build.Execution
                 returns, // returns may be null
                 keepDuplicateOutputs ?? String.Empty,
                 dependsOnTargets ?? String.Empty,
+                beforeTargets ?? String.Empty,
+                afterTargets ?? String.Empty,
                 _projectFileLocation,
                 String.IsNullOrEmpty(condition) ? null : ElementLocation.EmptyLocation,
                 String.IsNullOrEmpty(inputs) ? null : ElementLocation.EmptyLocation,
@@ -2237,8 +2249,8 @@ namespace Microsoft.Build.Execution
                 String.IsNullOrEmpty(returns) ? null : ElementLocation.EmptyLocation,
                 String.IsNullOrEmpty(keepDuplicateOutputs) ? null : ElementLocation.EmptyLocation,
                 String.IsNullOrEmpty(dependsOnTargets) ? null : ElementLocation.EmptyLocation,
-                null,
-                null,
+                String.IsNullOrEmpty(beforeTargets) ? null : ElementLocation.EmptyLocation,
+                String.IsNullOrEmpty(afterTargets) ? null : ElementLocation.EmptyLocation,
                 new ObjectModel.ReadOnlyCollection<ProjectTargetInstanceChild>(new List<ProjectTargetInstanceChild>()),
                 new ObjectModel.ReadOnlyCollection<ProjectOnErrorInstance>(new List<ProjectOnErrorInstance>()),
                 parentProjectSupportsReturnsAttribute

--- a/src/Build/Instance/ProjectTargetInstance.cs
+++ b/src/Build/Instance/ProjectTargetInstance.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Execution
     /// <remarks>
     /// This is an immutable class.
     /// </remarks>
-    [DebuggerDisplay("Name={_name} Count={_children.Count} Condition={_condition} Inputs={_inputs} Outputs={_outputs} DependsOnTargets={_dependsOnTargets}")]
+    [DebuggerDisplay("Name={_name} Count={_children.Count} Condition={_condition} Inputs={_inputs} Outputs={_outputs} DependsOnTargets={_dependsOnTargets} BeforeTargets={_beforeTargets} AfterTargets={_afterTargets}")]
     public sealed class ProjectTargetInstance : IImmutable, IKeyed, ITranslatable
     {
         /// <summary>
@@ -52,6 +52,16 @@ namespace Microsoft.Build.Execution
         /// Semicolon separated list of targets it depends on
         /// </summary>
         private string _dependsOnTargets;
+
+        /// <summary>
+        /// Semicolon separated list of targets it runs before
+        /// </summary>
+        private string _beforeTargets;
+
+        /// <summary>
+        /// Semicolon separated list of targets it runs after
+        /// </summary>
+        private string _afterTargets;
 
         /// <summary>
         /// Condition for whether to trim duplicate outputs
@@ -136,6 +146,8 @@ namespace Microsoft.Build.Execution
             string returns,
             string keepDuplicateOutputs,
             string dependsOnTargets,
+            string beforeTargets,
+            string afterTargets,
             ElementLocation location,
             ElementLocation conditionLocation,
             ElementLocation inputsLocation,
@@ -156,6 +168,8 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowInternalNull(outputs, "outputs");
             ErrorUtilities.VerifyThrowInternalNull(keepDuplicateOutputs, "keepDuplicateOutputs");
             ErrorUtilities.VerifyThrowInternalNull(dependsOnTargets, "dependsOnTargets");
+            ErrorUtilities.VerifyThrowInternalNull(beforeTargets, "beforeTargets");
+            ErrorUtilities.VerifyThrowInternalNull(afterTargets, "afterTargets");
             ErrorUtilities.VerifyThrowInternalNull(location, "location");
             ErrorUtilities.VerifyThrowInternalNull(children, "children");
             ErrorUtilities.VerifyThrowInternalNull(onErrorChildren, "onErrorChildren");
@@ -167,6 +181,8 @@ namespace Microsoft.Build.Execution
             _returns = returns;
             _keepDuplicateOutputs = keepDuplicateOutputs;
             _dependsOnTargets = dependsOnTargets;
+            _beforeTargets = beforeTargets;
+            _afterTargets = afterTargets;
             _location = location;
             _conditionLocation = conditionLocation;
             _inputsLocation = inputsLocation;
@@ -259,6 +275,28 @@ namespace Microsoft.Build.Execution
             [DebuggerStepThrough]
             get
             { return _dependsOnTargets; }
+        }
+
+        /// <summary>
+        /// Unevaluated semicolon separated list of targets it runs before.
+        /// May be empty string.
+        /// </summary>
+        public string BeforeTargets
+        {
+            [DebuggerStepThrough]
+            get
+            { return _beforeTargets; }
+        }
+
+        /// <summary>
+        /// Unevaluated semicolon separated list of targets it runs after.
+        /// May be empty string.
+        /// </summary>
+        public string AfterTargets
+        {
+            [DebuggerStepThrough]
+            get
+            { return _afterTargets; }
         }
 
         /// <summary>
@@ -520,6 +558,8 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _returns);
             translator.Translate(ref _keepDuplicateOutputs);
             translator.Translate(ref _dependsOnTargets);
+            translator.Translate(ref _beforeTargets);
+            translator.Translate(ref _afterTargets);
             translator.Translate(ref _location, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _conditionLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _inputsLocation, ElementLocation.FactoryForDeserialization);


### PR DESCRIPTION
`DependsOnTargets` is already exposed through `ProjectTargetInstance`, so this should be fairly non-controversial, I hope :).

The motivation here is that for consumers of the MSBuild API, like [MSBuildPrediction](https://github.com/microsoft/MSBuildPrediction), are forced to use `Project` instead of `ProjectInstance` to get the values of `BeforeTargets` and `AfterTargets` (via `ProjectTargetElement`). This helps alleviate the need for `Project` in those scenarios.