### PR TITLE
Fix copying of DiscardBuildResults flag for BuildParameters

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -832,7 +832,7 @@ namespace Microsoft.Build.Execution
             // ResetCaches is not transmitted.
             // LegacyThreadingSemantics is not transmitted.
             // InputResultsCacheFiles and OutputResultsCacheFile are not transmitted, as they are only used by the BuildManager
-            // DiscardBuildResults is not trasmitted.
+            // DiscardBuildResults is not transmitted.
         }
 
 #region INodePacketTranslatable Members

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -295,6 +295,7 @@ namespace Microsoft.Build.Execution
             _isolateProjects = other._isolateProjects;
             _inputResultsCacheFiles = other._inputResultsCacheFiles;
             _outputResultsCacheFile = other._outputResultsCacheFile;
+            DiscardBuildResults = other.DiscardBuildResults;
         }
 
 #if FEATURE_THREAD_PRIORITY
@@ -831,6 +832,7 @@ namespace Microsoft.Build.Execution
             // ResetCaches is not transmitted.
             // LegacyThreadingSemantics is not transmitted.
             // InputResultsCacheFiles and OutputResultsCacheFile are not transmitted, as they are only used by the BuildManager
+            // DiscardBuildResults is not trasmitted.
         }
 
 #region INodePacketTranslatable Members


### PR DESCRIPTION
When I added the `DiscardBuildResults` flag to `BuildParameters`, I forgot to add it to the `Clone` method. So the flag is lost in the `BuildManager` since the first thing it does is clone the parameters. Also added a comment to the effect that we do not serialize this to the nodes since it's not applicable there.