### PR TITLE
Move official build to dev16 machines

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -12,7 +12,7 @@ trigger:
 jobs:
 - job: Windows_NT
   pool: 
-    name: VSEng-MicroBuildVS2017
+    name: VSEng-MicroBuildVS2019
     demands:
     - agent.os -equals Windows_NT
 


### PR DESCRIPTION
Noticed this when investigating an official build failure that appears to have been one-off infra flakiness.