### PR TITLE
Adding a pkgdef for System.Resources.Extensions

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -291,6 +291,7 @@ folder InstallDir:\Common7\IDE\CommonExtensions\MSBuild
   file source=$(SourceDir)Framework\Microsoft.Build.Framework.pkgdef
   file source=$(SourceDir)Build\Microsoft.Build.pkgdef
   file source=$(SourceDir)Tasks\Microsoft.Build.Tasks.Core.pkgdef
+  file source=$(SourceDir)Tasks\System.Resources.Extensions.pkgdef
   file source=$(SourceDir)Utilities\Microsoft.Build.Utilities.Core.pkgdef
   file source=$(SourceDir)Deprecated\Conversion\Microsoft.Build.Conversion.Core.pkgdef
   file source=$(SourceDir)Deprecated\Engine\Microsoft.Build.Engine.pkgdef

--- a/src/Tasks/System.Resources.Extensions.pkgdef
+++ b/src/Tasks/System.Resources.Extensions.pkgdef
@@ -1,0 +1,7 @@
+[$RootKey$\RuntimeConfiguration\dependentAssembly\bindingRedirection\{1A1A9DA4-9F25-4AB8-89BF-BCEF73875CA8}]
+"name"="System.Resources.Extensions"
+"codeBase"="$BaseInstallDir$\MSBuild\Current\Bin\System.Resources.Extensions.dll"
+"publicKeyToken"="cc7b13ffcd2ddd51"
+"culture"="neutral"
+"oldVersion"="0.0.0.0-99.9.9.9"
+"newVersion"="4.0.0.0"


### PR DESCRIPTION
Adding a pkgdef for System.Resources.Extensions so that it gets added to the generated devenv.exe.config in VS. Without this, VS fails to find this assembly and ends up not loading the ngen version of Core.Tasks.dll, causing it to be jitted and regressing RPS.

I did a private build with this change, inserted into VS and ran RPS and RPS passed. The test insertion PR is here: https://devdiv.visualstudio.com/DevDiv/_git/a290117c-5a8a-40f7-bc2c-f14dbe3acf6d/pullrequest/192193?_a=overview