### PR TITLE
MSBuildGlob Interning Memory Improvement

### DIFF
--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Globbing
                 globRoot = Directory.GetCurrentDirectory();
             }
 
-            globRoot = FileUtilities.NormalizePath(globRoot).WithTrailingSlash();
+            globRoot = OpportunisticIntern.InternStringIfPossible(FileUtilities.NormalizePath(globRoot));
 
             var lazyState = new Lazy<GlobState>(() =>
             {

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build.Globbing
                 globRoot = Directory.GetCurrentDirectory();
             }
 
-            globRoot = OpportunisticIntern.InternStringIfPossible(FileUtilities.NormalizePath(globRoot));
+            globRoot = OpportunisticIntern.InternStringIfPossible(FileUtilities.NormalizePath(globRoot).WithTrailingSlash());
 
             var lazyState = new Lazy<GlobState>(() =>
             {


### PR DESCRIPTION
MSBuildGlob now interns the strings that pass through `MSBuildGlob.Parse`. This cuts down on ~90% of the string duplication that was occuring in `MSBuildGlob.Parse` 

![image](https://user-images.githubusercontent.com/4691428/61419008-4dd51a00-a8b1-11e9-932e-fef6752f3ffa.png)

Edit:
Should fix #4511 