### PR TITLE
Force content copying to either be recursive, 1-level, or legacy

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4473,31 +4473,44 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </MSBuild>
 
-    <!-- Projects opting in for 1-level content copying will have to replace OutputItemType metadata from ProjectReference items like so:
-        "Content" to "_OutputItemTypeContentItems"
-        "None" to "_OutputItemTypeNoneItems"
-        "EmbeddedResource" to "_OutputItemTypeEmbeddedResourceItems"
-     -->
-    <AssignTargetPath Files="@(_OutputItemTypeContentItems);@(_OutputItemTypeNoneItems);@(_OutputItemTypeEmbeddedResourceItems)" RootFolder="$(MSBuildProjectDirectory)">
-      <Output TaskParameter="AssignedFiles" ItemName="_OutputItemTypeTransitiveItems" />
-    </AssignTargetPath>
-
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
       <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
-
-      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_OutputItemTypeTransitiveItems->'%(FullPath)')" Condition="'%(_OutputItemTypeTransitiveItems.CopyToOutputDirectory)'=='Always'"/>
-      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_OutputItemTypeTransitiveItems->'%(FullPath)')" Condition="'%(_OutputItemTypeTransitiveItems.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
       <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
-      <_OutputItemTypeTransitiveItems            Remove="@(_OutputItemTypeTransitiveItems)"/>
-      <_OutputItemTypeContentItems               Remove="@(_OutputItemTypeContentItems)"/>
-      <_OutputItemTypeNoneItems                  Remove="@(_OutputItemTypeNoneItems)"/>
-      <_OutputItemTypeEmbeddedResourceItems      Remove="@(_OutputItemTypeEmbeddedResourceItems)"/>
+    </ItemGroup>
+
+    <!-- Copy paste _GetCopyToOutputDirectoryItemsFromThisProject but keep the items that came from other projects via ProjectReference's OutputItemType metadata -->
+    <ItemGroup>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'!=''"/>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'!=''"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest') AND '%(Compile.MSBuildSourceProjectFile)'!=''"/>
+    </ItemGroup>
+
+    <AssignTargetPath Files="@(_CompileItemsToCopy)" RootFolder="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="AssignedFiles" ItemName="_CompileItemsToCopyWithTargetPath" />
+    </AssignTargetPath>
+
+    <ItemGroup>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'!=''"/>
     </ItemGroup>
 
   </Target>
@@ -4508,17 +4521,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       Returns="@(_ThisProjectItemsToCopyToOutputDirectory)">
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(ContentWithTargetPath.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always'"/>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest' AND '%(EmbeddedResource.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="'%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_CompileItemsToCopy Include="@(Compile->'%(FullPath)')" Condition="('%(Compile.CopyToOutputDirectory)'=='Always' or '%(Compile.CopyToOutputDirectory)'=='PreserveNewest') AND '%(Compile.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
     <AssignTargetPath Files="@(_CompileItemsToCopy)" RootFolder="$(MSBuildProjectDirectory)">
@@ -4531,8 +4544,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ItemGroup>
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'==''"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest' AND '%(_NoneWithTargetPath.MSBuildSourceProjectFile)'==''"/>
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4439,7 +4439,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
      -->
     <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
     <!-- Enforce 1 level deep content copying by replacing the recursive content target with the target that retrieves the content for the current project only. -->
-    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject </_RecursiveTargetForContentCopying>
+    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
   <Target Name="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
@@ -4473,7 +4473,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </MSBuild>
 
-    <!-- Projects opting in for 1-level transitive content copying will have to replace OutputItemType metadata from ProjectReference items like so:
+    <!-- Projects opting in for 1-level content copying will have to replace OutputItemType metadata from ProjectReference items like so:
         "Content" to "_OutputItemTypeContentItems"
         "None" to "_OutputItemTypeNoneItems"
         "EmbeddedResource" to "_OutputItemTypeEmbeddedResourceItems"
@@ -4544,7 +4544,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       DependsOnTargets="$(GetCopyToOutputDirectoryItemsDependsOn)">
 
     <!-- Compose the content items as the union between transitive content items and content items from this project. -->
-    <!-- Use CallTarget to avoid breaking targets that hook right before GetCopyToOutputDirectoryItems but after _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences and _GetCopyToOutputDirectoryItemsFromThisProject -->
+    <!-- Use CallTarget to avoid breaking targets that hook right before GetCopyToOutputDirectoryItems but expect to run after _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences and _GetCopyToOutputDirectoryItemsFromThisProject -->
     <CallTarget Targets="_GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences">
       <Output TaskParameter="TargetOutputs" ItemName="_TransitiveItemsToCopyToOutputDirectory" />
     </CallTarget>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4411,16 +4411,38 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     ============================================================
     -->
   <PropertyGroup>
+    <_TargetsThatPrepareProjectReferences>_SplitProjectReferencesByFileExistence</_TargetsThatPrepareProjectReferences>
+    <!--
+      GetCopyToOutputDirectoryItems depends on an unspecified dependency _SplitProjectReferencesByFileExistence -> AssignProjectConfiguration (https://github.com/microsoft/msbuild/issues/4677).
+      When the unspecified dependency does not happen by accident, content copying is only 1 level deep instead of transitive.
+      This target enforces the dependency.
+
+      TODO: make transitive content copying the default when the breaking change is acceptable.
+    -->
+    <_TargetsThatPrepareProjectReferences Condition=" '$(MSBuildCopyContentTransitively)' == 'true' ">
+      AssignProjectConfiguration;
+      _SplitProjectReferencesByFileExistence
+    </_TargetsThatPrepareProjectReferences>
+
     <GetCopyToOutputDirectoryItemsDependsOn>
       AssignTargetPaths;
-      _SplitProjectReferencesByFileExistence;
+      $(_TargetsThatPrepareProjectReferences);
       _GetProjectReferenceTargetFrameworkProperties;
-
       <!-- Compose the content items as the union between transitive content items and content items from this project. -->
-      _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences;
       <!-- Get items from this project last so that they will be copied last. -->
+      _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences;
       _GetCopyToOutputDirectoryItemsFromThisProject
     </GetCopyToOutputDirectoryItemsDependsOn>
+
+    <!--
+      Mitigation for https://github.com/microsoft/msbuild/issues/4677
+      When MSBuildCopyContentTransitively == true, all content copying is transitive.
+      When MSBuildCopyContentTransitively == false, content copying is 1 level deep.
+      When MSBuildCopyContentTransitively != {true, false}, the legacy behaviour in https://github.com/microsoft/msbuild/issues/4677 manifests.
+     -->
+    <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
+    <!-- Enforce 1 level deep content copying by replacing the recursive content target with the target that retrieves the content for the current project only. -->
+    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject </_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
   <Target Name="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
@@ -4441,7 +4463,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Get items from child projects first. -->
     <MSBuild
         Projects="@(_MSBuildProjectReferenceExistent)"
-        Targets="GetCopyToOutputDirectoryItems"
+        Targets="$(_RecursiveTargetForContentCopying)"
         BuildInParallel="$(BuildInParallel)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework)"
         Condition="'@(_MSBuildProjectReferenceExistent)' != '' and '$(_GetChildProjectCopyToOutputDirectoryItems)' == 'true' and '%(_MSBuildProjectReferenceExistent.Private)' != 'false' and '$(UseCommonOutputDirectory)' != 'true'"
@@ -4453,6 +4475,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     </MSBuild>
 
+    <!-- Projects opting in for 1-level transitive content copying will have to replace OutputItemType metadata from ProjectReference items like so:
+        "Content" to "_OutputItemTypeContentItems"
+        "None" to "_OutputItemTypeNoneItems"
+        "EmbeddedResource" to "_OutputItemTypeEmbeddedResourceItems"
+     -->
+    <AssignTargetPath Files="@(_OutputItemTypeContentItems);@(_OutputItemTypeNoneItems);@(_OutputItemTypeEmbeddedResourceItems)" RootFolder="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="AssignedFiles" ItemName="_AllChildProjectItemsWithTargetPath" />
+    </AssignTargetPath>
+
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
       <_TransitiveItemsToCopyToOutputDirectoryAlways KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
@@ -4462,13 +4493,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
       <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
+      <_OutputItemTypeContentItems               Remove="@(_OutputItemTypeContentItems)"/>
+      <_OutputItemTypeNoneItems                  Remove="@(_OutputItemTypeNoneItems)"/>
+      <_OutputItemTypeEmbeddedResourceItems      Remove="@(_OutputItemTypeEmbeddedResourceItems)"/>
     </ItemGroup>
 
   </Target>
 
   <Target
       Name="_GetCopyToOutputDirectoryItemsFromThisProject"
-      DependsOnTargets="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
+      DependsOnTargets="AssignTargetPaths;_PopulateCommonStateForGetCopyToOutputDirectoryItems"
+      Returns="@(_ThisProjectItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectory)">
 
     <ItemGroup>
       <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
@@ -4511,6 +4546,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_SourceItemsToCopyToOutputDirectory                 Include="@(_TransitiveItemsToCopyToOutputDirectory);@(_ThisProjectItemsToCopyToOutputDirectory)"/>
       <AllItemsFullPathWithTargetPath                      Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
 
+      <!-- Empty intermediate items to release memory -->
       <_TransitiveItemsToCopyToOutputDirectoryAlways       Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
       <_TransitiveItemsToCopyToOutputDirectory             Remove="@(_TransitiveItemsToCopyToOutputDirectory)"/>
       <_ThisProjectItemsToCopyToOutputDirectoryAlways      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -718,7 +718,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!--
     Target that allows targets consuming source control confirmation to establish a dependency on targets producing this information.
 
-    Any target that reads SourceRevisionId, PrivateRepositoryUrl, SourceRoot, and other source control properties and items 
+    Any target that reads SourceRevisionId, PrivateRepositoryUrl, SourceRoot, and other source control properties and items
     should depend on this target and be conditioned on '$(SourceControlInformationFeatureSupported)' == 'true'.
 
     SourceRevisionId property uniquely identifies the source control revision of the repository the project belongs to.
@@ -730,11 +730,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     may include the repository URL in the nuspec file generated for NuGet package produced by the project if PublishRepositoryUrl is true.
 
     SourceRoot item group lists all source roots that the project source files reside under and their mapping to source control server URLs,
-    if available. This includes both source files under source control as well as source files in source packages. SourceRoot items are 
+    if available. This includes both source files under source control as well as source files in source packages. SourceRoot items are
     used by compilers to determine path map in deterministic build and by SourceLink provider, which maps local paths to URLs of source files
     stored on the source control server.
 
-    Source control information provider that sets these properties and items shall execute before this target (by including 
+    Source control information provider that sets these properties and items shall execute before this target (by including
     InitializeSourceControlInformation in its BeforeTargets) and set source control properties and items that haven't been initialized yet.
   -->
   <Target Name="InitializeSourceControlInformation" />
@@ -2745,7 +2745,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Frameworks node of the Solution Explorer in the IDE.
   -->
   <Target Name="ResolveFrameworkReferences" />
-  
+
   <!--
     ***********************************************************************************************
     ***********************************************************************************************
@@ -3001,7 +3001,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <PropertyGroup>
       <GenerateResourceMSBuildArchitecture Condition="'$(GenerateResourceMSBuildArchitecture)' == ''">$(PlatformTargetAsMSBuildArchitecture)</GenerateResourceMSBuildArchitecture>
-      
+
       <ResgenToolPath Condition="'$(ResgenToolPath)' == ''">$(TargetFrameworkSDKToolsDirectory)</ResgenToolPath>
     </PropertyGroup>
 
@@ -3405,8 +3405,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <CoreCompileCache Include="$(DefineConstants)" />
     </ItemGroup>
 
-    <Hash 
-      ItemsToHash="@(CoreCompileCache)" 
+    <Hash
+      ItemsToHash="@(CoreCompileCache)"
       IgnoreCase="$([MSBuild]::ValueOrDefault(`$(CoreCompileCacheIgnoreCase)`, `true`))">
       <Output TaskParameter="HashResult" PropertyName="CoreCompileDependencyHash" />
     </Hash>
@@ -3950,7 +3950,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- Flag primary dependencies-certain warnings emitted during application manifest generation apply only to them. -->
     <ItemGroup>
       <_SatelliteAssemblies Include="@(IntermediateSatelliteAssembliesWithTargetPath);@(ReferenceSatellitePaths)" />
-      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)" 
+      <_DeploymentReferencePaths Include="@(ReferenceCopyLocalPaths)"
                                  Condition="'%(Extension)' == '.dll' Or '%(Extension)' == '.exe'">
         <IsPrimary>true</IsPrimary>
       </_DeploymentReferencePaths>
@@ -3998,7 +3998,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <!-- We have to filter items out of the dependencies that have neither CopyLocal set to true, -->
     <!-- nor the dependency type manually set to 'Install'.                                       -->
     <ItemGroup>
-      <_DeploymentManifestDependencies Include="@(_DeploymentManifestDependenciesUnfiltered)" 
+      <_DeploymentManifestDependencies Include="@(_DeploymentManifestDependenciesUnfiltered)"
           Condition="!('%(_DeploymentManifestDependenciesUnfiltered.CopyLocal)' == 'false' And '%(_DeploymentManifestDependenciesUnfiltered.DependencyType)' != 'Install')" />
     </ItemGroup>
 
@@ -4414,16 +4414,16 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <GetCopyToOutputDirectoryItemsDependsOn>
       AssignTargetPaths;
       _SplitProjectReferencesByFileExistence;
-      _GetProjectReferenceTargetFrameworkProperties
+      _GetProjectReferenceTargetFrameworkProperties;
+
+      <!-- Compose the content items as the union between transitive content items and content items from this project. -->
+      _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences;
+      <!-- Get items from this project last so that they will be copied last. -->
+      _GetCopyToOutputDirectoryItemsFromThisProject
     </GetCopyToOutputDirectoryItemsDependsOn>
   </PropertyGroup>
-  <Target
-      Name="GetCopyToOutputDirectoryItems"
-      Returns="@(AllItemsFullPathWithTargetPath)"
-      KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToOutputDirectoryItemsOptimization)' == '' "
-      DependsOnTargets="$(GetCopyToOutputDirectoryItemsDependsOn)">
 
-
+  <Target Name="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
     <!-- In the general case, clients need very little of the metadata which is generated by invoking this target on this project and its children.  For those
          cases, we can immediately discard the unwanted metadata, reducing memory usage, particularly in very large and interconnected systems of projects.
          However, if some client does require the original functionality, it is sufficient to set MSBuildDisableGetCopyToOutputDirectoryItemsOptimization to
@@ -4432,6 +4432,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <_GCTODIKeepDuplicates>false</_GCTODIKeepDuplicates>
       <_GCTODIKeepMetadata>CopyToOutputDirectory;TargetPath</_GCTODIKeepMetadata>
     </PropertyGroup>
+  </Target>
+
+  <Target
+    Name="_GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences"
+    DependsOnTargets="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
 
     <!-- Get items from child projects first. -->
     <MSBuild
@@ -4450,24 +4455,29 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToOutputDirectory       KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_TransitiveItemsToCopyToOutputDirectoryAlways KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_TransitiveItemsToCopyToOutputDirectory       KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
-      <_AllChildProjectItemsWithTargetPath Remove="@(_AllChildProjectItemsWithTargetPath)"/>
+      <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
     </ItemGroup>
 
-    <!-- Get items from this project last so that they will be copied last. -->
+  </Target>
+
+  <Target
+      Name="_GetCopyToOutputDirectoryItemsFromThisProject"
+      DependsOnTargets="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
+
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -4479,17 +4489,32 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </AssignTargetPath>
 
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_SourceItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
+  </Target>
+
+  <Target
+      Name="GetCopyToOutputDirectoryItems"
+      Returns="@(AllItemsFullPathWithTargetPath)"
+      KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToOutputDirectoryItemsOptimization)' == '' "
+      DependsOnTargets="$(GetCopyToOutputDirectoryItemsDependsOn)">
+
     <ItemGroup>
-      <AllItemsFullPathWithTargetPath            Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
+      <_SourceItemsToCopyToOutputDirectoryAlways           Include="@(_TransitiveItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
+      <_SourceItemsToCopyToOutputDirectory                 Include="@(_TransitiveItemsToCopyToOutputDirectory);@(_ThisProjectItemsToCopyToOutputDirectory)"/>
+      <AllItemsFullPathWithTargetPath                      Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
+
+      <_TransitiveItemsToCopyToOutputDirectoryAlways       Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
+      <_TransitiveItemsToCopyToOutputDirectory             Remove="@(_TransitiveItemsToCopyToOutputDirectory)"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
+      <_ThisProjectItemsToCopyToOutputDirectory            Remove="@(_ThisProjectItemsToCopyToOutputDirectory)"/>
     </ItemGroup>
 
   </Target>
@@ -5810,7 +5835,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       ResolveReferences
     </CommonOutputGroupsDependsOn>
   </PropertyGroup>
-  
+
   <!--
     ============================================================
                                         AllProjectOutputGroupsDependencies
@@ -5867,7 +5892,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       $(CommonOutputGroupsDependsOn)
     </DebugSymbolsProjectOutputGroupDependenciesDependsOn>
   </PropertyGroup>
-  
+
   <Target
       Name="DebugSymbolsProjectOutputGroupDependencies"
       Condition="'$(DebugSymbols)'!='false'"
@@ -6018,7 +6043,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <!-- Expose the set of potential .editorconfig files so the project system can
        retrieve them. -->
   <Target Name="GetPotentialEditorConfigFiles" Returns="@(PotentialEditorConfigFiles)" />
-  
+
   <PropertyGroup>
     <CodeAnalysisTargets Condition="'$(CodeAnalysisTargets)'==''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeAnalysis\Microsoft.CodeAnalysis.targets</CodeAnalysisTargets>
   </PropertyGroup>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4428,10 +4428,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       AssignTargetPaths;
       $(_TargetsThatPrepareProjectReferences);
       _GetProjectReferenceTargetFrameworkProperties;
-      <!-- Compose the content items as the union between transitive content items and content items from this project. -->
-      <!-- Get items from this project last so that they will be copied last. -->
-      _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences;
-      _GetCopyToOutputDirectoryItemsFromThisProject
+      _PopulateCommonStateForGetCopyToOutputDirectoryItems
     </GetCopyToOutputDirectoryItemsDependsOn>
 
     <!--
@@ -4458,7 +4455,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
   <Target
     Name="_GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences"
-    DependsOnTargets="_PopulateCommonStateForGetCopyToOutputDirectoryItems">
+    DependsOnTargets="_PopulateCommonStateForGetCopyToOutputDirectoryItems"
+    Returns="@(_TransitiveItemsToCopyToOutputDirectory)">
 
     <!-- Get items from child projects first. -->
     <MSBuild
@@ -4481,18 +4479,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         "EmbeddedResource" to "_OutputItemTypeEmbeddedResourceItems"
      -->
     <AssignTargetPath Files="@(_OutputItemTypeContentItems);@(_OutputItemTypeNoneItems);@(_OutputItemTypeEmbeddedResourceItems)" RootFolder="$(MSBuildProjectDirectory)">
-      <Output TaskParameter="AssignedFiles" ItemName="_AllChildProjectItemsWithTargetPath" />
+      <Output TaskParameter="AssignedFiles" ItemName="_OutputItemTypeTransitiveItems" />
     </AssignTargetPath>
 
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
-      <_TransitiveItemsToCopyToOutputDirectoryAlways KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
-      <_TransitiveItemsToCopyToOutputDirectory       KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_AllChildProjectItemsWithTargetPath->'%(FullPath)')" Condition="'%(_AllChildProjectItemsWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
+
+      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_OutputItemTypeTransitiveItems->'%(FullPath)')" Condition="'%(_OutputItemTypeTransitiveItems.CopyToOutputDirectory)'=='Always'"/>
+      <_TransitiveItemsToCopyToOutputDirectory   KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_OutputItemTypeTransitiveItems->'%(FullPath)')" Condition="'%(_OutputItemTypeTransitiveItems.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
       <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
+      <_OutputItemTypeTransitiveItems            Remove="@(_OutputItemTypeTransitiveItems)"/>
       <_OutputItemTypeContentItems               Remove="@(_OutputItemTypeContentItems)"/>
       <_OutputItemTypeNoneItems                  Remove="@(_OutputItemTypeNoneItems)"/>
       <_OutputItemTypeEmbeddedResourceItems      Remove="@(_OutputItemTypeEmbeddedResourceItems)"/>
@@ -4503,15 +4505,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <Target
       Name="_GetCopyToOutputDirectoryItemsFromThisProject"
       DependsOnTargets="AssignTargetPaths;_PopulateCommonStateForGetCopyToOutputDirectoryItems"
-      Returns="@(_ThisProjectItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectory)">
+      Returns="@(_ThisProjectItemsToCopyToOutputDirectory)">
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(ContentWithTargetPath->'%(FullPath)')" Condition="'%(ContentWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(EmbeddedResource->'%(FullPath)')" Condition="'%(EmbeddedResource.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
@@ -4524,12 +4526,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </AssignTargetPath>
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_CompileItemsToCopyWithTargetPath)" Condition="'%(_CompileItemsToCopyWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
     <ItemGroup>
-      <_ThisProjectItemsToCopyToOutputDirectoryAlways KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='Always'"/>
       <_ThisProjectItemsToCopyToOutputDirectory       KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_NoneWithTargetPath->'%(FullPath)')" Condition="'%(_NoneWithTargetPath.CopyToOutputDirectory)'=='PreserveNewest'"/>
     </ItemGroup>
 
@@ -4541,16 +4543,37 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       KeepDuplicateOutputs=" '$(MSBuildDisableGetCopyToOutputDirectoryItemsOptimization)' == '' "
       DependsOnTargets="$(GetCopyToOutputDirectoryItemsDependsOn)">
 
+    <!-- Compose the content items as the union between transitive content items and content items from this project. -->
+    <!-- Use CallTarget to avoid breaking targets that hook right before GetCopyToOutputDirectoryItems but after _GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences and _GetCopyToOutputDirectoryItemsFromThisProject -->
+    <CallTarget Targets="_GetCopyToOutputDirectoryItemsFromTransitiveProjectReferences">
+      <Output TaskParameter="TargetOutputs" ItemName="_TransitiveItemsToCopyToOutputDirectory" />
+    </CallTarget>
+
+    <CallTarget Targets="_GetCopyToOutputDirectoryItemsFromThisProject">
+      <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
+    </CallTarget>
+
     <ItemGroup>
-      <_SourceItemsToCopyToOutputDirectoryAlways           Include="@(_TransitiveItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
-      <_SourceItemsToCopyToOutputDirectory                 Include="@(_TransitiveItemsToCopyToOutputDirectory);@(_ThisProjectItemsToCopyToOutputDirectory)"/>
-      <AllItemsFullPathWithTargetPath                      Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
+      <_TransitiveItemsToCopyToOutputDirectoryAlways               KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='Always'"/>
+      <_TransitiveItemsToCopyToOutputDirectoryPreserveNewest       KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='PreserveNewest'"/>
+
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways              KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_ThisProjectItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_ThisProjectItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='Always'"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest      KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_ThisProjectItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_ThisProjectItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='PreserveNewest'"/>
+
+      <!-- Append the items from this project last so that they will be copied last. -->
+      <_SourceItemsToCopyToOutputDirectoryAlways                   Include="@(_TransitiveItemsToCopyToOutputDirectoryAlways);@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
+      <_SourceItemsToCopyToOutputDirectory                         Include="@(_TransitiveItemsToCopyToOutputDirectoryPreserveNewest);@(_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest)"/>
+
+      <AllItemsFullPathWithTargetPath                              Include="@(_SourceItemsToCopyToOutputDirectoryAlways->'%(FullPath)');@(_SourceItemsToCopyToOutputDirectory->'%(FullPath)')"/>
 
       <!-- Empty intermediate items to release memory -->
-      <_TransitiveItemsToCopyToOutputDirectoryAlways       Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
-      <_TransitiveItemsToCopyToOutputDirectory             Remove="@(_TransitiveItemsToCopyToOutputDirectory)"/>
-      <_ThisProjectItemsToCopyToOutputDirectoryAlways      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
-      <_ThisProjectItemsToCopyToOutputDirectory            Remove="@(_ThisProjectItemsToCopyToOutputDirectory)"/>
+      <_TransitiveItemsToCopyToOutputDirectoryAlways               Remove="@(_TransitiveItemsToCopyToOutputDirectoryAlways)"/>
+      <_TransitiveItemsToCopyToOutputDirectoryPreserveNewest       Remove="@(_TransitiveItemsToCopyToOutputDirectoryPreserveNewest)"/>
+      <_TransitiveItemsToCopyToOutputDirectory                     Remove="@(_TransitiveItemsToCopyToOutputDirectory)"/>
+
+      <_ThisProjectItemsToCopyToOutputDirectoryAlways              Remove="@(_ThisProjectItemsToCopyToOutputDirectoryAlways)"/>
+      <_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest      Remove="@(_ThisProjectItemsToCopyToOutputDirectoryPreserveNewest)"/>
+      <_ThisProjectItemsToCopyToOutputDirectory                    Remove="@(_ThisProjectItemsToCopyToOutputDirectory)"/>
     </ItemGroup>
 
   </Target>

--- a/src/Tasks/Microsoft.Managed.targets
+++ b/src/Tasks/Microsoft.Managed.targets
@@ -11,7 +11,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project>
-   <!-- 
+   <!--
         We are doing a cross-targeting build if there is a non-empty list of target frameworks specified
         and there is no current target framework being built individually. In that case, a multitargeting
         project file like Microsoft.<language>.CrossTargeting.targets gets imported.
@@ -45,13 +45,19 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          Include="$([MSBuild]::Escape('$(MSBuildProjectDirectory)\$(MSBuildProjectName)*_wpftmp$(MSBuildProjectExtension)'))" />
    </ItemGroup>
 
+   <!-- Item copied from Microsoft.Common.Currentversion.targets   -->
+ <PropertyGroup>
+    <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
+    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject </_RecursiveTargetForContentCopying>
+  </PropertyGroup>
+
   <!--
     Properties for extension of ProjectReferenceTargets.
     Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
   -->
   <PropertyGroup>
     <ProjectReferenceTargetsForBuildInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForBuildInOuterBuild)</ProjectReferenceTargetsForBuildInOuterBuild>
-    <ProjectReferenceTargetsForBuild>.projectReferenceTargetsOrDefaultTargets;GetNativeManifest;GetCopyToOutputDirectoryItems;$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+    <ProjectReferenceTargetsForBuild>.projectReferenceTargetsOrDefaultTargets;GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
 
     <ProjectReferenceTargetsForCleanInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForCleanInOuterBuild)</ProjectReferenceTargetsForCleanInOuterBuild>
     <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>

--- a/src/Tasks/Microsoft.Managed.targets
+++ b/src/Tasks/Microsoft.Managed.targets
@@ -46,9 +46,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
    </ItemGroup>
 
    <!-- Item copied from Microsoft.Common.Currentversion.targets   -->
- <PropertyGroup>
+  <PropertyGroup>
     <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
-    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject </_RecursiveTargetForContentCopying>
+    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Fixes #4677 
Fixes #1054

This turned out to be more complicated [than it should be](https://github.com/microsoft/msbuild/issues/4677#issuecomment-529662821) in order to maintain backwards compatibility with legacy behaviour (described in #4677). For example, quickbuild depends on this bug and fixing it will take some time and it's probably low priority, so the ability to pin the bad behaviour and fix later is sadly okay here.

Feedback needed on:
- the toggling property name and value. Right now it's `$(MSBuildCopyContentTransitively )` [where](https://github.com/microsoft/msbuild/compare/master...cdmihai:contentCopying#diff-02872751bc64e0ff785c9b6c1cd919b5R4438-R4441) `true` means transitive, `false` means 1-level copying, nothing means legacy (which should be the same as `false`). Would you rather I named the values to `transitive`, `1-level`, `legacy` and set it to `legacy` by default?
- any ideas on automated testing, since the msbuild repo doesn't do any sdk integration testing. Since VS cares the most for what happens during `BuildProjectReferences=false`, seems like VS should test for this. Quickbuild will also test for this if it turns `/isolate` by default in its builds. Or I could add it to the Microsoft.Net.Sdk tests, if it wants to care about `BuildProjectReferences=false`