### PR TITLE
Unhandled exception when pipe to worker node closes suddenly

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.3.1</VersionPrefix>
+    <VersionPrefix>16.3.2</VersionPrefix>
     <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
If a worker closed between when it sent information and when it received it, it crashed MSBuild. This turns a fatal exception into a clean error message. Fixes #4768 