### PR TITLE
Port XslTransformation to .NET Core

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -801,6 +801,20 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.ITaskItem XmlInputPath { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class XslTransformation : Microsoft.Build.Tasks.TaskExtension
+    {
+        public XslTransformation() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] OutputPaths { get { throw null; } set { } }
+        public string Parameters { get { throw null; } set { } }
+        public bool UseTrustedSettings { get { throw null; } set { } }
+        public string XmlContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem[] XmlInputPaths { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XslCompiledDllPath { get { throw null; } set { } }
+        public string XslContent { get { throw null; } set { } }
+        public Microsoft.Build.Framework.ITaskItem XslInputPath { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public sealed partial class ZipDirectory : Microsoft.Build.Tasks.TaskExtension
     {
         public ZipDirectory() { }

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -30,6 +30,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_ASSEMBLYNAME_CLONE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCONSTRUCTOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COM_INTEROP</DefineConstants>
+    <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILED_XSL</DefineConstants>
     <DefineConstants Condition="'$(MonoBuild)' != 'true'">$(DefineConstants);FEATURE_COMPILE_IN_TESTS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONSOLE_BUFFERWIDTH</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONSTRAINED_EXECUTION</DefineConstants>

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -132,7 +132,6 @@
     <Compile Remove="VisualBasicParserUtilitites_Tests.cs" />
     <Compile Remove="VisualBasicTokenizer_Tests.cs" />
     <Compile Remove="WinMDExp_Tests.cs" />
-    <Compile Remove="XslTransformation_Tests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tasks.UnitTests/XslTransformation_Tests.cs
+++ b/src/Tasks.UnitTests/XslTransformation_Tests.cs
@@ -688,6 +688,7 @@ namespace Microsoft.Build.UnitTests
             CleanUp(dir);
         }
 
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Missing XsltCompiledDll file.
         /// </summary>
@@ -715,7 +716,7 @@ namespace Microsoft.Build.UnitTests
 
             CleanUp(dir);
         }
-
+#endif
         /// <summary>
         /// Bad XML on "Parameter" parameter.
         /// </summary>
@@ -814,6 +815,7 @@ namespace Microsoft.Build.UnitTests
             CleanUp(dir);
         }
 
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Passing a dll that has two types to XsltCompiledDll parameter without specifying a type.
         /// </summary>
@@ -826,10 +828,10 @@ namespace Microsoft.Build.UnitTests
             Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // doubletype
-            string doubleTypePath = Path.Combine(dir, "double.dll");
-#if FEATURE_COMPILED_XSL
+        string doubleTypePath = Path.Combine(dir, "double.dll");
+
             CompileDoubleType(doubleTypePath);
-#endif
+
             {
                 XslTransformation t = new XslTransformation();
                 t.BuildEngine = engine;
@@ -851,7 +853,7 @@ namespace Microsoft.Build.UnitTests
 
             CleanUp(dir);
         }
-
+#endif
         /// <summary>
         /// Matching XmlInputPaths and OutputPaths
         /// </summary>
@@ -956,6 +958,7 @@ namespace Microsoft.Build.UnitTests
             CleanUp(dir);
         }
 
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Validate that the XslTransformation task allows use of the document function
         /// </summary>
@@ -1009,6 +1012,7 @@ namespace Microsoft.Build.UnitTests
 
             CleanUp(dir);
         }
+#endif
 
         /// <summary>
         /// Prepares the test environment, creates necessary files.
@@ -1183,4 +1187,4 @@ namespace Microsoft.Build.UnitTests
         #endregion
     }
 #endif
-}
+    }

--- a/src/Tasks.UnitTests/XslTransformation_Tests.cs
+++ b/src/Tasks.UnitTests/XslTransformation_Tests.cs
@@ -99,14 +99,11 @@ namespace Microsoft.Build.UnitTests
         public void XmlXslParameters()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
             List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
             List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out xmlInputs, out xslInputs, out engine);
 
             // Test when Xml and Xsl parameters are correct
             for (int xmi = 0; xmi < xmlInputs.Count; xmi++)
@@ -509,6 +506,7 @@ namespace Microsoft.Build.UnitTests
             CleanUp(dir);
         }
 
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Compiled Dll with type information.
         /// </summary>
@@ -516,14 +514,10 @@ namespace Microsoft.Build.UnitTests
         public void CompiledDllWithType()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
             TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out xslCompiledPath, out outputPaths, out _, out _, out engine);
 
             // Test Compiled DLLs
 
@@ -551,14 +545,10 @@ namespace Microsoft.Build.UnitTests
         public void CompiledDllWithoutType()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
             TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out xslCompiledPath, out outputPaths, out _, out _, out engine);
 
             // without type specified.
             {
@@ -574,6 +564,7 @@ namespace Microsoft.Build.UnitTests
 
             CleanUp(dir);
         }
+#endif
 
         /// <summary>
         /// Load Xslt with incorrect character as CNAME (load exception).
@@ -582,14 +573,9 @@ namespace Microsoft.Build.UnitTests
         public void BadXsltFile()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // load bad xslt
             {
@@ -653,12 +639,9 @@ namespace Microsoft.Build.UnitTests
             string dir;
             TaskItem[] xmlPaths;
             TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out xmlPaths, out xslPath, out _, out outputPaths, out _, out _, out engine);
 
             // load missing xml
             {
@@ -685,12 +668,9 @@ namespace Microsoft.Build.UnitTests
             string dir;
             TaskItem[] xmlPaths;
             TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out xmlPaths, out xslPath, out _, out outputPaths, out _, out _, out engine);
 
             // load missing xsl
             {
@@ -715,14 +695,10 @@ namespace Microsoft.Build.UnitTests
         public void MissingCompiledDllFile()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
             TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out xslCompiledPath, out outputPaths, out _, out _, out engine);
 
             // missing xsltCompiledDll
             {
@@ -747,14 +723,9 @@ namespace Microsoft.Build.UnitTests
         public void BadXmlAsParameter()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // load bad xml on parameters
             {
@@ -785,14 +756,9 @@ namespace Microsoft.Build.UnitTests
         public void OutputFileCannotBeWritten()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // load bad output
             {
@@ -823,14 +789,9 @@ namespace Microsoft.Build.UnitTests
         public void XsltDocumentThrowsError()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // load error xslDocument
             {
@@ -860,18 +821,15 @@ namespace Microsoft.Build.UnitTests
         public void CompiledDllWithTwoTypes()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // doubletype
             string doubleTypePath = Path.Combine(dir, "double.dll");
+#if FEATURE_COMPILED_XSL
             CompileDoubleType(doubleTypePath);
+#endif
             {
                 XslTransformation t = new XslTransformation();
                 t.BuildEngine = engine;
@@ -903,12 +861,9 @@ namespace Microsoft.Build.UnitTests
             string dir;
             TaskItem[] xmlPaths;
             TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out xmlPaths, out xslPath, out _, out outputPaths, out _, out _, out engine);
 
             var otherXmlPath = new TaskItem(Path.Combine(dir, Guid.NewGuid().ToString()));
             using (StreamWriter sw = new StreamWriter(otherXmlPath.ItemSpec, false))
@@ -956,12 +911,9 @@ namespace Microsoft.Build.UnitTests
             string dir;
             TaskItem[] xmlPaths;
             TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out xmlPaths, out xslPath, out _, out outputPaths, out _, out _, out engine);
 
             // xmlPaths have one XmlPath, lets duplicate it **4 times **
             TaskItem[] xmlMultiPaths = new TaskItem[] { xmlPaths[0], xmlPaths[0], xmlPaths[0], xmlPaths[0] };
@@ -1011,14 +963,9 @@ namespace Microsoft.Build.UnitTests
         public void XslDocumentFunctionWorks()
         {
             string dir;
-            TaskItem[] xmlPaths;
-            TaskItem xslPath;
-            TaskItem xslCompiledPath;
             TaskItem[] outputPaths;
-            List<KeyValuePair<XslTransformation.XmlInput.XmlModes, object>> xmlInputs;
-            List<KeyValuePair<XslTransformation.XsltInput.XslModes, object>> xslInputs;
             MockEngine engine;
-            Prepare(out dir, out xmlPaths, out xslPath, out xslCompiledPath, out outputPaths, out xmlInputs, out xslInputs, out engine);
+            Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             var otherXslPath = new TaskItem(Path.Combine(dir, Guid.NewGuid().ToString() + ".xslt"));
             using (StreamWriter sw = new StreamWriter(otherXslPath.ItemSpec, false))
@@ -1104,8 +1051,9 @@ namespace Microsoft.Build.UnitTests
 
             xslInputs.Add(new KeyValuePair<XslTransformation.XsltInput.XslModes, object>(XslTransformation.XsltInput.XslModes.Xslt, _xslDocument));
             xslInputs.Add(new KeyValuePair<XslTransformation.XsltInput.XslModes, object>(XslTransformation.XsltInput.XslModes.XsltFile, xslPath));
-
+#if FEATURE_COMPILED_XSL
             Compile(xslPath.ItemSpec, xslCompiledPath.ItemSpec);
+#endif
 
             engine = new MockEngine();
             List<bool> results = new List<bool>();
@@ -1130,6 +1078,7 @@ namespace Microsoft.Build.UnitTests
 
 #pragma warning disable 0618 // XmlReaderSettings.ProhibitDtd is obsolete
 
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Compiles given stylesheets into an assembly.
         /// </summary>
@@ -1191,9 +1140,10 @@ namespace Microsoft.Build.UnitTests
 
             asmBldr.Save(Path.GetFileName(outputFile), PortableExecutableKinds.ILOnly, ImageFileMachine.I386);
         }
+#endif
 
 #pragma warning restore 0618
-
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// Creates a dll that has 2 types in it.
         /// </summary>
@@ -1213,6 +1163,7 @@ namespace Microsoft.Build.UnitTests
 
             ModuleBuilder modBldr = asmBldr.DefineDynamicModule(Path.GetFileName(outputFile), Path.GetFileName(outputFile), true);
 
+
             // Create TypeBuilder and compile the stylesheet into it
             TypeBuilder typeBldr = modBldr.DefineType(CompiledQueryName, TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
 
@@ -1227,6 +1178,8 @@ namespace Microsoft.Build.UnitTests
 
             asmBldr.Save(Path.GetFileName(outputFile), PortableExecutableKinds.ILOnly, ImageFileMachine.I386);
         }
+
+#endif
         #endregion
     }
 #endif

--- a/src/Tasks.UnitTests/XslTransformation_Tests.cs
+++ b/src/Tasks.UnitTests/XslTransformation_Tests.cs
@@ -66,12 +66,12 @@ namespace Microsoft.Build.UnitTests
         /// The contents of xsl document for tests.
         /// </summary>
         private readonly string _xslDocument = "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" xmlns:msxsl=\"urn:schemas-microsoft-com:xslt\" exclude-result-prefixes=\"msxsl\"><xsl:output method=\"xml\" indent=\"yes\"/><xsl:template match=\"@* | node()\"><surround><xsl:copy><xsl:apply-templates select=\"@* | node()\"/></xsl:copy></surround></xsl:template></xsl:stylesheet>";
-
+#if FEATURE_COMPILED_XSL
         /// <summary>
         /// The contents of another xsl document for tests
         /// </summary>
         private readonly string _xslDocument2 = "<?xml version = \"1.0\" ?><xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"><xsl:template match = \"myInclude\"><xsl:apply-templates select = \"document(@path)\"/></xsl:template><xsl:template match = \"@*|node()\"><xsl:copy><xsl:apply-templates select = \"@*|node()\"/></xsl:copy></xsl:template></xsl:stylesheet>";
-
+#endif
         /// <summary>
         /// The contents of xslparameters for tests.
         /// </summary>
@@ -828,7 +828,7 @@ namespace Microsoft.Build.UnitTests
             Prepare(out dir, out _, out _, out _, out outputPaths, out _, out _, out engine);
 
             // doubletype
-        string doubleTypePath = Path.Combine(dir, "double.dll");
+            string doubleTypePath = Path.Combine(dir, "double.dll");
 
             CompileDoubleType(doubleTypePath);
 
@@ -1167,7 +1167,6 @@ namespace Microsoft.Build.UnitTests
 
             ModuleBuilder modBldr = asmBldr.DefineDynamicModule(Path.GetFileName(outputFile), Path.GetFileName(outputFile), true);
 
-
             // Create TypeBuilder and compile the stylesheet into it
             TypeBuilder typeBldr = modBldr.DefineType(CompiledQueryName, TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
 
@@ -1187,4 +1186,4 @@ namespace Microsoft.Build.UnitTests
         #endregion
     }
 #endif
-    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -504,6 +504,7 @@
     <Compile Include="Warning.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="XslTransformation.cs" />
     <Compile Include="AssignCulture.cs" />
     <Compile Include="Culture.cs" />
     <Compile Include="CultureInfoCache.cs" />
@@ -653,7 +654,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="WinMDExp.cs" />
-    <Compile Include="XslTransformation.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="XamlTaskFactory\CommandLineGenerator.cs" />

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2263,6 +2263,10 @@
   <data name="XslTransform.UseTrustedSettings" xml:space="preserve">
     <value>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</value>
   </data>
+    <data name="XslTransform.PrecompiledXsltError" xml:space="preserve">
+    <value>MSB3705: Precompiled XSLTs are not supported in .NET Core</value>
+    <comment>{StrBegin="MSB3705: "}</comment>
+  </data>
 
 
   <!--

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2264,7 +2264,7 @@
     <value>The usage of the document() method and embedded scripts is prohibited by default, due to risks of foreign code execution.  If "{0}" is a trusted source that requires those constructs, please set the "UseTrustedSettings" parameter to "true" to allow their execution.</value>
   </data>
     <data name="XslTransform.PrecompiledXsltError" xml:space="preserve">
-    <value>MSB3705: Precompiled XSLTs are not supported in .NET Core</value>
+    <value>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</value>
     <comment>{StrBegin="MSB3705: "}</comment>
   </data>
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Nelze načíst argumenty pro úlohu XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Nelze zpracovat argument XsltParameters pro úlohu XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Die Argumente für die XslTransformation-Aufgabe können nicht geladen werden. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Das XsltParameters-Argument für die XslTransformation-Aufgabe kann nicht verarbeitet werden. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2649,8 +2649,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2648,6 +2648,11 @@
         <target state="new">MSB3701: Unable to load arguments for the XslTransformation task. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="new">MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: No se pueden cargar los argumentos para la tarea XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: No se puede procesar el argumento XsltParameters para la tarea XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Impossible de charger les arguments pour la tâche XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Impossible de traiter l'argument XsltParameters de la tâche XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: non è possibile caricare argomenti per l'attività XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: non è possibile elaborare l'argomento XsltParameters per l'attività XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: XslTransformation タスクの引数を読み込めません。{0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: XslTransformation タスクの XsltParameters 引数を処理できません。{0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: XslTransformation 작업의 인수를 로드할 수 없습니다. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: XslTransformation 작업에 대해 XsltParameters 인수를 처리할 수 없습니다. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Nie można załadować argumentów dla zadania XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Nie można przetwarzać argumentu XsltParameters dla zadania XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Não é possível carregar argumentos para a tarefa XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Não é possível processar o argumento XsltParameters para a tarefa XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: Не удалось загрузить аргументы для задачи XslTransformation. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: Не удалось обработать аргумент XsltParameters для задачи XslTransformation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: XslTransformation görevi için bağımsız değişkenler yüklenemiyor. {0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: XslTransformation görevi için XsltParameters bağımsız değişkeni işlenemiyor. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: 无法加载 XslTransformation 任务的参数。{0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: 无法处理 XslTransformation 任务的 XsltParameters 参数。{0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2589,8 +2589,8 @@
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.PrecompiledXsltError">
-        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
-        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <source>MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</source>
+        <target state="new">MSB3705: XslCompiledDllPath is not supported when building with .NET Core.</target>
         <note>{StrBegin="MSB3705: "}</note>
       </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2588,6 +2588,11 @@
         <target state="translated">MSB3701: 無法載入 XslTransformation 工作的引數。{0}</target>
         <note>{StrBegin="MSB3701: "}</note>
       </trans-unit>
+      <trans-unit id="XslTransform.PrecompiledXsltError">
+        <source>MSB3705: Precompiled XSLTs are not supported in .NET Core</source>
+        <target state="new">MSB3705: Precompiled XSLTs are not supported in .NET Core</target>
+        <note>{StrBegin="MSB3705: "}</note>
+      </trans-unit>
       <trans-unit id="XslTransform.XsltArgumentsError">
         <source>MSB3702: Unable to process the XsltParameters argument for the XslTransformation task. {0}</source>
         <target state="translated">MSB3702: 無法處理 XslTransformation 工作的 XsltParameters 引數。{0}</target>

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Build.Tasks
                         xslct.Load(t);
                         break;
 #else
-                        throw new Exception("This is not supported on .NET Core.");
+                        throw new PlatformNotSupportedException("Precompiled XSLTs are not supported on .NET Core.");
 #endif
                     default:
                         ErrorUtilities.ThrowInternalErrorUnreachable();

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -148,6 +148,11 @@ namespace Microsoft.Build.Tasks
             {
                 xslct = xsltinput.LoadXslt(UseTrustedSettings);
             }
+            catch (PlatformNotSupportedException)
+            {
+                Log.LogErrorWithCodeFromResources("XslTransform.PrecompiledXsltError");
+                return false;
+            }
             catch (Exception e)
             {
                 if (ExceptionHandling.IsCriticalException(e))
@@ -456,8 +461,8 @@ namespace Microsoft.Build.Tasks
 
                         xslct.Load(new XPathDocument(XmlReader.Create(_data)), settings, new XmlUrlResolver());
                         break;
-#if FEATURE_COMPILED_XSL
                     case XslModes.XsltCompiledDll:
+#if FEATURE_COMPILED_XSL
                         // We accept type in format: assembly_name[;type_name]. type_name may be omitted if assembly has just one type defined
                         string dll = _data;
                         string[] pair = dll.Split(MSBuildConstants.SemicolonChar);
@@ -468,7 +473,7 @@ namespace Microsoft.Build.Tasks
                         xslct.Load(t);
                         break;
 #else
-                        throw new PlatformNotSupportedException("Precompiled XSLTs are not supported on .NET Core.");
+                        throw new PlatformNotSupportedException("Precompiled XSLTs are not supported in .NET Core");
 #endif
                     default:
                         ErrorUtilities.ThrowInternalErrorUnreachable();

--- a/src/Tasks/XslTransformation.cs
+++ b/src/Tasks/XslTransformation.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Build.Tasks
 
                         xslct.Load(new XPathDocument(XmlReader.Create(_data)), settings, new XmlUrlResolver());
                         break;
-#if !MONO
+#if FEATURE_COMPILED_XSL
                     case XslModes.XsltCompiledDll:
                         // We accept type in format: assembly_name[;type_name]. type_name may be omitted if assembly has just one type defined
                         string dll = _data;
@@ -467,6 +467,8 @@ namespace Microsoft.Build.Tasks
                         Type t = FindType(assemblyPath, typeName);
                         xslct.Load(t);
                         break;
+#else
+                        throw new Exception("This is not supported on .NET Core.");
 #endif
                     default:
                         ErrorUtilities.ThrowInternalErrorUnreachable();


### PR DESCRIPTION
Fixes #3368 

XslTransformation was ported over to .NET Core. though any functionality having to do with compiled DLLs had to be cut. This functionality is locked behind the flag: `FEATURE_COMPILED_XSL` which is defined under non-mono builds.