### PR TITLE
Apply DependentUpon Convention Only to .resx Files

### DIFF
--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -417,6 +417,47 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Opt into DependentUpon convention but don't expect it to be used for this file.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DependentUponConvention_DoesNotApplyToNonResx(bool explicitlySpecifyType)
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var csFile = env.CreateFile("SR1.cs", "namespace MyStuff.Namespace { class Class { } }");
+                const string ResourceFileName = "SR1.txt";
+                var resourceFile = env.CreateFile(ResourceFileName, "");
+
+                // Default resource naming is based on the item include, so use a relative
+                // path here instead of a full path.
+                env.SetCurrentDirectory(Path.GetDirectoryName(resourceFile.Path));
+                ITaskItem i = new TaskItem(ResourceFileName);
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                if (explicitlySpecifyType)
+                {
+                    i.SetMetadata("Type", "Non-Resx");
+                }
+                // Don't set DependentUpon so it goes by convention
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = true,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.ShouldHaveSingleItem();
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe(ResourceFileName, "Expecting to find the namespace & class name from SR1.cs");
+            }
+        }
+
+
+        /// <summary>
         /// Opt into DependentUpon convention and load the expected file properly when the file is in a subfolder.
         /// </summary>
         [Fact]

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -146,8 +146,13 @@ namespace Microsoft.Build.Tasks
                     string fileName = resourceFile.ItemSpec;
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
 
-                    // If opted into convention and no DependentUpon metadata, reference "<filename>.cs" if it exists.
-                    if (UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
+                    string fileType = resourceFile.GetMetadata("Type");
+
+                    // If it has a file type metadata is "Resx" or has the file extension ".resx", we know it's a resx file.
+                    bool isResxFile = (!string.IsNullOrEmpty(fileType) && fileType == "Resx") || Path.GetExtension(fileName) == ".resx";
+
+                    // If opted into convention and no DependentUpon metadata and is a resx file, reference "<filename>.cs" if it exists.
+                    if (isResxFile && UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
                         string conventionDependentUpon = Path.ChangeExtension(Path.GetFileName(fileName), SourceFileExtension);
 

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -148,10 +148,11 @@ namespace Microsoft.Build.Tasks
 
                     string fileType = resourceFile.GetMetadata("Type");
 
-                    // If it has a file type metadata is "Resx"
+                    // If it has "type" metadata and the value is "Resx"
+                    // This value can be specified by the user, if not it will have been automatically assigned by the SplitResourcesByCulture target.
                     bool isResxFile = (!string.IsNullOrEmpty(fileType) && fileType == "Resx");
 
-                    //fall back onto the extension
+                    // If not, fall back onto the extension.
                     if (string.IsNullOrEmpty(fileType))
                     {
                         isResxFile = Path.GetExtension(fileName) == ".resx";

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -148,8 +148,14 @@ namespace Microsoft.Build.Tasks
 
                     string fileType = resourceFile.GetMetadata("Type");
 
-                    // If it has a file type metadata is "Resx" or has the file extension ".resx", we know it's a resx file.
-                    bool isResxFile = (!string.IsNullOrEmpty(fileType) && fileType == "Resx") || Path.GetExtension(fileName) == ".resx";
+                    // If it has a file type metadata is "Resx"
+                    bool isResxFile = (!string.IsNullOrEmpty(fileType) && fileType == "Resx");
+
+                    //fall back onto the extension
+                    if (string.IsNullOrEmpty(fileType))
+                    {
+                        isResxFile = Path.GetExtension(fileName) == ".resx";
+                    }
 
                     // If opted into convention and no DependentUpon metadata and is a resx file, reference "<filename>.cs" if it exists.
                     if (isResxFile && UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))


### PR DESCRIPTION
## Description
Fix #4740, build or runtime failures that arise because non-resx resources get embedded with an unexpected name.

## Customer Impact

Builds fail with `CS1508` or applications fail to extract a resource at runtime. Roadblock to adopting the final 3.0 SDK and to migrating to .NET Core 3.0 for applications with embedded resources (UI applications in particular).

Reported by multiple internal partners (CoreFX, EF) and customers.

### Workaround

Users can explicitly opt out of the new behavior back into preview8 behavior with a property

```xml
<EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>
```

## Regression?

Yes, builds fail in cases that passed before. Introduced with #4597, a new feature to support (resx) resources without project-file impact.

## Testing
Automated tests, including a new one for this specific case. e2e validation in failing scenarios using privates.

## Risk
Low. Targeted fix in a conditioned codepath, so the existing workarounds will continue to work and can mitigate any problems.

----

Taking the suggestion made by @nguerrera to restrict dependentupon convention to .resx files. 
https://github.com/microsoft/msbuild/issues/4740#issuecomment-532962819
> Restricting to resx makes sense because that is the case that would have been persisted with DependentUpon in a classic project. I'm not aware of anything that would have put DependentUpon for non-resx in your project unless you did it manually so I don't think it should have been part of the convention to do so.

Added a check on the `Type` metadata and file extension to prevent dependent upon convention from being used on non-resx files.

Users can manually assign the `Type` metadata when including embedded resources in their projects like so:
`<EmbeddedResource Include="MyResource.txt" WithCulture="false" Type="Non-Resx" />`

If the metadata isn't set, it should automatically be populated by the time the task runs.

In case the `Type` metadata is missing for whatever reason when the task runs, a check on the file's extension will be made to determine whether or not it's a resx file.