### PR TITLE
Implementation of Directory.Solution.props and Directory.Solution.targets

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2325,21 +2325,31 @@ EndGlobal
                     </PropertyGroup>
                 </Project>");
 
+            if (projectPath.StartsWith("Custom", StringComparison.OrdinalIgnoreCase))
+            {
+                // If a custom file name was given, create a Directory.Solution.props and Directory.Build.targets to ensure that they aren't imported
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.props"), $@"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <PropertyGroup>
+                        <PropertyA>This file should not be imported</PropertyA>
+                    </PropertyGroup>
+                </Project>");
+
+                ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine(baseDirectory, "Directory.Solution.targets"), $@"
+                <Project ToolsVersion=""msbuilddefaulttoolsversion"" xmlns=""msbuildnamespace"">
+                    <PropertyGroup>
+                        <PropertyA>This file should not be imported</PropertyA>
+                    </PropertyGroup>
+                </Project>");
+            }
+
             try
             {
                 Dictionary<string, string> globalProperties = new Dictionary<string, string>();
                 if (!enable)
                 {
-                    switch (projectName)
-                    {
-                        case "Directory.Solution.props":
-                            globalProperties["ImportDirectorySolutionProps"] = "false";
-                            break;
-
-                        case "Directory.Solution.targets":
-                            globalProperties["ImportDirectorySolutionTargets"] = "false";
-                            break;
-                    }
+                    globalProperties["ImportDirectorySolutionProps"] = "false";
+                    globalProperties["ImportDirectorySolutionTargets"] = "false";
                 }
                 else
                 {

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Build.Construction
     /// </summary>
     internal class SolutionProjectGenerator
     {
-        #region Private Fields
-
         /// <summary>
         /// Name of the property used to store the path to the solution being built.
         /// </summary>
@@ -142,10 +140,6 @@ namespace Microsoft.Build.Construction
         /// </summary>
         private readonly int _submissionId;
 
-#endregion // Private Fields
-
-#region Constructors
-
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -172,10 +166,6 @@ namespace Microsoft.Build.Construction
                 _targetNames = targetNames.Select(i => i.Split(MSBuildConstants.ColonChar, 2, StringSplitOptions.RemoveEmptyEntries).Last()).ToList();
             }
         }
-
-#endregion // Constructors
-
-#region Methods
 
         /// <summary>
         /// This method generates an MSBuild project file from the list of projects and project dependencies 
@@ -857,6 +847,42 @@ namespace Microsoft.Build.Construction
             ProjectImportElement importAfter = traversalProject.CreateImportElement(@"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter\*");
             importAfter.Condition = @"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter')"; // Avoids wildcard perf problem
 
+            ProjectPropertyGroupElement directorySolutionPropsPropertyGroup = traversalProject.CreatePropertyGroupElement();
+            directorySolutionPropsPropertyGroup.Condition = "'$(ImportDirectorySolutionProps)' != 'false' and '$(DirectorySolutionPropsPath)' == ''";
+
+            ProjectPropertyElement directorySolutionPropsFileProperty = traversalProject.CreatePropertyElement("_DirectorySolutionPropsFile");
+            directorySolutionPropsFileProperty.Value = "Directory.Solution.props";
+            directorySolutionPropsFileProperty.Condition = "'$(_DirectorySolutionPropsFile)' == ''";
+
+            ProjectPropertyElement directorySolutionPropsBasePathProperty = traversalProject.CreatePropertyElement("_DirectorySolutionPropsBasePath");
+            directorySolutionPropsBasePathProperty.Value = "$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectorySolutionPropsFile)'))";
+            directorySolutionPropsBasePathProperty.Condition = "'$(_DirectorySolutionPropsBasePath)' == ''";
+
+            ProjectPropertyElement directorySolutionPropsPathProperty = traversalProject.CreatePropertyElement("DirectorySolutionPropsPath");
+            directorySolutionPropsPathProperty.Value = "$([System.IO.Path]::Combine('$(_DirectorySolutionPropsBasePath)', '$(_DirectorySolutionPropsFile)'))";
+            directorySolutionPropsPathProperty.Condition = "'$(_DirectorySolutionPropsBasePath)' != '' and '$(_DirectorySolutionPropsFile)' != ''";
+
+            ProjectImportElement directorySolutionPropsImport = traversalProject.CreateImportElement("$(DirectorySolutionPropsPath)");
+            directorySolutionPropsImport.Condition = "'$(ImportDirectorySolutionProps)' != 'false' and exists('$(DirectorySolutionPropsPath)')";
+
+            ProjectPropertyGroupElement directorySolutionTargetsPropertyGroup = traversalProject.CreatePropertyGroupElement();
+            directorySolutionTargetsPropertyGroup.Condition = "'$(ImportDirectorySolutionTargets)' != 'false' and '$(DirectorySolutionTargetsPath)' == ''";
+
+            ProjectPropertyElement directorySolutionTargetsFileProperty = traversalProject.CreatePropertyElement("_DirectorySolutionTargetsFile");
+            directorySolutionTargetsFileProperty.Value = "Directory.Solution.targets";
+            directorySolutionTargetsFileProperty.Condition = "'$(_DirectorySolutionTargetsFile)' == ''";
+
+            ProjectPropertyElement directorySolutionTargetsBasePathProperty = traversalProject.CreatePropertyElement("_DirectorySolutionTargetsBasePath");
+            directorySolutionTargetsBasePathProperty.Value = "$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectorySolutionTargetsFile)'))";
+            directorySolutionTargetsBasePathProperty.Condition = "'$(_DirectorySolutionTargetsBasePath)' == ''";
+
+            ProjectPropertyElement directorySolutionTargetsPathProperty = traversalProject.CreatePropertyElement("DirectorySolutionTargetsPath");
+            directorySolutionTargetsPathProperty.Value = "$([System.IO.Path]::Combine('$(_DirectorySolutionTargetsBasePath)', '$(_DirectorySolutionTargetsFile)'))";
+            directorySolutionTargetsPathProperty.Condition = "'$(_DirectorySolutionTargetsBasePath)' != '' and '$(_DirectorySolutionTargetsFile)' != ''";
+
+            ProjectImportElement directorySolutionTargetsImport = traversalProject.CreateImportElement("$(DirectorySolutionTargetsPath)");
+            directorySolutionTargetsImport.Condition = "'$(ImportDirectorySolutionTargets)' != 'false' and exists('$(DirectorySolutionTargetsPath)')";
+
             // Add our local extensibility points to the project representing the solution
             // Imported at the top: before.mysolution.sln.targets
             // Imported at the bottom: after.mysolution.sln.targets
@@ -872,9 +898,21 @@ namespace Microsoft.Build.Construction
 
             // Put locals second so they can override globals if they want
             traversalProject.PrependChild(importBeforeLocal);
+            traversalProject.PrependChild(directorySolutionPropsImport);
+            traversalProject.PrependChild(directorySolutionPropsPropertyGroup);
             traversalProject.PrependChild(importBefore);
             traversalProject.AppendChild(importAfter);
+            traversalProject.AppendChild(directorySolutionTargetsPropertyGroup);
+            traversalProject.AppendChild(directorySolutionTargetsImport);
             traversalProject.AppendChild(importAfterLocal);
+
+            directorySolutionTargetsPropertyGroup.AppendChild(directorySolutionTargetsFileProperty);
+            directorySolutionTargetsPropertyGroup.AppendChild(directorySolutionTargetsBasePathProperty);
+            directorySolutionTargetsPropertyGroup.AppendChild(directorySolutionTargetsPathProperty);
+
+            directorySolutionPropsPropertyGroup.AppendChild(directorySolutionPropsFileProperty);
+            directorySolutionPropsPropertyGroup.AppendChild(directorySolutionPropsBasePathProperty);
+            directorySolutionPropsPropertyGroup.AppendChild(directorySolutionPropsPathProperty);
 
             // These are just dummies necessary to make the evaluation into a project instance succeed when 
             // any custom imported targets have declarations like BeforeTargets="Build"
@@ -2364,7 +2402,5 @@ namespace Microsoft.Build.Construction
                                                             initialTarget.Location,
                                                             new List<ProjectPropertyGroupTaskPropertyInstance> { property }));
         }
-
-#endregion // Methods
     }
 }

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -847,6 +847,29 @@ namespace Microsoft.Build.Construction
             ProjectImportElement importAfter = traversalProject.CreateImportElement(@"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter\*");
             importAfter.Condition = @"'$(ImportByWildcardBeforeSolution)' != 'false' and exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\SolutionFile\ImportAfter')"; // Avoids wildcard perf problem
 
+
+            /* The code below adds the following XML:
+
+            - TOP -
+
+                <PropertyGroup Condition="'$(ImportDirectorySolutionProps)' != 'false' and '$(DirectorySolutionPropsPath)' == ''">
+                  <_DirectorySolutionPropsFile Condition="'$(_DirectorySolutionPropsFile)' == ''">Directory.Solution.props</_DirectorySolutionPropsFile>
+                  <_DirectorySolutionPropsBasePath Condition="'$(_DirectorySolutionPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectorySolutionPropsFile)'))</_DirectorySolutionPropsBasePath>
+                  <DirectorySolutionPropsPath Condition="'$(_DirectorySolutionPropsBasePath)' != '' and '$(_DirectorySolutionPropsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectorySolutionPropsBasePath)', '$(_DirectorySolutionPropsFile)'))</DirectorySolutionPropsPath>
+                </PropertyGroup>
+
+                <Import Project="$(DirectorySolutionPropsPath)" Condition="'$(ImportDirectorySolutionProps)' != 'false' and exists('$(DirectorySolutionPropsPath)')"/>
+
+            - BOTTOM -
+
+                <PropertyGroup Condition="'$(ImportDirectorySolutionTargets)' != 'false' and '$(DirectorySolutionTargetsPath)' == ''">
+                  <_DirectorySolutionTargetsFile Condition="'$(_DirectorySolutionTargetsFile)' == ''">Directory.Solution.targets</_DirectorySolutionTargetsFile>
+                  <_DirectorySolutionTargetsBasePath Condition="'$(_DirectorySolutionTargetsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), '$(_DirectorySolutionTargetsFile)'))</_DirectorySolutionTargetsBasePath>
+                  <DirectorySolutionTargetsPath Condition="'$(_DirectorySolutionTargetsBasePath)' != '' and '$(_DirectorySolutionTargetsFile)' != ''">$([System.IO.Path]::Combine('$(_DirectorySolutionTargetsBasePath)', '$(_DirectorySolutionTargetsFile)'))</DirectorySolutionTargetsPath>
+                </PropertyGroup>
+
+                <Import Project="$(DirectorySolutionTargetsPath)" Condition="'$(ImportDirectorySolutionTargets)' != 'false' and exists('$(DirectorySolutionTargetsPath)')"/>
+            */
             ProjectPropertyGroupElement directorySolutionPropsPropertyGroup = traversalProject.CreatePropertyGroupElement();
             directorySolutionPropsPropertyGroup.Condition = "'$(ImportDirectorySolutionProps)' != 'false' and '$(DirectorySolutionPropsPath)' == ''";
 


### PR DESCRIPTION
Implementation of https://github.com/microsoft/msbuild/issues/4784 

For the generated metaproj project this imports a file named `Directory.Solution.props` at the top and a file named `Directory.Solution.targets` at the bottom.

This allows users to create a single file that lets them extend the building of all solution files in their repository.

