### PR TITLE
Deliver v16 props file in VSIX

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -11,7 +11,7 @@ vs.dependencies
 
 folder InstallDir:\MSBuild\Current
   file source=$(X86BinPath)Microsoft.Common.props
-  file source=$(X86BinPath)Microsoft.VisualStudioVersion.v15.Common.props
+  file source=$(X86BinPath)Microsoft.VisualStudioVersion.v16.Common.props
   file source=$(ThirdPartyNotice)
 
 folder InstallDir:\MSBuild\Current\Bin


### PR DESCRIPTION
Props file initiates the wrong version.

Fixes #4728.

Successful VS insertion:
https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/207287?_a=overview