### PR TITLE
Point to d16.3 channel for OptProf data collection

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -37,7 +37,7 @@ stages:
     - name: VisualStudio.MajorVersion
       value: 16
     - name: VisualStudio.ChannelName
-      value: 'int.master'
+      value: 'int.d16.3'
     - name: VisualStudio.DropName
       value: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
 


### PR DESCRIPTION
## Description

Collect OptProf profiles from the d16.3 branch, now that we have had the final snap to that branch internally.

## Customer Impact

Improved performance due to ngen optimizations. Ability to continue inserting MSBuild into VS.

## Regression

No, expected infrastructure change as part of the release process.

## Risk

Low.