### PR TITLE
Enable Arcade Pipelines logging in Windows builds

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -10,7 +10,7 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - task: BatchScript@1
-    displayName: cibuild.cmd
+    displayName: cibuild_bootstrapped_msbuild.cmd
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
   - task: PublishTestResults@2
@@ -54,7 +54,7 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - task: BatchScript@1
-    displayName: cibuild.cmd
+    displayName: cibuild_bootstrapped_msbuild.cmd
     inputs:
       filename: 'eng/cibuild_bootstrapped_msbuild.cmd'
       arguments: '-msbuildEngine dotnet'

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -7,6 +7,10 @@ Param(
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
+# Ensure that static state in tools is aware that this is
+# a CI scenario
+$ci = $true
+
 . $PSScriptRoot\common\tools.ps1
 
 Set-StrictMode -Version 2.0

--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -83,6 +83,7 @@ try {
   {
     $buildToolPath = Join-Path $bootstrapRoot "net472\MSBuild\Current\Bin\MSBuild.exe"
     $buildToolCommand = "";
+    $buildToolFramework = "net472"
 
     if ($configuration -eq "Debug-MONO" -or $configuration -eq "Release-MONO")
     {
@@ -95,6 +96,7 @@ try {
   {
     $buildToolPath = $dotnetExePath
     $buildToolCommand = Join-Path $bootstrapRoot "netcoreapp2.1\MSBuild\MSBuild.dll"
+    $buildToolFramework = "netcoreapp2.1"
   }
 
   # Use separate artifacts folder for stage 2
@@ -107,7 +109,7 @@ try {
     Move-Item -Path $ArtifactsDir -Destination $Stage1Dir -Force
   }
 
-  $buildTool = @{ Path = $buildToolPath; Command = $buildToolCommand }
+  $buildTool = @{ Path = $buildToolPath; Command = $buildToolCommand; Tool = $msbuildEngine; Framework = $buildToolFramework }
   $global:_BuildTool = $buildTool
 
   # turn vbcscompiler back on to save on time. It speeds up the build considerably


### PR DESCRIPTION
Example output: https://dev.azure.com/dnceng/public/_build/results?buildId=432144&view=results

Not sure why that didn't push checks annotations except from the *nix legs that were already working, but it appears to annotate the errors correctly in AzDO.