### PR TITLE
Permissive string types

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/MSBuildResXReader_Tests.cs
@@ -93,16 +93,18 @@ namespace Microsoft.Build.Tasks.UnitTests.GenerateResource
                 .Value.ShouldBeNull();
         }
 
-        [Fact]
-        public void LoadsStringFromFileRefAsString()
+        [Theory]
+        [InlineData("System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+        [InlineData("System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
+        public void LoadsStringFromFileRefAsString(string stringType)
         {
             File.Exists(Path.Combine("ResourceHandling", "TextFile1.txt")).ShouldBeTrue("Test deployment is missing None files");
 
             var resxWithLinkedString = MSBuildResXReader.GetResourcesFromString(
                 ResXHelper.SurroundWithBoilerplate(
-@"  <assembly alias=""System.Windows.Forms"" name=""System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" />
+$@"  <assembly alias=""System.Windows.Forms"" name=""System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"" />
   <data name=""TextFile1"" type=""System.Resources.ResXFileRef, System.Windows.Forms"">
-    <value>ResourceHandling\TextFile1.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+    <value>ResourceHandling\TextFile1.txt;{stringType};utf-8</value>
   </data>"));
 
             AssertSingleStringResource(resxWithLinkedString, "TextFile1", "Contents of TextFile1");

--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -81,14 +81,15 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         private const string ByteArraySerializedObjectMimeType = "application/x-microsoft.net.object.bytearray.base64";
         private const string ResMimeType = "text/microsoft-resx";
 
-        private const string StringTypeName = "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        private const string StringTypeName20 = "System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        private const string StringTypeName40 = "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
         private const string MemoryStreamTypeNameDesktopFramework = "System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 
         private static string GetFullTypeNameFromAlias(string aliasedTypeName, Dictionary<string, string> aliases)
         {
             if (aliasedTypeName == null)
             {
-                return StringTypeName;
+                return StringTypeName40;
             }
 
             int indexStart = aliasedTypeName.IndexOf(',');
@@ -100,7 +101,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
             // Allow "System.String" bare
             if (aliasedTypeName.Equals("System.String", StringComparison.Ordinal))
             {
-                return StringTypeName;
+                return StringTypeName40;
             }
 
             // No alias found. Hope it's sufficiently complete to be resolved at runtime
@@ -132,7 +133,7 @@ namespace Microsoft.Build.Tasks.ResourceHandling
 
             typename = GetFullTypeNameFromAlias(typename, aliases);
 
-            if (typename == StringTypeName)
+            if (IsString(typename))
             {
                 if (mimetype == null)
                 {
@@ -274,7 +275,8 @@ namespace Microsoft.Build.Tasks.ResourceHandling
 
         internal static bool IsString(string fileRefType)
         {
-            return fileRefType == StringTypeName;
+            return fileRefType.Equals(StringTypeName40, StringComparison.Ordinal) ||
+                fileRefType.Equals(StringTypeName20, StringComparison.Ordinal);
         }
 
         internal static bool IsMemoryStream(string fileRefType)


### PR DESCRIPTION
This builds on #4588; the only new change is 8c2ff60, but I wanted to expand on the newly-extracted `IsString()`.

https://github.com/rainersigwald/msbuild/compare/StronglyTypedResourceBuilder-ResXDataNode...permissive-string-types

## Description

Support more assembly-qualified names for `string` in `.resx` files.

## Customer Impact

Some legacy `.resx` files created with .NET 2.0 type references caused exceptions at runtime rather than returning strings.

## Regression

Regression from .NET Framework functionality; bugs in features new to crossplatform .NET Core MSBuild.

## Risk

Low--impacts only the new resource codepaths.
