### PR TITLE
Linguist tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,64 +2,6 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
-###############################################################################
-# Set default behavior for command prompt diff.
-#
-# This is need for earlier builds of msysgit that does not have it on by
-# default for csharp files.
-# Note: This is only used by command line
-###############################################################################
-#*.cs     diff=csharp
-
-###############################################################################
-# Set the merge driver for project and solution files
-#
-# Merging from the command prompt will add diff markers to the files if there
-# are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following
-# file extensions to fail to load in VS. An alternative would be to treat
-# these files as binary and thus will always conflict and require user
-# intervention with every merge. To do so, just uncomment the entries below
-###############################################################################
-#*.sln       merge=binary
-#*.csproj    merge=binary
-#*.vbproj    merge=binary
-#*.vcxproj   merge=binary
-#*.vcproj    merge=binary
-#*.dbproj    merge=binary
-#*.fsproj    merge=binary
-#*.lsproj    merge=binary
-#*.wixproj   merge=binary
-#*.modelproj merge=binary
-#*.sqlproj   merge=binary
-#*.wwaproj   merge=binary
-
-###############################################################################
-# behavior for image files
-#
-# image files are treated as binary by default.
-###############################################################################
-#*.jpg   binary
-#*.png   binary
-#*.gif   binary
-
-###############################################################################
-# diff behavior for common document formats
-#
-# Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the
-# entries below.
-###############################################################################
-#*.doc   diff=astextplain
-#*.DOC   diff=astextplain
-#*.docx  diff=astextplain
-#*.DOCX  diff=astextplain
-#*.dot   diff=astextplain
-#*.DOT   diff=astextplain
-#*.pdf   diff=astextplain
-#*.PDF   diff=astextplain
-#*.rtf   diff=astextplain
-#*.RTF   diff=astextplain
 
 # Force bash scripts to always use lf line endings so that if a repro is accessed
 # in Unix via a file share from Windows, the scripts will work.

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,18 @@
 
 # Ensure .bin files are stored as binary
 *.bin binary
+
+###############################################################################
+# Linguist customization (https://github.com/github/linguist#overrides)
+###############################################################################
+
+# Include MSBuild in repo stats
+src/Tasks/*.props linguist-detectable=true
+src/Tasks/*.targets linguist-detectable=true
+src/Tasks/*.tasks linguist-detectable=true
+
+# Don't include Arcade-owned path
+eng/common/** linguist-detectable=false
+
+# Display XLF files collapsed by default in PR diffs
+*.xlf linguist-generated=true


### PR DESCRIPTION
Just happened across documentation that enabled me to do some things I've wanted for a while:

* Include MSBuild core props/targets in repo stats (it's a bunch of our code!)
* Exclude Arcade code from repo stats (we don't use CMake!)
* Mark XLF files as generated (collapse them by default in PRs)

Current stats:

![image](https://user-images.githubusercontent.com/3347530/62796046-c472cb00-ba9d-11e9-978e-4a820b32f72f.png)
