### PR TITLE
Improve incremental behavior on MSB3822

### DIFF
--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -449,6 +449,8 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
             {
                 t.Sources = new ITaskItem[] { new TaskItem(resxFile) };
 
+                string outputResource = Path.ChangeExtension(Path.GetFullPath(resxFile), ".resources");
+
 #if NETFRAMEWORK
                 if (!usePreserialized)
                 {
@@ -477,9 +479,10 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 else
                 {
                     Utilities.AssertLogContainsResource(t, "GenerateResource.PreserializedResourcesRequiresExtensions");
+                    Utilities.AssertLogContainsResource(t, "GenerateResource.CorruptOutput", outputResource);
                 }
 
-                File.Exists(Path.ChangeExtension(Path.GetFullPath(resxFile), ".resources"))
+                File.Exists(outputResource)
                     .ShouldBeFalse("Resources file was left on disk even though resource creation failed.");
             }
             finally

--- a/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/ResourceHandling/GenerateResource_Tests.cs
@@ -478,6 +478,9 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
                 {
                     Utilities.AssertLogContainsResource(t, "GenerateResource.PreserializedResourcesRequiresExtensions");
                 }
+
+                File.Exists(Path.ChangeExtension(Path.GetFullPath(resxFile), ".resources"))
+                    .ShouldBeFalse("Resources file was left on disk even though resource creation failed.");
             }
             finally
             {

--- a/src/Tasks/GenerateResource.cs
+++ b/src/Tasks/GenerateResource.cs
@@ -3361,6 +3361,10 @@ namespace Microsoft.Build.Tasks
 
                 // one of the above should have been logged as we would have used preserialized writer otherwise.
                 Debug.Assert(_logger.HasLoggedErrors);
+
+                // We may have partially written some string resources to a file, then bailed out
+                // because we encountered a non-string resource but don't meet the prereqs.
+                RemoveCorruptedFile(filename);
             }
         }
 


### PR DESCRIPTION
## Description

Fixes #4553, an issue where a build would fail with a (correctly emitted) MSB3822 error, but subsequent builds would succeed, producing corrupted outputs without all of the resources embedded.

## Customer Impact

Fixes an error that would cause builds to fail and pass apparently randomly, while silently producing bad output when the build passed.

## Regression

Bug in new functionality introduced by .NET Core resx support for non-string types. Desktop MSBuild building desktop projects did not regress.

## Risk

Low. Impacts only the new resx codepath and uses an existing delete-or-warn function.
