### PR TITLE
Clarify comment on _ExplicitReference

### DIFF
--- a/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.CSharp.CurrentVersion.targets
@@ -366,7 +366,8 @@ using System.Reflection%3b
     <ItemGroup Condition=" '$(NoCompilerStandardLib)' == 'true' and '$(NoStdLib)' != 'true' ">
       <!-- Note that unlike VB, C# does not automatically locate System.dll as a "standard library"
            instead the reference is always passed from the project. Also, for mscorlib.dll 
-           we need to provide the explicit location in order to maintain the correct behaviour
+           we need to provide the explicit location in order to avoid resolving from, e.g.,
+           {CandidateAssemblyFiles}.
       -->
         <_ExplicitReference Include="$(FrameworkPathOverride)\mscorlib.dll" />
     </ItemGroup>

--- a/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.VisualBasic.CurrentVersion.targets
@@ -369,8 +369,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <!-- Note that unlike C#, VB gets its mscorlib.dll path from the $(FrameworkPathOverride) property
            via the /sdkpath parameter.
            In addition to that, VB normally treats System.dll as a "standard library" however since we are
-           passing NoCompilerStandardLib=true we need an explicit reference to System in order to maintain the
-           correct behaviour.
+           passing NoCompilerStandardLib=true we need an explicit reference to System in order to avoid
+           resolving it from, e.g., {CandidateAssemblyFiles}.
       -->
         <_ExplicitReference Include="$(FrameworkPathOverride)\System.dll" />
     </ItemGroup>


### PR DESCRIPTION
(Looked this up when poking around near #4687, but it's not a fix)

From the internal bug
http://vstfdevdiv:8080/DevDiv/Dev10/_workitems/edit/564085

(December 19, 2009)

> The issue here is the new requirement to automatically add an explicit
reference to mscorlib for C# projects. When doing so, the reference
resolution considers files in the "CandidateAssemblyFiles" set which
includes those items in the project that are to be copied to the output
location.

> The solution here is to pre-resolve the mscorlib path and pass that to
 RAR rather than an unresolved assembly name.