### PR TITLE
Update System.Threading.Tasks.Dataflow to 4.9.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -39,10 +39,7 @@
     <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
-
-    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.5.24.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
-    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.6.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'"/>
-
+    <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Update="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Update="System.Xml.XPath" Version="4.3.0" />
     <PackageReference Update="xunit.assert" Version="$(XUnitVersion)" />

--- a/src/nuget/Microsoft.Build.nuspec
+++ b/src/nuget/Microsoft.Build.nuspec
@@ -58,7 +58,7 @@
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
         <dependency id="System.Threading.Tasks" version="4.0.11" />
-        <dependency id="System.Threading.Tasks.Dataflow" version="4.6.0" />
+        <dependency id="System.Threading.Tasks.Dataflow" version="4.9.0" />
         <dependency id="System.Threading.Thread" version="4.0.0" />
         <dependency id="System.Threading.ThreadPool" version="4.0.10" />
         <dependency id="System.Xml.ReaderWriter" version="4.0.11" />


### PR DESCRIPTION
#### Description

Consolidate versions used between VS and .NET Core.

#### Customer Impact

This avoids an RPS regression in VS 16.3 which is about to switch to Dataflow 4.9.0

#### Regression

No.

#### Risk

Low.