### PR TITLE
Allow specifying relative paths in .rsp files

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1182,6 +1182,31 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
+        /// <summary>
+        /// A response file should support path replacement (%MSBuildThisFileDirectory% becomes full path to the
+        /// rsp file directory).
+        /// </summary>
+        [Fact]
+        public void ResponseFileSupportsThisFileDirectory()
+        {
+            using (var env = UnitTests.TestEnvironment.Create())
+            {
+                var content = ObjectModelHelpers.CleanupFileContents(
+                    "<Project ToolsVersion='msbuilddefaulttoolsversion' xmlns='msbuildnamespace'><Target Name='t'><Warning Text='[A=$(A)]'/></Target></Project>");
+
+                var directory = env.CreateFolder();
+                directory.CreateFile("Directory.Build.rsp", "/p:A=%MSBuildThisFileDirectory%");
+                var projectPath = directory.CreateFile("my.proj", content).Path;
+
+                var msbuildParameters = "\"" + projectPath + "\"";
+
+                string output = RunnerUtilities.ExecMSBuild(msbuildParameters, out var successfulExit);
+                successfulExit.ShouldBeTrue();
+
+                output.ShouldContain($"[A={directory.Path}{Path.DirectorySeparatorChar}]");
+            }
+        }
+
 #region IgnoreProjectExtensionTests
 
         /// <summary>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 using Microsoft.Build.Evaluation;
@@ -1768,6 +1769,7 @@ namespace Microsoft.Build.CommandLine
 
                     if (!isRepeatedResponseFile)
                     {
+                        var responseFileDirectory = FileUtilities.EnsureTrailingSlash(Path.GetDirectoryName(responseFile));
                         s_includedResponseFiles.Add(responseFile);
 
                         ArrayList argsFromResponseFile;
@@ -1788,6 +1790,10 @@ namespace Microsoft.Build.CommandLine
                                 // skip comment lines beginning with #
                                 if (!responseFileLine.StartsWith("#", StringComparison.Ordinal))
                                 {
+                                    // Allow special case to support a path relative to the .rsp file being processed.
+                                    responseFileLine = Regex.Replace(responseFileLine, responseFilePathReplacement,
+                                        responseFileDirectory, RegexOptions.IgnoreCase);
+
                                     // treat each line of the response file like a command line i.e. args separated by whitespace
                                     argsFromResponseFile.AddRange(QuotingUtilities.SplitUnquoted(Environment.ExpandEnvironmentVariables(responseFileLine)));
                                 }
@@ -1920,9 +1926,14 @@ namespace Microsoft.Build.CommandLine
         private const string autoResponseFileName = "MSBuild.rsp";
 
         /// <summary>
-        /// THe name of an auto-response file to search for in the project directory and above.
+        /// The name of an auto-response file to search for in the project directory and above.
         /// </summary>
         private const string directoryResponseFileName = "Directory.Build.rsp";
+
+        /// <summary>
+        /// String replacement pattern to support paths in response files.
+        /// </summary>
+        private const string responseFilePathReplacement = "%MSBuildThisFileDirectory%";
 
         /// <summary>
         /// Whether switches from the auto-response file are being used.


### PR DESCRIPTION
This would allow for a scenario where you want to specify a logger for all builds in a repo. Example:

Directory.Build.rsp
```bash
-ConsoleLoggerParameters:Verbosity=Minimal;Summary;ForceNoAlign
-MaxCPUCount
-NodeReuse:false
-Restore
-logger:%MSBuildThisFileDirectory%\build\MyLogger.dll
```

This will work assuming that `build\MyLogger.dll` is checked into the repo.

I can add tests, just wanted feedback on the name. Not thrilled that it uses the MSBuild property syntax, but couldn't think of something better :)

Edit: Switched to `%` instead.