### PR TITLE
Support ResXNullRef in MSBuildResXReader

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
@@ -76,6 +76,24 @@ namespace Microsoft.Build.Tasks.UnitTests.GenerateResource
         }
 
         [Fact]
+        public void ResXNullRefProducesNullLiveObject()
+        {
+            var resxWithNullRef = MSBuildResXReader.GetResourcesFromString(
+                ResXHelper.SurroundWithBoilerplate(
+@"  <assembly alias=""System.Windows.Forms"" name=""System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" />
+  <data name=""$this.AccessibleDescription"" type=""System.Resources.ResXNullRef, System.Windows.Forms, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"">
+    <value />
+  </data>"));
+
+            resxWithNullRef.ShouldHaveSingleItem();
+
+            resxWithNullRef[0].Name.ShouldBe("$this.AccessibleDescription");
+
+            resxWithNullRef[0].ShouldBeOfType<LiveObjectResource>()
+                .Value.ShouldBeNull();
+        }
+
+        [Fact]
         public void LoadsStringFromFileRefAsString()
         {
             File.Exists(Path.Combine("ResourceHandling", "TextFile1.txt")).ShouldBeTrue("Test deployment is missing None files");

--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -151,6 +151,12 @@ namespace Microsoft.Build.Tasks.ResourceHandling
                 return;
             }
 
+            if (typename.StartsWith("System.Resources.ResXNullRef", StringComparison.Ordinal))
+            {
+                resources.Add(new LiveObjectResource(name, null));
+                return;
+            }
+
             // TODO: validate typename at this point somehow to make sure it's vaguely right?
 
             if (mimetype == null)


### PR DESCRIPTION
Fixes #4634

## Description

Handle the special type `ResXNullRef` in the new .NET Core-compat resource handling. Fixes #4634.

## Customer Impact

Some `.resx` files caused exceptions at runtime rather than returning `null` as a resource.

## Regression

Regression from .NET Framework functionality; bugs in features new to crossplatform .NET Core MSBuild.

## Risk

Low--impacts only the new resource codepaths.