### PR TITLE
Switch to VS2019 queue for official build

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -23,7 +23,7 @@ stages:
   jobs:
   - job: Windows_NT
     pool:
-      name: VSEng-MicroBuildVS2017
+      name: VSEng-MicroBuildVS2019
       demands:
       - agent.os -equals Windows_NT
 


### PR DESCRIPTION
Should fix [this error in our official build](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=3128260&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=13896748-c84b-5918-2517-67b7d331a1d1&l=25):

```
##[error].packages\microsoft.dotnet.arcade.sdk\1.0.0-beta.19502.6\tools\Tools.proj(0,0): error : Version 3.0.100 of the .NET Core SDK requires at least version 16.3.0 of MSBuild. The current available version of MSBuild is 16.0.461.62831. Change the .NET Core SDK specified in global.json to an older version that requires the MSBuild version currently available.
```