### PR TITLE
Stop setting LastWriteTime for binlog imports

### DIFF
--- a/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
+++ b/src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            using (Stream entryStream = OpenArchiveEntry(filePath, fileInfo.LastWriteTime))
+            using (Stream entryStream = OpenArchiveEntry(filePath))
             using (FileStream content = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
             {
                 content.CopyTo(entryStream);
@@ -144,18 +144,17 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
-            using (Stream entryStream = OpenArchiveEntry(filePath, DateTime.UtcNow))
+            using (Stream entryStream = OpenArchiveEntry(filePath))
             using (var content = new MemoryStream(Encoding.UTF8.GetBytes(data)))
             {
                 content.CopyTo(entryStream);
             }
         }
 
-        private Stream OpenArchiveEntry(string filePath, DateTime lastWriteTime)
+        private Stream OpenArchiveEntry(string filePath)
         {
             string archivePath = CalculateArchivePath(filePath);
             var archiveEntry = _zipArchive.CreateEntry(archivePath);
-            archiveEntry.LastWriteTime = lastWriteTime;
             return archiveEntry.Open();
         }
 


### PR DESCRIPTION
## Description

Fixes #4714 by not setting LastWriteTime on imported project files. Now that we know that this is an operation that can fail, it doesn't seem worth the risk to attempt to preserve the information.

## Customer Impact

MSBuild binlogs don't contain all the files they should, harming debuggability and our team's ability to support customers who encounter problems.

### Workaround

None after encountering it. Conceivably a user could update the LastWriteTime on all of their installed SDK files, but they'd have to know to do it.

## Regression?

MSBuild has never been able to log these files, but that had never been noticed before NuGet/NuGet.Client#2989 started setting the dates on packaged files to near the critical time. It's a regression in the overall SDK experience.

## Testing

Validated fix using local build.

## Risk
Low. Removes a possibly-failing operation.
