### PR TITLE
[Static Graph] Move cache miss error under task logging context

### DIFF
--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -185,16 +185,16 @@ BuildEngine5.BuildProjectFilesInParallel(
         [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/3876")]
         public void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuiltAndOnContinueOnError()
         {
-            CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(addContinueOnError: true);
+            CacheEnforcementImpl(addContinueOnError: true);
         }
 
         [Fact]
         public void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuiltWithoutContinueOnError()
         {
-            CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(addContinueOnError: false);
+            CacheEnforcementImpl(addContinueOnError: false);
         }
 
-        private void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(bool addContinueOnError)
+        private void CacheEnforcementImpl(bool addContinueOnError)
         {
             AssertBuild(
                 new[] {"BuildDeclaredReference"},
@@ -206,6 +206,14 @@ BuildEngine5.BuildProjectFilesInParallel(
 
                     logger.Errors.First()
                         .Message.ShouldStartWith("MSB4252:");
+
+                    logger.Errors.First().BuildEventContext.ShouldNotBe(BuildEventContext.Invalid);
+
+                    logger.Errors.First().BuildEventContext.NodeId.ShouldNotBe(BuildEventContext.InvalidNodeId);
+                    logger.Errors.First().BuildEventContext.ProjectInstanceId.ShouldNotBe(BuildEventContext.InvalidProjectInstanceId);
+                    logger.Errors.First().BuildEventContext.ProjectContextId.ShouldNotBe(BuildEventContext.InvalidProjectContextId);
+                    logger.Errors.First().BuildEventContext.TargetId.ShouldNotBe(BuildEventContext.InvalidTargetId);
+                    logger.Errors.First().BuildEventContext.TaskId.ShouldNotBe(BuildEventContext.InvalidTaskId);
                 },
                 addContinueOnError: addContinueOnError);
         }

--- a/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
+++ b/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.UnitTests;
 using Shouldly;
@@ -392,6 +393,12 @@ namespace Microsoft.Build.Experimental.Graph.UnitTests
             results["1"].Result.OverallResult.ShouldBe(BuildResultCode.Failure);
             results["1"].Logger.ErrorCount.ShouldBe(1);
             results["1"].Logger.Errors.First().Message.ShouldContain("MSB4252");
+
+            results["1"].Logger.Errors.First().BuildEventContext.NodeId.ShouldNotBe(BuildEventContext.InvalidNodeId);
+            results["1"].Logger.Errors.First().BuildEventContext.ProjectInstanceId.ShouldNotBe(BuildEventContext.InvalidProjectInstanceId);
+            results["1"].Logger.Errors.First().BuildEventContext.ProjectContextId.ShouldNotBe(BuildEventContext.InvalidProjectContextId);
+            results["1"].Logger.Errors.First().BuildEventContext.TargetId.ShouldNotBe(BuildEventContext.InvalidTargetId);
+            results["1"].Logger.Errors.First().BuildEventContext.TaskId.ShouldNotBe(BuildEventContext.InvalidTaskId);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -929,6 +929,16 @@ namespace Microsoft.Build.BackEnd
                         {
                             overallSuccess = false;
                         }
+
+                        if (!string.IsNullOrEmpty(results[i].SchedulerInducedError))
+                        {
+                            LoggingContext.LogErrorFromText(
+                                subcategoryResourceName: null,
+                                errorCode: null,
+                                helpKeyword: null,
+                                file: new BuildEventFileInfo(ProjectFileOfTaskNode, LineNumberOfTaskNode, ColumnNumberOfTaskNode),
+                                message: results[i].SchedulerInducedError);
+                        }
                     }
 
                     ErrorUtilities.VerifyThrow(results.Length == projectFileNames.Length || overallSuccess == false, "The number of results returned {0} cannot be less than the number of project files {1} unless one of the results indicated failure.", results.Length, projectFileNames.Length);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1832,21 +1832,14 @@ namespace Microsoft.Build.BackEnd
                     : string.Join(";", request.Targets));
 
             // Issue a failed build result to have the msbuild task marked as failed and thus stop the build
-            BuildResult result = new BuildResult(request, new InvalidOperationException(errorMessage));
+            BuildResult result = new BuildResult(request);
             result.SetOverallResult(false);
+
+            // Log an error to have something useful displayed to the user and to avoid having a failed build with 0 errors
+            result.SchedulerInducedError = errorMessage;
 
             var response = GetResponseForResult(nodeForResults, request, result);
             responses.Add(response);
-
-            // Log an error to have something displayed to the user and to avoid having a failed build with 0 errors
-            // todo Search if there's a way to have the error automagically logged in response to the failed build result
-            _componentHost.LoggingService.LogErrorFromText(
-                NewBuildEventContext(),
-                null,
-                null,
-                null,
-                new BuildEventFileInfo(requestConfig.ProjectFullPath),
-                errorMessage);
 
             return false;
 

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -114,6 +114,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private ProjectInstance _projectStateAfterBuild;
 
+        private string _schedulerInducedError;
+
         /// <summary>
         /// Constructor for serialization.
         /// </summary>
@@ -471,6 +473,16 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Container used to transport errors from the scheduler (issued while computing a build result)
+        /// to the TaskHost that has the proper logging context (project id, target id, task id, file location)
+        /// </summary>
+        internal string SchedulerInducedError
+        {
+            get => _schedulerInducedError;
+            set => _schedulerInducedError = value;
+        }
+
+        /// <summary>
         /// Indexer which sets or returns results for the specified target
         /// </summary>
         /// <param name="target">The target</param>
@@ -564,6 +576,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _baseOverallResult);
             translator.Translate(ref _projectStateAfterBuild, ProjectInstance.FactoryForDeserialization);
             translator.Translate(ref _savedCurrentDirectory);
+            translator.Translate(ref _schedulerInducedError);
             translator.TranslateDictionary(ref _savedEnvironmentVariables, StringComparer.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
Whenever I get a cache access error, almost all the time I have to debug into msbuild to see what the global properties where.

One fix to the problem is to parent the error under the msbuild task's logging context, so that it shows up in the bin log, under the task, as opposed to not showing up at all like it currently happens. This enables one to look at the global properties in the binlog.
Regarding the implementation, the main problem is getting the error message from the build manager node where the scheduler runs and issues the error, to the TaskHost that executes the msbuild task, which may be in a different process. Ideally, we'd need an official mechanism for ferrying these messages. Practically, I just piggy backed on the BuildResult. This seemed like the least intrusive change. Perf wise, the extra message is ferried only when a build fails, so there should be no relevant impact.
Regarding tests, there already are two existing tests that check for this error, so it's already covered:
- CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuiltWithoutContinueOnError
- MissingResultFromCacheShouldErrorDueToIsolatedBuildCacheEnforcement

Another fix would be to print out the global properties for each the two projects involved in the message. But I considered that the previous fix also enables the binlogger to display the error in the first place, so it has more benefit.

Before:
![image](https://user-images.githubusercontent.com/2255729/64829989-72810180-d583-11e9-8087-246e5245d4eb.png)

After:
![image](https://user-images.githubusercontent.com/2255729/64829926-3057c000-d583-11e9-85c3-b985d9c6e93e.png)
