### PR TITLE
LogProjectImports no longer cached

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Logging
 {
@@ -40,7 +41,7 @@ namespace Microsoft.Build.Logging
         private BuildEventArgsWriter eventArgsWriter;
         private ProjectImportsCollector projectImportsCollector;
         private string _initialTargetOutputLogging;
-        private string _initialLogImports;
+        private bool _initialLogImports;
 
         /// <summary>
         /// Describes whether to collect the project files (including imported project files) used during the build.
@@ -88,10 +89,11 @@ namespace Microsoft.Build.Logging
         public void Initialize(IEventSource eventSource)
         {
             _initialTargetOutputLogging = Environment.GetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING");
-            _initialLogImports = Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS");
+            _initialLogImports = Traits.Instance.EscapeHatches.LogProjectImports;
 
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", "true");
             Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", "1");
+            Traits.Instance.EscapeHatches.LogProjectImports = true;
 
             ProcessParameters();
 
@@ -148,7 +150,8 @@ namespace Microsoft.Build.Logging
         public void Shutdown()
         {
             Environment.SetEnvironmentVariable("MSBUILDTARGETOUTPUTLOGGING", _initialTargetOutputLogging);
-            Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", _initialLogImports);
+            Environment.SetEnvironmentVariable("MSBUILDLOGIMPORTS", _initialLogImports ? "1" : "");
+            Traits.Instance.EscapeHatches.LogProjectImports = _initialLogImports;
 
             if (projectImportsCollector != null)
             {

--- a/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
+++ b/src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.IO.Compression" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\MSBuild\MSBuild.csproj" />
     <ProjectReference Include="..\Utilities\Microsoft.Build.Utilities.csproj" />
     <ProjectReference Include="..\Xunit.NetCore.Extensions\Xunit.NetCore.Extensions.csproj" />

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -17,6 +17,8 @@ using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
 using Shouldly;
+using Microsoft.Build.Logging;
+using System.IO.Compression;
 
 namespace Microsoft.Build.UnitTests
 {
@@ -2076,6 +2078,46 @@ namespace Microsoft.Build.UnitTests
             string logContents = ExecuteMSBuildExeExpectSuccess(projectContents, arguments: arguments);
 
             logContents.ShouldContain("MSBuildInteractive = [true]");
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/microsoft/msbuild/issues/4631
+        /// </summary>
+        [Fact]
+        public void BinaryLogContainsImportedFiles()
+        {
+            using (TestEnvironment testEnvironment = UnitTests.TestEnvironment.Create())
+            {
+                var testProject = testEnvironment.CreateFile("Importer.proj", ObjectModelHelpers.CleanupFileContents(@"
+                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                    <Import Project=""TestProject.proj"" />
+
+                    <Target Name=""Build"">
+                    </Target>
+  
+                </Project>"));
+
+                testEnvironment.CreateFile("TestProject.proj", @"
+                <Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                  <Target Name=""Build"">
+                    <Message Text=""Hello from TestProject!"" />
+                  </Target>
+                </Project>
+                ");
+
+                string binLogLocation = testEnvironment.DefaultTestDirectory.Path;
+
+                string output = RunnerUtilities.ExecMSBuild($"\"{testProject.Path}\" \"/bl:{binLogLocation}/output.binlog\"", out var success, _output);
+
+                success.ShouldBeTrue(output);
+
+                RunnerUtilities.ExecMSBuild($"\"{binLogLocation}/output.binlog\" \"/bl:{binLogLocation}/replay.binlog;ProjectImports=ZipFile\"", out success, _output);
+
+                using (ZipArchive archive = ZipFile.OpenRead($"{binLogLocation}/replay.ProjectImports.zip"))
+                {
+                     archive.Entries.ShouldContain(e => e.FullName.EndsWith(".proj", StringComparison.OrdinalIgnoreCase), 2);
+                }
+            }
         }
 
         private string CopyMSBuild()

--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -17,7 +17,6 @@ using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
 using Shouldly;
-using Microsoft.Build.Logging;
 using System.IO.Compression;
 
 namespace Microsoft.Build.UnitTests

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -107,10 +107,27 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Emit events for project imports.
         /// </summary>
-        /// <remarks>
-        /// This is not cached because the environment variable can be modified inside msbuild.exe
-        /// </remarks>
-        public bool LogProjectImports => Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS") == "1";
+        private bool? _logProjectImports;
+
+        /// <summary>
+        /// Emit events for project imports.
+        /// </summary>
+        public bool LogProjectImports
+        {
+            get
+            {
+                // Cache the first time
+                if (_logProjectImports == null)
+                {
+                    _logProjectImports = !String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS"));
+                }
+                return _logProjectImports.Value;
+            }
+            set
+            {
+                _logProjectImports = value;
+            }
+        }
 
         /// <summary>
         /// Read information only once per file per ResolveAssemblyReference invocation.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -104,7 +104,13 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
-        public readonly bool LogProjectImports = Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS") == "1";
+        /// <summary>
+        /// Emit events for project imports.
+        /// </summary>
+        /// <remarks>
+        /// This is not cached because the environment variable can be modified inside msbuild.exe
+        /// </remarks>
+        public bool LogProjectImports => Environment.GetEnvironmentVariable("MSBUILDLOGIMPORTS") == "1";
 
         /// <summary>
         /// Read information only once per file per ResolveAssemblyReference invocation.


### PR DESCRIPTION
## Description

Fixes an issue where binary logs omits all project project import events.

## Customer Impact

Restores expected binary logger behavior improving customer's ability to debug and our ability to help customers.

## Regression
Yes introduced by https://github.com/microsoft/msbuild/pull/4485

## Risk

Low

-------------------

Fixes https://github.com/microsoft/msbuild/issues/4631

LogProjectImports is modified to always pull from environment instead of caching. This is due to the environment variable itself potentially being modified within msbuild.exe.