### PR TITLE
GenerateFullPaths

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,10 @@
 
   <!-- Override project defaults provided by Repo toolset -->
   <PropertyGroup>
+    <!-- Ensure that compiler errors emit full paths so that files
+         can be correctly annotated in GitHub. -->
+    <GenerateFullPaths>true</GenerateFullPaths>
+
     <!-- Do not mangle paths for test assemblies, because Shoudly assertions want actual on-disk paths. -->
     <DeterministicSourcePaths Condition="'$(IsTestProject)' == 'true'">false</DeterministicSourcePaths>
 


### PR DESCRIPTION
Ensure that compiler errors emit full paths so that files
can be correctly annotated in GitHub.

For example:

![image](https://user-images.githubusercontent.com/3347530/68043425-45a7bb80-fca3-11e9-8551-047745183627.png)
