### PR TITLE
ResXFileRef special cases

### DIFF
--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -230,6 +230,17 @@ namespace Microsoft.Build.Tasks.ResourceHandling
                     return;
                 }
             }
+            else if (IsByteArray(fileRefType))
+            {
+                using (FileStream s = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    byte[] byteArray = new byte[s.Length];
+                    s.Read(byteArray, 0, (int)s.Length);
+
+                    resources.Add(new LiveObjectResource(name, byteArray));
+                    return;
+                }
+            }
 
             resources.Add(new FileStreamResource(name, fileRefType, fileName, resxFilename));
         }

--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -155,14 +155,10 @@ namespace Microsoft.Build.Tasks.ResourceHandling
 
             if (mimetype == null)
             {
-                if (typename.IndexOf("System.Byte[]") != -1 && typename.IndexOf("mscorlib") != -1)
+                if (IsByteArray(typename))
                 {
                     byte[] byteArray = Convert.FromBase64String(value);
 
-                    // Comment and logic from https://github.com/dotnet/winforms/blob/16b192389b377c647ab3d280130781ab1a9d3385/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs#L411-L416
-                    // Handle byte[]'s, which are stored as base-64 encoded strings.
-                    // We can't hard-code byte[] type name due to version number
-                    // updates & potential whitespace issues with ResX files.
                     resources.Add(new LiveObjectResource(name, byteArray));
                     return;
                 }
@@ -236,6 +232,20 @@ namespace Microsoft.Build.Tasks.ResourceHandling
             }
 
             resources.Add(new FileStreamResource(name, fileRefType, fileName, resxFilename));
+        }
+
+        /// <summary>
+        /// Does this assembly-qualified type name represent an array of bytes?
+        /// </summary>
+        /// <remarks>
+        /// Comment and logic from https://github.com/dotnet/winforms/blob/16b192389b377c647ab3d280130781ab1a9d3385/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs#L411-L416
+        /// </remarks>
+        // Handle byte[]'s, which are stored as base-64 encoded strings.
+        // We can't hard-code byte[] type name due to version number
+        // updates & potential whitespace issues with ResX files.
+        private static bool IsByteArray(string fileRefType)
+        {
+            return fileRefType.IndexOf("System.Byte[]") != -1 && fileRefType.IndexOf("mscorlib") != -1;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Add special cases in build-time resource embedding for the resource types `byte[]` and `MemoryStream`. Fixes #4581.

Enable `StronglyTypedResourceBuilder` when running on .NET Core and ensure that projects built using the .NET Core codepath get code generated using the expected types for resources. Fixes #4588, fixes #2272.

## Customer Impact

Accessing some resources would throw an exception at runtime instead of returning a resource of type `byte[]` or `MemoryStream`.

Projects affected by either problem would have to workaround by:
1. Build using desktop `MSBuild.exe`, not `dotnet build`
2. Explicitly disable the new .NET Core resource-handling codepath in the projects.

## Regression

Regression from .NET Framework functionality; bugs in features new to crossplatform .NET Core MSBuild.

## Risk

Low--impacts only the new resource codepaths.
