### PR TITLE
WinRT: Accept Implementation metadata only when it's a DLL

### DIFF
--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -898,7 +898,9 @@ namespace Microsoft.Build.Tasks
                 {
                     var implementationFile = reference.PrimarySourceItem.GetMetadata(ItemMetadataNames.winmdImplmentationFile);
 
-                    if (!String.IsNullOrEmpty(implementationFile))
+                    // Static library projects can produce a .winmd with an associated .lib, but that is not
+                    // a real ImplementationAssembly--it would fail downstream when trying to read its PE header.
+                    if (!String.IsNullOrEmpty(implementationFile) && Path.GetExtension(implementationFile) == ".dll")
                     {
                         companionFile = Path.Combine(Path.GetDirectoryName(baseName), implementationFile);
                     }


### PR DESCRIPTION
Fixes #4547 by respecting the Implementation metadata only when it's a .dll. The <16.2.0 behavior would only find a .dll, and the comment on ImplementationAssembly expects it to always be a .dll, so I think this is reasonable.