### PR TITLE
Permissive MemoryStream typename

### DIFF
--- a/src/Tasks/ResourceHandling/MSBuildResXReader.cs
+++ b/src/Tasks/ResourceHandling/MSBuildResXReader.cs
@@ -81,9 +81,9 @@ namespace Microsoft.Build.Tasks.ResourceHandling
         private const string ByteArraySerializedObjectMimeType = "application/x-microsoft.net.object.bytearray.base64";
         private const string ResMimeType = "text/microsoft-resx";
 
-        private const string StringTypeName20 = "System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        private const string StringTypeNamePrefix = "System.String, mscorlib,";
         private const string StringTypeName40 = "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
-        private const string MemoryStreamTypeNameDesktopFramework = "System.IO.MemoryStream, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        private const string MemoryStreamTypeNamePrefix = "System.IO.MemoryStream, mscorlib,";
 
         private static string GetFullTypeNameFromAlias(string aliasedTypeName, Dictionary<string, string> aliases)
         {
@@ -275,13 +275,12 @@ namespace Microsoft.Build.Tasks.ResourceHandling
 
         internal static bool IsString(string fileRefType)
         {
-            return fileRefType.Equals(StringTypeName40, StringComparison.Ordinal) ||
-                fileRefType.Equals(StringTypeName20, StringComparison.Ordinal);
+            return fileRefType.StartsWith(StringTypeNamePrefix, StringComparison.Ordinal);
         }
 
         internal static bool IsMemoryStream(string fileRefType)
         {
-            return fileRefType.Equals(MemoryStreamTypeNameDesktopFramework, StringComparison.Ordinal);
+            return fileRefType.StartsWith(MemoryStreamTypeNamePrefix, StringComparison.Ordinal);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4773 by treating string and MemoryStream types as a prefix match on the mscorlib identity,
hoping to more closely match `Type.GetType`'s behavior.