### PR TITLE
Avoid writing to c:\Debug\ConsoleApp1.exe

### DIFF
--- a/src/Tasks.UnitTests/MSBuild_Tests.cs
+++ b/src/Tasks.UnitTests/MSBuild_Tests.cs
@@ -355,6 +355,7 @@ namespace Microsoft.Build.UnitTests
                 Path.Combine("bug'533'369", "Sub;Dir", "ConsoleApplication1", "ConsoleApplication1.csproj"), @"
 
                 <Project DefaultTargets=`Build` ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                  <Import Project=`$(MSBuildBinPath)\Microsoft.Common.props` />
                   <PropertyGroup>
                     <Configuration Condition=` '$(Configuration)' == '' `>Debug</Configuration>
                     <Platform Condition=` '$(Platform)' == '' `>AnyCPU</Platform>


### PR DESCRIPTION
A series of bad imports caused this test to have BaseIntermediateOutputDirectory set to `\`, which expanded to c:\ because on most machines TEMP is under C:\