### PR TITLE
Fix VerifyFileHash error logging

### DIFF
--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Build.UnitTests
         private readonly ProjectCollection _projectCollection = new ProjectCollection();
         private readonly bool _logToConsole;
         private readonly ConcurrentDictionary<object, object> _objectCache = new ConcurrentDictionary<object, object>();
+        private readonly ConcurrentQueue<BuildErrorEventArgs> _errorEvents = new ConcurrentQueue<BuildErrorEventArgs>();
 
         internal MockEngine() : this(false)
         {
@@ -49,6 +50,8 @@ namespace Microsoft.Build.UnitTests
         internal int Warnings { get; set; }
 
         internal int Errors { get; set; }
+
+        public BuildErrorEventArgs[] ErrorEvents => _errorEvents.ToArray();
 
         internal MockLogger MockLogger { get; }
 
@@ -67,6 +70,8 @@ namespace Microsoft.Build.UnitTests
 
         public void LogErrorEvent(BuildErrorEventArgs eventArgs)
         {
+            _errorEvents.Enqueue(eventArgs);
+
             string message = string.Empty;
 
             if (!string.IsNullOrEmpty(eventArgs.File))

--- a/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
+++ b/src/Tasks.UnitTests/VerifyFileHash_Tests.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Build.UnitTests
             .Execute()
             .ShouldBeFalse();
 
-            _mockEngine.Log.ShouldContain("MSB3951");
+            var errorEvent = _mockEngine.ErrorEvents.ShouldHaveSingleItem();
+
+            errorEvent.Code.ShouldBe("MSB3951");
         }
 
         [Fact]
@@ -49,7 +51,9 @@ namespace Microsoft.Build.UnitTests
             .Execute()
             .ShouldBeFalse();
 
-            _mockEngine.Log.ShouldContain("MSB3953");
+            var errorEvent = _mockEngine.ErrorEvents.ShouldHaveSingleItem();
+
+            errorEvent.Code.ShouldBe("MSB3953");
         }
 
         [Fact]
@@ -65,7 +69,9 @@ namespace Microsoft.Build.UnitTests
             .Execute()
             .ShouldBeFalse();
 
-            _mockEngine.Log.ShouldContain("MSB3954");
+            var errorEvent = _mockEngine.ErrorEvents.ShouldHaveSingleItem();
+
+            errorEvent.Code.ShouldBe("MSB3954");
         }
 
         [Theory]
@@ -84,7 +90,9 @@ namespace Microsoft.Build.UnitTests
 
             task.Execute().ShouldBeFalse(() => _mockEngine.Log);
 
-            _mockEngine.Log.ShouldContain("MSB3952");
+            var errorEvent = _mockEngine.ErrorEvents.ShouldHaveSingleItem();
+
+            errorEvent.Code.ShouldBe("MSB3952");
         }
 
         [Theory]

--- a/src/Tasks/FileIO/VerifyFileHash.cs
+++ b/src/Tasks/FileIO/VerifyFileHash.cs
@@ -40,19 +40,19 @@ namespace Microsoft.Build.Tasks
         {
             if (!FileSystems.Default.FileExists(File))
             {
-                Log.LogErrorFromResources("FileHash.FileNotFound", File);
+                Log.LogErrorWithCodeFromResources("FileHash.FileNotFound", File);
                 return false;
             }
 
             if (!GetFileHash.SupportsAlgorithm(Algorithm))
             {
-                Log.LogErrorFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
+                Log.LogErrorWithCodeFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
                 return false;
             }
 
             if (!GetFileHash.TryParseHashEncoding(HashEncoding, out var encoding))
             {
-                Log.LogErrorFromResources("FileHash.UnrecognizedHashEncoding", HashEncoding);
+                Log.LogErrorWithCodeFromResources("FileHash.UnrecognizedHashEncoding", HashEncoding);
                 return false;
             }
 
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Tasks
                 : StringComparison.Ordinal;
             if (!string.Equals(actualHash, Hash, comparison))
             {
-                Log.LogErrorFromResources("VerifyFileHash.HashMismatch", File, Algorithm, Hash, actualHash);
+                Log.LogErrorWithCodeFromResources("VerifyFileHash.HashMismatch", File, Algorithm, Hash, actualHash);
                 return false;
             }
 


### PR DESCRIPTION
Call `LogErrorWithCodeFromResources` so that the `Code` property is set in the `BuildErrorEventArgs` object

Also updated unit test and `MockEngine` to store build events for more in depth validation

Fixes #4851 