### PR TITLE
Ngen twice

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,5 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);*.binlog</DefaultItemExcludes>
 
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-
-    <MicroBuildPluginsSwixBuildVersion>1.0.670</MicroBuildPluginsSwixBuildVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,5 +79,7 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);*.binlog</DefaultItemExcludes>
 
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+
+    <MicroBuildPluginsSwixBuildVersion>1.0.670</MicroBuildPluginsSwixBuildVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,7 @@
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
     <SemanticVersioningV1>true</SemanticVersioningV1>
+    <MicroBuildPluginsSwixBuildVersion>1.0.672</MicroBuildPluginsSwixBuildVersion>
   </PropertyGroup>
   <!-- Repo Toolset Features -->
   <PropertyGroup>

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -15,13 +15,13 @@ folder InstallDir:\MSBuild\Current
   file source=$(ThirdPartyNotice)
 
 folder InstallDir:\MSBuild\Current\Bin
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
-  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Conversion.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
+  file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.tlb
-  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
-  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
+  file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenApplications="[installDir]\Common7\IDE\vsn.exe" vs.file.ngenApplications="[installDir]\MSBuild\Current\Bin\MSBuild.exe" vs.file.ngenArchitecture=all vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe vs.file.ngenArchitecture=x86 vs.file.ngenPriority=1
   file source=$(X86BinPath)MSBuild.exe.config
   file source=$(TaskHostBinPath)MSBuildTaskHost.exe vs.file.ngenArchitecture=x86


### PR DESCRIPTION
## Description

NGen msbuild assemblies twice. Once for vsn.exe and once for msbuild.exe, so that both these processes can load ngened assemblies independently of them referencing dlls that are different between these processes.

## Customer Impact

MSBuild assmeblies in VS are being jitted, causing performance regressions in VS. In some of the tests, there was a 10% total time regression attributed to jitting.

### Workaround

None.

## Regression?

Yes. MSBuild took dependencies on new assemblies, which caused some of its dlls to be jitted as loading the ngened version of the dlls failed due to conflicts between VS versions of these new dlls and msbuild's.

## Testing
Create a private build with these changes, inserted into VS and ran RPS tests against it. Insertion test PR: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/201435?_a=overview.

Improvement in jitting with this change:

![image](https://user-images.githubusercontent.com/367554/64644307-3b65f100-d3c7-11e9-85d5-b08d3f516460.png)

## Risk
Low. Using the setup authoring changes recommended by the VS Setup authoring team.
