### PR TITLE
Allow <Exec> commands to inherit the console code page

### DIFF
--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1365,7 +1365,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or Ideally a new EncodingUtilities.CurrentConsoleEncoding
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or ideally a new EncodingUtilities.CurrentConsoleEncoding based on GetConsoleCP
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1365,7 +1365,7 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, EncodingUtilities.CurrentSystemOemEncoding);
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, Console.InputEncoding); // Or Ideally a new EncodingUtilities.CurrentConsoleEncoding
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 


### PR DESCRIPTION
MSBuild's `<Exec>` task executes its commands in such a way that the child processes do not inherit the console code page from MSBuild (which itself inherited it from its parent). The console code page for children processes is rather reset to the OEM code page, which cannot encode Unicode characters in any Windows OS language in its default configuration. This means that it is impossible to use MSBuild's `<Exec>` task to run a program that will output Japanese characters on an English OS without it coming out as a bunch of `?????`.

Specifically, the use of `ProcessStartInfo.CreateNoWindow = true` in `ToolTask` will reset the console code page of the child process to the OEM code page. With this fixed, the batch file must also be written in the console code page since that is what `cmd.exe` will be using to read it.

With this change, a parent process can set the console output code page to 65001 (UTF-8) and have some hope of getting Unicode data back from the programs started by MSBuild.

This change has had minimal testing. I only built it and verified that `chcp` called in `<Exec>` will now output the console code page as inherited from MSBuild's parent process. There is also a risk of regression since some ill-behaved programs always output in the OEM code page, no matter what the console output code page is, and with this change they will have to face the reality of their misdeeds. Regressions would only happen when an ancestor process explicitly changes the console output code page from the default OEM code page to something else.

Fixes #4870