### PR TITLE
Completely automate experimental branch builds

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -91,7 +91,27 @@ stages:
                 /p:TeamName=MSBuild
                 /p:DotNetPublishUsingPipelines=true
       displayName: Build
-      condition: succeeded()
+      condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')))
+      
+    - script: eng/CIBuild.cmd
+                -configuration $(BuildConfiguration)
+                -officialBuildId $(Build.BuildNumber)
+                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
+                /p:RepositoryName=$(Build.Repository.Name)
+                /p:VisualStudioIbcSourceBranchName=master
+                /p:VisualStudioDropAccessToken=$(System.AccessToken)
+                /p:VisualStudioDropName=$(VisualStudio.DropName)
+                /p:DotNetSignType=$(SignType)
+                /p:DotNetPublishToBlobFeed=true
+                /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+                /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+                /p:PublishToSymbolServer=true
+                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                /p:TeamName=MSBuild
+                /p:DotNetPublishUsingPipelines=true
+      displayName: Exp-Build
+      condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/'))
 
     # Publish OptProf configuration files
     - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -11,6 +11,10 @@ trigger:
 #   SkipApplyOptimizationData: false
 
 variables:
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')) }}:
+    SourceBranch: master
+  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/'))) }}:
+    SourceBranch: $(IbcSourceBranchName)
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory
@@ -78,7 +82,7 @@ stages:
                 -officialBuildId $(Build.BuildNumber)
                 -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
                 /p:RepositoryName=$(Build.Repository.Name)
-                /p:VisualStudioIbcSourceBranchName=$(IbcSourceBranchName)
+                /p:VisualStudioIbcSourceBranchName=SourceBranch
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)
                 /p:DotNetSignType=$(SignType)
@@ -91,27 +95,7 @@ stages:
                 /p:TeamName=MSBuild
                 /p:DotNetPublishUsingPipelines=true
       displayName: Build
-      condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')))
-      
-    - script: eng/CIBuild.cmd
-                -configuration $(BuildConfiguration)
-                -officialBuildId $(Build.BuildNumber)
-                -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
-                /p:RepositoryName=$(Build.Repository.Name)
-                /p:VisualStudioIbcSourceBranchName=master
-                /p:VisualStudioDropAccessToken=$(System.AccessToken)
-                /p:VisualStudioDropName=$(VisualStudio.DropName)
-                /p:DotNetSignType=$(SignType)
-                /p:DotNetPublishToBlobFeed=true
-                /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                /p:PublishToSymbolServer=true
-                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                /p:TeamName=MSBuild
-                /p:DotNetPublishUsingPipelines=true
-      displayName: Exp-Build
-      condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/'))
+      condition: succeeded()
 
     # Publish OptProf configuration files
     - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -11,10 +11,11 @@ trigger:
 #   SkipApplyOptimizationData: false
 
 variables:
+  - name: SourceBranch
+    value: $(IbcSourceBranchName)
   - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
-    SourceBranch: master
-  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')) }}:
-    SourceBranch: $(IbcSourceBranchName)
+    - name: SourceBranch
+      value: master
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - name: _DotNetValidationArtifactsCategory

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -11,9 +11,9 @@ trigger:
 #   SkipApplyOptimizationData: false
 
 variables:
-  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')) }}:
+  - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/') }}:
     SourceBranch: master
-  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/'))) }}:
+  - ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/heads/exp/')) }}:
     SourceBranch: $(IbcSourceBranchName)
   - name: _DotNetArtifactsCategory
     value: .NETCore
@@ -82,7 +82,7 @@ stages:
                 -officialBuildId $(Build.BuildNumber)
                 -officialSkipApplyOptimizationData $(SkipApplyOptimizationData)
                 /p:RepositoryName=$(Build.Repository.Name)
-                /p:VisualStudioIbcSourceBranchName=SourceBranch
+                /p:VisualStudioIbcSourceBranchName=$(SourceBranch)
                 /p:VisualStudioDropAccessToken=$(System.AccessToken)
                 /p:VisualStudioDropName=$(VisualStudio.DropName)
                 /p:DotNetSignType=$(SignType)


### PR DESCRIPTION
Builds prefixed with `exp/` use `master` for their `IbcSourceBranchName`
Builds NOT prefixed with `exp/` use the default `IbcSourceBranchName` (which is the branch name itself).

With this change inserted, branches prefixed with `exp/` will no longer fail because of optprof data not existing for that branch.

Yay automation!