### PR TITLE
Changing source file extension to protected in CreateManifestResourceName

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/net/Microsoft.Build.Tasks.Core.cs
@@ -195,6 +195,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
+        protected override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -220,6 +221,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
+        protected abstract string SourceFileExtension { get; }
         public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
@@ -238,6 +240,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
+        protected override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateCSharpManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateCSharpManifestResourceName() { }
+        protected override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }
@@ -150,6 +151,7 @@ namespace Microsoft.Build.Tasks
         [Microsoft.Build.Framework.OutputAttribute]
         public Microsoft.Build.Framework.ITaskItem[] ResourceFilesWithManifestResourceNames { get { throw null; } set { } }
         public string RootNamespace { get { throw null; } set { } }
+        protected abstract string SourceFileExtension { get; }
         public bool UseDependentUponConvention { get { throw null; } set { } }
         protected abstract string CreateManifestName(string fileName, string linkFileName, string rootNamespaceName, string dependentUponFileName, System.IO.Stream binaryStream);
         public override bool Execute() { throw null; }
@@ -168,6 +170,7 @@ namespace Microsoft.Build.Tasks
     public partial class CreateVisualBasicManifestResourceName : Microsoft.Build.Tasks.CreateManifestResourceName
     {
         public CreateVisualBasicManifestResourceName() { }
+        protected override string SourceFileExtension { get { throw null; } }
         protected override string CreateManifestName(string fileName, string linkFileName, string rootNamespace, string dependentUponFileName, System.IO.Stream binaryStream) { throw null; }
         protected override bool IsSourceFile(string fileName) { throw null; }
     }

--- a/src/Tasks/CreateCSharpManifestResourceName.cs
+++ b/src/Tasks/CreateCSharpManifestResourceName.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateCSharpManifestResourceName : CreateManifestResourceName
     {
-        internal override string SourceFileExtension => ".cs";
+        protected override string SourceFileExtension => ".cs";
 
         /// <summary>
         /// Utility function for creating a C#-style manifest name from 

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Tasks
 
         public bool UseDependentUponConvention { get; set; }
 
-        internal abstract string SourceFileExtension { get; }
+        protected abstract string SourceFileExtension { get; }
 
         /// <summary>
         /// The possibly dependent resource files.

--- a/src/Tasks/CreateVisualBasicManifestResourceName.cs
+++ b/src/Tasks/CreateVisualBasicManifestResourceName.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     public class CreateVisualBasicManifestResourceName : CreateManifestResourceName
     {
-        internal override string SourceFileExtension => ".vb";
+        protected override string SourceFileExtension => ".vb";
 
         /// <summary>
         /// Utility function for creating a VB-style manifest name from 


### PR DESCRIPTION
Fix for #4759 

Allow users to override the default source file extension