### PR TITLE
Optimize Project Instance and expander to reduce memory consumption when building large projects.

### DIFF
--- a/src/Build/Definition/ProjectItem.cs
+++ b/src/Build/Definition/ProjectItem.cs
@@ -1077,14 +1077,13 @@ namespace Microsoft.Build.Evaluation
             /// </summary>
             public string GetEscapedValueIfPresent(string itemType, string name)
             {
-                string value = null;
 
                 if ((itemType == null) || String.Equals(_item.ItemType, itemType, StringComparison.OrdinalIgnoreCase))
                 {
-                    value = GetEscapedValue(name);
+                    return GetEscapedValue(name);
                 }
 
-                return value;
+                return null;
             }
         }
     }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2031,7 +2031,7 @@ namespace Microsoft.Build.Evaluation
                 // Remove trailing separator if we added one
                 if (itemsFromCapture.Count > 0)
                     builder.Length--;
-                
+
                 return false;
             }
 
@@ -3117,7 +3117,7 @@ namespace Microsoft.Build.Evaluation
                 IFileSystem fileSystem)
             {
                 // Used to aggregate all the components needed for a Function
-                FunctionBuilder<T> functionBuilder = new FunctionBuilder<T> {FileSystem = fileSystem};
+                FunctionBuilder<T> functionBuilder = new FunctionBuilder<T> { FileSystem = fileSystem };
 
                 // By default the expression root is the whole function expression
                 var expressionRoot = expressionFunction;
@@ -3328,7 +3328,7 @@ namespace Microsoft.Build.Evaluation
                             //
                             string startingDirectory = String.IsNullOrWhiteSpace(elementLocation.File) ? String.Empty : Path.GetDirectoryName(elementLocation.File);
 
-                            args = new []
+                            args = new[]
                             {
                                 args[0],
                                 startingDirectory,
@@ -3731,7 +3731,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (ElementsOfType(args, typeof(string)))
                             {
-                                returnVal = IntrinsicFunctions.NormalizePath(Array.ConvertAll(args, o => (string) o));
+                                returnVal = IntrinsicFunctions.NormalizePath(Array.ConvertAll(args, o => (string)o));
                                 return true;
                             }
                         }
@@ -3907,7 +3907,7 @@ namespace Microsoft.Build.Evaluation
                                 default:
                                     if (ElementsOfType(args, typeof(string)))
                                     {
-                                        returnVal = Path.Combine(Array.ConvertAll(args, o => (string) o));
+                                        returnVal = Path.Combine(Array.ConvertAll(args, o => (string)o));
                                         return true;
                                     }
                                     break;
@@ -4339,10 +4339,6 @@ namespace Microsoft.Build.Evaluation
 
                 // If the string has no dot, or is nothing but a dot, we have no
                 // namespace to look for, so we can't help.
-                if (assemblyNameEnd <= 0)
-                {
-                    return null;
-                }
 
                 // We will work our way up the namespace looking for an assembly that matches
                 while (assemblyNameEnd > 0)
@@ -4469,7 +4465,7 @@ namespace Microsoft.Build.Evaluation
                 BindingFlags defaultBindingFlags = BindingFlags.IgnoreCase | BindingFlags.Public;
 
                 ReadOnlySpan<char> expressionFunctionAsSpan = expressionFunction.AsSpan();
-                
+
                 ReadOnlySpan<char> expressionSubstringAsSpan = argumentStartIndex > -1 ? expressionFunctionAsSpan.Slice(methodStartIndex, argumentStartIndex - methodStartIndex) : ReadOnlySpan<char>.Empty;
 
                 // There are arguments that need to be passed to the function

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -999,7 +999,7 @@ namespace Microsoft.Build.Evaluation
 
                     // Append the result with the portion of the expression up to
                     // (but not including) the "$(", and advance the sourceIndex pointer.
-                    if (propertyStartIndex - sourceIndex > 0)
+                    if (propertyStartIndex > sourceIndex)
                     {
                         if (results == null)
                         {
@@ -1139,7 +1139,7 @@ namespace Microsoft.Build.Evaluation
 
                         // And if we couldn't find anymore property tags in the expression,
                         // so just literally copy the remainder into the result.
-                        if (expression.Length - sourceIndex > 0)
+                        if (expression.Length > sourceIndex)
                         {
                             result.Append(expression, sourceIndex, expression.Length - sourceIndex);
                         }

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -2324,14 +2324,9 @@ namespace Microsoft.Build.Evaluation
                             ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidItemFunctionExpression", functionName, item.Key, e.Message);
                         }
 
-                        while (!String.IsNullOrEmpty(directoryName))
+                        // Make sure we have not already gotten this directory (and all its ancestors) in the set.
+                        while (!(String.IsNullOrEmpty(directoryName) || directories.Contains(directoryName)))
                         {
-                            if (directories.Contains(directoryName))
-                            {
-                                // We've already got this directory (and all its ancestors) in the set.
-                                break;
-                            }
-
                             directories.Add(directoryName);
                             directoryName = Path.GetDirectoryName(directoryName);
                         }

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1736,9 +1736,7 @@ namespace Microsoft.Build.Execution
         {
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this, FileSystems.Default);
 
-            string result = expander.ExpandIntoStringAndUnescape(unexpandedValue, ExpanderOptions.ExpandPropertiesAndItems, ProjectFileLocation);
-
-            return result;
+            return expander.ExpandIntoStringAndUnescape(unexpandedValue, ExpanderOptions.ExpandPropertiesAndItems, ProjectFileLocation);
         }
 
         /// <summary>
@@ -1754,7 +1752,7 @@ namespace Microsoft.Build.Execution
         {
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander = new Expander<ProjectPropertyInstance, ProjectItemInstance>(this, this, FileSystems.Default);
 
-            bool result = ConditionEvaluator.EvaluateCondition(
+            return ConditionEvaluator.EvaluateCondition(
                 condition,
                 ParserOptions.AllowPropertiesAndItemLists,
                 expander,
@@ -1764,8 +1762,6 @@ namespace Microsoft.Build.Execution
                 null /* no logging service */,
                 BuildEventContext.Invalid,
                 FileSystems.Default);
-
-            return result;
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2676,8 +2676,7 @@ namespace Microsoft.Build.Execution
                     directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(item.DirectMetadataCount);
                     foreach (ProjectMetadata directMetadatum in item.DirectMetadata)
                     {
-                        ProjectMetadataInstance directMetadatumInstance = new ProjectMetadataInstance(directMetadatum);
-                        directMetadata.Set(directMetadatumInstance);
+                        directMetadata.Set(ProjectMetadataInstance(directMetadatum));
                     }
                 }
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2164,10 +2164,9 @@ namespace Microsoft.Build.Execution
             {
                 return beforeTargetsForTarget;
             }
-            else
-            {
-                return Array.Empty<TargetSpecification>();
-            }
+
+            return Array.Empty<TargetSpecification>();
+
         }
 
         /// <summary>
@@ -2181,10 +2180,9 @@ namespace Microsoft.Build.Execution
             {
                 return afterTargetsForTarget;
             }
-            else
-            {
-                return Array.Empty<TargetSpecification>();
-            }
+
+            return Array.Empty<TargetSpecification>();
+
         }
 
         /// <summary>
@@ -2455,14 +2453,11 @@ namespace Microsoft.Build.Execution
         /// <param name="dictionary">Dictionary to clone.</param>
         private static IDictionary<string, TValue> CreateCloneDictionary<TValue>(IDictionary<string, TValue> dictionary) where TValue : class, IKeyed
         {
-            if (dictionary == null)
-            {
-                return ReadOnlyEmptyDictionary<string, TValue>.Instance;
-            }
-            else
+            if (dictionary != null)
             {
                 return new RetrievableEntryHashSet<TValue>(dictionary, StringComparer.OrdinalIgnoreCase, readOnly: true);
             }
+            return ReadOnlyEmptyDictionary<string, TValue>.Instance;
         }
 
         /// <summary>

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2676,7 +2676,8 @@ namespace Microsoft.Build.Execution
                     directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(item.DirectMetadataCount);
                     foreach (ProjectMetadata directMetadatum in item.DirectMetadata)
                     {
-                        directMetadata.Set(ProjectMetadataInstance(directMetadatum));
+                        ProjectMetadataInstance directMetadatumInstance = new ProjectMetadataInstance(directMetadatum);
+                        directMetadata.Set(directMetadatumInstance);
                     }
                 }
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Build.Execution
             _directory = directory;
             _projectFileLocation = ElementLocation.Create(fullPath);
             _hostServices = hostServices;
-            
+
             EvaluationId = data.EvaluationId;
 
             var immutable = (settings & ProjectInstanceSettings.Immutable) == ProjectInstanceSettings.Immutable;
@@ -499,13 +499,13 @@ namespace Microsoft.Build.Execution
                 this.DefaultTargets = new List<string>(that.DefaultTargets);
                 this.InitialTargets = new List<string>(that.InitialTargets);
                 ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                    ProjectItemDefinitionInstance>) this).BeforeTargets = CreateCloneDictionary(
+                    ProjectItemDefinitionInstance>)this).BeforeTargets = CreateCloneDictionary(
                     ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                        ProjectItemDefinitionInstance>) that).BeforeTargets, StringComparer.OrdinalIgnoreCase);
+                        ProjectItemDefinitionInstance>)that).BeforeTargets, StringComparer.OrdinalIgnoreCase);
                 ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                    ProjectItemDefinitionInstance>) this).AfterTargets = CreateCloneDictionary(
+                    ProjectItemDefinitionInstance>)this).AfterTargets = CreateCloneDictionary(
                     ((IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance,
-                        ProjectItemDefinitionInstance>) that).AfterTargets, StringComparer.OrdinalIgnoreCase);
+                        ProjectItemDefinitionInstance>)that).AfterTargets, StringComparer.OrdinalIgnoreCase);
                 this.TaskRegistry =
                     that.TaskRegistry; // UNDONE: This isn't immutable, should be cloned or made immutable; it currently has a pointer to project collection
 
@@ -1914,7 +1914,7 @@ namespace Microsoft.Build.Execution
             translator.TranslateDictionary(ref _globalProperties, ProjectPropertyInstance.FactoryForDeserialization);
             translator.TranslateDictionary(ref _properties, ProjectPropertyInstance.FactoryForDeserialization);
 
-            var globalPropertiesToTreatAsLocal = (HashSet<string>) _globalPropertiesToTreatAsLocal;
+            var globalPropertiesToTreatAsLocal = (HashSet<string>)_globalPropertiesToTreatAsLocal;
             translator.Translate(ref globalPropertiesToTreatAsLocal);
 
             if (translator.Mode == TranslationDirection.ReadFromStream)
@@ -2669,19 +2669,22 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                CopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata = null;
+                ProjectItemInstance instance = null;
 
                 if (item.DirectMetadata != null)
                 {
-                    directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(item.DirectMetadataCount);
+                    CopyOnWritePropertyDictionary<ProjectMetadataInstance> directMetadata = new CopyOnWritePropertyDictionary<ProjectMetadataInstance>(item.DirectMetadataCount);
                     foreach (ProjectMetadata directMetadatum in item.DirectMetadata)
                     {
                         ProjectMetadataInstance directMetadatumInstance = new ProjectMetadataInstance(directMetadatum);
                         directMetadata.Set(directMetadatumInstance);
                     }
+                    instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, ProjectCollection.Escape(item.Xml.ContainingProject.FullPath));
                 }
-
-                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, ProjectCollection.Escape(item.Xml.ContainingProject.FullPath));
+                else
+                {
+                    instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, null, inheritedItemDefinitions, ProjectCollection.Escape(item.Xml.ContainingProject.FullPath));
+                }
 
                 _items.Add(instance);
 

--- a/src/Deprecated/Engine/Engine/Expander.cs
+++ b/src/Deprecated/Engine/Engine/Expander.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Build.BuildEngine
                 // We couldn't find anymore property tags in the expression,
                 // so just literally copy the remainder into the result
                 // and return.
-                if (expression.Length > sourseIndex)
+                if (expression.Length > sourceIndex)
                 {
                     results.Add(expression.Substring(sourceIndex, expression.Length - sourceIndex));
                 }

--- a/src/Deprecated/Engine/Engine/Expander.cs
+++ b/src/Deprecated/Engine/Engine/Expander.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Build.BuildEngine
         }
 
         internal Expander(Expander expander, SpecificItemDefinitionLibrary itemDefinitionLibrary)
-            : this(expander.lookup, null , expander.options)
+            : this(expander.lookup, null, expander.options)
         {
             if (implicitMetadataItemType == null)
             {
@@ -132,7 +132,7 @@ namespace Microsoft.Build.BuildEngine
             this.specificItemDefinitionLibrary = itemDefinitionLibrary;
         }
 
-#endregion
+        #endregion
 
         /// <summary>
         /// Adds metadata to the table being used by this expander.
@@ -469,7 +469,7 @@ namespace Microsoft.Build.BuildEngine
 
                 // Append the targetString with the portion of the sourceString up to
                 // (but not including) the "$(", and advance the sourceIndex pointer.
-                if (propertyStartIndex - sourceIndex > 0)
+                if (propertyStartIndex > sourceIndex)
                 {
                     results.Add(expression.Substring(sourceIndex, propertyStartIndex - sourceIndex));
                 }
@@ -558,7 +558,7 @@ namespace Microsoft.Build.BuildEngine
                 // We couldn't find anymore property tags in the expression,
                 // so just literally copy the remainder into the result
                 // and return.
-                if (expression.Length - sourceIndex > 0)
+                if (expression.Length > sourseIndex)
                 {
                     results.Add(expression.Substring(sourceIndex, expression.Length - sourceIndex));
                 }
@@ -706,7 +706,7 @@ namespace Microsoft.Build.BuildEngine
 
             return (nestLevel == 0) ? index : -1;
         }
-        
+
         /// <summary>
         /// Expand the body of the property, including any functions that it may contain
         /// </summary>
@@ -873,7 +873,7 @@ namespace Microsoft.Build.BuildEngine
         private string ExpandRegistryValue(string registryExpression, XmlNode node)
         {
             string registryLocation = registryExpression.Substring(9);
-            
+
             // Split off the value name -- the part after the "@" sign. If there's no "@" sign, then it's the default value name
             // we want.
             int firstAtSignOffset = registryLocation.IndexOf('@');
@@ -881,9 +881,9 @@ namespace Microsoft.Build.BuildEngine
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(firstAtSignOffset == lastAtSignOffset, node, "InvalidRegistryPropertyExpression", "$(" + registryExpression + ")", String.Empty);
 
-            string valueName = lastAtSignOffset == -1 || lastAtSignOffset == registryLocation.Length - 1 
+            string valueName = lastAtSignOffset == -1 || lastAtSignOffset == registryLocation.Length - 1
                 ? null : registryLocation.Substring(lastAtSignOffset + 1);
-            
+
             // If there's no '@', or '@' is first, then we'll use null or String.Empty for the location; otherwise
             // the location is the part before the '@'
             string registryKeyName = lastAtSignOffset != -1 ? registryLocation.Substring(0, lastAtSignOffset) : registryLocation;
@@ -1190,7 +1190,7 @@ namespace Microsoft.Build.BuildEngine
                         // change the type of the final unescaped string into the destination
                         args[0] = Convert.ChangeType(args[0], objectInstance.GetType(), CultureInfo.InvariantCulture);
                     }
-                    
+
                     // If we've been asked for and instance to be constructed, then we
                     // need to locate an appropriate constructor and invoke it
                     if (String.Equals("new", this.name, StringComparison.OrdinalIgnoreCase))
@@ -1234,7 +1234,7 @@ namespace Microsoft.Build.BuildEngine
                     {
                         functionResult = EscapingUtilities.Escape((string)functionResult);
                     }
-                    
+
                     // There's nothing left to deal within the function expression, return the result from the execution
                     if (String.IsNullOrEmpty(remainder))
                     {
@@ -1483,7 +1483,7 @@ namespace Microsoft.Build.BuildEngine
 
                 return objectType;
             }
-            
+
             /// <summary>
             /// Factory method to construct a function for property evaluation
             /// </summary>
@@ -1957,7 +1957,7 @@ namespace Microsoft.Build.BuildEngine
             {
                 metadataValue = GetDefaultMetadataValue(itemType, metadataName, metadataValue);
             }
-            
+
             return metadataValue ?? String.Empty;
         }
 

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Build.Shared
             /// because we could otherwise hold a huge builder indefinitely.
             /// This size seems reasonable for MSBuild uses (mostly expression expansion)
             /// </summary>
-            private const int MaxBuilderSize = 1024;
+            private const int MaxBuilderSize = 2048;
 
             /// <summary>
             /// The shared builder.


### PR DESCRIPTION
Issue #4199 says a large portion of memory used when creating a snapshot in the Project Instance class is the creation of Sync Objects, so I have optimized this portion to be more efficient.