### PR TITLE
Hard code RepositoryName=Microsoft/msbuild

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -76,7 +76,7 @@ stages:
                 -configuration $(BuildConfiguration)
                 -officialBuildId $(Build.BuildNumber)
                 -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=$(Build.Repository.Name)
+                /p:RepositoryName=Microsoft/msbuild
                 /p:VisualStudioIbcSourceBranchName=$(IbcSourceBranchName)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)


### PR DESCRIPTION
## Description
A case difference between `Microsoft` and `microsoft` is failing builds that attempt to consume OptProf data (published to `Microsoft) from a build that thinks it's connected to `microsoft`. Hard-coding the capitalized version.
## Customer Impact
Fixed builds for VS and SDK insertion.
## Regression?
Yes, this worked until something changed and caught up to the lower-case name.
## Risk
Minimal. This hard codes a case-munged copy of the repo name that would have been provided for all internal builds. The URL `https://github.com/Microsoft/msbuild` should keep working with GitHub redirects.