### PR TITLE
UseLegacyFipsThrow=false

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -9,7 +9,7 @@
   <runtime>
     <DisableFXClosureWalk enabled="true" />
     <generatePublisherEvidence enabled="false" />
-    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
This setting matches the .NET 4.8 behavior when running in FIPS mode.

Closes #4750.