### PR TITLE
Fix error message

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -504,10 +504,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PlatformTargetAsMSBuildArchitectureExplicitlySet Condition="'$(PlatformTargetAsMSBuildArchitecture)' != ''">true</PlatformTargetAsMSBuildArchitectureExplicitlySet>
     <PlatformTargetAsMSBuildArchitectureExplicitlySet Condition="'$(PlatformTargetAsMSBuildArchitecture)' == ''">false</PlatformTargetAsMSBuildArchitectureExplicitlySet>
 
-    <PlatformTargetAsMSBuildArchitecture Condition="('$(PlatformTarget)' == 'x86' and '$(MSBuildExtensionsPath86)' != '') or ('$(PlatformTarget)' == 'x64' and '$(MSBuildExtensionsPath64)' != '')">$(PlatformTarget)</PlatformTargetAsMSBuildArchitecture>
+    <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'x86' or ('$(PlatformTarget)' == 'x64' and '$(MSBuildExtensionsPath64)' != '')">$(PlatformTarget)</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'arm'">x86</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="('$(PlatformTarget)' == 'ia64' and '$(MSBuildExtensionsPath64)' != '')">x64</PlatformTargetAsMSBuildArchitecture>
-    <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTargetAsMSBuildArchitecture)' == ''">CurrentArchitecture</PlatformTargetAsMSBuildArchitecture>
+    <PlatformTargetAsMSBuildArchitecture Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(PlatformTargetAsMSBuildArchitecture)' == ''">CurrentArchitecture</PlatformTargetAsMSBuildArchitecture>
   </PropertyGroup>
 
   <!-- Flavor is the project flavor. For example, Client, Smart Devices, SQL Server, etc. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -496,7 +496,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
 
   <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values. The Core and Mono runtimes do not currently support specifying task architecture or runtime.
-       The change to limit this to the 'Full' runtime originated from the 'ResolveComReferences' target in this file. The team that owns that target explicitly said they are not going to port it to .NET Core, so if you remove the below check, add a similar check in ResolveComReferences. -->
+       If support for out-of-proc task execution is added on other runtimes, make sure each task's logic is checked against the current state of support. -->
   <PropertyGroup Condition="'$(DisableOutOfProcTaskHost)' == '' and '$(MSBuildRuntimeType)' == 'Full'">
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkVersion)' == 'v2.0' or '$(TargetFrameworkVersion)' == 'v3.0' or '$(TargetFrameworkVersion)' == 'v3.5'">CLR2</TargetFrameworkAsMSBuildRuntime>
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkVersion)' == 'v4.0' or '$(TargetFrameworkVersion)' == 'v4.5'">CLR4</TargetFrameworkAsMSBuildRuntime>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -495,7 +495,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
 
-  <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values. The Core and Mono runtimes do not currently support custom architectures or runtimes.
+  <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values. The Core and Mono runtimes do not currently support specifying task architecture or runtime.
        The change to limit this to the 'Full' runtime originated from the 'ResolveComReferences' target in this file. The team that owns that target explicitly said they are not going to port it to .NET Core, so if you remove the below check, add a similar check in ResolveComReferences. -->
   <PropertyGroup Condition="'$(DisableOutOfProcTaskHost)' == '' and '$(MSBuildRuntimeType)' == 'Full'">
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkVersion)' == 'v2.0' or '$(TargetFrameworkVersion)' == 'v3.0' or '$(TargetFrameworkVersion)' == 'v3.5'">CLR2</TargetFrameworkAsMSBuildRuntime>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -495,8 +495,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
 
-  <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values -->
-  <PropertyGroup Condition="'$(DisableOutOfProcTaskHost)' == ''">
+  <!-- Sensible defaults for the most-commonly-desired MSBuildRuntime and MSBuildArchitecture values. The Core and Mono runtimes do not currently support custom architectures or runtimes.
+       The change to limit this to the 'Full' runtime originated from the 'ResolveComReferences' target in this file. The team that owns that target explicitly said they are not going to port it to .NET Core, so if you remove the below check, add a similar check in ResolveComReferences. -->
+  <PropertyGroup Condition="'$(DisableOutOfProcTaskHost)' == '' and '$(MSBuildRuntimeType)' == 'Full'">
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkVersion)' == 'v2.0' or '$(TargetFrameworkVersion)' == 'v3.0' or '$(TargetFrameworkVersion)' == 'v3.5'">CLR2</TargetFrameworkAsMSBuildRuntime>
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkVersion)' == 'v4.0' or '$(TargetFrameworkVersion)' == 'v4.5'">CLR4</TargetFrameworkAsMSBuildRuntime>
     <TargetFrameworkAsMSBuildRuntime Condition="'$(TargetFrameworkAsMSBuildRuntime)' == ''">CurrentRuntime</TargetFrameworkAsMSBuildRuntime>
@@ -507,7 +508,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'x86' or ('$(PlatformTarget)' == 'x64' and '$(MSBuildExtensionsPath64)' != '')">$(PlatformTarget)</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'arm'">x86</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="('$(PlatformTarget)' == 'ia64' and '$(MSBuildExtensionsPath64)' != '')">x64</PlatformTargetAsMSBuildArchitecture>
-    <PlatformTargetAsMSBuildArchitecture Condition="'$(MSBuildRuntimeType)' == 'Core' or '$(PlatformTargetAsMSBuildArchitecture)' == ''">CurrentArchitecture</PlatformTargetAsMSBuildArchitecture>
+    <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTargetAsMSBuildArchitecture)' == ''">CurrentArchitecture</PlatformTargetAsMSBuildArchitecture>
   </PropertyGroup>
 
   <!-- Flavor is the project flavor. For example, Client, Smart Devices, SQL Server, etc. -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -504,7 +504,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <PlatformTargetAsMSBuildArchitectureExplicitlySet Condition="'$(PlatformTargetAsMSBuildArchitecture)' != ''">true</PlatformTargetAsMSBuildArchitectureExplicitlySet>
     <PlatformTargetAsMSBuildArchitectureExplicitlySet Condition="'$(PlatformTargetAsMSBuildArchitecture)' == ''">false</PlatformTargetAsMSBuildArchitectureExplicitlySet>
 
-    <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'x86' or ('$(PlatformTarget)' == 'x64' and '$(MSBuildExtensionsPath64)' != '')">$(PlatformTarget)</PlatformTargetAsMSBuildArchitecture>
+    <PlatformTargetAsMSBuildArchitecture Condition="('$(PlatformTarget)' == 'x86' and '$(MSBuildExtensionsPath86)' != '') or ('$(PlatformTarget)' == 'x64' and '$(MSBuildExtensionsPath64)' != '')">$(PlatformTarget)</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTarget)' == 'arm'">x86</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="('$(PlatformTarget)' == 'ia64' and '$(MSBuildExtensionsPath64)' != '')">x64</PlatformTargetAsMSBuildArchitecture>
     <PlatformTargetAsMSBuildArchitecture Condition="'$(PlatformTargetAsMSBuildArchitecture)' == ''">CurrentArchitecture</PlatformTargetAsMSBuildArchitecture>


### PR DESCRIPTION
If the platform target is explicitly set to x86, it sets the MSBuild architecture to the same. It then passes over the real problem when using dotnet build and returns a confusing error message instead. Fixes #4332.