### PR TITLE
Release branding for 16.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>16.3.0</VersionPrefix>
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>


### PR DESCRIPTION
We shouldn't merge this until we're ready, as every change after that will require a manual version bump.