### PR TITLE
Optimize defining file field

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -233,6 +233,7 @@ namespace Microsoft.Build.Construction
         public Microsoft.Build.Construction.ElementLocation DefaultTargetsLocation { get { throw null; } }
         public string DirectoryPath { get { throw null; } }
         public System.Text.Encoding Encoding { get { throw null; } }
+        public string EscapedFullPath { get { throw null; } }
         public string FullPath { get { throw null; } set { } }
         public bool HasUnsavedChanges { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportGroupElement> ImportGroups { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -233,6 +233,7 @@ namespace Microsoft.Build.Construction
         public Microsoft.Build.Construction.ElementLocation DefaultTargetsLocation { get { throw null; } }
         public string DirectoryPath { get { throw null; } }
         public System.Text.Encoding Encoding { get { throw null; } }
+        public string EscapedFullPath { get { throw null; } }
         public string FullPath { get { throw null; } set { } }
         public bool HasUnsavedChanges { get { throw null; } }
         public System.Collections.Generic.ICollection<Microsoft.Build.Construction.ProjectImportGroupElement> ImportGroups { get { throw null; } }

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -108,6 +108,11 @@ namespace Microsoft.Build.Construction
         private ElementLocation _projectFileLocation;
 
         /// <summary>
+        /// The project file's full path, escaped.
+        /// </summary>
+        private string _escapedFullPath;
+
+        /// <summary>
         /// The directory that the project is in. 
         /// Essential for evaluating relative paths.
         /// If the project is not loaded from disk, returns the current-directory from 
@@ -365,6 +370,8 @@ namespace Microsoft.Build.Construction
             // Used during solution load to ensure solutions which were created from a file have a location.
         }
 
+        public string EscapedFullPath => _escapedFullPath ?? (_escapedFullPath = ProjectCollection.Escape(FullPath));
+
         /// <summary>
         /// Full path to the project file.
         /// If the project has not been loaded from disk and has not been given a path, returns null.
@@ -394,6 +401,7 @@ namespace Microsoft.Build.Construction
                 }
 
                 _projectFileLocation = ElementLocation.Create(newFullPath);
+                _escapedFullPath = null;
                 _directory = Path.GetDirectoryName(newFullPath);
 
                 if (XmlDocument != null)
@@ -2005,6 +2013,7 @@ namespace Microsoft.Build.Construction
                     }
 
                     _projectFileLocation = ElementLocation.Create(fullPath);
+                    _escapedFullPath = null;
                     _directory = Path.GetDirectoryName(fullPath);
 
                     if (XmlDocument != null)

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2681,7 +2681,7 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, ProjectCollection.Escape(item.Xml.ContainingProject.FullPath));
+                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, item.Xml.ContainingProject.EscapedFullPath);
 
                 _items.Add(instance);
 


### PR DESCRIPTION
This fixes #4151 which causes many duplicate strings to be created. Instead of escaping a `ProjectRootElement`'s path over and over creating new strings each time, we just have it created once. This saves about 2% of the managed heap of a large solution open.