### PR TITLE
Miscellaneous test diagnosability

### DIFF
--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -596,7 +596,8 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                 File.WriteAllText(includeFileA, "aaaaaaa");
                 File.WriteAllText(includeFileB, "bbbbbbb");
 
-                MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("a.proj");
+                MockLogger logger = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess("a.proj", logger);
                 logger.AssertNoWarnings();
             }
             finally

--- a/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
+++ b/src/Build.OM.UnitTests/Instance/ProjectInstance_Tests.cs
@@ -15,6 +15,7 @@ using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.OM.Instance
 {
@@ -23,6 +24,13 @@ namespace Microsoft.Build.UnitTests.OM.Instance
     /// </summary>
     public class ProjectInstance_Tests
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public ProjectInstance_Tests(ITestOutputHelper output)
+        {
+            _testOutput = output;
+        }
+
         /// <summary>
         /// Verify that a cloned off project instance can see environment variables
         /// </summary>

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Build.UnitTests
             Project project = ObjectModelHelpers.CreateInMemoryProject(projectContents, logger);
 
             bool success = project.Build();
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -207,7 +207,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj", logger);
             string error = String.Format(AssemblyResources.GetString("MSBuild.ProjectFileNotFound"), "this_project_does_not_exist.csproj");
             Assert.Contains(error, logger.FullLog);
         }
@@ -228,7 +229,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj", logger);
             string error = String.Format(AssemblyResources.GetString("MSBuild.ProjectFileNotFound"), "this_project_does_not_exist.csproj");
             Assert.Equal(0, logger.WarningCount);
             Assert.Equal(1, logger.ErrorCount);
@@ -260,7 +262,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             string message = String.Format(AssemblyResources.GetString("MSBuild.ProjectFileNotFoundMessage"), "this_project_does_not_exist.csproj");
@@ -297,7 +300,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             string message = String.Format(AssemblyResources.GetString("MSBuild.ProjectFileNotFoundMessage"), "this_project_does_not_exist.csproj");
@@ -340,7 +344,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"BuildingVCProjMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"BuildingVCProjMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             string error = String.Format(AssemblyResources.GetString("MSBuild.ProjectUpgradeNeededToVcxProj"), "blah.vcproj");
@@ -446,7 +451,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"bug'533'369\Sub;Dir\TeamBuild.proj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"bug'533'369\Sub;Dir\TeamBuild.proj", logger);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"bug'533'369\Sub;Dir\binaries\ConsoleApplication1.exe");
         }
@@ -622,7 +628,8 @@ namespace Microsoft.Build.UnitTests
                     </Project>
                 ");
 
-                var logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(projectFile);
+                MockLogger logger = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess(projectFile, logger);
 
                 Console.WriteLine(logger.FullLog);
 

--- a/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/MSBuild_Tests.cs
@@ -12,13 +12,17 @@ using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     public sealed class MSBuildTask_Tests : IDisposable
     {
-        public MSBuildTask_Tests()
+        private readonly ITestOutputHelper _testOutput;
+
+        public MSBuildTask_Tests(ITestOutputHelper testOutput)
         {
+            _testOutput = testOutput;
             ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -21,6 +21,7 @@ using LegacyThreadingData = Microsoft.Build.Execution.LegacyThreadingData;
 using TargetDotNetFrameworkVersion = Microsoft.Build.Utilities.TargetDotNetFrameworkVersion;
 using ToolLocationHelper = Microsoft.Build.Utilities.ToolLocationHelper;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.BackEnd
 {
@@ -29,6 +30,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
     /// </summary>
     public class TaskBuilder_Tests : ITargetBuilderCallback
     {
+
 #if FEATURE_CODEDOM
         /// <summary>
         /// Task definition for a task that outputs items containing null metadata.
@@ -148,6 +150,8 @@ namespace ItemCreationTask
         /// </summary>
         private MockHost _host;
 
+        private readonly ITestOutputHelper _testOutput;
+
         /// <summary>
         /// The temporary project we use to run the test
         /// </summary>
@@ -156,9 +160,10 @@ namespace ItemCreationTask
         /// <summary>
         /// Prepares the environment for the test.
         /// </summary>
-        public TaskBuilder_Tests()
+        public TaskBuilder_Tests(ITestOutputHelper output)
         {
             _host = new MockHost();
+            _testOutput = output;
             _testProject = CreateTestProject();
         }
 

--- a/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskBuilder_Tests.cs
@@ -938,7 +938,8 @@ namespace ItemCreationTask
                 File.WriteAllText(projectAPath, ObjectModelHelpers.CleanupFileContents(projectAContents));
                 File.WriteAllText(projectBPath, ObjectModelHelpers.CleanupFileContents(projectBContents));
 
-                MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("a.proj");
+                MockLogger logger = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess("a.proj", logger);
                 logger.AssertNoWarnings();
             }
             finally

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -1108,7 +1108,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-            MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+            MockLogger log = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class;Library16.dll", @"Did not find expected file obj\debug\Class;Library16.dll");
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class;Library16.pdb", @"Did not find expected file obj\debug\Class;Library16.pdb");
@@ -1167,7 +1168,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-                MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+                MockLogger log = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class;Library16.dll", @"Did not find expected file obj\debug\Class;Library16.dll");
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class;Library16.pdb", @"Did not find expected file obj\debug\Class;Library16.pdb");
@@ -1226,7 +1228,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-            MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+            MockLogger log = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class$(prop)Library16.dll", @"Did not find expected file obj\debug\Class$(prop)Library16.dll");
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class$(prop)Library16.pdb", @"Did not find expected file obj\debug\Class$(prop)Library16.pdb");
@@ -1285,7 +1288,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-                MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+                MockLogger log = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class$(prop)Library16.dll", @"Did not find expected file obj\debug\Class$(prop)Library16.dll");
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\Class$(prop)Library16.pdb", @"Did not find expected file obj\debug\Class$(prop)Library16.pdb");
@@ -1344,7 +1348,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-            MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+            MockLogger log = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\ClassLibrary16.dll", @"Did not find expected file obj\debug\ClassLibrary16.dll");
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\ClassLibrary16.pdb", @"Did not find expected file obj\debug\ClassLibrary16.pdb");
@@ -1403,7 +1408,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 }
             ");
 
-                MockLogger log = ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj");
+                MockLogger log = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectSuccess("foo.csproj", log);
 
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\ClassLibrary16.dll", @"Did not find expected file obj\debug\ClassLibrary16.dll");
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\debug\ClassLibrary16.pdb", @"Did not find expected file obj\debug\ClassLibrary16.pdb");
@@ -1579,7 +1585,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Cons.ole;!@(foo)'^(Application1
             string targetForFirstProject = "Cons_ole_!__foo__^_Application1";
 
-            ObjectModelHelpers.BuildTempProjectFileWithTargetsExpectSuccess(@"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1.sln", new string[] { targetForFirstProject }, null);
+            MockLogger log = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileWithTargetsExpectSuccess(@"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1.sln", new string[] { targetForFirstProject }, null, log);
 
             Assert.True(File.Exists(Path.Combine(ObjectModelHelpers.TempProjectDir, @"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1\bin\debug\Console;!@(foo)'^(Application1.exe"))); //                     @"Did not find expected file Console;!@(foo)'^(Application1.exe"
         }
@@ -1750,7 +1757,8 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Cons.ole;!@(foo)'^(Application1
                 string targetForFirstProject = "Cons_ole_!__foo__^_Application1";
 
-                ObjectModelHelpers.BuildTempProjectFileWithTargetsExpectSuccess(@"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1.sln", new string[] { targetForFirstProject }, null);
+                MockLogger log = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileWithTargetsExpectSuccess(@"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1.sln", new string[] { targetForFirstProject }, null, log);
 
                 Assert.True(File.Exists(Path.Combine(ObjectModelHelpers.TempProjectDir, @"SLN;!@(foo)'^1\Console;!@(foo)'^(Application1\bin\debug\Console;!@(foo)'^(Application1.exe"))); //                         @"Did not find expected file Console;!@(foo)'^(Application1.exe"
             }

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -663,7 +663,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             project.SetGlobalProperty("MyGlobalProperty", "foo%253bbar");
 
             bool success = project.Build(logger);
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
 
             logger.AssertLogContains("MyGlobalProperty = 'foo%3bbar'");
         }
@@ -693,7 +693,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ");
 
                 bool success = project.Build(logger);
-                Assert.True(success); // "Build failed.  See Standard Out tab for details"
+                Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
                 logger.AssertLogContains("[*]");
             }
             finally
@@ -731,7 +731,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 ");
 
                 bool success = project.Build(logger);
-                Assert.True(success); // "Build failed.  See Standard Out tab for details"
+                Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
                 logger.AssertLogContains("[*]");
             }
             finally
@@ -790,7 +790,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             MockLogger logger = new MockLogger();
 
             bool success = project.Build(logger);
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
             logger.AssertLogContains("[OVERRIDE]");
         }
 
@@ -986,7 +986,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
             // Build the default targets using the Configuration "a;b'c".
             project.SetGlobalProperty("Configuration", EscapingUtilities.Escape("a;b'c"));
             bool success = project.Build(logger);
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\a;b'c\ClassLibrary16.dll");
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"bin\a;b'c\ClassLibrary16.dll");
@@ -1051,7 +1051,7 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
                 // Build the default targets using the Configuration "a;b'c".
                 project.SetGlobalProperty("Configuration", EscapingUtilities.Escape("a;b'c"));
                 bool success = project.Build(logger);
-                Assert.True(success); // "Build failed.  See Standard Out tab for details"
+                Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
 
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"obj\a;b'c\ClassLibrary16.dll");
                 ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(@"bin\a;b'c\ClassLibrary16.dll");

--- a/src/Build.UnitTests/EscapingInProjects_Tests.cs
+++ b/src/Build.UnitTests/EscapingInProjects_Tests.cs
@@ -22,6 +22,7 @@ using FileUtilities = Microsoft.Build.Shared.FileUtilities;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using ResourceUtilities = Microsoft.Build.Shared.ResourceUtilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
 {
@@ -901,6 +902,13 @@ namespace Microsoft.Build.UnitTests.EscapingInProjects_Tests
 #if FEATURE_COMPILE_IN_TESTS
     public class FullProjectsUsingMicrosoftCommonTargets
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public FullProjectsUsingMicrosoftCommonTargets(ITestOutputHelper output)
+        {
+            _testOutput = output;
+        }
+
         private const string SolutionFileContentsWithUnusualCharacters = @"Microsoft Visual Studio Solution File, Format Version 11.00
                 Project(`{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}`) = `Cons.ole;!@(foo)'^(Application1`, `Console;!@(foo)'^(Application1\Cons.ole;!@(foo)'^(Application1.csproj`, `{770F2381-8C39-49E9-8C96-0538FA4349A7}`
                 EndProject

--- a/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
+++ b/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Build.UnitTests
                     </Project>
                 "));
 
-                MockLogger ml = ObjectModelHelpers.BuildTempProjectFileExpectFailure(file);
+                MockLogger ml = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectFailure(file, ml);
 
                 // Make sure the log contains the error code and file/line/col for the circular dependency
                 ml.AssertLogContains("MSB4006");
@@ -102,7 +103,8 @@ namespace Microsoft.Build.UnitTests
                         <Target Name=[invalid] />
                     </Project>"));
 
-                var _ = ObjectModelHelpers.BuildTempProjectFileExpectFailure(file);
+                MockLogger logger = new MockLogger(_testOutput);
+                ObjectModelHelpers.BuildTempProjectFileExpectFailure(file, logger);
 
                 Assert.True(false, "Loading an invalid project should have thrown an InvalidProjectFileException.");
             }

--- a/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
+++ b/src/Build.UnitTests/InvalidProjectFileException_Tests.cs
@@ -7,11 +7,19 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Microsoft.Build.Exceptions;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     public class InvalidProjectFileExceptionTests
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public InvalidProjectFileExceptionTests(ITestOutputHelper output)
+        {
+            _testOutput = output;
+        }
+
         /// <summary>
         /// Verify I implemented ISerializable correctly
         /// </summary>

--- a/src/Build.UnitTests/TargetsFile_Test.cs
+++ b/src/Build.UnitTests/TargetsFile_Test.cs
@@ -1267,13 +1267,13 @@ namespace Microsoft.Build.UnitTests
 
             string stdout = ObjectModelHelpers.RunTempProjectBuiltApplication(@"bin\debug\ConsoleApplication37.exe");
 
-            Assert.IsTrue(@"ConsoleApplication37.exe did not emit Usage string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication37.exe did not emit Usage string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("Hello world!  Isn't it a beautiful day?"));
 
-            Assert.IsTrue(@"ConsoleApplication37.exe did not emit InvalidChildElement string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication37.exe did not emit InvalidChildElement string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("The element Foo is not allowed here."));
 
-            Assert.IsTrue(@"ConsoleApplication37.exe did not emit CopyrightMessage string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication37.exe did not emit CopyrightMessage string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("Copyright (C) 2005, The MSBuild Team"));
         }
 
@@ -1401,13 +1401,13 @@ namespace Microsoft.Build.UnitTests
 
             string stdout = ObjectModelHelpers.RunTempProjectBuiltApplication(@"bin\debug\ConsoleApplication38.exe");
 
-            Assert.IsTrue(@"ConsoleApplication38.exe did not emit Usage string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication38.exe did not emit Usage string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("Hello world!  Isn't it a beautiful day?"));
 
-            Assert.IsTrue(@"ConsoleApplication38.exe did not emit InvalidChildElement string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication38.exe did not emit InvalidChildElement string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("The element Foo is not allowed here."));
 
-            Assert.IsTrue(@"ConsoleApplication38.exe did not emit CopyrightMessage string.  See Standard Out tab for details.", 
+            Assert.IsTrue(@"ConsoleApplication38.exe did not emit CopyrightMessage string.  See test output (Attachments in Azure Pipelines) for details.", 
                 stdout.Contains("Copyright (C) 2005, The MSBuild Team"));
         }
     }
@@ -1878,8 +1878,8 @@ namespace Microsoft.Build.UnitTests
             string[] configurations = p.GetConditionedProperties("Configuration");
 
             Console.WriteLine("Configurations found = " + String.Join(", ", configurations));
-            Assert.AreEqual("See Standard Out tab for details", 1, configurations.Length);
-            Assert.AreEqual("See Standard Out tab for details", "FooConfig", configurations[0]);
+            Assert.AreEqual("See test output (Attachments in Azure Pipelines) for details", 1, configurations.Length);
+            Assert.AreEqual("See test output (Attachments in Azure Pipelines) for details", "FooConfig", configurations[0]);
         }
 
         /// <summary>
@@ -1969,8 +1969,8 @@ namespace Microsoft.Build.UnitTests
             string[] configurations = p.GetConditionedProperties("Configuration");
 
             Console.WriteLine("Configurations found = " + String.Join(", ", configurations));
-            Assert.AreEqual("See Standard Out tab for details", 1, configurations.Length);
-            Assert.AreEqual("See Standard Out tab for details", "FooConfig", configurations[0]);
+            Assert.AreEqual("See test output (Attachments in Azure Pipelines) for details", 1, configurations.Length);
+            Assert.AreEqual("See test output (Attachments in Azure Pipelines) for details", "FooConfig", configurations[0]);
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -910,34 +910,27 @@ namespace Microsoft.Build.UnitTests
         /// </summary>
         /// <param name="projectFileRelativePath"></param>
         /// <returns></returns>
-        internal static MockLogger BuildTempProjectFileExpectSuccess(string projectFileRelativePath)
+        internal static void BuildTempProjectFileExpectSuccess(string projectFileRelativePath, MockLogger logger)
         {
-            return BuildTempProjectFileWithTargetsExpectSuccess(projectFileRelativePath, null, null);
+            BuildTempProjectFileWithTargetsExpectSuccess(projectFileRelativePath, null, null, logger);
         }
 
         /// <summary>
         /// Builds a project file from disk, and asserts if the build does not succeed.
         /// </summary>
-        internal static MockLogger BuildTempProjectFileWithTargetsExpectSuccess(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties)
+        internal static void BuildTempProjectFileWithTargetsExpectSuccess(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties, MockLogger logger)
         {
-            MockLogger logger = new MockLogger();
             BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger)
                 .ShouldBeTrue("Build failed.  See Standard Out tab for details");
-
-            return logger;
         }
 
         /// <summary>
         /// Builds a project file from disk, and asserts if the build succeeds.
         /// </summary>
-        internal static MockLogger BuildTempProjectFileExpectFailure(string projectFileRelativePath)
+        internal static void BuildTempProjectFileExpectFailure(string projectFileRelativePath, MockLogger logger)
         {
-            MockLogger logger = new MockLogger();
-
             BuildTempProjectFileWithTargets(projectFileRelativePath, null, null, logger)
                 .ShouldBeFalse("Build unexpectedly succeeded.  See Standard Out tab for details");
-
-            return logger;
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -941,18 +941,6 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
-        /// Builds a project file from disk, and asserts if the build succeeds.
-        /// </summary>
-        internal static MockLogger BuildTempProjectFileWithTargetsExpectFailure(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties)
-        {
-            MockLogger logger = new MockLogger();
-            BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger)
-                .ShouldBeFalse("Build unexpectedly succeeded.  See Standard Out tab for details");
-
-            return logger;
-        }
-
-        /// <summary>
         /// Loads a project file from disk
         /// </summary>
         /// <param name="fileRelativePath"></param>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -750,7 +750,7 @@ namespace Microsoft.Build.UnitTests
             Project project = CreateInMemoryProject(projectContents, logger);
 
             bool success = project.Build(logger);
-            Assert.False(success); // "Build succeeded, but shouldn't have.  See Standard Out tab for details"
+            Assert.False(success); // "Build succeeded, but shouldn't have.  See test output (Attachments in Azure Pipelines) for details"
         }
 
         /// <summary>
@@ -921,7 +921,7 @@ namespace Microsoft.Build.UnitTests
         internal static void BuildTempProjectFileWithTargetsExpectSuccess(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties, MockLogger logger)
         {
             BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger)
-                .ShouldBeTrue("Build failed.  See Standard Out tab for details");
+                .ShouldBeTrue("Build failed.  See test output (Attachments in Azure Pipelines) for details");
         }
 
         /// <summary>
@@ -930,7 +930,7 @@ namespace Microsoft.Build.UnitTests
         internal static void BuildTempProjectFileExpectFailure(string projectFileRelativePath, MockLogger logger)
         {
             BuildTempProjectFileWithTargets(projectFileRelativePath, null, null, logger)
-                .ShouldBeFalse("Build unexpectedly succeeded.  See Standard Out tab for details");
+                .ShouldBeFalse("Build unexpectedly succeeded.  See test output (Attachments in Azure Pipelines) for details");
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -921,9 +921,8 @@ namespace Microsoft.Build.UnitTests
         internal static MockLogger BuildTempProjectFileWithTargetsExpectSuccess(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties)
         {
             MockLogger logger = new MockLogger();
-            bool success = BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger);
-
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger)
+                .ShouldBeTrue("Build failed.  See Standard Out tab for details");
 
             return logger;
         }
@@ -934,9 +933,9 @@ namespace Microsoft.Build.UnitTests
         internal static MockLogger BuildTempProjectFileExpectFailure(string projectFileRelativePath)
         {
             MockLogger logger = new MockLogger();
-            bool success = BuildTempProjectFileWithTargets(projectFileRelativePath, null, null, logger);
 
-            Assert.False(success); // "Build unexpectedly succeeded.  See Standard Out tab for details"
+            BuildTempProjectFileWithTargets(projectFileRelativePath, null, null, logger)
+                .ShouldBeFalse("Build unexpectedly succeeded.  See Standard Out tab for details");
 
             return logger;
         }
@@ -947,9 +946,8 @@ namespace Microsoft.Build.UnitTests
         internal static MockLogger BuildTempProjectFileWithTargetsExpectFailure(string projectFileRelativePath, string[] targets, IDictionary<string, string> additionalProperties)
         {
             MockLogger logger = new MockLogger();
-            bool success = BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger);
-
-            Assert.False(success); // "Build unexpectedly succeeded.  See Standard Out tab for details"
+            BuildTempProjectFileWithTargets(projectFileRelativePath, targets, additionalProperties, logger)
+                .ShouldBeFalse("Build unexpectedly succeeded.  See Standard Out tab for details");
 
             return logger;
         }

--- a/src/Tasks.UnitTests/CallTarget_Tests.cs
+++ b/src/Tasks.UnitTests/CallTarget_Tests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Build.UnitTests
 
             ProjectInstance instance = project.CreateProjectInstance();
             bool success = instance.Build();
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
 
             IEnumerable<ProjectItemInstance> targetOutputs = instance.GetItems("myfancytargetoutputs");
 

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -6,11 +6,19 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     sealed public class CreateItem_Tests
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public CreateItem_Tests(ITestOutputHelper output)
+        {
+            _testOutput = output;
+        }
+
         /// <summary>
         /// CreateIteming identical lists results in empty list.
         /// </summary>

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -149,7 +149,8 @@ namespace Microsoft.Build.UnitTests
             ObjectModelHelpers.CreateFileInTempProjectDirectory("Foo.txt", "foo");
             ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine("Subdir", "Bar.txt"), "bar");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("Myapp.proj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("Myapp.proj", logger);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(Path.Combine("Destination", "Foo.txt"));
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(Path.Combine("Destination", "Subdir", "Bar.txt"));

--- a/src/Tasks.UnitTests/MSBuild_Tests.cs
+++ b/src/Tasks.UnitTests/MSBuild_Tests.cs
@@ -190,7 +190,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj", logger);
             Assert.Contains("MSB3202", logger.FullLog); // project file not found
         }
 
@@ -210,7 +211,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentProjectsMain.csproj", logger);
             Assert.Equal(0, logger.WarningCount);
             Assert.Equal(1, logger.ErrorCount);
             Assert.Contains("MSB3202", logger.FullLog); // project file not found
@@ -241,7 +243,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             Assert.Equal(0, logger.WarningCount);
@@ -276,7 +279,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentProjectsMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             Assert.Equal(0, logger.WarningCount);
@@ -317,7 +321,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"BuildingVCProjMain.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"BuildingVCProjMain.csproj", logger);
 
             logger.AssertLogContains("Hello from foo.csproj");
             Assert.Equal(0, logger.WarningCount);
@@ -426,7 +431,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(Path.Combine("bug'533'369", "Sub;Dir", "TeamBuild.proj"));
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(Path.Combine("bug'533'369", "Sub;Dir", "TeamBuild.proj"), logger);
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(Path.Combine("bug'533'369", "Sub;Dir", "binaries", "ConsoleApplication1.exe"));
         }
@@ -1363,7 +1369,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentTargets.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess(@"SkipNonexistentTargets.csproj", logger);
 
             // Target t2 should still execute
             logger.FullLog.ShouldContain("t2 executing");
@@ -1388,7 +1395,8 @@ namespace Microsoft.Build.UnitTests
                 </Project>
                 ");
 
-            MockLogger logger = ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentTargets.csproj");
+            MockLogger logger = new MockLogger(_testOutput);
+            ObjectModelHelpers.BuildTempProjectFileExpectFailure(@"SkipNonexistentTargets.csproj", logger);
 
             logger.WarningCount.ShouldBe(0);
             logger.ErrorCount.ShouldBe(1);

--- a/src/Tasks.UnitTests/MSBuild_Tests.cs
+++ b/src/Tasks.UnitTests/MSBuild_Tests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.UnitTests
             Project project = ObjectModelHelpers.CreateInMemoryProject(projectContents, logger);
 
             bool success = project.Build();
-            Assert.True(success); // "Build failed.  See Standard Out tab for details"
+            Assert.True(success); // "Build failed.  See test output (Attachments in Azure Pipelines) for details"
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResourceOutOfProc_Tests.cs
@@ -2409,7 +2409,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                     }
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("lib1.csproj");
+            MockLogger logger = new MockLogger(_output);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("lib1.csproj", logger);
 
             string p2pReference = Path.Combine(ObjectModelHelpers.TempProjectDir, @"bin\debug\lib1.dll");
             Assert.True(File.Exists(p2pReference)); // "lib1.dll doesn't exist."
@@ -2594,7 +2595,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
                     }
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("ClassLibrary20.csproj");
+            MockLogger logger = new MockLogger(_output);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("ClassLibrary20.csproj", logger);
 
             // -------------------------------------------------------------------------------
             // Done producing an assembly on disk.

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -2752,7 +2752,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                     }
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("lib1.csproj");
+            MockLogger logger = new MockLogger(_output);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("lib1.csproj", logger);
 
             string p2pReference = Path.Combine(ObjectModelHelpers.TempProjectDir, "bin", "debug", "lib1.dll");
             Assert.True(File.Exists(p2pReference)); // "lib1.dll doesn't exist."
@@ -2938,7 +2939,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                     }
                 ");
 
-            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("ClassLibrary20.csproj");
+            MockLogger logger = new MockLogger(_output);
+            ObjectModelHelpers.BuildTempProjectFileExpectSuccess("ClassLibrary20.csproj", logger);
 
             // -------------------------------------------------------------------------------
             // Done producing an assembly on disk.


### PR DESCRIPTION
https://dev.azure.com/dnceng/public/_build/results?buildId=252713&view=ms.vss-test-web.build-test-results-tab&runId=6527076&resultId=100097&paneView=debug failed in a way that's not possible to diagnose:

```

Error message
Assert.True() Failure\r\nExpected: True\r\nActual: False

Stack trace
   at Microsoft.Build.UnitTests.ObjectModelHelpers.BuildTempProjectFileWithTargetsExpectSuccess(String projectFileRelativePath, String[] targets, IDictionary`2 additionalProperties) in D:\a\1\s\src\Shared\UnitTests\ObjectModelHelpers.cs:line 926
   at Microsoft.Build.UnitTests.MSBuildTask_Tests.PropertyOverridesContainSemicolon() in D:\a\1\s\src\Tasks.UnitTests\MSBuild_Tests.cs:line 429
```

with no log to look at.

Instead, force callers of that helper method to pass in a log, and plumb XUnit helpers through to all of those callsites so the log actually gets captured.