### PR TITLE
Disable intermittently-hanging tests

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -211,6 +211,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// A simple successful graph build.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void SimpleGraphBuild()
         {
             string contents = CleanupFileContents(@"
@@ -4027,6 +4028,7 @@ $@"<Project InitialTargets=`Sleep`>
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void GraphBuildValid()
         {
             string project1 = _env.CreateFile(".proj").Path;
@@ -4067,6 +4069,7 @@ $@"<Project InitialTargets=`Sleep`>
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void GraphBuildInvalid()
         {
             string project1 = _env.CreateFile(".proj").Path;
@@ -4098,6 +4101,7 @@ $@"<Project InitialTargets=`Sleep`>
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void GraphBuildFail()
         {
             string project1 = _env.CreateFile(".proj").Path;
@@ -4140,6 +4144,7 @@ $@"<Project InitialTargets=`Sleep`>
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
         public void GraphBuildCircular()
         {
             string project1 = _env.CreateFile(".proj").Path;

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Build.Experimental.Graph.UnitTests
 {
+    [ActiveIssue("https://github.com/Microsoft/msbuild/issues/4368")]
     public class ProjectGraphTests : IDisposable
     {
         private TestEnvironment _env;


### PR DESCRIPTION
Since I'm having trouble with #4374, disabling affected test.

cc @cdmihai -- make sure you reenable this locally as you're doing graph testing. Sorry, continuing to work on the real fix!