### PR TITLE
Enable automatic VS-insertions when on experimental branches

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -1,6 +1,7 @@
 trigger:
 - master
 - vs*
+- exp/*
 
 # If defined here, these values are not overrideable
 # Once they exist, we should define these as "runtime parameters"


### PR DESCRIPTION
Branches we've been using to examine VS Insertions have typically been prefixed with `exp/` (short for experimental). This change essentually adopts the `exp/` prefix as our format for automatically triggering VS insertions to measure performance.