### PR TITLE
Add support for optional loggers

### DIFF
--- a/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
+++ b/src/MSBuild.UnitTests/CommandLineSwitches_Tests.cs
@@ -537,6 +537,51 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void OptionalLoggerSwitchIdentificationTests()
+        {
+            CommandLineSwitches.IsParameterizedSwitch("optionallogger", out var parameterizedSwitch,
+                out var duplicateSwitchErrorMessage, out var multipleParametersAllowed,
+                out var missingParametersErrorMessage, out var unquoteParameters, out _).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.OptionalLogger);
+            duplicateSwitchErrorMessage.ShouldBeNull();
+            multipleParametersAllowed.ShouldBeFalse();
+            missingParametersErrorMessage.ShouldBe("MissingLoggerError");
+            unquoteParameters.ShouldBeFalse();
+
+            CommandLineSwitches.IsParameterizedSwitch("OPTIONALLOGGER", out parameterizedSwitch,
+                out duplicateSwitchErrorMessage, out multipleParametersAllowed,
+                out missingParametersErrorMessage, out unquoteParameters, out _).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.OptionalLogger);
+            duplicateSwitchErrorMessage.ShouldBeNull();
+            multipleParametersAllowed.ShouldBeFalse();
+            missingParametersErrorMessage.ShouldBe("MissingLoggerError");
+            unquoteParameters.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void OptionalDistributedLoggerSwitchIdentificationTests()
+        {
+            CommandLineSwitches.IsParameterizedSwitch("optionaldistributedlogger",
+                out CommandLineSwitches.ParameterizedSwitch parameterizedSwitch, out _,
+                out bool multipleParametersAllowed, out string missingParametersErrorMessage,
+                out bool unquoteParameters, out bool emptyParametersAllowed).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.OptionalDistributedLogger);
+            multipleParametersAllowed.ShouldBeFalse();
+            missingParametersErrorMessage.ShouldBe("MissingLoggerError");
+            unquoteParameters.ShouldBeFalse();
+            emptyParametersAllowed.ShouldBeFalse();
+
+            CommandLineSwitches.IsParameterizedSwitch("OPTIONALDISTRIBUTEDLOGGER", out parameterizedSwitch, out _,
+                out multipleParametersAllowed, out missingParametersErrorMessage, out unquoteParameters,
+                out emptyParametersAllowed).ShouldBeTrue();
+            parameterizedSwitch.ShouldBe(CommandLineSwitches.ParameterizedSwitch.OptionalDistributedLogger);
+            multipleParametersAllowed.ShouldBeFalse();
+            missingParametersErrorMessage.ShouldBe("MissingLoggerError");
+            unquoteParameters.ShouldBeFalse();
+            emptyParametersAllowed.ShouldBeFalse();
+        }
+
+        [Fact]
         public void VerbositySwitchIdentificationTests()
         {
             CommandLineSwitches.ParameterizedSwitch parameterizedSwitch;

--- a/src/MSBuild/CommandLineSwitches.cs
+++ b/src/MSBuild/CommandLineSwitches.cs
@@ -71,7 +71,9 @@ namespace Microsoft.Build.CommandLine
             Target,
             Property,
             Logger,
+            OptionalLogger,
             DistributedLogger,
+            OptionalDistributedLogger,
             Verbosity,
 #if FEATURE_XML_SCHEMA_VALIDATION
             Validate,
@@ -239,7 +241,9 @@ namespace Microsoft.Build.CommandLine
             new ParameterizedSwitchInfo(  new string[] { "target", "t"},                        ParameterizedSwitch.Target,                     null,                           true,           "MissingTargetError",                  true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "property", "p" },                     ParameterizedSwitch.Property,                   null,                           true,           "MissingPropertyError",                true,   false  ),
             new ParameterizedSwitchInfo(  new string[] { "logger", "l" },                       ParameterizedSwitch.Logger,                     null,                           false,          "MissingLoggerError",                  false,  false  ),
+            new ParameterizedSwitchInfo(  new string[] { "optionallogger" },                    ParameterizedSwitch.OptionalLogger,             null,                           false,          "MissingLoggerError",                  false,  false  ),
             new ParameterizedSwitchInfo(  new string[] { "distributedlogger", "dl" },           ParameterizedSwitch.DistributedLogger,          null,                           false,          "MissingLoggerError",                  false,  false  ),
+            new ParameterizedSwitchInfo(  new string[] { "optionalDistributedlogger" },         ParameterizedSwitch.OptionalDistributedLogger,  null,                           false,          "MissingLoggerError",                  false,  false  ),
             new ParameterizedSwitchInfo(  new string[] { "verbosity", "v" },                    ParameterizedSwitch.Verbosity,                  null,                           false,          "MissingVerbosityError",               true,   false  ),
 #if FEATURE_XML_SCHEMA_VALIDATION
             new ParameterizedSwitchInfo(  new string[] { "validate", "val" },                   ParameterizedSwitch.Validate,                   null,                           false,          null,                                  true,   false  ),

--- a/src/MSBuild/Resources/Strings.resx
+++ b/src/MSBuild/Resources/Strings.resx
@@ -262,6 +262,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:
@@ -416,6 +418,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </value>
     <comment>
       LOCALIZATION: The following should not be localized:
@@ -1167,6 +1171,14 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       This error is shown when a user specifies an logger that does not exist e.g. "msbuild -logger:FooLoggerClass,FooAssembly". The
       logger class must exist in the given assembly.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </comment>
+  </data>
+  <data name="OptionalLoggerCreationMessage" UESanitized="true" Visibility="Public">
+    <value>MSBUILD : Cannot create an instance of the optional logger. {0}</value>
+    <comment>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </comment>
   </data>
   <data name="ProjectUpgradeNeededToVcxProj">

--- a/src/MSBuild/Resources/xlf/Strings.cs.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.cs.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;protok_nást&gt;   Použít daný protokolovací nástroj k protokolování
+        <target state="needs-review-translation">  -logger:&lt;protok_nást&gt;   Použít daný protokolovací nástroj k protokolování
                      událostí nástroje MSBuild. Chcete-li zadat více protokolovacích
                     nástrojů, musíte je zadat jednotlivě.
                      Syntaxe hodnoty &lt;protok_nást&gt;:
@@ -605,8 +607,10 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedlogger:&lt;centr_protok_nást&gt;*&lt;předáv_protok_nást&gt;                     
+        <target state="needs-review-translation">  -distributedlogger:&lt;centr_protok_nást&gt;*&lt;předáv_protok_nást&gt;                     
                      Použít zadaný protokolovací nástroj pro protokolování událostí
                      z nástroje MSBuild; ke každému uzlu připojit jinou instanci 
                      protokolovacího nástroje. Chcete-li zadat více 
@@ -1131,6 +1135,15 @@ Copyright (C) Microsoft Corporation. Všechna práva vyhrazena.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.de.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.de.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;Protokollierung&gt;   Mithilfe dieser Protokollierung werden Ereignisse von MSBuild protokolliert. Um mehrere Protokollierungen anzugeben, 
+        <target state="needs-review-translation">  -logger:&lt;Protokollierung&gt;   Mithilfe dieser Protokollierung werden Ereignisse von MSBuild protokolliert. Um mehrere Protokollierungen anzugeben, 
                      wird jede Protokollierung gesondert angegeben.
                      Die Syntax für die &lt;Protokollierung&gt; lautet:
                        [&lt;Protokollierungsklasse&gt;,]&lt;Protokollierungsassembly&gt;[;&lt;Protokollierungsparameter&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedlogger:&lt;Zentrale Protokollierung&gt;*&lt;Weiterleitende Protokollierung&gt;
+        <target state="needs-review-translation">  -distributedlogger:&lt;Zentrale Protokollierung&gt;*&lt;Weiterleitende Protokollierung&gt;
                      Mithilfe dieser Protokollierung werden Ereignisse von MSBuild protokolliert, wobei an jeden Knoten eine andere 
                      Protokollierungsinstanz angefügt wird. Um mehrere Protokollierungen anzugeben, wird jede Protokollierung 
                      gesondert angegeben. 
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation. Alle Rechte vorbehalten.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.en.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.en.xlf
@@ -345,6 +345,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
         <target state="new">  -logger:&lt;logger&gt;   Use this logger to log events from MSBuild. To specify
                      multiple loggers, specify each logger separately.
@@ -359,6 +361,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </target>
         <note>
       LOCALIZATION: The following should not be localized:
@@ -612,6 +616,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
         <target state="new">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
                      Use this logger to log events from MSBuild, attaching a
@@ -629,6 +635,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </target>
         <note>
       LOCALIZATION: The following should not be localized:
@@ -1312,6 +1320,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.es.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.es.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;registrador&gt;   Use este registrador para registrar eventos de MSBuild. Para especificar
+        <target state="needs-review-translation">  -logger:&lt;registrador&gt;   Use este registrador para registrar eventos de MSBuild. Para especificar
                      varios registradores, especifique cada uno de ellos por separado.
                      La sintaxis del &lt;registrador&gt; es:
                        [&lt;clase del registrador&gt;,]&lt;ensamblado del registrador&gt;[;&lt;parámetros del registrador&gt;]
@@ -604,8 +606,10 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;registrador central&gt;*&lt;registrador de reenvío&gt;                    
+        <target state="needs-review-translation">  -distributedLogger:&lt;registrador central&gt;*&lt;registrador de reenvío&gt;                    
                      Use este registrador para registrar eventos de MSBuild, adjuntando una
                      interfaz de registrador diferente a cada nodo. Para especificar
                      varios registradores, especifique cada uno de ellos por separado.
@@ -1125,6 +1129,15 @@ Copyright (C) Microsoft Corporation. Todos los derechos reservados.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.fr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.fr.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;journaliseur&gt;   Journaliseur des événements MSBuild. Pour indiquer
+        <target state="needs-review-translation">  -logger:&lt;journaliseur&gt;   Journaliseur des événements MSBuild. Pour indiquer
          plusieurs journaliseurs, spécifiez chacun d'eux séparément.
          Syntaxe de &lt;journaliseur&gt; :
            [&lt;classe de journalisation&gt;,]&lt;assembly de journalisation&gt;
@@ -604,8 +606,10 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;journaliseur central&gt;*&lt;journaliseur de transfert&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;journaliseur central&gt;*&lt;journaliseur de transfert&gt;
          Utilise ce journaliseur pour consigner les événements MSBuild, en
          attachant une instance de journaliseur différente à chaque nœud. Pour
          indiquer plusieurs journaliseurs, spécifiez chacun d'eux séparément.
@@ -1128,6 +1132,15 @@ Copyright (C) Microsoft Corporation. Tous droits réservés.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.it.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.it.xlf
@@ -345,8 +345,10 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;logger&gt;   Usare questo logger per registrare eventi da MSBuild. Per specificare
+        <target state="needs-review-translation">  -logger:&lt;logger&gt;   Usare questo logger per registrare eventi da MSBuild. Per specificare
                      più logger, specificare ogni logger separatamente.
                      La sintassi di &lt;logger&gt; è la seguente:
                      [&lt;classe logger&gt;,]&lt;assembly logger&gt;[;&lt;parametri logger&gt;]
@@ -620,8 +622,10 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;logger centrale&gt;*&lt;logger inoltro&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;logger centrale&gt;*&lt;logger inoltro&gt;
                                Usare questo logger per registrare eventi da MSBuild,
                                associando un'istanza di logger diversa a ogni nodo. Per
                                specificare più logger, specificare ogni logger
@@ -1144,6 +1148,15 @@ Copyright (C) Microsoft Corporation. Tutti i diritti sono riservati.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.ja.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ja.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;logger&gt;   このロガーを使用して、MSBuild からのイベントのログを記録します。複数のロガーを
+        <target state="needs-review-translation">  -logger:&lt;logger&gt;   このロガーを使用して、MSBuild からのイベントのログを記録します。複数のロガーを
                      指定するには、各ロガーを別個に指定します。
                      &lt;logger&gt; の構文:
                        [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation.All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
                      このロガーを使用して MSBuild からのイベントのログを記録し、
                      別のロガー インスタンスを各ノードに追加します。
                      複数のロガーを指定するには、各ロガーを別個に指定します。
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation.All rights reserved.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.ko.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ko.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;logger&gt;   이 로거를 사용하여 MSBuild의 이벤트를 기록합니다. 
+        <target state="needs-review-translation">  -logger:&lt;logger&gt;   이 로거를 사용하여 MSBuild의 이벤트를 기록합니다. 
                      여러 로거를 지정하려면 각 로거를 개별적으로 지정합니다.
                      &lt;logger&gt; 구문은 다음과 같습니다.
                        [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
                      이 로거를 통해 MSBuild의 이벤트를 기록하여 
                      각 노드에 다른 로거 인스턴스를 연결합니다. 
                      여러 로거를 지정하려면 각 로거를 개별적으로 지정합니다.
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.pl.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pl.xlf
@@ -342,8 +342,10 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;rejestrator&gt;  Umożliwia użycie podanego rejestratora do rejestrowania
+        <target state="needs-review-translation">  -logger:&lt;rejestrator&gt;  Umożliwia użycie podanego rejestratora do rejestrowania
                          zdarzeń pochodzących z programu MSBuild. Aby określić
                      wiele rejestratorów, określ każdy z nich osobno.
                      Składnia elementu &lt;rejestrator&gt;:
@@ -615,8 +617,10 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;centralny rejestrator&gt;*&lt;rejestrator przekazujący&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;centralny rejestrator&gt;*&lt;rejestrator przekazujący&gt;
                      Umożliwia użycie podanego rejestratora do rejestrowania
                      zdarzeń pochodzących z programu MSBuild. Aby określić
                      wiele rejestratorów, określ każdy z nich osobno.
@@ -1138,6 +1142,15 @@ Copyright (C) Microsoft Corporation. Wszelkie prawa zastrzeżone.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.pt-BR.xlf
@@ -336,8 +336,10 @@ isoladamente.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;logger&gt;   Use esse agente para registrar em log os eventos do MSBuild. Para especificar
+        <target state="needs-review-translation">  -logger:&lt;logger&gt;   Use esse agente para registrar em log os eventos do MSBuild. Para especificar
                      vários agentes, especifique cada agente separadamente.
                      A sintaxe de &lt;logger&gt; é:
                        [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
@@ -603,8 +605,10 @@ isoladamente.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;central logger&gt;*&lt;forwarding logger&gt;
                      Use esse agente para registrar eventos do MSBuild anexando uma
                      instância de agente diferente a cada nó. Para especificar
                      vários agentes, especifique cada agente separadamente.
@@ -1124,6 +1128,15 @@ isoladamente.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.ru.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.ru.xlf
@@ -334,8 +334,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;журнал&gt;   Использовать этот журнал для регистрации событий из MSBuild. Чтобы
+        <target state="needs-review-translation">  -logger:&lt;журнал&gt;   Использовать этот журнал для регистрации событий из MSBuild. Чтобы
                      задать несколько журналов, укажите каждый из них отдельно.
                      Синтаксис &lt;журнала&gt;:
                        [&lt;класс журнала&gt;,]&lt;сборка журнала&gt;[;&lt;параметры журнала&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;центральный журнал&gt;*&lt;журнал перенаправления&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;центральный журнал&gt;*&lt;журнал перенаправления&gt;
                      Использовать этот журнал для регистрации событий из MSBuild, присоединяя
                      отдельный экземпляр журнала к каждому узлу. Чтобы задать
                      несколько журналов, укажите каждый из них отдельно.
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.tr.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.tr.xlf
@@ -335,8 +335,10 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;günlükçü&gt; MSBuild'daki olayları günlüğe almak için bu günlükçüyü 
+        <target state="needs-review-translation">  -logger:&lt;günlükçü&gt; MSBuild'daki olayları günlüğe almak için bu günlükçüyü 
                      kullanın. Birden çok günlükçü belirtmek için, her 
                      günlükçüyü ayrı ayrı belirtin.
                      &lt;günlükçü&gt; söz dizimi şöyledir:
@@ -604,8 +606,10 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedlogger:&lt;merkezi günlükçü&gt;*&lt;iletilen günlükçü&gt;  
+        <target state="needs-review-translation">  -distributedlogger:&lt;merkezi günlükçü&gt;*&lt;iletilen günlükçü&gt;  
                      MSBuild'dan gelen olayları her düğüme farklı bir günlükçü 
                      örneği iliştirerek günlüğe almak için bu günlükçüyü 
                      kullanın. Birden çok günlükçü belirtmek için, her 
@@ -1130,6 +1134,15 @@ Telif Hakkı (C) Microsoft Corporation. Tüm hakları saklıdır.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hans.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;logger&gt;  使用此记录器来记录 MSBuild 中的事件。若要指定
+        <target state="needs-review-translation">  -logger:&lt;logger&gt;  使用此记录器来记录 MSBuild 中的事件。若要指定
            多个记录器，请分别指定每个记录器。
            &lt;logger&gt; 语法为:
             [&lt;logger class&gt;,]&lt;logger assembly&gt;[;&lt;logger parameters&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated"> -distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;           
+        <target state="needs-review-translation"> -distributedlogger:&lt;central logger&gt;*&lt;forwarding logger&gt;           
            使用此记录器来记录 MSBuild 中的事件，向每个节点
            附加不同的记录器实例。若要指定
            多个记录器，请分别指定每个记录器。
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">

--- a/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/MSBuild/Resources/xlf/Strings.zh-Hant.xlf
@@ -335,8 +335,10 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      Examples:
                        -logger:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -logger:XMLLogger,C:\Loggers\MyLogger.dll;OutputAsHTML
+                     Note: Using -optionallogger will allow the build to
+                     continue if the logger can't be created.
 </source>
-        <target state="translated">  -logger:&lt;記錄器&gt;   使用此記錄器可記錄 MSBuild 的事件。
+        <target state="needs-review-translation">  -logger:&lt;記錄器&gt;   使用此記錄器可記錄 MSBuild 的事件。
                      若要指定多個記錄器，請各別指定每個記錄器。
                      &lt;logger&gt; 語法為:
                        [&lt;記錄器類別&gt;,]&lt;記錄器組件&gt;[;&lt;記錄器參數&gt;]
@@ -602,8 +604,10 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
                      Examples:
                        -dl:XMLLogger,MyLogger,Version=1.0.2,Culture=neutral
                        -dl:MyLogger,C:\My.dll*ForwardingLogger,C:\Logger.dll
+                     Note: Using -optionaldistributedlogger will allow the
+                     build to continue if the logger can't be created.
 </source>
-        <target state="translated">  -distributedLogger:&lt;中央記錄器&gt;*&lt;轉寄記錄器&gt;
+        <target state="needs-review-translation">  -distributedLogger:&lt;中央記錄器&gt;*&lt;轉寄記錄器&gt;
                      使用此記錄器可記錄 MSBuild 的事件，
                      同時為每個節點附加一個不同的記錄器執行個體。
                      若要指定多個記錄器，請各別指定每個記錄器。
@@ -1123,6 +1127,15 @@ Copyright (C) Microsoft Corporation. 著作權所有，並保留一切權利。
         <note>
       {StrBegin="MSBUILD : error MSB1024: "}UE: The user did something like msbuild -validate:foo.xsd -validate:bar.xsd. We only allow one schema to be specified.
       LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized.
+    </note>
+      </trans-unit>
+      <trans-unit id="OptionalLoggerCreationMessage">
+        <source>MSBUILD : Cannot create an instance of the optional logger. {0}</source>
+        <target state="new">MSBUILD : Cannot create an instance of the optional logger. {0}</target>
+        <note>
+      UE: This error is shown when a logger cannot be loaded and instantiated from its assembly.
+      LOCALIZATION: The prefix "MSBUILD : error MSBxxxx:" should not be localized. {0} contains a message explaining why the
+      logger could not be created -- this message comes from the CLR/FX and is localized.
     </note>
       </trans-unit>
       <trans-unit id="PickedUpSwitchesFromAutoResponse">


### PR DESCRIPTION
When specified, do not fail the build for optional loggers.

Current behavior:
```
d:\src\MSBuildPrediction>d:\src\msbuild.fork6\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\msbuild.exe /logger:EmptyLogger2.dll /t:Restore
Microsoft (R) Build Engine version 16.3.0-dev-19369-01+79f9c820f for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

MSBUILD : error MSB1021: Cannot create an instance of the logger.
Switch: EmptyLogger2.dll
```

Optional logger behavior:
```
d:\src\MSBuildPrediction>d:\src\msbuild.fork6\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\msbuild.exe /optionallogger:EmptyLogger2.dll /t:Restore /v:diag
Microsoft (R) Build Engine version 16.3.0-dev-19369-01+79f9c820f for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

MSBUILD : Cannot create an instance of the optional logger. Could not load file or assembly 'EmptyLogger2.dll' or one of its dependencies. The system cannot find the file specified.
... And the rest of the build here ...
```

First draft of the proposed change I mentioned previously to get feedback. Let me know if the approach looks ok.

For background, this change will allow for loggers to be specified (say in a `Directory.Build.rsp`) that are optional. We plan to use this internally to collect build telemetry (for example how long it takes to build, was the build incremental, and scope of build in a repo). We can distributed the logger via other mechanisms, but we don't want to fail the build if it hasn't been installed or deleted.