### PR TITLE
[tests] Fix Evaluation logging test which broke on mono

### DIFF
--- a/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
@@ -125,28 +125,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
             AssertLoggingEvents(
                 (project, firstEvaluationLogger) =>
                 {
-                    var allBuildEvents = firstEvaluationLogger.AllBuildEvents;
+                    var allBuildEvents = firstEvaluationLogger.AllBuildEvents.Where(be => be is ProjectEvaluationStartedEventArgs || be is ProjectEvaluationFinishedEventArgs).ToList();
 
-                    allBuildEvents.Count.ShouldBeGreaterThan(2);
-
-                    for (var i = 0; i < allBuildEvents.Count; i++)
-                    {
-                        var buildEvent = allBuildEvents[i];
-
-                        if (i == 0)
-                        {
-                            buildEvent.Message.ShouldStartWith("Evaluation started");
-                        }
-                        else if (i == allBuildEvents.Count - 1)
-                        {
-                            buildEvent.Message.ShouldStartWith("Evaluation finished");
-                        }
-                        else
-                        {
-                            buildEvent.Message.ShouldNotStartWith("Evaluation started");
-                            buildEvent.Message.ShouldNotStartWith("Evaluation finished");
-                        }
-                    }
+                    allBuildEvents.Count.ShouldBe(2);
+                    allBuildEvents[0].GetType().ShouldBe(typeof(ProjectEvaluationStartedEventArgs));
+                    allBuildEvents[1].GetType().ShouldBe(typeof(ProjectEvaluationFinishedEventArgs));
                 });
         }
 


### PR DESCRIPTION
Failing test:

```
	Microsoft.Build.UnitTests.Evaluation.EvaluationLogging_Tests.GivenOneProjectThereShouldBeOneStartedAndOneEndedEvent [FAIL]
	  Shouldly.ShouldAssertException : Shouldly uses your source code to generate its great error messages, build your test project with full debug information to get better error messages
	  The provided expression
		  should start with
	  "Evaluation started"
		  but was
	  "Property reassignment: $(MSBuildFrameworkToolsRoot)="\Microsoft.NET\Framework\" (previous value: "/Library/Frameworks/Mono.framework/Versions/6.4.0/lib/mono") at "
	  Stack Trace:
		  at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T] (T actual, System.Func`2[T,TResult] specifiedConstraint, System.Object originalActual, System.Object originalExpected, System.Func`1[TResult] customMessage, System.String shouldlyMethod) [0x00056] in <cd631af7e9d7403ea1721c3ce03185bf>:0
		  at Shouldly.ShouldBeStringTestExtensions.ShouldStartWith (System.String actual, System.String expected, System.Func`1[TResult] customMessage, Shouldly.Case caseSensitivity) [0x00014] in <cd631af7e9d7403ea1721c3ce03185bf>:0
		  at Shouldly.ShouldBeStringTestExtensions.ShouldStartWith (System.String actual, System.String expected) [0x00000] in <cd631af7e9d7403ea1721c3ce03185bf>:0
		  at Microsoft.Build.UnitTests.Evaluation.EvaluationLogging_Tests+<>c.<GivenOneProjectThereShouldBeOneStartedAndOneEndedEvent>b__4_0 (Microsoft.Build.Evaluation.Project project, Microsoft.Build.UnitTests.MockLogger firstEvaluationLogger) [0x00033] in <559c19036a814aa4b96da7f3191f05ee>:0
		  at Microsoft.Build.UnitTests.Evaluation.EvaluationLogging_Tests.AssertLoggingEvents (System.Action`2[T1,T2] loggingTest, Microsoft.Build.UnitTests.MockLogger firstEvaluationLogger, System.Func`2[T,TResult] reevaluationLoggerFactory) [0x000d3] in <559c19036a814aa4b96da7f3191f05ee>:0
		  at Microsoft.Build.UnitTests.Evaluation.EvaluationLogging_Tests.GivenOneProjectThereShouldBeOneStartedAndOneEndedEvent () [0x00009] in <559c19036a814aa4b96da7f3191f05ee>:0
		  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
		  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <b60d3e0e49a1407283b1fb67d86fa164>:0
```

Recent commit:

```
commit 7150dc9643fbb2651f973e0cf7efcbfe31a8b806
Author: Matt Neely <49730556+maneely@users.noreply.github.com>
Date:   Mon Aug 19 13:59:31 2019 -0700

	Adding tracking of properties with relevant events. (#4461)
	...

```

.. changed how property changes get logged, causing the following to show up in
the logs, when running the test on mono:

```
Property reassignment: $(MSBuildFrameworkToolsRoot)="\Microsoft.NET\Framework\" (previous value: "/Library/Frameworks/Mono.framework/Versions/6.4.0/lib/mono") at
```

.. before the `Evaluation started` line, causing the test to break.
Instead of making assumptions about the exact message strings, we can check for
exactly the events that we are interested in -
	`ProjectEvaluationStartedEvent` and `ProjectEvaluationFinishedEvent`.