### PR TITLE
Enable lost debug-only code

### DIFF
--- a/src/Shared/InterningBinaryReader.cs
+++ b/src/Shared/InterningBinaryReader.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build
         /// <summary>
         /// The maximum size, in bytes, to read at once.
         /// </summary>
-#if _DEBUG
+#if DEBUG
         private const int MaxCharsBuffer = 10;
 #else
         private const int MaxCharsBuffer = 20000;

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Build
             }
 
             string result = s_si.InterningToString(candidate);
-#if _DEBUG
+#if DEBUG
             string expected = candidate.ExpensiveConvertToString();
             if (!String.Equals(result, expected))
             {

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Build.Utilities
             // should have error codes.
             string errorCode;
             ResourceUtilities.ExtractMessageCode(true /* only msbuild codes */, message, out errorCode);
-            Debug.Assert(errorCode == null, errorCode, "This message contains an error code (" + errorCode + "), yet it was logged as a regular message: " + message);
+            ErrorUtilities.VerifyThrow(errorCode == null, errorCode, "This message contains an error code (" + errorCode + "), yet it was logged as a regular message: " + message);
 #endif
         }
 
@@ -469,7 +469,7 @@ namespace Microsoft.Build.Utilities
             // should have error codes.
             string errorCode;
             ResourceUtilities.ExtractMessageCode(true /* only msbuild codes */, FormatResourceString(messageResourceName, messageArgs), out errorCode);
-            Debug.Assert(errorCode == null, errorCode, FormatResourceString(messageResourceName, messageArgs));
+            ErrorUtilities.VerifyThrow(errorCode == null, errorCode, FormatResourceString(messageResourceName, messageArgs));
 #endif
         }
 
@@ -701,7 +701,8 @@ namespace Microsoft.Build.Utilities
             // message code when there probably isn't one.
             string messageCode;
             string throwAwayMessageBody = ResourceUtilities.ExtractMessageCode(true /* only msbuild codes */, FormatResourceString(messageResourceName, messageArgs), out messageCode);
-            Debug.Assert(messageCode == null || messageCode.Length == 0, "Called LogErrorFromResources instead of LogErrorWithCodeFromResources, but message '" + throwAwayMessageBody + "' does have an error code '" + messageCode + "'");
+
+            ErrorUtilities.VerifyThrow(messageCode == null || messageCode.Length == 0, "Called LogErrorFromResources instead of LogErrorWithCodeFromResources, but message '" + throwAwayMessageBody + "' does have an error code '" + messageCode + "'");
 #endif
 
             LogError
@@ -1017,7 +1018,7 @@ namespace Microsoft.Build.Utilities
             // Check this only in debug, to avoid the cost of attempting to extract a
             // message code when there probably isn't one.
             string throwAwayMessageBody = ResourceUtilities.ExtractMessageCode(true /* only msbuild codes */, FormatResourceString(messageResourceName, messageArgs), out string messageCode);
-            Debug.Assert(string.IsNullOrEmpty(messageCode), "Called LogWarningFromResources instead of LogWarningWithCodeFromResources, but message '" + throwAwayMessageBody + "' does have an error code '" + messageCode + "'");
+            ErrorUtilities.VerifyThrow(string.IsNullOrEmpty(messageCode), "Called LogWarningFromResources instead of LogWarningWithCodeFromResources, but message '" + throwAwayMessageBody + "' does have an error code '" + messageCode + "'");
 #endif
 
             LogWarning

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Build.Utilities
             // should have error codes.
             string errorCode;
             ResourceUtilities.ExtractMessageCode(true /* only msbuild codes */, message, out errorCode);
-            ErrorUtilities.VerifyThrow(errorCode == null, errorCode, "This message contains an error code (" + errorCode + "), yet it was logged as a regular message: " + message);
+            ErrorUtilities.VerifyThrow(errorCode == null, "This message contains an error code (" + errorCode + "), yet it was logged as a regular message: " + message);
 #endif
         }
 

--- a/src/Shared/TaskLoggingHelper.cs
+++ b/src/Shared/TaskLoggingHelper.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Build.Utilities
             }
 
             BuildEngine.LogMessageEvent(e);
-#if _DEBUG
+#if DEBUG
             // Assert that the message does not contain an error code.  Only errors and warnings
             // should have error codes.
             string errorCode;
@@ -464,7 +464,7 @@ namespace Microsoft.Build.Utilities
             ErrorUtilities.VerifyThrowArgumentNull(messageResourceName, nameof(messageResourceName));
 
             LogMessage(importance, FormatResourceString(messageResourceName, messageArgs));
-#if _DEBUG
+#if DEBUG
             // Assert that the message does not contain an error code.  Only errors and warnings
             // should have error codes.
             string errorCode;
@@ -694,7 +694,7 @@ namespace Microsoft.Build.Utilities
                 subcategory = FormatResourceString(subcategoryResourceName);
             }
 
-#if _DEBUG
+#if DEBUG
             // If the message does have a message code, LogErrorWithCodeFromResources
             // should have been called instead, so that the errorCode field gets populated.
             // Check this only in debug, to avoid the cost of attempting to extract a

--- a/src/Tasks/AssemblyDependency/AssemblyInformation.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyInformation.cs
@@ -547,7 +547,7 @@ namespace Microsoft.Build.Tasks
             {
                 StringBuilder runtimeVersion;
                 uint hresult;
-#if _DEBUG
+#if DEBUG
                 // Just to make sure and exercise the code that doubles the size
                 // every time GetRequestedRuntimeInfo fails due to insufficient buffer size.
                 int bufferLength = 1;

--- a/src/Tasks/AssemblyDependency/Reference.cs
+++ b/src/Tasks/AssemblyDependency/Reference.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="filenameExtension">This is the filename extension.</param>
         internal void AddRelatedFileExtension(string filenameExtension)
         {
-#if _DEBUG
+#if DEBUG
             Debug.Assert(filenameExtension[0]=='.', "Expected extension to start with '.'");
 #endif
             _relatedFileExtensions.Add(filenameExtension);
@@ -441,7 +441,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="filename">This is the filename relative the this reference.</param>
         internal void AddSatelliteFile(string filename)
         {
-#if _DEBUG
+#if DEBUG
             Debug.Assert(!Path.IsPathRooted(filename), "Satellite path should be relative to the current reference.");
 #endif
             _satelliteFiles.Add(filename);
@@ -453,7 +453,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="filename">This is the filename relative the this reference.</param>
         internal void AddSerializationAssemblyFile(string filename)
         {
-#if _DEBUG
+#if DEBUG
             Debug.Assert(!Path.IsPathRooted(filename), "Serialization assembly path should be relative to the current reference.");
 #endif
             _serializationAssemblyFiles.Add(filename);

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Utilities;

--- a/src/Tasks/AssignCulture.cs
+++ b/src/Tasks/AssignCulture.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Build.Tasks
                     Log.LogErrorWithCodeFromResources("AssignCulture.CannotExtractCulture", Files[i].ItemSpec, e.Message);
                     retValue = false;
                 }
-#if _DEBUG
+#if DEBUG
                 catch (Exception e)
                 {
                     Debug.Assert(false, "Unexpected exception in AssignCulture.Execute. " + 

--- a/src/Tasks/RegisterAssembly.cs
+++ b/src/Tasks/RegisterAssembly.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Build.Tasks
                         Log.LogErrorWithCodeFromResources("General.InvalidAssemblyName", Assemblies[i], ex.Message);
                         taskReturnValue = false;
                     }
-#if _DEBUG
+#if DEBUG
                     catch (Exception e)
                     {
                         Debug.Assert(false, "Unexpected exception in AssemblyRegistration.Execute. " + 

--- a/src/Tasks/ResolveNativeReference.cs
+++ b/src/Tasks/ResolveNativeReference.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;

--- a/src/Tasks/ResolveNativeReference.cs
+++ b/src/Tasks/ResolveNativeReference.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Build.Tasks
 
                 if (!String.IsNullOrEmpty(path))
                 {
-#if _DEBUG
+#if DEBUG
                     try
                     {
 #endif
@@ -139,7 +139,7 @@ namespace Microsoft.Build.Tasks
                     {
                         retValue = false;
                     }
-#if _DEBUG
+#if DEBUG
                     }
                     catch (Exception)
                     {

--- a/src/Tasks/UnregisterAssembly.cs
+++ b/src/Tasks/UnregisterAssembly.cs
@@ -4,6 +4,7 @@
 #if FEATURE_APPDOMAIN
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/Tasks/UnregisterAssembly.cs
+++ b/src/Tasks/UnregisterAssembly.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Build.Tasks
                         Log.LogErrorWithCodeFromResources("General.InvalidAssemblyName", assemblyPath, ex.Message);
                         taskReturnValue = false;
                     }
-#if _DEBUG
+#if DEBUG
                     catch (Exception e)
                     {
                         Debug.Assert(false, "Unexpected exception in AssemblyRegistration.Execute. " + 
@@ -261,7 +261,7 @@ namespace Microsoft.Build.Tasks
                     // rethrow other exceptions
                     else
                     {
-#if _DEBUG
+#if DEBUG
                         Debug.Assert(false, "Unexpected exception in UnregisterAssembly.DoExecute. " + 
                             "Please log a MSBuild bug specifying the steps to reproduce the problem.");
 #endif


### PR DESCRIPTION
At some point we stopped defining _DEBUG for debug builds, so all this conditional code was never being built.

```sh-session
$ rep -r "#if _DEBUG" "#if DEBUG" *.cs
1993 files processed. 9 files changed. 14 replacements.
```