### PR TITLE
Add Microsoft.Common.props in Current to CoreXT overlay

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,9 +16,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>16.3.2</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <!-- <DotNetFinalVersionKind>release</DotNetFinalVersionKind> -->
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
-    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>vs-ldr</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
     <SemanticVersioningV1>true</SemanticVersioningV1>

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -14,6 +14,7 @@
     <file src="$repoRoot$/src/Package/MsBuild.Engine.Corext/README.md" target=""/>
     <file src="$repoRoot$/THIRDPARTYNOTICES.txt" target="v15.0/bin/THIRDPARTYNOTICES.txt" />
     <file src="$X86BinPath$/Microsoft.Common.props" target="\Extensions\15.0" />
+    <file src="$X86BinPath$/Microsoft.Common.props" target="\Extensions\Current" />
     <file src="$X86BinPath$/Microsoft.VisualStudioVersion.v15.Common.props" target="\Extensions\15.0" />
 
     <!-- x86 -->


### PR DESCRIPTION
In the VS repo, some projects attempted to import based on $(MSBuildToolsVersion), and got confused in the '15.0 package with the 16.3 engine' situation.

The right long-term fix is to move to 16.x packages, but for now we can just duplicate this file; all other files seemed to be loaded from the right folders automatically.

This unblocks #4823. @duncanmak and I have been using it in private testing and it looks good.