### PR TITLE
Fix cases where UTF8 wasn't supported.

### DIFF
--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Construction
             {
                 // Open the file
                 fileStream = File.OpenRead(solutionFile);
-                reader = new StreamReader(fileStream, Encoding.UTF8); // HIGHCHAR: If solution files have no byte-order marks, then assume UFT8-8.
+                reader = new StreamReader(fileStream, Encoding.UTF8); // HIGHCHAR: If solution files have no byte-order marks, then assume UFT-8.
 
                 // Read first 4 lines of the solution file. 
                 // The header is expected to be in line 1 or 2

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Construction
             {
                 // Open the file
                 fileStream = File.OpenRead(solutionFile);
-                reader = new StreamReader(fileStream, Encoding.UTF8); // HIGHCHAR: If solution files have no byte-order marks, then assume UFT-8.
+                reader = new StreamReader(fileStream, Encoding.UTF8); // HIGHCHAR: If solution files have no byte-order marks, then assume UTF-8 (which also supports ASCII).
 
                 // Read first 4 lines of the solution file. 
                 // The header is expected to be in line 1 or 2

--- a/src/Build/Construction/Solution/SolutionFile.cs
+++ b/src/Build/Construction/Solution/SolutionFile.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Build.Construction
             {
                 // Open the file
                 fileStream = File.OpenRead(solutionFile);
-                reader = new StreamReader(fileStream, Encoding.GetEncoding(0)); // HIGHCHAR: If solution files have no byte-order marks, then assume ANSI rather than ASCII.
+                reader = new StreamReader(fileStream, Encoding.UTF8); // HIGHCHAR: If solution files have no byte-order marks, then assume UFT8-8.
 
                 // Read first 4 lines of the solution file. 
                 // The header is expected to be in line 1 or 2

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1353,11 +1353,11 @@ namespace Microsoft.Build.Utilities
                         // Use sh rather than bash, as not all 'nix systems necessarily have Bash installed
                         File.AppendAllText(_temporaryBatchFile, "#!/bin/sh\n"); // first line for UNIX is ANSI
                         // This is a hack..!
-                        File.AppendAllText(_temporaryBatchFile, AdjustCommandsForOperatingSystem(commandLineCommands), EncodingUtilities.CurrentSystemOemEncoding);
+                        File.AppendAllText(_temporaryBatchFile, AdjustCommandsForOperatingSystem(commandLineCommands), StandardOutputEncoding);
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, EncodingUtilities.CurrentSystemOemEncoding);
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, StandardOutputEncoding);
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1353,11 +1353,11 @@ namespace Microsoft.Build.Utilities
                         // Use sh rather than bash, as not all 'nix systems necessarily have Bash installed
                         File.AppendAllText(_temporaryBatchFile, "#!/bin/sh\n"); // first line for UNIX is ANSI
                         // This is a hack..!
-                        File.AppendAllText(_temporaryBatchFile, AdjustCommandsForOperatingSystem(commandLineCommands), StandardOutputEncoding);
+                        File.AppendAllText(_temporaryBatchFile, AdjustCommandsForOperatingSystem(commandLineCommands), EncodingUtilities.CurrentSystemOemEncoding);
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, StandardOutputEncoding);
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, EncodingUtilities.CurrentSystemOemEncoding);
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 


### PR DESCRIPTION
- Fix an issue where .sln files are created without BOM fallback to asci.  This limits to just EN language. 
 Instead, fallback to UTF-8, which is a superset of asci.  The VS IDE by default creates sln in UFT8.
(UNDO)- When UseCommandProcessor is true, it will create a .cmd (aka .bat) file to run.  This file encoding is hardcoded for OS lang which is sometimes incorrect, but it doesn't provide a way to override.  Using StandardOutputEncoding as a override mechanism.
