### PR TITLE
Fix warning when newline in hintpath

### DIFF
--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -535,6 +535,19 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void CannotNormalizePathWithNewLineAndSpace()
+        {
+            string filePath = "\r\n      C:\\work\\sdk3\\artifacts\\tmp\\Debug\\SimpleNamesWi---6143883E\\NETFrameworkLibrary\\bin\\Debug\\net462\\NETFrameworkLibrary.dll\r\n      ";
+
+#if FEATURE_LEGACY_GETFULLPATH
+            Assert.Throws<ArgumentException>(() => FileUtilities.NormalizePath(filePath));
+#else
+            Assert.NotEqual("C:\\work\\sdk3\\artifacts\\tmp\\Debug\\SimpleNamesWi---6143883E\\NETFrameworkLibrary\\bin\\Debug\\net462\\NETFrameworkLibrary.dll", FileUtilities.NormalizePath(filePath));
+#endif
+        }
+
+        [Fact]
         public void FileOrDirectoryExistsNoThrow()
         {
             var isWindows = NativeMethodsShared.IsWindows;

--- a/src/Tasks.UnitTests/HintPathResolver_Tests.cs
+++ b/src/Tasks.UnitTests/HintPathResolver_Tests.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Build.Tasks.UnitTests
+{
+    public class HintPathResolver_Tests : IDisposable
+    {
+        private readonly TestEnvironment _env;
+
+        public HintPathResolver_Tests(ITestOutputHelper testOutput)
+        {
+            _env = TestEnvironment.Create(testOutput);
+        }
+
+        public void Dispose()
+        {
+            _env.Dispose();
+        }
+
+        [Fact]
+        public void CanResolveHintPath()
+        {
+            var tempFile = _env.CreateFile("FakeSystem.Net.Http.dll", "");
+            bool result = ResolveHintPath(tempFile.Path);
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void CanResolveLongNonNormalizedHintPath()
+        {
+            var tempfolder = _env.DefaultTestDirectory.CreateDirectory("tempfolder_for_CanResolveLongHintPath");
+            tempfolder.CreateFile("FakeSystem.Net.Http.dll");
+            var longTempFilePath = tempfolder.Path + "\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\..\\tempfolder_for_CanResolveLongHintPath\\FakeSystem.Net.Http.dll";
+            bool result = ResolveHintPath(longTempFilePath);
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        public void CanNotResolveHintPathWithNewLine()
+        {
+            var tempFile = _env.CreateFile("FakeSystem.Net.Http.dll", "");
+            bool result = ResolveHintPath(Environment.NewLine + tempFile.Path + Environment.NewLine);
+
+            result.ShouldBe(false);
+        }
+
+        [Fact]
+        public void CanNotResolveHintPathWithSpace()
+        {
+            var tempFile = _env.CreateFile("FakeSystem.Net.Http.dll", "");
+            bool result = ResolveHintPath("  " + tempFile.Path + "  ");
+
+            result.ShouldBe(false);
+        }
+        private bool ResolveHintPath(string hintPath)
+        {
+            var hintPathResolver = new HintPathResolver(
+                searchPathElement: "{HintPathFromItem}",
+                getAssemblyName: (path) => throw new NotImplementedException(), // not called in this code path
+                fileExists: p => FileUtilities.FileExistsNoThrow(p),
+                getRuntimeVersion: (path) => throw new NotImplementedException(), // not called in this code path
+                targetedRuntimeVesion: Version.Parse("4.0.30319"));
+
+            var result = hintPathResolver.Resolve(new AssemblyNameExtension("FakeSystem.Net.Http"),
+                sdkName: "",
+                rawFileNameCandidate: "FakeSystem.Net.Http",
+                isPrimaryProjectReference: true,
+                wantSpecificVersion: false,
+                executableExtensions: new string[] { ".winmd", ".dll", ".exe" },
+                hintPath: hintPath,
+                assemblyFolderKey: "",
+                assembliesConsideredAndRejected: new List<ResolutionSearchLocation>(),
+                foundPath: out var findPath,
+                userRequestedSpecificFile: out var userResquestedSpecificFile);
+            return result;
+        }
+    }
+}

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Build.Tasks
             out bool userRequestedSpecificFile
         )
         {
-            if (!string.IsNullOrEmpty(hintPath))
+            if (!string.IsNullOrEmpty(hintPath) && !FileUtilities.PathIsInvalid(hintPath))
             {
                 if (ResolveAsFile(FileUtilities.NormalizePath(hintPath), assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))
                 {

--- a/src/Tasks/AssemblyDependency/HintPathResolver.cs
+++ b/src/Tasks/AssemblyDependency/HintPathResolver.cs
@@ -51,6 +51,10 @@ namespace Microsoft.Build.Tasks
             out bool userRequestedSpecificFile
         )
         {
+            // If there is newline or white space `FileUtilities.NormalizePath` will get garbage result(throw on fullframework).
+            // Adding FileUtilities.NormalizePath (https://github.com/microsoft/msbuild/pull/4414) caused https://github.com/microsoft/msbuild/issues/4593
+            // It is fixed by adding skip when the path is not valid
+            // However, we should consider Trim() the hintpath https://github.com/microsoft/msbuild/issues/4603
             if (!string.IsNullOrEmpty(hintPath) && !FileUtilities.PathIsInvalid(hintPath))
             {
                 if (ResolveAsFile(FileUtilities.NormalizePath(hintPath), assemblyName, isPrimaryProjectReference, wantSpecificVersion, true, assembliesConsideredAndRejected))


### PR DESCRIPTION
### Description

If there are newlines or white spaces passed to `Path.GetFullpath`, it will throw on fullframework. [Adding `Path.GetFullpath`](https://github.com/microsoft/msbuild/pull/4414/files) in previous change caused extra warning from Resolve Assembly Reference. This change added "skip when the path is not valid" to being back the "no warning but skip" behavior of 16.1.

### Customer Impact

If the customer has _warning as error_ enabled, a build would be successful in 16.1 but would be fail in the latest version

### Regression?

Yes. by https://github.com/microsoft/msbuild/pull/4414, since 16.2

### Risk

Low risk.

### Test changes in this PR

Additional unit tests and manual end to end tests.

------------------------------

fix https://github.com/microsoft/msbuild/issues/4593

This is a strict fix for the warning problem. Please look at `CannotNormalizePathWithNewLineAndSpace` test. `FileUtilities.NormalizePath` will get garbage output like (`c:\work\test   \r\n c:\work\referenced\file.dll`) when called with newline. So `File.Exists` cannot find the correct file anyway. The fix is only to make it quiet.

It behaves differently in core because Path.GetFullpath no longer throws when there is invalid char
To be discuss

1. Should we make it work? Instead of skip when contains invalid char, should we Trim it instead?
2. Is master the right branch? Do I need ask mode template for 16.3?
