### PR TITLE
Hardcode channel-publish repo name

### DIFF
--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -99,7 +99,7 @@ stages:
             /p:ArtifactsCategory=$(_DotNetArtifactsCategory)
             /p:IsStableBuild=$(IsStableBuild)
             /p:IsInternalBuild=$(IsInternalBuild)
-            /p:RepositoryName=$(Build.Repository.Name)
+            /p:RepositoryName='microsoft-msbuild'
             /p:CommitSha=$(Build.SourceVersion)
             /p:NugetPath=$(NuGetExeToolPath)
             /p:AzdoTargetFeedPAT='$(dn-bot-dnceng-universal-packages-rw)'


### PR DESCRIPTION
Work around dotnet/arcade#4087 by hardcoding the repo name in the one channel relevant to 16.3 servicing.