### PR TITLE
Support convention-based DependentUpon for resx files in folders

### DIFF
--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -149,9 +149,9 @@ namespace Microsoft.Build.Tasks
                     // If opted into convention and no DependentUpon metadata, reference "<filename>.cs" if it exists.
                     if (UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
-                        string conventionDependentUpon = Path.ChangeExtension(fileName, SourceFileExtension);
+                        string conventionDependentUpon = Path.ChangeExtension(Path.GetFileName(fileName), SourceFileExtension);
 
-                        if (File.Exists(conventionDependentUpon))
+                        if (File.Exists(Path.Combine(Path.GetDirectoryName(fileName), conventionDependentUpon)))
                         {
                             dependentUpon = conventionDependentUpon;
                         }


### PR DESCRIPTION
## Description
Fix #4695, build failures that arise when a `.resx` file does not specify `DependentUpon` and is in a subfolder.

## Customer Impact

Builds fail with `MSB3041`. Impacts EF migrations (aspnet/EntityFramework6#1225), some WinForms projects, and some plain-vanilla projects.

### Workaround

Users can explicitly opt out of the new behavior back into preview8 behavior with a property

```xml
<EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
```

Or explicitly specify `DependentUpon` for all resources:

```xml
<ItemGroup>
  <EmbeddedResource Update="Migrations\*.resx">
    <DependentUpon>%(FileName).cs</DependentUpon>
  </EmbeddedResource>
</ItemGroup>
```

## Regression?

Yes, builds fail in cases that passed before. Introduced with #4597, a new feature to support resources without project-file impact.

## Testing
Automated tests, including a new one for this specific case. e2e validation in failing scenarios using privates.

## Risk
Low. Targeted fix in a conditioned codepath, so the existing workarounds will continue to work and can mitigate any problems.
