### PR TITLE
Adjust ngen priority of assemblies for perf gains

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -16,13 +16,13 @@ folder InstallDir:\MSBuild\Current
 
 folder InstallDir:\MSBuild\Current\Bin
   file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.tlb
-  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86
+  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe.config
@@ -31,8 +31,8 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)System.Numerics.Vectors.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Resources.Extensions.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Runtime.CompilerServices.Unsafe.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)System.Threading.Tasks.Dataflow.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)System.Collections.Immutable.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)Microsoft.Common.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.Common.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.Common.overridetasks


### PR DESCRIPTION
These changes support an effort to improve VS performance after an update by tuning the assemblies ngen'd during setup.

After this change, the following assemblies should be ngen'd at priority 1:

```
msbuild\current\bin\microsoft.build.dll
msbuild\current\bin\microsoft.build.tasks.core.dll
msbuild\current\bin\microsoft.build.utilities.core.dll
msbuild\current\bin\msbuild.exe
msbuild\current\bin\system.collections.immutable.dll
msbuild\current\bin\system.threading.tasks.dataflow.dll
```