### PR TITLE
CI definition tweaks

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -4,48 +4,6 @@ trigger:
 - vs*
 
 jobs:
-- job: FullOnWindows
-  displayName: "Build and test on Windows using full MSBuild"
-  pool:
-    name: 'Hosted'
-    vmImage: 'windows-2019'
-  steps:
-  - task: BatchScript@1
-    displayName: cibuild.cmd
-    inputs:
-      filename: 'eng/cibuild.cmd'
-      arguments: '-test'
-  - task: PublishTestResults@2
-    displayName: Publish .NET Framework Test Results
-    inputs:
-      testRunTitle: 'Windows-on-full Full Framework'
-      testRunner: XUnit
-      testResultsFiles: 'artifacts/TestResults/Debug/*UnitTests_net472*.xml'
-      publishRunAttachments: true
-      mergeTestResults: true
-    condition: always()
-  - task: PublishTestResults@2
-    displayName: Publish .NET Core 2.1 Test Results
-    inputs:
-      testRunTitle: 'Windows-on-full .NET Core 2.1'
-      testRunner: XUnit
-      testResultsFiles: 'artifacts/TestResults/Debug/*UnitTests_netcoreapp2.1*.xml'
-      publishRunAttachments: true
-      mergeTestResults: true
-    condition: always()
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: logs'
-    inputs:
-      PathtoPublish: 'artifacts/log/Debug'
-      ArtifactName: 'FullOnWindows build logs'
-    condition: always()
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: TestResults'
-    inputs:
-      PathtoPublish: 'artifacts/TestResults'
-      ArtifactName: 'FullOnWindows test logs'
-    condition: always()
-
 - job: BootstrapMSBuildOnFullFrameworkWindows
   displayName: "Build and test on Windows using bootstrapped full MSBuild"
   pool:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -5,7 +5,7 @@ trigger:
 
 jobs:
 - job: BootstrapMSBuildOnFullFrameworkWindows
-  displayName: "Build and test on Windows using bootstrapped full MSBuild"
+  displayName: "Windows Full"
   pool:
     name: 'Hosted'
     vmImage: 'windows-2019'
@@ -46,7 +46,7 @@ jobs:
     condition: always()
 
 - job: BootstrapMSBuildOnCoreWindows
-  displayName: "Build and test on Windows using bootstrapped core MSBuild"
+  displayName: "Windows Core"
   pool:
     name: 'Hosted'
     vmImage: 'windows-2019'
@@ -88,7 +88,7 @@ jobs:
     condition: always()
 
 - job: FullReleaseOnWindows
-  displayName: "Build and test Release on Windows using full MSBuild"
+  displayName: "Windows Full Release (no bootstrap)"
   pool:
     name: 'Hosted'
     vmImage: 'windows-2019'
@@ -130,7 +130,7 @@ jobs:
     condition: always()
 
 - job: CoreBootstrappedOnLinux
-  displayName: "Build and test on Linux using bootstrapped .NET Core MSBuild"
+  displayName: "Linux Core"
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -159,7 +159,7 @@ jobs:
     condition: always()
 
 - job: CoreOnMac
-  displayName: "Build and test on macOS using bootstrapped .NET Core MSBuild"
+  displayName: "macOS Core"
   pool:
     vmImage: 'macOS-10.14'
   steps:

--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -78,13 +78,13 @@ jobs:
     displayName: 'Publish Artifact: logs'
     inputs:
       PathtoPublish: 'artifacts/log/Debug'
-      ArtifactName: 'FullOnWindows build logs'
+      ArtifactName: 'CoreOnWindows build logs'
     condition: always()
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
       PathtoPublish: 'artifacts/TestResults'
-      ArtifactName: 'FullOnWindows test logs'
+      ArtifactName: 'CoreOnWindows test logs'
     condition: always()
 
 - job: FullReleaseOnWindows


### PR DESCRIPTION
Three significant changes here:

1. Drop the Windows, full-framework, no-bootstrap build -- we have win/full/debug/bootstrap and win/full/release/nobootstrap so it doesn't seem helpful.
1. Stop uploading logs from both win/core/bootstrap and win/full/bootstrap to the same artifact named "FullOnWindows" 😔
1. Shorten display names so that the GitHub
![image](https://user-images.githubusercontent.com/3347530/60996699-c456a280-a31a-11e9-8b05-78c747d74b07.png)
and Pipelines
![image](https://user-images.githubusercontent.com/3347530/60996714-cde00a80-a31a-11e9-81c7-1ba83fd8d948.png)
UIs don't truncate away useful information.