### PR TITLE
Resource Naming DependentUpon Convention

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -194,7 +194,6 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
-        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -220,7 +219,6 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
-        public abstract string SourceFileExtension { get; }
         public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
@@ -239,7 +237,6 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
-        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -194,6 +194,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
+        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -219,6 +220,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
+        public abstract string SourceFileExtension { get; }
+        public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
         protected abstract bool IsSourceFile(string fileName);
@@ -236,6 +239,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
+        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -124,7 +124,6 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
-        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -150,7 +149,6 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
-        public abstract string SourceFileExtension { get; }
         public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
@@ -169,7 +167,6 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
-        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
+        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -149,6 +150,8 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
+        public abstract string SourceFileExtension { get; }
+        public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
         protected abstract bool IsSourceFile(string fileName);
@@ -166,6 +169,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
+        public override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Build.UnitTests
 
                 t.Execute().ShouldBeTrue("Expected the task to succeed.");
 
-                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+                t.ManifestResourceNames.ShouldHaveSingleItem();
 
                 t.ManifestResourceNames[0].ItemSpec.ShouldBe("MyStuff.Namespace.Class", "Expecting to find the namespace & class name from SR1.cs");
             }
@@ -444,7 +444,7 @@ namespace Microsoft.Build.UnitTests
 
                 t.Execute().ShouldBeTrue("Expected the task to succeed.");
 
-                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource should exist");
+                t.ManifestResourceNames.ShouldHaveSingleItem();
 
                 t.ManifestResourceNames[0].ItemSpec.ShouldBe("SR1", "Expected only the file name.");
             }
@@ -475,7 +475,7 @@ namespace Microsoft.Build.UnitTests
 
                 t.Execute().ShouldBeTrue("Expected the task to succeed.");
 
-                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+                t.ManifestResourceNames.ShouldHaveSingleItem();
 
                 t.ManifestResourceNames[0].ItemSpec.ShouldBe("MyStuff2.Namespace.Class2", "Expected the namespace & class of SR2.");
             }
@@ -511,7 +511,7 @@ namespace Microsoft.Build.UnitTests
 
                 t.Execute().ShouldBeTrue("Expected the task to succeed.");
 
-                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+                t.ManifestResourceNames.ShouldHaveSingleItem();
 
                 t.ManifestResourceNames[0].ItemSpec.ShouldBe("SR1", "Expected only the file name.");
             }

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -481,8 +481,6 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-
-
         /// <summary>
         /// When disabling UseDependentUponConvention it will find no .cs file and default to filename.
         /// </summary>
@@ -516,7 +514,6 @@ namespace Microsoft.Build.UnitTests
                 t.ManifestResourceNames[0].ItemSpec.ShouldBe("SR1", "Expected only the file name.");
             }
         }
-
 
         /// <summary>
         /// helper method for verifying manifest resource names

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -8,12 +8,21 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
+using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     sealed public class CreateCSharpManifestResourceName_Tests
     {
+
+        private readonly ITestOutputHelper _testOutput;
+
+        public CreateCSharpManifestResourceName_Tests(ITestOutputHelper output)
+        {
+            _testOutput = output;
+        }
         /// <summary>
         /// Test the basic functionality.
         /// </summary>
@@ -376,6 +385,138 @@ namespace Microsoft.Build.UnitTests
             Assert.Single(resourceNames);
             Assert.Equal(@"CustomToolTest.SR1", resourceNames[0].ItemSpec);
         }
+
+        /// <summary>
+        /// Opt into DependentUpon convention and load the expected file properly.
+        /// </summary>
+        [Fact]
+        public void DependentUpon_UseConvention()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var csFile = env.CreateFile("SR1.cs", "namespace MyStuff.Namespace { class Class { } }");
+                var resXFile = env.CreateFile("SR1.resx", "");
+
+                ITaskItem i = new TaskItem(resXFile.Path);
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                // Don't set DependentUpon so it goes by convention
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = true,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe("MyStuff.Namespace.Class", "Expecting to find the namespace & class name from SR1.cs");
+            }
+        }
+
+        /// <summary>
+        /// Opt into DependentUpon convention without creating the equivalent .cs file for our resource file.
+        /// </summary>
+        [Fact]
+        public void DependentUpon_UseConventionFileDoesNotExist()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                // cs file doesn't exist for this case.
+                var resXFile = env.CreateFile("SR1.resx", "");
+
+                ITaskItem i = new TaskItem(Path.GetFileName(resXFile.Path));
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                // Don't set DependentUpon so it goes by convention
+
+                // Use relative paths to ensure short manifest name based on the path to the resx.
+                // See CreateManifestNameImpl
+                env.SetCurrentDirectory(Path.GetDirectoryName(resXFile.Path));
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = true,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource should exist");
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe("SR1", "Expected only the file name.");
+            }
+        }
+
+        /// <summary>
+        /// Opt into DependentUponConvention, but include DependentUpon metadata with different name.
+        /// </summary>
+        [Fact]
+        public void DependentUpon_SpecifyNewFile()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var conventionCSFile = env.CreateFile("SR1.cs", "namespace MyStuff.Namespace { class Class { } }");
+                var nonConventionCSFile = env.CreateFile("SR2.cs", "namespace MyStuff2.Namespace { class Class2 { } }");
+                var resXFile = env.CreateFile("SR1.resx", "");
+
+                ITaskItem i = new TaskItem(resXFile.Path);
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                i.SetMetadata("DependentUpon", "SR2.cs");
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = true,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe("MyStuff2.Namespace.Class2", "Expected the namespace & class of SR2.");
+            }
+        }
+
+
+
+        /// <summary>
+        /// When disabling UseDependentUponConvention it will find no .cs file and default to filename.
+        /// </summary>
+        [Fact]
+        public void DependentUpon_DisableConvention()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var csFile = env.CreateFile("SR1.cs", "namespace MyStuff.Namespace { class Class { } }");
+                var resXFile = env.CreateFile("SR1.resx", "");
+
+                ITaskItem i = new TaskItem(Path.GetFileName(resXFile.Path));
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                i.SetMetadata("DependentUpon", "");
+
+                // Use relative paths to ensure short manifest name based on the path to the resx.
+                // See CreateManifestNameImpl
+                env.SetCurrentDirectory(Path.GetDirectoryName(resXFile.Path));
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = false,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.Length.ShouldBe(1, "Only 1 resource file should exist");
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe("SR1", "Expected only the file name.");
+            }
+        }
+
 
         /// <summary>
         /// helper method for verifying manifest resource names

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Build.UnitTests
         /// Opt into DependentUpon convention and load the expected file properly.
         /// </summary>
         [Fact]
-        public void DependentUpon_UseConvention()
+        public void DependentUponConvention_FindsMatch()
         {
             using (var env = TestEnvironment.Create())
             {
@@ -487,7 +487,7 @@ namespace Microsoft.Build.UnitTests
         /// When disabling UseDependentUponConvention it will find no .cs file and default to filename.
         /// </summary>
         [Fact]
-        public void DependentUpon_DisableConvention()
+        public void DependentUponConvention_ConventionDisabledDoesNotReadConventionFile()
         {
             using (var env = TestEnvironment.Create())
             {

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Build.UnitTests
 
                 ITaskItem i = new TaskItem(Path.GetFileName(resXFile.Path));
                 i.SetMetadata("BuildAction", "EmbeddedResource");
-                i.SetMetadata("DependentUpon", "");
+                // No need to set DependentUpon
 
                 // Use relative paths to ensure short manifest name based on the path to the resx.
                 // See CreateManifestNameImpl

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateCSharpManifestResourceName : CreateManifestResourceName
     {
-        public override string SourceFileExtension => ".cs";
+        internal override string SourceFileExtension => ".cs";
 
         /// <summary>
         /// Utility function for creating a C#-style manifest name from 

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateCSharpManifestResourceName : CreateManifestResourceName
     {
+        public override string SourceFileExtension => ".cs";
+
         /// <summary>
         /// Utility function for creating a C#-style manifest name from 
         /// a resource name. 

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Build.Tasks
                     string fileName = resourceFile.ItemSpec;
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
 
+                    //If opted into convention and no DependentUpon metadata, go by convention "<filename>.cs" if it exists.
                     if(UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
                         string conventionDependentUpon = Path.ChangeExtension(fileName, SourceFileExtension);

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Tasks
 
         public bool UseDependentUponConvention { get; set; }
 
-        public abstract string SourceFileExtension { get; }
+        internal abstract string SourceFileExtension { get; }
 
         /// <summary>
         /// The possibly dependent resource files.
@@ -146,7 +146,7 @@ namespace Microsoft.Build.Tasks
                     string fileName = resourceFile.ItemSpec;
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
 
-                    //If opted into convention and no DependentUpon metadata, go by convention "<filename>.cs" if it exists.
+                    // If opted into convention and no DependentUpon metadata, reference "<filename>.cs" if it exists.
                     if(UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
                         string conventionDependentUpon = Path.ChangeExtension(fileName, SourceFileExtension);

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -147,11 +147,11 @@ namespace Microsoft.Build.Tasks
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
 
                     // If opted into convention and no DependentUpon metadata, reference "<filename>.cs" if it exists.
-                    if(UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
+                    if (UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
                         string conventionDependentUpon = Path.ChangeExtension(fileName, SourceFileExtension);
 
-                        if(File.Exists(conventionDependentUpon))
+                        if (File.Exists(conventionDependentUpon))
                         {
                             dependentUpon = conventionDependentUpon;
                         }

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -33,6 +33,10 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public bool PrependCultureAsDirectory { get; set; } = true;
 
+        public bool UseDependentUponConvention { get; set; }
+
+        public abstract string SourceFileExtension { get; }
+
         /// <summary>
         /// The possibly dependent resource files.
         /// </summary>
@@ -141,6 +145,16 @@ namespace Microsoft.Build.Tasks
                 {
                     string fileName = resourceFile.ItemSpec;
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
+
+                    if(UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
+                    {
+                        string conventionDependentUpon = Path.ChangeExtension(fileName, SourceFileExtension);
+
+                        if(File.Exists(conventionDependentUpon))
+                        {
+                            dependentUpon = conventionDependentUpon;
+                        }
+                    }
 
                     // Pre-log some information.
                     bool isDependentOnSourceFile = !string.IsNullOrEmpty(dependentUpon) && IsSourceFile(dependentUpon);

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateVisualBasicManifestResourceName : CreateManifestResourceName
     {
-        public override string SourceFileExtension => ".vb";
+        internal override string SourceFileExtension => ".vb";
 
         /// <summary>
         /// Utility function for creating a VB-style manifest name from 

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateVisualBasicManifestResourceName : CreateManifestResourceName
     {
+        public override string SourceFileExtension => ".vb";
+
         /// <summary>
         /// Utility function for creating a VB-style manifest name from 
         /// a resource name. 

--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -99,7 +99,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Create manifest names for culture and non-culture Resx files, and for non-culture Non-Resx resources -->
         <CreateCSharpManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
-              RootNamespace="$(RootNamespace)"              
+              RootNamespace="$(RootNamespace)"
+              UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and ('%(EmbeddedResource.WithCulture)' == 'false' or '%(EmbeddedResource.Type)' == 'Resx')">
 
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
@@ -111,6 +112,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
               ResourceFiles="@(EmbeddedResource)"
               RootNamespace="$(RootNamespace)"
               PrependCultureAsDirectory="false"
+              UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and '%(EmbeddedResource.WithCulture)' == 'true' and '%(EmbeddedResource.Type)' == 'Non-Resx'">
 
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -100,6 +100,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CreateVisualBasicManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
               RootNamespace="$(RootNamespace)"
+              UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and ('%(EmbeddedResource.WithCulture)' == 'false' or '%(EmbeddedResource.Type)' == 'Resx')">
 
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />
@@ -110,7 +111,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CreateVisualBasicManifestResourceName
               ResourceFiles="@(EmbeddedResource)"
               RootNamespace="$(RootNamespace)"
-              PrependCultureAsDirectory="false"              
+              PrependCultureAsDirectory="false"
+              UseDependentUponConvention="$(EmbeddedResourceUseDependentUponConvention)"
               Condition="'%(EmbeddedResource.ManifestResourceName)' == '' and '%(EmbeddedResource.WithCulture)' == 'true' and '%(EmbeddedResource.Type)' == 'Non-Resx'">
 
             <Output TaskParameter="ResourceFilesWithManifestResourceNames" ItemName="_Temporary" />


### PR DESCRIPTION
### Description

In SDK projects and new project system, we have eliminated the need for DependentUpon to make the appropriate file nesting in the IDE tree. However, there is a place where the build actually uses DependentUpon to:

1. Locate a source file, and _parse (!)_ it to get first class name and namespace
2. Generate .resources accordingly.

But people and features in VS rely on this and it has been a consistent source of feedback in moving to .NET Core 3.0. This opts into new behavior to use a convention instead of requiring explicit metadata.

Original issue: https://github.com/microsoft/msbuild/issues/4488

 This change is dependent upon: https://github.com/dotnet/sdk/pull/3533

### Customer Impact

In a fairly common situation for projects that use resources, avoids the need to specify `DependentUpon` metadata for each resource.

### Regression?

No

### Risk

Low risk.

### Test changes in this PR

------------------------------

Fixes #4488 

Added new argument to CreateManifestResourceName: `UseDependentUponConvention`