### PR TITLE
Fix possible null dereference pointer in test

### DIFF
--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -251,14 +251,14 @@ namespace Microsoft.Build.UnitTests
 
             for (var i = 0; i < expectedItems.Length; i++)
             {
-                if (normalizeSlashes)
+                if (!normalizeSlashes)
                 {
-                    var normalizedItem = NormalizeSlashes(expectedItems[i]);
-                    items[i].EvaluatedInclude.ShouldBe(normalizedItem);
+                    items[i].EvaluatedInclude.ShouldBe(expectedItems[i]);
                 }
                 else
                 {
-                    items[i].EvaluatedInclude.ShouldBe(expectedItems[i]);
+                    var normalizedItem = NormalizeSlashes(expectedItems[i]);
+                    items[i].EvaluatedInclude.ShouldBe(normalizedItem);
                 }
 
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);
@@ -449,7 +449,7 @@ namespace Microsoft.Build.UnitTests
             Assert.Equal(expected.Length, actual.Length); // "Expected array length of <" + expected.Length + "> but was <" + actual.Length + ">.");
 
             // Now that we've verified they're both non-null and of the same length, compare each item in the array.
-            for (int i = expected.Length - 1; i >= 0; i--)
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.Equal(expected[i], actual[i]); // "At index " + i + " expected " + expected[i].ToString() + " but was " + actual.ToString());
             }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -251,14 +251,14 @@ namespace Microsoft.Build.UnitTests
 
             for (var i = 0; i < expectedItems.Length; i++)
             {
-                if (!normalizeSlashes)
-                {
-                    items[i].EvaluatedInclude.ShouldBe(expectedItems[i]);
-                }
-                else
+                if (normalizeSlashes)
                 {
                     var normalizedItem = NormalizeSlashes(expectedItems[i]);
                     items[i].EvaluatedInclude.ShouldBe(normalizedItem);
+                }
+                else
+                {
+                    items[i].EvaluatedInclude.ShouldBe(expectedItems[i]);
                 }
 
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);
@@ -442,16 +442,14 @@ namespace Microsoft.Build.UnitTests
             if (expected == null)
             {
                 Assert.Null(actual); // "Expected a null array"
-            }
-            else
-            {
-                Assert.NotNull(actual); // "Result should be non-null."
+                return;
             }
 
+            Assert.NotNull(actual); // "Result should be non-null."
             Assert.Equal(expected.Length, actual.Length); // "Expected array length of <" + expected.Length + "> but was <" + actual.Length + ">.");
 
             // Now that we've verified they're both non-null and of the same length, compare each item in the array.
-            for (int i = 0; i < expected.Length; i++)
+            for (int i = expected.Length - 1; i >= 0; i--)
             {
                 Assert.Equal(expected[i], actual[i]); // "At index " + i + " expected " + expected[i].ToString() + " but was " + actual.ToString());
             }


### PR DESCRIPTION
In the object model helper test, if the expected array is null, and the other one is null, the test will then compare their contents. This is not supposed to happen, as the comment clearly states "Now that we verified the arrays are nonnull and equal in length..."

Had to do a logic fix there.