### PR TITLE
StronglyTypedResourceBuilder output should be strongly typed

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -1014,11 +1014,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR without references yields proper output, message
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact (Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResources()
         {
             GenerateResource t = Utilities.CreateTask(_output);
@@ -1075,11 +1071,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR without references yields proper output, message
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourcesUpToDate()
         {
             GenerateResource t = Utilities.CreateTask(_output);
@@ -1160,11 +1152,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         /// STR class file is out of date, but resources are up to date. Should still generate it.
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourcesOutOfDate()
         {
             string resxFile = null;
@@ -1251,11 +1239,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         /// Verify STR generation with a specified specific filename
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourcesWithFilename()
         {
             string txtFile = null;
@@ -1310,11 +1294,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR with VB
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourcesVB()
         {
             GenerateResource t = Utilities.CreateTask(_output);
@@ -1370,11 +1350,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR namespace can be empty
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourcesWithoutNamespaceOrClassOrFilename()
         {
             GenerateResource t = Utilities.CreateTask(_output);
@@ -1493,11 +1469,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR with resource namespace yields proper output, message (CS)
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void STRWithResourcesNamespaceCS()
         {
             Utilities.STRNamespaceTestHelper("CSharp", "MyResourcesNamespace", null, _output);
@@ -1506,11 +1478,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR with resource namespace yields proper output, message (VB)
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void STRWithResourcesNamespaceVB()
         {
             Utilities.STRNamespaceTestHelper("VB", "MyResourcesNamespace", null, _output);
@@ -1519,11 +1487,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR with resource namespace and STR namespace yields proper output, message (CS)
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void STRWithResourcesNamespaceAndSTRNamespaceCS()
         {
             Utilities.STRNamespaceTestHelper("CSharp", "MyResourcesNamespace", "MySTClassNamespace", _output);
@@ -1532,11 +1496,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR with resource namespace and STR namespace yields proper output, message (CS)
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void STRWithResourcesNamespaceAndSTRNamespaceVB()
         {
             Utilities.STRNamespaceTestHelper("VB", "MyResourcesNamespace", "MySTClassNamespace", _output);
@@ -1844,11 +1804,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  Invalid STR Class name
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void FailedSTRProperty()
         {
             GenerateResource t = Utilities.CreateTask(_output);
@@ -2142,11 +2098,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR class name derived from output file transformation
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "mono-windows-failing")]
         public void StronglyTypedClassName()
@@ -2193,11 +2145,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR class file name derived from class name transformation
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "mono-windows-failing")]
         public void StronglyTypedFileName()
@@ -2471,11 +2419,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  Invalid StronglyTypedLanguage yields CodeDOM exception
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         [Trait("Category", "mono-osx-failing")]
         public void UnknownStronglyTypedLanguage()
         {
@@ -2541,11 +2485,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         ///  STR class name derived from output file transformation
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void BadStronglyTypedFilename()
         {
             string txtFile = null;
@@ -2684,11 +2624,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
         /// <summary>
         /// Verify that passing a STR language with more than 1 sources errors
         /// </summary>
-#if FEATURE_CODEDOM
         [Fact]
-#else
-        [Fact(Skip = "Does not support strongly typed resources on netcore")]
-#endif
         public void StronglyTypedResourceFileIsExistingDirectory()
         {
             string dir = null;

--- a/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Build.Tasks.UnitTests.GenerateResource
 
             var resource = (TypeConverterByteArrayResource)resxWithEmbeddedBitmap[0];
             resource.Name.ShouldBe("pictureBox1.Image");
-            resource.TypeName.ShouldBe("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            resource.TypeAssemblyQualifiedName.ShouldBe("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace Microsoft.Build.Tasks.UnitTests.GenerateResource
 
             var resource = (TypeConverterStringResource)resxWithEmbeddedBitmap[0];
             resource.Name.ShouldBe("color");
-            resource.TypeName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            resource.TypeAssemblyQualifiedName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             resource.StringRepresentation.ShouldBe("Blue");
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Build.Tasks.UnitTests.GenerateResource
 
             var resource = (TypeConverterStringResource)resxWithEmbeddedBitmap[0];
             resource.Name.ShouldBe("Color1");
-            resource.TypeName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            resource.TypeAssemblyQualifiedName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             resource.StringRepresentation.ShouldBe("Blue");
         }
 
@@ -220,7 +220,7 @@ $@"  <data name='Image1' type='System.Resources.ResXFileRef, System.Windows.Form
 
             var resource = (FileStreamResource)resxWithLinkedBitmap[0];
             resource.Name.ShouldBe("Image1");
-            resource.TypeName.ShouldBe("System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            resource.TypeAssemblyQualifiedName.ShouldBe("System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
         }
 
         [Fact]
@@ -236,7 +236,7 @@ $@"  <data name='Image1' type='System.Resources.ResXFileRef, System.Windows.Form
 
             var resource = (TypeConverterStringResource)resxWithEmbeddedBitmap[0];
             resource.Name.ShouldBe("Color1");
-            resource.TypeName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+            resource.TypeAssemblyQualifiedName.ShouldBe("System.Drawing.Color, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
             resource.StringRepresentation.ShouldBe("Blue");
         }
 

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3498,17 +3498,12 @@ namespace Microsoft.Build.Tasks
             {
                 provider = CodeDomProvider.CreateProvider(stronglyTypedLanguage);
             }
+            catch (Exception e) when
 #if FEATURE_SYSTEM_CONFIGURATION
-            catch (ConfigurationException e)
+             (e is ConfigurationException || e is SecurityException)
 #else
-            // For some reason, ConfigurationException isn't caught on Core
-            catch (ConfigurationErrorsException e)
+             (e is SystemException && e.GetType().Name == "ConfigurationErrorsException") // TODO: catch specific exception type once it is public https://github.com/dotnet/corefx/issues/40456
 #endif
-            {
-                logger.LogErrorWithCodeFromResources("GenerateResource.STRCodeDomProviderFailed", stronglyTypedLanguage, e.Message);
-                return false;
-            }
-            catch (SecurityException e)
             {
                 logger.LogErrorWithCodeFromResources("GenerateResource.STRCodeDomProviderFailed", stronglyTypedLanguage, e.Message);
                 return false;

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3869,15 +3869,15 @@ namespace Microsoft.Build.Tasks
             public String cultureName;
             // We use a list to preserve the resource ordering (primarily for easier testing),
             // but also use a hash table to check for duplicate names.
-            public ArrayList resources;
-            public Hashtable resourcesHashTable;
+            public List<IResource> resources;
+            public Dictionary<string, IResource> resourcesHashTable;
             public String assemblySimpleName;  // The main assembly's simple name (ie, no .resources)
             public bool fromNeutralResources;  // Was this from the main assembly (or if the NRLA specified fallback to satellite, that satellite?)
 
             public ReaderInfo()
             {
-                resources = new ArrayList();
-                resourcesHashTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                resources = new List<IResource>();
+                resourcesHashTable = new Dictionary<string, IResource>(StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -485,6 +485,8 @@
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCodeType.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCompilers.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryTaskInfo.cs" />
+    <Compile Include="System.Design.cs" />
+    <Compile Include="system.design\stronglytypedresourcebuilder.cs" />
     <Compile Include="TaskExtension.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -634,16 +636,12 @@
     <Compile Include="SignFile.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="system.design\stronglytypedresourcebuilder.cs">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
     <Compile Include="StrongNameException.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="StrongNameUtils.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="System.Design.cs" />
     <Compile Include="TlbImp.cs" />
     <Compile Include="TlbReference.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Tasks/ResourceHandling/BinaryFormatterByteArrayResource.cs
+++ b/src/Tasks/ResourceHandling/BinaryFormatterByteArrayResource.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string OriginatingFile { get; }
         public byte[] Bytes { get; }
 
+        /// <summary>
+        /// BinaryFormatter byte arrays contain the type name, but it is not directly accessible from the resx.
+        /// </summary>
+        public string TypeFullName => null;
+
         public BinaryFormatterByteArrayResource(string name, byte[] bytes, string originatingFile)
         {
             Name = name;

--- a/src/Tasks/ResourceHandling/BinaryFormatterByteArrayResource.cs
+++ b/src/Tasks/ResourceHandling/BinaryFormatterByteArrayResource.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         /// <summary>
         /// BinaryFormatter byte arrays contain the type name, but it is not directly accessible from the resx.
         /// </summary>
+        public string TypeAssemblyQualifiedName => null;
+
+        /// <summary>
+        /// BinaryFormatter byte arrays contain the type name, but it is not directly accessible from the resx.
+        /// </summary>
         public string TypeFullName => null;
 
         public BinaryFormatterByteArrayResource(string name, byte[] bytes, string originatingFile)

--- a/src/Tasks/ResourceHandling/FileStreamResource.cs
+++ b/src/Tasks/ResourceHandling/FileStreamResource.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
     internal class FileStreamResource : IResource
     {
         public string Name { get; }
-        public string TypeName { get; }
+        public string TypeAssemblyQualifiedName { get; }
         public string OriginatingFile { get; }
         public string FileName { get; }
 
@@ -24,13 +24,13 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         /// Construct a new linked resource.
         /// </summary>
         /// <param name="name">The resource's name</param>
-        /// <param name="typeName">The assembly-qualified type name of the resource (at runtime).</param>
+        /// <param name="assemblyQualifiedTypeName">The assembly-qualified type name of the resource (at runtime).</param>
         /// <param name="fileName">The absolute path of the file to be embedded as a resource.</param>
         /// <param name="originatingFile">The absolute path of the file that defined the ResXFileRef to this resource.</param>
-        public FileStreamResource(string name, string typeName, string fileName, string originatingFile)
+        public FileStreamResource(string name, string assemblyQualifiedTypeName, string fileName, string originatingFile)
         {
             Name = name;
-            TypeName = typeName;
+            TypeAssemblyQualifiedName = assemblyQualifiedTypeName;
             FileName = fileName;
             OriginatingFile = originatingFile;
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
             {
                 FileStream fileStream = new FileStream(FileName, FileMode.Open, FileAccess.Read, FileShare.Read);
 
-                preserializedResourceWriter.AddActivatorResource(Name, fileStream, TypeName, closeAfterWrite: true);
+                preserializedResourceWriter.AddActivatorResource(Name, fileStream, TypeAssemblyQualifiedName, closeAfterWrite: true);
             }
             else
             {

--- a/src/Tasks/ResourceHandling/FileStreamResource.cs
+++ b/src/Tasks/ResourceHandling/FileStreamResource.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string OriginatingFile { get; }
         public string FileName { get; }
 
+        public string TypeFullName => NameUtilities.FullNameFromAssemblyQualifiedName(TypeAssemblyQualifiedName);
+
         /// <summary>
         /// Construct a new linked resource.
         /// </summary>

--- a/src/Tasks/ResourceHandling/IResource.cs
+++ b/src/Tasks/ResourceHandling/IResource.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         string Name { get; }
 
         /// <summary>
+        /// The resource's type's full name. May be null when the type is not knowable from the source.
+        /// </summary>
+        string TypeFullName { get; }
+
+        /// <summary>
         /// Adds the resource represented by this object to the specified writer.
         /// </summary>
         void AddTo(IResourceWriter writer);

--- a/src/Tasks/ResourceHandling/IResource.cs
+++ b/src/Tasks/ResourceHandling/IResource.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         string Name { get; }
 
         /// <summary>
+        /// The resource's type's assembly-qualified name. May be null when the type is not knowable from the source.
+        /// </summary>
+        string TypeAssemblyQualifiedName { get; }
+
+        /// <summary>
         /// The resource's type's full name. May be null when the type is not knowable from the source.
         /// </summary>
         string TypeFullName { get; }

--- a/src/Tasks/ResourceHandling/LiveObjectResource.cs
+++ b/src/Tasks/ResourceHandling/LiveObjectResource.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string Name { get; }
         public object Value { get; }
 
+        public string TypeAssemblyQualifiedName => Value.GetType().AssemblyQualifiedName;
+
         public string TypeFullName => Value.GetType().FullName;
 
         public void AddTo(IResourceWriter writer)

--- a/src/Tasks/ResourceHandling/LiveObjectResource.cs
+++ b/src/Tasks/ResourceHandling/LiveObjectResource.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string Name { get; }
         public object Value { get; }
 
+        public string TypeFullName => Value.GetType().FullName;
+
         public void AddTo(IResourceWriter writer)
         {
             writer.AddResource(Name, Value);

--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
             return fileRefType == StringTypeName;
         }
 
-        private static bool IsMemoryStream(string fileRefType)
+        internal static bool IsMemoryStream(string fileRefType)
         {
             return fileRefType.Equals(MemoryStreamTypeNameDesktopFramework, StringComparison.Ordinal);
         }

--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
                     fileName);
             }
 
-            if (fileRefType == StringTypeName)
+            if (IsString(fileRefType))
             {
                 string fileRefEncoding = null;
                 if (fileRefInfo.Length == 3)
@@ -264,6 +264,11 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         private static bool IsByteArray(string fileRefType)
         {
             return fileRefType.IndexOf("System.Byte[]") != -1 && fileRefType.IndexOf("mscorlib") != -1;
+        }
+
+        internal static bool IsString(string fileRefType)
+        {
+            return fileRefType == StringTypeName;
         }
 
         private static bool IsMemoryStream(string fileRefType)

--- a/src/Tasks/ResourceHandling/NameUtilities.cs
+++ b/src/Tasks/ResourceHandling/NameUtilities.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Tasks.ResourceHandling
+{
+    static class NameUtilities
+    {
+        /// <summary>
+        /// Extract the full name of a type from an assembly-qualified name string.
+        /// </summary>
+        /// <param name="assemblyQualifiedName"></param>
+        /// <returns></returns>
+        internal static string FullNameFromAssemblyQualifiedName(string assemblyQualifiedName)
+        {
+            var commaIndex = assemblyQualifiedName.IndexOf(',');
+
+            if (commaIndex == -1)
+            {
+                throw new ArgumentException(nameof(assemblyQualifiedName));
+            }
+
+            return assemblyQualifiedName.Substring(0, commaIndex);
+        }
+    }
+}

--- a/src/Tasks/ResourceHandling/StringResource.cs
+++ b/src/Tasks/ResourceHandling/StringResource.cs
@@ -10,26 +10,21 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Build.Tasks.ResourceHandling
 {
-    internal class StringResource : IResource
+    internal class StringResource : LiveObjectResource
     {
-        public string Name { get; }
-
         public string OriginatingFile { get; }
 
-        public string Value { get; }
+        public new string TypeFullName => typeof(string).FullName;
 
-        public string TypeFullName => typeof(string).FullName;
-
-        public StringResource(string name, string value, string filename)
+        public StringResource(string name, string value, string filename) :
+            base(name, value)
         {
-            Name = name;
-            Value = value;
             OriginatingFile = filename;
         }
 
-        public void AddTo(IResourceWriter writer)
+        public new void AddTo(IResourceWriter writer)
         {
-            writer.AddResource(Name, Value);
+            writer.AddResource(Name, (string)Value);
         }
 
         public override string ToString()

--- a/src/Tasks/ResourceHandling/StringResource.cs
+++ b/src/Tasks/ResourceHandling/StringResource.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
 
         public string Value { get; }
 
+        public string TypeFullName => typeof(string).FullName;
+
         public StringResource(string name, string value, string filename)
         {
             Name = name;

--- a/src/Tasks/ResourceHandling/TypeConverterByteArrayResource.cs
+++ b/src/Tasks/ResourceHandling/TypeConverterByteArrayResource.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string OriginatingFile { get; }
         public byte[] Bytes { get; }
 
+        public string TypeFullName => NameUtilities.FullNameFromAssemblyQualifiedName(TypeAssemblyQualifiedName);
+
         public TypeConverterByteArrayResource(string name, string assemblyQualifiedTypeName, byte[] bytes, string originatingFile)
         {
             Name = name;

--- a/src/Tasks/ResourceHandling/TypeConverterByteArrayResource.cs
+++ b/src/Tasks/ResourceHandling/TypeConverterByteArrayResource.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Build.Tasks.ResourceHandling
     internal class TypeConverterByteArrayResource : IResource
     {
         public string Name { get; }
-        public string TypeName { get; }
+        public string TypeAssemblyQualifiedName { get; }
         public string OriginatingFile { get; }
         public byte[] Bytes { get; }
 
-        public TypeConverterByteArrayResource(string name, string typeName, byte[] bytes, string originatingFile)
+        public TypeConverterByteArrayResource(string name, string assemblyQualifiedTypeName, byte[] bytes, string originatingFile)
         {
             Name = name;
-            TypeName = typeName;
+            TypeAssemblyQualifiedName = assemblyQualifiedTypeName;
             Bytes = bytes;
             OriginatingFile = originatingFile;
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         {
             if (writer is PreserializedResourceWriter preserializedResourceWriter)
             {
-                preserializedResourceWriter.AddTypeConverterResource(Name, Bytes, TypeName);
+                preserializedResourceWriter.AddTypeConverterResource(Name, Bytes, TypeAssemblyQualifiedName);
             }
             else
             {

--- a/src/Tasks/ResourceHandling/TypeConverterStringResource.cs
+++ b/src/Tasks/ResourceHandling/TypeConverterStringResource.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         public string OriginatingFile { get; }
         public string StringRepresentation { get; }
 
+        public string TypeFullName => NameUtilities.FullNameFromAssemblyQualifiedName(TypeAssemblyQualifiedName);
+
         public TypeConverterStringResource(string name, string assemblyQualifiedTypeName, string stringRepresentation, string originatingFile)
         {
             Name = name;

--- a/src/Tasks/ResourceHandling/TypeConverterStringResource.cs
+++ b/src/Tasks/ResourceHandling/TypeConverterStringResource.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Build.Tasks.ResourceHandling
     internal class TypeConverterStringResource : IResource
     {
         public string Name { get; }
-        public string TypeName { get; }
+        public string TypeAssemblyQualifiedName { get; }
         public string OriginatingFile { get; }
         public string StringRepresentation { get; }
 
-        public TypeConverterStringResource(string name, string typeName, string stringRepresentation, string originatingFile)
+        public TypeConverterStringResource(string name, string assemblyQualifiedTypeName, string stringRepresentation, string originatingFile)
         {
             Name = name;
-            TypeName = typeName;
+            TypeAssemblyQualifiedName = assemblyQualifiedTypeName;
             StringRepresentation = stringRepresentation;
             OriginatingFile = originatingFile;
         }
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         {
             if (writer is PreserializedResourceWriter preserializedResourceWriter)
             {
-                preserializedResourceWriter.AddResource(Name, StringRepresentation, TypeName);
+                preserializedResourceWriter.AddResource(Name, StringRepresentation, TypeAssemblyQualifiedName);
             }
             else
             {

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -263,6 +263,7 @@ namespace Microsoft.Build.Tasks
                 throw new ArgumentNullException(nameof(resxFile));
             }
 
+#if FEATURE_RESX_RESOURCE_READER
             // Read the resources from a ResX file into a dictionary - name & type name
             Dictionary<String, ResourceData> resourceList = new Dictionary<String, ResourceData>(StringComparer.InvariantCultureIgnoreCase);
             using (ResXResourceReader rr = new ResXResourceReader(resxFile))
@@ -283,6 +284,9 @@ namespace Microsoft.Build.Tasks
             // keywords, etc.  So there's no point to duplicating the code above.
 
             return InternalCreate(resourceList, baseName, generatedCodeNamespace, resourcesNamespace, codeProvider, internalClass, out unmatchable);
+#else
+            throw new PlatformNotSupportedException("Creating strongly-typed resources directly from a resx file is not currently supported on .NET Core");
+#endif
         }
 
         private static void AddGeneratedCodeAttributeforMember(CodeTypeMember typeMember)

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -91,12 +91,7 @@ namespace Microsoft.Build.Tasks
             internal String ValueAsString { get; }
         }
 
-        internal static CodeCompileUnit Create(IDictionary resourceList, String baseName, String generatedCodeNamespace, CodeDomProvider codeProvider, bool internalClass, out String[] unmatchable)
-        {
-            return Create(resourceList, baseName, generatedCodeNamespace, null, codeProvider, internalClass, out unmatchable);
-        }
-
-        internal static CodeCompileUnit Create(IDictionary resourceList, String baseName, String generatedCodeNamespace, String resourcesNamespace, CodeDomProvider codeProvider, bool internalClass, out String[] unmatchable)
+        internal static CodeCompileUnit Create(Dictionary<string, IResource> resourceList, String baseName, String generatedCodeNamespace, String resourcesNamespace, CodeDomProvider codeProvider, bool internalClass, out String[] unmatchable)
         {
             if (resourceList == null)
             {
@@ -104,13 +99,13 @@ namespace Microsoft.Build.Tasks
             }
 
             var resourceTypes = new Dictionary<String, ResourceData>(StringComparer.InvariantCultureIgnoreCase);
-            foreach (DictionaryEntry de in resourceList)
+            foreach (KeyValuePair<string, IResource> de in resourceList)
             {
                 var node = de.Value as ResXDataNode;
                 ResourceData data;
                 if (node != null)
                 {
-                    string keyname = (string)de.Key;
+                    string keyname = de.Key;
                     if (keyname != node.Name)
                     {
                         throw new ArgumentException(SR.GetString(SR.MismatchedResourceName, keyname, node.Name));
@@ -138,7 +133,7 @@ namespace Microsoft.Build.Tasks
                     Type type = de.Value?.GetType() ?? typeof(Object);
                     data = new ResourceData(type, de.Value?.ToString());
                 }
-                resourceTypes.Add((String)de.Key, data);
+                resourceTypes.Add(de.Key, data);
             }
 
             // Note we still need to verify the resource names are valid language

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -121,6 +121,15 @@ namespace Microsoft.Build.Tasks
                     String valueAsString = node.GetValue((AssemblyName[])null).ToString();
                     data = new ResourceData(type, valueAsString);
                 }
+               else if (de.Value is StringResource sr)
+                {
+                    data = new ResourceData(typeof(string), sr.Value);
+                }
+                else if (de.Value is FileStreamResource fsr)
+                {
+                    data = new ResourceData(fsr.TypeAssemblyQualifiedName.Substring(0, fsr.TypeAssemblyQualifiedName.IndexOf(',')));
+                }
+                // TODO: other cases!
                 else
                 {
                     // If the object is null, we don't have a good way of guessing the

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -528,9 +528,8 @@ namespace Microsoft.Build.Tasks
 
                 valueType = new CodeTypeReference(data.TypeFullName);
 
-                // TODO: can we do better here than exact comparisons against something that may vary over time?
-                isString = false;
-                isStream = false;
+                isString = MSBuildResXReader.IsString(data.TypeAssemblyQualifiedName);
+                isStream = MSBuildResXReader.IsMemoryStream(data.TypeAssemblyQualifiedName);
             }
 
             var prop = new CodeMemberProperty

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -85,20 +85,20 @@ namespace Microsoft.Build.Tasks
             internal ResourceData(Type type, String valueAsString)
             {
                 Type = type;
-                TypeName = type.FullName;
+                TypeFullName = type.FullName;
                 ValueAsString = valueAsString;
             }
 
             internal ResourceData(string typeName)
             {
                 Type = null;
-                TypeName = typeName;
+                TypeFullName = typeName;
                 ValueAsString = null;
             }
 
             internal Type Type { get; }
 
-            internal string TypeName { get; }
+            internal string TypeFullName { get; }
 
             internal String ValueAsString { get; }
         }
@@ -514,7 +514,6 @@ namespace Microsoft.Build.Tasks
 
                 isString = type == typeof(String);
                 isStream = type == typeof(UnmanagedMemoryStream) || type == typeof(MemoryStream);
-
             }
             else
             {
@@ -523,7 +522,7 @@ namespace Microsoft.Build.Tasks
 
                 // TODO: can we do the type gymnastics here, too?
 
-                valueType = new CodeTypeReference(data.TypeName);
+                valueType = new CodeTypeReference(data.TypeFullName);
 
                 // TODO: can we do better here than exact comparisons against something that may vary over time?
                 isString = false;
@@ -563,7 +562,7 @@ namespace Microsoft.Build.Tasks
 
             if (!isString) // Stream or Object
             {
-                typeName = TruncateAndFormatCommentStringForOutput(data.TypeName);
+                typeName = TruncateAndFormatCommentStringForOutput(data.TypeFullName);
             }
 
             if (isString)

--- a/src/Tasks/system.design/stronglytypedresourcebuilder.cs
+++ b/src/Tasks/system.design/stronglytypedresourcebuilder.cs
@@ -85,13 +85,15 @@ namespace Microsoft.Build.Tasks
             internal ResourceData(Type type, String valueAsString)
             {
                 Type = type;
+                TypeAssemblyQualifiedName = type.AssemblyQualifiedName;
                 TypeFullName = type.FullName;
                 ValueAsString = valueAsString;
             }
 
-            internal ResourceData(string typeName)
+            internal ResourceData(string typeName, string typeAssemblyQualifiedName)
             {
                 Type = null;
+                TypeAssemblyQualifiedName = typeAssemblyQualifiedName;
                 TypeFullName = typeName;
                 ValueAsString = null;
             }
@@ -99,6 +101,8 @@ namespace Microsoft.Build.Tasks
             internal Type Type { get; }
 
             internal string TypeFullName { get; }
+
+            internal string TypeAssemblyQualifiedName { get; }
 
             internal String ValueAsString { get; }
         }
@@ -115,7 +119,7 @@ namespace Microsoft.Build.Tasks
             {
                 ResourceData data = resource.Value is LiveObjectResource liveObject
                     ? new ResourceData(liveObject.Value.GetType(), liveObject.Value.ToString())
-                    : new ResourceData(resource.Value.TypeFullName);
+                    : new ResourceData(resource.Value.TypeFullName, resource.Value.TypeAssemblyQualifiedName);
                 resourceTypes.Add(resource.Key, data);
             }
 


### PR DESCRIPTION
This regressed (#4582) with #4420, because the (untyped, .NET 1.0) `Dictionary` passed to `Create` never contained `ResXDataNode`s any more, but the new type `LiveObjectResource` that holds live deserialized objects in memory.

~This fixes _only_ the full-framework scenarios that use `$(GenerateResourceUsePreserializedResources)=false`. When building for .NET Core with the default settings, or _using_ .NET Core to build, `StronglyTypedResourceBuilder` still doesn't work (#2272).~

## Description

Enable `StronglyTypedResourceBuilder` when running on .NET Core and ensure that projects built using the .NET Core codepath get code generated using the expected types for resources. Fixes #4588, fixes #2272.

## Customer Impact

Projects that used `ResXFileCodeGenerator` could fail to compile due to generated code losing type information. This impacted WPF.

Projects affected by either problem would have to workaround by:
1. Build using desktop `MSBuild.exe`, not `dotnet build`
2. Explicitly disable the new .NET Core resource-handling codepath in the projects.

## Regression

Regression from .NET Framework functionality; bugs in features new to crossplatform .NET Core MSBuild.

## Risk

Low--impacts only the new resource codepaths.
