### PR TITLE
Reference RTM version of 3.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -32,7 +32,7 @@
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
+    <PackageReference Update="System.Resources.Extensions" Version="4.6.0" />
     <PackageReference Update="System.Resources.Writer" Version="4.0.0" />
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Runtime.Loader" Version="4.0.0" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,10 +6,4 @@
       <Sha>372f44450f51552a8cf725acf705dc477bd8391f</Sha>
     </Dependency>
   </ToolsetDependencies>
-  <ProductDependencies>
-    <Dependency Name="System.Resources.Extensions" Version="4.6.0-rc2.19458.3">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>173d70b99a5dbb3ff9298a6e2e9c7f7e7b56dd7c</Sha>
-    </Dependency>
-  </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,10 +34,6 @@
   <PropertyGroup>
     <DotNetCliVersion>3.0.100-preview6-012264</DotNetCliVersion>
   </PropertyGroup>
-  <!-- Product Dependencies -->
-  <PropertyGroup>
-    <SystemResourcesExtensionsVersion>4.6.0-rc2.19458.3</SystemResourcesExtensionsVersion>
-  </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386
 


### PR DESCRIPTION
Drop darc/maestro-updated reference to System.Resources.Extensions since it's now public.