### PR TITLE
Workaround to unblock builds

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -110,7 +110,7 @@ stages:
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(InternalInstallersBlobFeedKey)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -110,7 +110,7 @@ stages:
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(InternalInstallersBlobFeedKey)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -77,7 +77,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -77,7 +77,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'


### PR DESCRIPTION
Currently we cannot publish assets from a build in devdiv to a feed in dnceng. We need this change to unblock builds while dotnet/arcade#3942 is fixed and publish to blob feeds in the meanwhile.