### PR TITLE
Include path to MSBuild in node handshake salt

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -655,7 +655,9 @@ namespace Microsoft.Build.Internal
         /// <returns>Base Handshake</returns>
         private static long GetBaseHandshakeForContext(TaskHostContext hostContext)
         {
-            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
+            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") +
+                Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") +
+                Environment.GetEnvironmentVariable("DOTNET_ROOT");
 
             long nodeHandshakeSalt = 0;
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -655,16 +655,7 @@ namespace Microsoft.Build.Internal
         /// <returns>Base Handshake</returns>
         private static long GetBaseHandshakeForContext(TaskHostContext hostContext)
         {
-            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") +
-                Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") +
-                Environment.GetEnvironmentVariable("DOTNET_ROOT");
-
-            long nodeHandshakeSalt = 0;
-
-            if (!string.IsNullOrEmpty(salt))
-            {
-                nodeHandshakeSalt = GetHandshakeHashCode(salt);
-            }
+            long salt = GetHandshakeHashCode(Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + FileUtilities.ExecutingAssemblyPath);
 
             //FileVersionHash (32 bits) is shifted 8 bits to avoid session ID collision
             //hostContext (4 bits) is shifted just after the FileVersionHash
@@ -672,7 +663,7 @@ namespace Microsoft.Build.Internal
             //the most significant byte (leftmost 8 bits) will get zero'd out to avoid connecting to older builds.
             //| masked out | nodeHandshakeSalt | hostContext |              fileVersionHash             | SessionID
             //  0000 0000     0000 0000 0000        0000        0000 0000 0000 0000 0000 0000 0000 0000   0000 0000
-            long baseHandshake = (nodeHandshakeSalt << 44) | ((long)hostContext << 40) | ((long)FileVersionHash << 8);
+            long baseHandshake = (salt << 44) | ((long)hostContext << 40) | ((long)FileVersionHash << 8);
             return baseHandshake;
         }
 


### PR DESCRIPTION
Prevent unwanted node reuse.

Fixes #3137.