### PR TITLE
Prevent String::Copy property function from allocating

### DIFF
--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3686,7 +3686,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArg(args, out string arg0))
                             {
-                                returnVal = string.Copy(arg0);
+                                returnVal = arg0;
                                 return true;
                             }
                         }


### PR DESCRIPTION
Fixes #4615

Does not fix the larger issue #1155, calling instance methods on metadata.