### PR TITLE
VS Setup authoring for System.Resource.Extensions

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -28,6 +28,7 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
+    <PackageReference Update="System.Memory" Version="4.5.2" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -28,7 +28,7 @@
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
     <PackageReference Update="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Update="System.Linq.Parallel" Version="4.0.1" />
-    <PackageReference Update="System.Memory" Version="4.5.2" />
+    <PackageReference Update="System.Memory" Version="4.5.3" />
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -33,6 +33,7 @@
 
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
+    <PackageReference Include="System.Memory" />
 
     <PackageReference Include="System.Reflection.Metadata" Condition="'$(MonoBuild)' == 'true'" />
   </ItemGroup>

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -30,6 +30,7 @@
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Resources.Extensions.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
 
@@ -74,6 +75,7 @@
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Resources.Extensions.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
 

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -28,6 +28,9 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin" />
+    <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/MSBuild" />
@@ -69,6 +72,9 @@
     <file src="$X86BinPath$/Microsoft.Build.Tasks.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Build.Utilities.Core.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Collections.Immutable.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Memory.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Numerics.Vectors.dll" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/System.Runtime.CompilerServices.Unsafe.dll" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/System.Threading.Tasks.Dataflow.dll" target="v15.0/bin/amd64" />
 
     <file src="$X86BinPath$/Microsoft.Build.Core.xsd" target="v15.0/bin/amd64/MSBuild" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -26,6 +26,10 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
+  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
@@ -161,6 +165,10 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -29,6 +29,7 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
@@ -168,6 +169,7 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Memory.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all


### PR DESCRIPTION
S.Resources.Extensions depends on System.Memory, so I've ripped off @BenVillalobos's S.Memory setup authoring work from #4394, but not the part that actually uses Span.

I did update to 4.5.3 to match the dependency from S.Resource.Extensions.

The actual new dependency was added in the same way.