### PR TITLE
applied platform specific attribute to avoid unnecessary test execution

### DIFF
--- a/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectRootElement_Tests.cs
@@ -956,13 +956,10 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// Build a project file that can't be accessed
         /// </summary>
         [Fact]
+        [PlatformSpecific (TestPlatforms.Windows)]
+        // FileSecurity class is not supported on Unix
         public void ProjectCanNotBeOpened()
         {
-            if (NativeMethodsShared.IsUnixLike)
-            {
-                return; // FileSecurity class is not supported on Unix
-            }
-
             Assert.Throws<InvalidProjectFileException>(() =>
             {
                 string projectFile = null;


### PR DESCRIPTION
solved ticket number #331 

if test platform is windows then the return is tested. 