### PR TITLE
Enable long-disabled exception from TaskExecutionHost finalizer

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -161,7 +162,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         ~TaskExecutionHost()
         {
-            // Debug.Fail("Unexpected finalization.  Dispose should already have been called.");
+            Debug.Fail("Unexpected finalization.  Dispose should already have been called.");
             Dispose(false);
         }
 


### PR DESCRIPTION
This reverts commit ea574a45c6856127c38957716e446b3a150687fe.

Fixes #234.