### PR TITLE
Minor binlog doc change

### DIFF
--- a/documentation/wiki/Providing-Binary-Logs.md
+++ b/documentation/wiki/Providing-Binary-Logs.md
@@ -6,6 +6,6 @@ However, you should be aware what type of information is captured in the binary 
 
 ⚠ NOTE: some build environments make secrets available using environment variables. Before sharing a binary log, make sure it does not expose API tokens or other important secrets.
 
-You can create a binary log by passing the `/bl` parameter to MSBuild.  You can explore the contents of the generated .binlog file using [MSBuild Structured Log Viewer](http://msbuildlog.com/).
+You can create a binary log by passing the `-bl` parameter to MSBuild.  You can explore the contents of the generated .binlog file using [MSBuild Structured Log Viewer](http://msbuildlog.com/).
 
 [More details about binary logs](Binary-Log.md)


### PR DESCRIPTION
Change `/bl` to `-bl` to follow other places where `/` was replaced with `-` in help texts and documentation.

@dotnet-bot skip ci