### PR TITLE
Add SimpleProjectRootElementCache

### DIFF
--- a/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
@@ -14,18 +14,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
             collectionWithDefaultCache.ProjectRootElementCache.ShouldBeOfType<ProjectRootElementCache>();
 
             const string envKey = "MsBuildUseSimpleProjectRootElementCacheConcurrency";
-            string originalEnvVar = Environment.GetEnvironmentVariable(envKey);
 
-            try
+            using (TestEnvironment env = TestEnvironment.Create())
             {
-                Environment.SetEnvironmentVariable(envKey, "true");
-
+                env.SetEnvironmentVariable(envKey, "true");
                 var collectionWithSimpleCache = new ProjectCollection();
                 collectionWithSimpleCache.ProjectRootElementCache.ShouldBeOfType<SimpleProjectRootElementCache>();
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(envKey, originalEnvVar);
             }
         }
     }

--- a/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Build.Evaluation;
+﻿using Microsoft.Build.Evaluation;
 using Shouldly;
 using Xunit;
 

--- a/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectCollection_Tests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.Build.Evaluation;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    public class ProjectCollection_Tests
+    {
+        [Fact]
+        public void ProjectRootElementCache_IsDeterminedByEnvironmentVariable()
+        {
+            var collectionWithDefaultCache = new ProjectCollection();
+            collectionWithDefaultCache.ProjectRootElementCache.ShouldBeOfType<ProjectRootElementCache>();
+
+            const string envKey = "MsBuildUseSimpleProjectRootElementCacheConcurrency";
+            string originalEnvVar = Environment.GetEnvironmentVariable(envKey);
+
+            try
+            {
+                Environment.SetEnvironmentVariable(envKey, "true");
+
+                var collectionWithSimpleCache = new ProjectCollection();
+                collectionWithSimpleCache.ProjectRootElementCache.ShouldBeOfType<SimpleProjectRootElementCache>();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envKey, originalEnvVar);
+            }
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectRootElementCache_Tests.cs
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using Microsoft.Build.Execution;
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Collections;
-using Microsoft.Build.Framework;
-using System.Collections;
 using System;
 using System.IO;
 

--- a/src/Build.UnitTests/Evaluation/SimpleProjectRootElementCache_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SimpleProjectRootElementCache_Tests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests.Evaluation
+{
+    public class SimpleProjectRootElementCache_Tests : IDisposable
+    {
+        public SimpleProjectRootElementCache_Tests()
+        {
+            // Empty the cache
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+        }
+
+        public void Dispose()
+        {
+            // Empty the cache
+            ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+        }
+
+        [Fact]
+        public void Get_GivenCachedProjectFile_ReturnsRootElement()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string projectFileToCache = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFileToCache);
+
+            var cache = new SimpleProjectRootElementCache();
+            cache.AddEntry(rootElementToCache);
+
+            ProjectRootElement actualRootElement = cache.Get(projectFile, null, false, null);
+            actualRootElement.ShouldBe(rootElementToCache);
+        }
+
+        [Fact]
+        public void Get_GivenCachedProjectFileWithDifferentCasing_ReturnsRootElement()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string projectFileToCache = NativeMethodsShared.IsUnixLike ? "/Foo" : "c:\\Foo";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFileToCache);
+
+            var cache = new SimpleProjectRootElementCache();
+            cache.AddEntry(rootElementToCache);
+
+            ProjectRootElement actualRootElement = cache.Get(projectFile, null, false, null);
+            actualRootElement.ShouldBe(rootElementToCache);
+        }
+
+        [Fact]
+        public void Get_GivenOpenFuncWhichAddsRootElement_ReturnsRootElement()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string projectFileToCache = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFileToCache);
+            ProjectRootElement OpenFunc(string pathArg, ProjectRootElementCacheBase cacheArg)
+            {
+                cacheArg.AddEntry(rootElementToCache);
+                return rootElementToCache;
+            }
+
+            var cache = new SimpleProjectRootElementCache();
+            cache.AddEntry(rootElementToCache);
+
+            ProjectRootElement actualRootElement = cache.Get(projectFile, OpenFunc, false, null);
+            actualRootElement.ShouldBe(rootElementToCache);
+        }
+
+        [Fact]
+        public void Get_GivenOpenFuncWhichAddsRootElementWithDifferentCasing_ReturnsRootElement()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string projectFileToCache = NativeMethodsShared.IsUnixLike ? "/Foo" : "c:\\Foo";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFileToCache);
+            ProjectRootElement OpenFunc(string pathArg, ProjectRootElementCacheBase cacheArg)
+            {
+                cacheArg.AddEntry(rootElementToCache);
+                return rootElementToCache;
+            }
+
+            var cache = new SimpleProjectRootElementCache();
+            cache.AddEntry(rootElementToCache);
+
+            ProjectRootElement actualRootElement = cache.Get(projectFile, OpenFunc, false, null);
+            actualRootElement.ShouldBe(rootElementToCache);
+        }
+
+        [Fact]
+        public void Get_GivenOpenFuncWhichReturnsNull_ThrowsInternalErrorException()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            ProjectRootElement OpenFunc(string pathArg, ProjectRootElementCacheBase cacheArg) => null;
+
+            var cache = new SimpleProjectRootElementCache();
+
+            Should.Throw<InternalErrorException>(() =>
+            {
+                cache.Get(projectFile, OpenFunc, false, null);
+            });
+        }
+
+        [Fact]
+        public void Get_GivenOpenFuncWhichReturnsIncorrectProject_ThrowsInternalErrorException()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string projectFileToCache = NativeMethodsShared.IsUnixLike ? "/bar" : "c:\\bar";
+            ProjectRootElement rootElementToCache = ProjectRootElement.Create(projectFileToCache);
+            ProjectRootElement OpenFunc(string pathArg, ProjectRootElementCacheBase cacheArg)
+            {
+                cacheArg.AddEntry(rootElementToCache);
+                return rootElementToCache;
+            }
+
+            var cache = new SimpleProjectRootElementCache();
+
+            Should.Throw<InternalErrorException>(() =>
+            {
+                cache.Get(projectFile, OpenFunc, false, null);
+            });
+        }
+
+        [Fact]
+        public void Get_GivenOpenFuncWhichDoesNotAddToCache_ThrowsInternalErrorException()
+        {
+            string projectFile = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            string openFuncPath = NativeMethodsShared.IsUnixLike ? "/foo" : "c:\\foo";
+            ProjectRootElement openFuncElement = ProjectRootElement.Create(openFuncPath);
+            ProjectRootElement OpenFunc(string pathArg, ProjectRootElementCacheBase cacheArg) => openFuncElement;
+
+            var cache = new SimpleProjectRootElementCache();
+
+            Should.Throw<InternalErrorException>(() =>
+            {
+                cache.Get(projectFile, OpenFunc, false, null);
+            });
+        }
+    }
+}

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -704,7 +704,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The one and only project root element cache to be used for the build.
         /// </summary>
-        internal ProjectRootElementCache ProjectRootElementCache { get; set; }
+        internal ProjectRootElementCacheBase ProjectRootElementCache { get; set; }
 
 #if FEATURE_APPDOMAIN
         /// <summary>
@@ -882,7 +882,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Centralization of the common parts of construction.
         /// </summary>
-        private void Initialize(PropertyDictionary<ProjectPropertyInstance> environmentProperties, ProjectRootElementCache projectRootElementCache, ToolsetProvider toolsetProvider)
+        private void Initialize(PropertyDictionary<ProjectPropertyInstance> environmentProperties, ProjectRootElementCacheBase projectRootElementCache, ToolsetProvider toolsetProvider)
         {
             _buildProcessEnvironment = CommunicationsUtilities.GetEnvironmentVariables();
             _environmentProperties = environmentProperties;

--- a/src/Build/BackEnd/BuildManager/BuildRequestData.cs
+++ b/src/Build/BackEnd/BuildManager/BuildRequestData.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Build.Execution
         IgnoreExistingProjectState = 1 << 2,
 
         /// <summary>
-        /// When this flag is present, caches including the <see cref="ProjectRootElementCache"/> will be cleared
+        /// When this flag is present, caches including the <see cref="ProjectRootElementCacheBase"/> will be cleared
         /// after the build request completes.  This is used when the build request is known to modify a lot of
         /// state such as restoring packages or generating parts of the import graph.
         /// </summary>

--- a/src/Build/BackEnd/Node/OutOfProcNode.cs
+++ b/src/Build/BackEnd/Node/OutOfProcNode.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Execution
         /// The one and only project root element cache to be used for the build
         /// on this out of proc node.
         /// </summary>
-        private static ProjectRootElementCache s_projectRootElementCache;
+        private static ProjectRootElementCacheBase s_projectRootElementCacheBase;
 
         /// <summary>
         /// The endpoint used to talk to the host.
@@ -166,9 +166,9 @@ namespace Microsoft.Build.Execution
 
             _sdkResolverService = (this as IBuildComponentHost).GetComponent(BuildComponentType.SdkResolverService) as ISdkResolverService;
             
-            if (s_projectRootElementCache == null)
+            if (s_projectRootElementCacheBase == null)
             {
-                s_projectRootElementCache = new ProjectRootElementCache(true /* automatically reload any changes from disk */);
+                s_projectRootElementCacheBase = new ProjectRootElementCache(true /* automatically reload any changes from disk */);
             }
 
             _buildRequestEngine.OnEngineException += OnEngineException;
@@ -526,7 +526,7 @@ namespace Microsoft.Build.Execution
                 // Optionally clear out the cache. This has the advantage of releasing memory,
                 // but the disadvantage of causing the next build to repeat the load and parse.
                 // We'll experiment here and ship with the best default.
-                s_projectRootElementCache = null;
+                s_projectRootElementCacheBase = null;
             }
 
             // Since we aren't going to be doing any more work, lets clean up all our memory usage.
@@ -639,7 +639,7 @@ namespace Microsoft.Build.Execution
             // Grab the system parameters.
             _buildParameters = configuration.BuildParameters;
 
-            _buildParameters.ProjectRootElementCache = s_projectRootElementCache;
+            _buildParameters.ProjectRootElementCache = s_projectRootElementCacheBase;
 
             // Snapshot the current environment
             _savedEnvironment = CommunicationsUtilities.GetEnvironmentVariables();

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// The singleton delegate that loads projects into the ProjectRootElement
         /// </summary>
-        private static readonly ProjectRootElementCache.OpenProjectRootElement s_openLoaderDelegate = OpenLoader;
+        private static readonly ProjectRootElementCacheBase.OpenProjectRootElement s_openLoaderDelegate = OpenLoader;
 
-        private static readonly ProjectRootElementCache.OpenProjectRootElement s_openLoaderPreserveFormattingDelegate = OpenLoaderPreserveFormatting;
+        private static readonly ProjectRootElementCacheBase.OpenProjectRootElement s_openLoaderPreserveFormattingDelegate = OpenLoaderPreserveFormatting;
 
         /// <summary>
         /// Used to determine if a file is an empty XML file if it ONLY contains an XML declaration like &lt;?xml version="1.0" encoding="utf-8"?&gt;.
@@ -145,7 +145,7 @@ namespace Microsoft.Build.Construction
         /// Leaves the project dirty, indicating there are unsaved changes.
         /// Used to create a root element for solutions loaded by the 3.5 version of the solution wrapper.
         /// </summary>
-        internal ProjectRootElement(XmlReader xmlReader, ProjectRootElementCache projectRootElementCache, bool isExplicitlyLoaded,
+        internal ProjectRootElement(XmlReader xmlReader, ProjectRootElementCacheBase projectRootElementCache, bool isExplicitlyLoaded,
             bool preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentNull(xmlReader, nameof(xmlReader));
@@ -165,7 +165,7 @@ namespace Microsoft.Build.Construction
         /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
         /// Leaves the project dirty, indicating there are unsaved changes.
         /// </summary>
-        private ProjectRootElement(ProjectRootElementCache projectRootElementCache, NewProjectFileOptions projectFileOptions)
+        private ProjectRootElement(ProjectRootElementCacheBase projectRootElementCache, NewProjectFileOptions projectFileOptions)
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
 
@@ -194,7 +194,7 @@ namespace Microsoft.Build.Construction
         /// Assumes path is already normalized.
         /// May throw InvalidProjectFileException.
         /// </summary>
-        private ProjectRootElement(string path, ProjectRootElementCache projectRootElementCache,
+        private ProjectRootElement(string path, ProjectRootElementCacheBase projectRootElementCache,
             bool preserveFormatting)
         {
             ErrorUtilities.VerifyThrowArgumentLength(path, nameof(path));
@@ -221,7 +221,7 @@ namespace Microsoft.Build.Construction
         /// <remarks>
         /// Do not make public: we do not wish to expose particular XML API's.
         /// </remarks>
-        private ProjectRootElement(XmlDocumentWithLocation document, ProjectRootElementCache projectRootElementCache)
+        private ProjectRootElement(XmlDocumentWithLocation document, ProjectRootElementCacheBase  projectRootElementCache)
         {
             ErrorUtilities.VerifyThrowArgumentNull(document, nameof(document));
             ErrorUtilities.VerifyThrowArgumentNull(projectRootElementCache, nameof(projectRootElementCache));
@@ -661,7 +661,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Retrieves the root element cache with which this root element is associated.
         /// </summary>
-        internal ProjectRootElementCache ProjectRootElementCache { get; }
+        internal ProjectRootElementCacheBase ProjectRootElementCache { get; }
 
         /// <summary>
         /// Gets a value indicating whether this PRE is known by its containing collection.
@@ -1661,12 +1661,12 @@ namespace Microsoft.Build.Construction
         /// Initialize an in-memory, empty ProjectRootElement instance that can be saved later.
         /// Uses the specified project root element cache.
         /// </summary>
-        internal static ProjectRootElement Create(ProjectRootElementCache projectRootElementCache)
+        internal static ProjectRootElement Create(ProjectRootElementCacheBase projectRootElementCache)
         {
             return new ProjectRootElement(projectRootElementCache, Project.DefaultNewProjectTemplateOptions);
         }
 
-        internal static ProjectRootElement Create(ProjectRootElementCache projectRootElementCache, NewProjectFileOptions projectFileOptions)
+        internal static ProjectRootElement Create(ProjectRootElementCacheBase projectRootElementCache, NewProjectFileOptions projectFileOptions)
         {
             return new ProjectRootElement(projectRootElementCache, projectFileOptions);
         }
@@ -1677,7 +1677,7 @@ namespace Microsoft.Build.Construction
         /// Uses the specified project root element cache.
         /// May throw InvalidProjectFileException.
         /// </summary>
-        internal static ProjectRootElement Open(string path, ProjectRootElementCache projectRootElementCache, bool isExplicitlyLoaded,
+        internal static ProjectRootElement Open(string path, ProjectRootElementCacheBase projectRootElementCache, bool isExplicitlyLoaded,
             bool? preserveFormatting)
         {
             ErrorUtilities.VerifyThrowInternalRooted(path);
@@ -1710,7 +1710,7 @@ namespace Microsoft.Build.Construction
         /// Path provided must be a canonicalized full path.
         /// May throw InvalidProjectFileException or an IO-related exception.
         /// </summary>
-        internal static ProjectRootElement OpenProjectOrSolution(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion, ProjectRootElementCache projectRootElementCache, bool isExplicitlyLoaded)
+        internal static ProjectRootElement OpenProjectOrSolution(string fullPath, IDictionary<string, string> globalProperties, string toolsVersion, ProjectRootElementCacheBase projectRootElementCache, bool isExplicitlyLoaded)
         {
             ErrorUtilities.VerifyThrowInternalRooted(fullPath);
 
@@ -1774,7 +1774,7 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Bubbles a Project dirty notification up to the ProjectRootElementCache and ultimately to the ProjectCollection.
+        /// Bubbles a Project dirty notification up to the ProjectRootElementCacheBase and ultimately to the ProjectCollection.
         /// </summary>
         /// <param name="project">The dirtied project.</param>
         internal void MarkProjectDirty(Project project)
@@ -1915,17 +1915,17 @@ namespace Microsoft.Build.Construction
         /// </summary>
         /// <param name="path">The path to the file to load.</param>
         /// <param name="projectRootElementCache">The cache to load the PRE into.</param>
-        private static ProjectRootElement OpenLoader(string path, ProjectRootElementCache projectRootElementCache)
+        private static ProjectRootElement OpenLoader(string path, ProjectRootElementCacheBase projectRootElementCache)
         {
             return OpenLoader(path, projectRootElementCache, preserveFormatting: false);
         }
 
-        private static ProjectRootElement OpenLoaderPreserveFormatting(string path, ProjectRootElementCache projectRootElementCache)
+        private static ProjectRootElement OpenLoaderPreserveFormatting(string path, ProjectRootElementCacheBase projectRootElementCache)
         {
             return OpenLoader(path, projectRootElementCache, preserveFormatting: true);
         }
 
-        private static ProjectRootElement OpenLoader(string path, ProjectRootElementCache projectRootElementCache, bool preserveFormatting)
+        private static ProjectRootElement OpenLoader(string path, ProjectRootElementCacheBase projectRootElementCache, bool preserveFormatting)
         {
             return new ProjectRootElement(
                 path,
@@ -1943,7 +1943,7 @@ namespace Microsoft.Build.Construction
         private static ProjectRootElement CreateProjectFromPath
             (
                 string projectFile,
-                ProjectRootElementCache projectRootElementCache,
+                ProjectRootElementCacheBase projectRootElementCache,
                 bool preserveFormatting
             )
         {

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -18,7 +18,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Internal;
-
+using Microsoft.Build.Utilities;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 using ILoggingService = Microsoft.Build.BackEnd.Logging.ILoggingService;
 using InternalLoggerException = Microsoft.Build.Exceptions.InternalLoggerException;
@@ -921,7 +921,7 @@ namespace Microsoft.Build.Evaluation
         /// - So that the owner of this project collection can force the XML to be loaded again
         /// from disk, by doing <see cref="UnloadAllProjects"/>.
         /// </summary>
-        internal ProjectRootElementCache ProjectRootElementCache { get; }
+        internal ProjectRootElementCacheBase ProjectRootElementCache { get; }
 
         /// <summary>
         /// Escape a string using MSBuild escaping format. For example, "%3b" for ";".
@@ -1591,7 +1591,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Handler which is called when a project is added to the RootElementCache of this project collection. We then fire an event indicating that a project was added to the collection itself.
         /// </summary>
-        private void ProjectRootElementCache_ProjectRootElementAddedHandler(object sender, ProjectRootElementCache.ProjectRootElementCacheAddEntryEventArgs e)
+        private void ProjectRootElementCache_ProjectRootElementAddedHandler(object sender, ProjectRootElementCacheAddEntryEventArgs e)
         {
             ProjectAdded?.Invoke(this, new ProjectAddedToProjectCollectionEventArgs(e.RootElement));
         }

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -309,7 +309,15 @@ namespace Microsoft.Build.Evaluation
             _loadedProjects = new LoadedProjectCollection();
             ToolsetLocations = toolsetDefinitionLocations;
             MaxNodeCount = maxNodeCount;
-            ProjectRootElementCache = new ProjectRootElementCache(false /* do not automatically reload changed files from disk */, loadProjectsReadOnly);
+
+            if (Traits.Instance.UseSimpleProjectRootElementCacheConcurrency)
+            {
+                ProjectRootElementCache = new SimpleProjectRootElementCache();
+            }
+            else
+            {
+                ProjectRootElementCache = new ProjectRootElementCache(false /* do not automatically reload changed files from disk */, loadProjectsReadOnly);
+            }
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
 
             try

--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -316,7 +316,7 @@ namespace Microsoft.Build.Evaluation
             }
             else
             {
-                ProjectRootElementCache = new ProjectRootElementCache(false /* do not automatically reload changed files from disk */, loadProjectsReadOnly);
+                ProjectRootElementCache = new ProjectRootElementCache(autoReloadFromDisk: false, loadProjectsReadOnly);
             }
             OnlyLogCriticalEvents = onlyLogCriticalEvents;
 

--- a/src/Build/Definition/Toolset.cs
+++ b/src/Build/Definition/Toolset.cs
@@ -841,7 +841,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="buildEventContext">The build event context used to log during task registration.</param>
         /// <param name="projectRootElementCache">The <see cref="ProjectRootElementCache"/> to use.</param>
         /// <returns>The task registry</returns>
-        internal TaskRegistry GetTaskRegistry(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCache projectRootElementCache)
+        internal TaskRegistry GetTaskRegistry(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCacheBase projectRootElementCache)
         {
             RegisterDefaultTasks(loggingServices, buildEventContext, projectRootElementCache);
             return _defaultTaskRegistry;
@@ -869,7 +869,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="buildEventContext">The build event context used to log during task registration.</param>
         /// <param name="projectRootElementCache">The <see cref="ProjectRootElementCache"/> to use.</param>
         /// <returns>The task registry</returns>
-        internal TaskRegistry GetOverrideTaskRegistry(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCache projectRootElementCache)
+        internal TaskRegistry GetOverrideTaskRegistry(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCacheBase projectRootElementCache)
         {
             RegisterOverrideTasks(loggingServices, buildEventContext, projectRootElementCache);
             return _overrideTaskRegistry;
@@ -889,7 +889,7 @@ namespace Microsoft.Build.Evaluation
         /// <param name="loggingServices">The logging services to use to log during this registration.</param>
         /// <param name="buildEventContext">The build event context to use to log during this registration.</param>
         /// <param name="projectRootElementCache">The <see cref="ProjectRootElementCache"/> to use.</param>
-        private void RegisterDefaultTasks(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCache projectRootElementCache)
+        private void RegisterDefaultTasks(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCacheBase projectRootElementCache)
         {
             if (!_defaultTasksRegistrationAttempted)
             {
@@ -986,7 +986,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Used to load information about MSBuild override tasks i.e. tasks that override tasks declared in tasks or project files.
         /// </summary>
-        private void RegisterOverrideTasks(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCache projectRootElementCache)
+        private void RegisterOverrideTasks(ILoggingService loggingServices, BuildEventContext buildEventContext, ProjectRootElementCacheBase projectRootElementCache)
         {
             if (!_overrideTasksRegistrationAttempted)
             {
@@ -1044,7 +1044,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Do the actual loading of the tasks or override tasks file and register the tasks in the task registry
         /// </summary>
-        private void LoadAndRegisterFromTasksFile(string searchPath, string[] defaultTaskFiles, ILoggingService loggingServices, BuildEventContext buildEventContext, string defaultTasksFilePattern, string taskFileError, ProjectRootElementCache projectRootElementCache, TaskRegistry registry)
+        private void LoadAndRegisterFromTasksFile(string searchPath, string[] defaultTaskFiles, ILoggingService loggingServices, BuildEventContext buildEventContext, string defaultTasksFilePattern, string taskFileError, ProjectRootElementCacheBase projectRootElementCache, TaskRegistry registry)
         {
             foreach (string defaultTasksFile in defaultTaskFiles)
             {

--- a/src/Build/Evaluation/ConditionEvaluator.cs
+++ b/src/Build/Evaluation/ConditionEvaluator.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Build.Evaluation
             ILoggingService loggingServices,
             BuildEventContext buildEventContext,
             IFileSystem fileSystem,
-            ProjectRootElementCache projectRootElementCache = null)
+            ProjectRootElementCacheBase projectRootElementCache = null)
             where P : class, IProperty
             where I : class, IItem
         {
@@ -217,7 +217,7 @@ namespace Microsoft.Build.Evaluation
             ILoggingService loggingServices,
             BuildEventContext buildEventContext,
             IFileSystem fileSystem,
-            ProjectRootElementCache projectRootElementCache = null
+            ProjectRootElementCacheBase projectRootElementCache = null
         )
             where P : class, IProperty
             where I : class, IItem
@@ -367,7 +367,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             ///     PRE cache
             /// </summary>
-            ProjectRootElementCache LoadedProjectsCache { get; }
+            ProjectRootElementCacheBase LoadedProjectsCache { get; }
 
             IFileSystem FileSystem { get; }
         }
@@ -406,7 +406,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// PRE collection. 
             /// </summary>
-            public ProjectRootElementCache LoadedProjectsCache { get; }
+            public ProjectRootElementCacheBase LoadedProjectsCache { get; }
 
             internal ConditionEvaluationState
                 (
@@ -417,7 +417,7 @@ namespace Microsoft.Build.Evaluation
                 string evaluationDirectory,
                 ElementLocation elementLocation,
                 IFileSystem fileSystem,
-                ProjectRootElementCache projectRootElementCache = null
+                ProjectRootElementCacheBase projectRootElementCache = null
                 )
             {
                 ErrorUtilities.VerifyThrowArgumentNull(condition, "condition");

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// The cache to consult for any imports that need loading.
         /// </summary>
-        private readonly ProjectRootElementCache _projectRootElementCache;
+        private readonly ProjectRootElementCacheBase _projectRootElementCache;
 
         /// <summary>
         /// The logging context to be used and piped down throughout evaluation
@@ -196,7 +196,7 @@ namespace Microsoft.Build.Evaluation
             PropertyDictionary<ProjectPropertyInstance> environmentProperties,
             IItemFactory<I, I> itemFactory,
             IToolsetProvider toolsetProvider,
-            ProjectRootElementCache projectRootElementCache,
+            ProjectRootElementCacheBase projectRootElementCache,
             ISdkResolverService sdkResolverService,
             int submissionId,
             EvaluationContext evaluationContext,
@@ -273,7 +273,7 @@ namespace Microsoft.Build.Evaluation
             ILoggingService loggingService,
             IItemFactory<I, I> itemFactory,
             IToolsetProvider toolsetProvider,
-            ProjectRootElementCache projectRootElementCache,
+            ProjectRootElementCacheBase projectRootElementCache,
             BuildEventContext buildEventContext,
             ISdkResolverService sdkResolverService,
             int submissionId,
@@ -2524,7 +2524,7 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCache projectRootElementCache = null)
+        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCacheBase projectRootElementCache = null)
         {
             return EvaluateConditionCollectingConditionedProperties(element, element.Condition, expanderOptions, parserOptions, projectRootElementCache);
         }
@@ -2532,7 +2532,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Evaluate a given condition, collecting conditioned properties.
         /// </summary>
-        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, string condition, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCache projectRootElementCache = null)
+        private bool EvaluateConditionCollectingConditionedProperties(ProjectElement element, string condition, ExpanderOptions expanderOptions, ParserOptions parserOptions, ProjectRootElementCacheBase projectRootElementCache = null)
         {
             if (condition.Length == 0)
             {

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Construction;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal abstract class ProjectRootElementCacheBase
+    {
+        public bool LoadProjectsReadOnly { get; protected set; }
+
+        /// <summary>
+        /// Handler for which project root element just got added to the cache
+        /// </summary>
+        internal delegate void ProjectRootElementCacheAddEntryHandler(object sender, ProjectRootElementCacheAddEntryEventArgs e);
+
+        /// <summary>
+        /// Delegate for StrongCacheEntryRemoved event
+        /// </summary>
+        internal delegate void StrongCacheEntryRemovedDelegate(object sender, ProjectRootElement projectRootElement);
+
+        /// <summary>
+        /// Callback to create a ProjectRootElement if need be
+        /// </summary>
+        internal delegate ProjectRootElement OpenProjectRootElement(string path, ProjectRootElementCacheBase cache);
+
+        /// <summary>
+        /// Event that is fired when an entry in the Strong Cache is removed.
+        /// </summary>
+        internal static event StrongCacheEntryRemovedDelegate StrongCacheEntryRemoved;
+
+        /// <summary>
+        /// Event which is fired when a project root element is added to this cache.
+        /// </summary>
+        internal event ProjectRootElementCacheAddEntryHandler ProjectRootElementAddedHandler;
+
+        /// <summary>
+        /// Event which is fired when a project root element in this cache is dirtied.
+        /// </summary>
+        internal event EventHandler<ProjectXmlChangedEventArgs> ProjectRootElementDirtied;
+
+        /// <summary>
+        /// Event which is fired when a project is marked dirty.
+        /// </summary>
+        internal event EventHandler<ProjectChangedEventArgs> ProjectDirtied;
+
+        internal abstract ProjectRootElement Get(string projectFile, OpenProjectRootElement openProjectRootElement,
+            bool isExplicitlyLoaded,
+            bool? preserveFormatting);
+
+        internal abstract void AddEntry(ProjectRootElement projectRootElement);
+
+        internal abstract void RenameEntry(string oldFullPath, ProjectRootElement projectRootElement);
+
+        internal abstract ProjectRootElement TryGet(string projectFile);
+
+        internal abstract ProjectRootElement TryGet(string projectFile, bool? preserveFormatting);
+
+        internal abstract void DiscardStrongReferences();
+
+        internal abstract void Clear();
+
+        internal abstract void DiscardImplicitReferences();
+
+        internal abstract void DiscardAnyWeakReference(ProjectRootElement projectRootElement);
+
+        /// <summary>
+        /// Raises the <see cref="ProjectRootElementDirtied"/> event.
+        /// </summary>
+        /// <param name="sender">The dirtied project root element.</param>
+        /// <param name="e">Details on the PRE and the nature of the change.</param>
+        internal void OnProjectRootElementDirtied(ProjectRootElement sender, ProjectXmlChangedEventArgs e)
+        {
+            var cacheDirtied = ProjectRootElementDirtied;
+            cacheDirtied?.Invoke(sender, e);
+        }
+
+        /// <summary>
+        /// Raises the <see cref="ProjectDirtied"/> event.
+        /// </summary>
+        /// <param name="sender">The dirtied project.</param>
+        /// <param name="e">Details on the Project and the change.</param>
+        internal void OnProjectDirtied(Project sender, ProjectChangedEventArgs e)
+        {
+            var projectDirtied = ProjectDirtied;
+            projectDirtied?.Invoke(sender, e);
+        }
+
+        /// <summary>
+        /// Raises an event which is raised when a project root element is added to the cache.
+        /// </summary>
+        protected void RaiseProjectRootElementAddedToCacheEvent(ProjectRootElement rootElement)
+        {
+            ProjectRootElementAddedHandler?.Invoke(this, new ProjectRootElementCacheAddEntryEventArgs(rootElement));
+        }
+
+        /// <summary>
+        /// Raises an event which is raised when a project root element is removed from the strong cache.
+        /// </summary>
+        protected void RaiseProjectRootElementRemovedFromStrongCache(ProjectRootElement projectRootElement)
+        {
+            StrongCacheEntryRemovedDelegate removedEvent = StrongCacheEntryRemoved;
+            removedEvent?.Invoke(this, projectRootElement);
+        }
+    }
+
+    /// <summary>
+    /// This class is an event that holds which ProjectRootElement was added to the root element cache.
+    /// </summary>
+    internal class ProjectRootElementCacheAddEntryEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Takes the root element which was added to the results cache.
+        /// </summary>
+        internal ProjectRootElementCacheAddEntryEventArgs(ProjectRootElement element)
+        {
+            RootElement = element;
+        }
+
+        /// <summary>
+        /// Root element which was just added to the cache.
+        /// </summary>
+        internal readonly ProjectRootElement RootElement;
+    }
+}

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="sender">The dirtied project root element.</param>
         /// <param name="e">Details on the PRE and the nature of the change.</param>
-        internal void OnProjectRootElementDirtied(ProjectRootElement sender, ProjectXmlChangedEventArgs e)
+        internal virtual void OnProjectRootElementDirtied(ProjectRootElement sender, ProjectXmlChangedEventArgs e)
         {
             var cacheDirtied = ProjectRootElementDirtied;
             cacheDirtied?.Invoke(sender, e);
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         /// <param name="sender">The dirtied project.</param>
         /// <param name="e">Details on the Project and the change.</param>
-        internal void OnProjectDirtied(Project sender, ProjectChangedEventArgs e)
+        internal virtual void OnProjectDirtied(Project sender, ProjectChangedEventArgs e)
         {
             var projectDirtied = ProjectDirtied;
             projectDirtied?.Invoke(sender, e);

--- a/src/Build/Evaluation/ProjectRootElementCacheBase.cs
+++ b/src/Build/Evaluation/ProjectRootElementCacheBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -98,7 +98,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Raises an event which is raised when a project root element is removed from the strong cache.
         /// </summary>
-        protected void RaiseProjectRootElementRemovedFromStrongCache(ProjectRootElement projectRootElement)
+        protected virtual void RaiseProjectRootElementRemovedFromStrongCache(ProjectRootElement projectRootElement)
         {
             StrongCacheEntryRemovedDelegate removedEvent = StrongCacheEntryRemoved;
             removedEvent?.Invoke(this, projectRootElement);

--- a/src/Build/Evaluation/ProjectStringCache.cs
+++ b/src/Build/Evaluation/ProjectStringCache.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public ProjectStringCache()
         {
-            ProjectRootElementCache.StrongCacheEntryRemoved += OnStrongCacheEntryRemoved;
+            ProjectRootElementCacheBase.StrongCacheEntryRemoved += OnStrongCacheEntryRemoved;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Maintains a cache of all loaded ProjectRootElement instances for design time purposes.
+    ///
+    /// This avoids the LRU cache and class-wide lock used within ProjectRootElementCache and replaces these mechanisms
+    /// with a single ConcurrentDictionary as a tradeoff for increased performance when evaluating projects in parallel.
+    /// As a tradeoff, this implementation uses more memory, and is not intended for use when the cache needs to be
+    /// long-lived e.g. within Visual Studio.
+    ///
+    /// SimpleProjectRootElementCache is not currently intended for use outside of evaluation. Several code paths
+    /// executed within a full build take a hard dependency on the strong/weak reference behavior used within
+    /// ProjectRootElementCache, and further investigation is required to determine the best way to hide these behind
+    /// an abstraction. As such, any method unused by evaluation will throw NotImplementedException.
+    /// </summary>
+    internal class SimpleProjectRootElementCache : ProjectRootElementCacheBase
+    {
+        private readonly ConcurrentDictionary<string, ProjectRootElement> _cache;
+
+        internal SimpleProjectRootElementCache()
+        {
+            _cache = new ConcurrentDictionary<string, ProjectRootElement>(StringComparer.OrdinalIgnoreCase);
+            LoadProjectsReadOnly = true;
+        }
+
+        internal override ProjectRootElement Get(
+            string projectFile,
+            OpenProjectRootElement openProjectRootElement,
+            bool isExplicitlyLoaded,
+            bool? preserveFormatting)
+        {
+            // Should already have been canonicalized
+            ErrorUtilities.VerifyThrowInternalRooted(projectFile);
+
+            return openProjectRootElement == null
+                ? GetFromCache(projectFile)
+                : GetFromOrAddToCache(projectFile, openProjectRootElement);
+        }
+
+        private ProjectRootElement GetFromCache(string projectFile)
+        {
+            if (_cache.TryGetValue(projectFile, out ProjectRootElement projectRootElement))
+            {
+                return projectRootElement;
+            }
+
+            return null;
+        }
+
+        private ProjectRootElement GetFromOrAddToCache(string projectFile, OpenProjectRootElement openFunc)
+        {
+            return _cache.GetOrAdd(projectFile, key =>
+            {
+                var rootElement = openFunc(key, this);
+                ErrorUtilities.VerifyThrowInternalNull(rootElement, "projectRootElement");
+                ErrorUtilities.VerifyThrow(rootElement.FullPath.Equals(key, StringComparison.OrdinalIgnoreCase),
+                    "Got project back with incorrect path");
+                ErrorUtilities.VerifyThrow(_cache.TryGetValue(key, out _),
+                    "Open should have renamed into cache and boosted");
+
+                return rootElement;
+            });
+        }
+
+        internal override void AddEntry(ProjectRootElement projectRootElement)
+        {
+            if (_cache.TryAdd(projectRootElement.FullPath, projectRootElement))
+            {
+                RaiseProjectRootElementAddedToCacheEvent(projectRootElement);
+            }
+        }
+
+
+        internal override void RenameEntry(string oldFullPath, ProjectRootElement projectRootElement)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override ProjectRootElement TryGet(string projectFile)
+        {
+            return TryGet(projectFile, null);
+        }
+
+
+        internal override ProjectRootElement TryGet(string projectFile, bool? preserveFormatting)
+        {
+            return Get(
+                projectFile,
+                null,
+                false,
+                preserveFormatting);
+        }
+
+        internal override void DiscardStrongReferences()
+        {
+        }
+
+        internal override void Clear()
+        {
+            _cache.Clear();
+        }
+
+        internal override void DiscardImplicitReferences()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override void DiscardAnyWeakReference(ProjectRootElement projectRootElement)
+        {
+            ErrorUtilities.VerifyThrowArgumentNull(projectRootElement, "projectRootElement");
+
+            // A PRE may be unnamed if it was only used in memory.
+            if (projectRootElement.FullPath != null)
+            {
+                _cache.TryRemove(projectRootElement.FullPath, out _);
+            }
+        }
+    }
+}

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -122,6 +122,16 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
+        internal override void OnProjectRootElementDirtied(ProjectRootElement sender, ProjectXmlChangedEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override void OnProjectDirtied(Project sender, ProjectChangedEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void RaiseProjectRootElementRemovedFromStrongCache(ProjectRootElement projectRootElement)
         {
              throw new NotImplementedException();

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Evaluation
         {
             return _cache.GetOrAdd(projectFile, key =>
             {
-                var rootElement = openFunc(key, this);
+                ProjectRootElement rootElement = openFunc(key, this);
                 ErrorUtilities.VerifyThrowInternalNull(rootElement, "projectRootElement");
                 ErrorUtilities.VerifyThrow(rootElement.FullPath.Equals(key, StringComparison.OrdinalIgnoreCase),
                     "Got project back with incorrect path");
@@ -78,7 +78,6 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-
         internal override void RenameEntry(string oldFullPath, ProjectRootElement projectRootElement)
         {
             throw new NotImplementedException();
@@ -88,7 +87,6 @@ namespace Microsoft.Build.Evaluation
         {
             return TryGet(projectFile, null);
         }
-
 
         internal override ProjectRootElement TryGet(string projectFile, bool? preserveFormatting)
         {

--- a/src/Build/Evaluation/SimpleProjectRootElementCache.cs
+++ b/src/Build/Evaluation/SimpleProjectRootElementCache.cs
@@ -121,5 +121,10 @@ namespace Microsoft.Build.Evaluation
                 _cache.TryRemove(projectRootElement.FullPath, out _);
             }
         }
+
+        protected override void RaiseProjectRootElementRemovedFromStrongCache(ProjectRootElement projectRootElement)
+        {
+             throw new NotImplementedException();
+        }
     }
 }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1120,7 +1120,7 @@ namespace Microsoft.Build.Execution
         /// that began the build. This is a thread-safe object.
         /// It's held here so it can get passed to the build.
         /// </summary>
-        internal ProjectRootElementCache ProjectRootElementCache
+        internal ProjectRootElementCacheBase ProjectRootElementCache
         {
             get;
             private set;
@@ -1841,7 +1841,7 @@ namespace Microsoft.Build.Execution
         /// When project instances get serialized between nodes, they need to be initialized with node specific information.
         /// The node specific information cannot come from the constructor, because that information is not available to INodePacketTranslators
         /// </summary>
-        internal void LateInitialize(ProjectRootElementCache projectRootElementCache, HostServices hostServices)
+        internal void LateInitialize(ProjectRootElementCacheBase projectRootElementCache, HostServices hostServices)
         {
             ErrorUtilities.VerifyThrow(ProjectRootElementCache == null, $"{nameof(ProjectRootElementCache)} is already set. Cannot set again");
             ErrorUtilities.VerifyThrow(_hostServices == null, $"{nameof(HostServices)} is already set. Cannot set again");
@@ -2351,7 +2351,7 @@ namespace Microsoft.Build.Execution
         (string projectFile,
             IDictionary<string, string> globalProperties,
             string toolsVersion,
-            ProjectRootElementCache projectRootElementCache,
+            ProjectRootElementCacheBase projectRootElementCache,
             BuildParameters buildParameters,
             ILoggingService loggingService,
             BuildEventContext projectBuildEventContext,

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -145,13 +145,13 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// The cache to load the *.tasks files into
         /// </summary>
-        internal ProjectRootElementCache RootElementCache { get; set; }
+        internal ProjectRootElementCacheBase RootElementCache { get; set; }
 
         /// <summary>
         /// Creates a task registry that does not fall back to any other task registry.
         /// Default constructor does no work because the tables are initialized lazily when a task is registered
         /// </summary>
-        internal TaskRegistry(ProjectRootElementCache projectRootElementCache)
+        internal TaskRegistry(ProjectRootElementCacheBase projectRootElementCache)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, "projectRootElementCache");
 
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Execution
         /// </summary>
         /// <param name="toolset">The Toolset containing the toolser task registry</param>
         /// <param name="projectRootElementCache">The <see cref="ProjectRootElementCache"/> to use.</param>
-        internal TaskRegistry(Toolset toolset, ProjectRootElementCache projectRootElementCache)
+        internal TaskRegistry(Toolset toolset, ProjectRootElementCacheBase projectRootElementCache)
         {
             ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, "projectRootElementCache");
             ErrorUtilities.VerifyThrowInternalNull(toolset, "toolset");

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -522,6 +522,7 @@
     <Compile Include="Evaluation\IPropertyProvider.cs" />
     <Compile Include="Evaluation\Preprocessor.cs" />
     <Compile Include="Evaluation\ProjectParser.cs" />
+    <Compile Include="Evaluation\ProjectRootElementCacheBase.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
     <Compile Include="Evaluation\ProjectStringCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -524,6 +524,7 @@
     <Compile Include="Evaluation\ProjectParser.cs" />
     <Compile Include="Evaluation\ProjectRootElementCacheBase.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
+        <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
     <Compile Include="Evaluation\ProjectStringCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Shared\FileSystemSources.proj" />
   <Import Project="..\Shared\DebuggingSources.proj" />
@@ -524,7 +524,7 @@
     <Compile Include="Evaluation\ProjectParser.cs" />
     <Compile Include="Evaluation\ProjectRootElementCacheBase.cs" />
     <Compile Include="Evaluation\ProjectRootElementCache.cs" />
-        <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
+    <Compile Include="Evaluation\SimpleProjectRootElementCache.cs" />
     <Compile Include="Evaluation\ProjectStringCache.cs" />
     <Compile Include="Evaluation\SemiColonTokenizer.cs" />
     <Compile Include="Evaluation\StringMetadataTable.cs" />

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool UseSimpleInternConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleInternConcurrency"));
 
+        public readonly bool UseSimpleProjectRootElementCacheConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleProjectRootElementCacheConcurrency"));
+
         /// <summary>
         /// Cache wildcard expansions for the entire process
         /// </summary>


### PR DESCRIPTION
```ProjectRootElementCache``` is currently the largest source of perf issues in the parsing stage of our internal build engine, holding up anywhere from 35% to 60% of total parse time, almost entirely due to lock contention. It holds a single lock for all operations on the cache as it needs to synchronize access between a dictionary of weak references and LRU cache of strong references, guard against potential concurrent modifications to ```ProjectRootElement``` state, and reload on disk changes. All of these properties are important for the Visual Studio scenario, but not for a pure evaluation where state should not change and the cache is short-lived, and has a large impact on performance when parallelizing project evaluation.

This adds a ```SimpleProjectRootElementCache``` only intended for use in evaluation, which can be enabled via environment variable. It implements the cache through a ConcurrentDictionary and avoids implementing any of the strong/weak reference methods on the original cache. Ideally these would just be removed as a requirement from the base class and  ```SimpleProjectRootElementCache``` would be usable in a full build, but several areas of MSBuild currently seem to take a hard dependency on the strong/weak reference implementation details of the original, so it would take more effort to generalize.

### **Before**
![image](https://user-images.githubusercontent.com/32187633/60554033-de74fd00-9cea-11e9-8920-c2035ad1cbfd.png)

### **After**
![image](https://user-images.githubusercontent.com/32187633/60554055-f9477180-9cea-11e9-9783-1527a2c182cc.png)
