### PR TITLE
Allow case-varying solution targets

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2103,8 +2103,10 @@ EndGlobal
         /// <summary>
         /// Verifies that illegal user target names (the ones already used internally) don't crash the SolutionProjectGenerator
         /// </summary>
-        [Fact]
-        public void IllegalUserTargetNamesDoNotThrow()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IllegalUserTargetNamesDoNotThrow(bool forceCaseDifference)
         {
             SolutionFile solution = SolutionFile_Tests.ParseSolutionHelper
             (@"
@@ -2145,7 +2147,18 @@ EndGlobal
                 "ValidateProjects",
             })
             {
-                instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, CreateMockLoggingService(), builtInTargetName == null ? null : new [] { builtInTargetName });
+                string[] targetNames;
+
+                if (builtInTargetName == null)
+                {
+                    targetNames = null;
+                } else
+                {
+                    string targetName = forceCaseDifference ? builtInTargetName.ToUpperInvariant() : builtInTargetName;
+                    targetNames = new[] { targetName };
+                }
+
+                instances = SolutionProjectGenerator.Generate(solution, globalProperties, null, BuildEventContext.Invalid, CreateMockLoggingService(), targetNames);
 
                 Assert.Single(instances);
 

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -2152,7 +2152,8 @@ EndGlobal
                 if (builtInTargetName == null)
                 {
                     targetNames = null;
-                } else
+                }
+                else
                 {
                     string targetName = forceCaseDifference ? builtInTargetName.ToUpperInvariant() : builtInTargetName;
                     targetNames = new[] { targetName };

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// A known list of target names to create.  This is for backwards compatibility.
         /// </summary>
-        internal static readonly ISet<string> _defaultTargetNames = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
+        internal static readonly ImmutableHashSet<string> _defaultTargetNames = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase,
             "Build",
             "Clean",
             "Rebuild",


### PR DESCRIPTION
Fixes #4811 by switching to the concrete implementation type for the `_defaultTargetNames` set.

As `ISet<T>`, the overload resolved for Union was from Linq and did not respect the left-hand
set's comparer. By moving the field to the concrete `ImmutableHashSet<T>` type, the overload
from that type is used, which does use the collection's comparer (case-insensitive).

When the target names are correctly unioned, the null-reference exception is avoided, because
the dummy target is removed only once, instead of twice (throwing NRE on the second time).