### PR TITLE
Add intrinsic property function to compare versions

### DIFF
--- a/src/Build.UnitTests/Evaluation/SimpleVersion_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SimpleVersion_Tests.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    public class SimpleVersion_Tests
+    {
+        [Fact]
+        public void Ctor_Default()
+        {
+            VerifyVersion(new SimpleVersion(), 0, 0, 0, 0);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        [InlineData(int.MaxValue)]
+        public static void Ctor_Int(int major)
+        {
+            VerifyVersion(new SimpleVersion(major), major, 0, 0, 0);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(2, 3)]
+        [InlineData(int.MaxValue, int.MaxValue)]
+        public static void Ctor_Int_Int(int major, int minor)
+        {
+            VerifyVersion(new SimpleVersion(major, minor), major, minor, 0, 0);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(2, 3, 4)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue)]
+        public static void Ctor_Int_Int_Int(int major, int minor, int build)
+        {
+            VerifyVersion(new SimpleVersion(major, minor, build), major, minor, build, 0);
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(2, 3, 4, 7)]
+        [InlineData(2, 3, 4, 32767)]
+        [InlineData(2, 3, 4, 32768)]
+        [InlineData(2, 3, 4, 65535)]
+        [InlineData(2, 3, 4, 65536)]
+        [InlineData(2, 3, 4, 2147483647)]
+        [InlineData(2, 3, 4, 2147450879)]
+        [InlineData(2, 3, 4, 2147418112)]
+        [InlineData(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue)]
+        public static void Ctor_Int_Int_Int_Int(int major, int minor, int build, int revision)
+        {
+            VerifyVersion(new SimpleVersion(major, minor, build, revision), major, minor, build, revision);
+        }
+
+        [Fact]
+        public void Ctor_NegativeMajor_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("major", () => new SimpleVersion(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("major", () => new SimpleVersion(-1, 0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("major", () => new SimpleVersion(-1, 0, 0, 0));
+        }
+
+        [Fact]
+        public void Ctor_NegativeMinor_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("minor", () => new SimpleVersion(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("minor", () => new SimpleVersion(0, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>("minor", () => new SimpleVersion(0, -1, 0, 0));
+        }
+
+        [Fact]
+        public void Ctor_NegativeBuild_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("build", () => new SimpleVersion(0, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>("build", () => new SimpleVersion(0, 0, -1, 0));
+        }
+
+        [Fact]
+        public void Ctor_NegativeRevision_ThrowsArgumentOutOfRangeException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("revision", () => new SimpleVersion(0, 0, 0, -1));
+        }
+
+        public static IEnumerable<object[]> Comparison_TestData()
+        {
+            foreach (var input in new (SimpleVersion v1, SimpleVersion v2, int expectedSign)[]
+            {
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 2), 0),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 3), -1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 1), 1),
+                (new SimpleVersion(1, 2), new SimpleVersion(2, 0), -1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 2, 1), -1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 2, 0, 1), -1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 0), 1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 0, 1), 1),
+                (new SimpleVersion(1, 2), new SimpleVersion(1, 0, 0, 1), 1),
+
+                (new SimpleVersion(3, 2, 1), new SimpleVersion(2, 2, 1), 1),
+                (new SimpleVersion(3, 2, 1), new SimpleVersion(3, 1, 1), 1),
+                (new SimpleVersion(3, 2, 1), new SimpleVersion(3, 2, 0), 1),
+
+                (new SimpleVersion(1, 2, 3, 4), new SimpleVersion(1, 2, 3, 4), 0),
+                (new SimpleVersion(1, 2, 3, 4), new SimpleVersion(1, 2, 3, 5), -1),
+                (new SimpleVersion(1, 2, 3, 4), new SimpleVersion(1, 2, 3, 3), 1)
+            })
+            {
+                yield return new object[] { input.v1, input.v2, input.expectedSign };
+                yield return new object[] { input.v2, input.v1, input.expectedSign * -1 };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_TestData))]
+        public void CompareTo_ReturnsExpected(object version1Object, object version2Object, int expectedSign)
+        {
+            var version1 = (SimpleVersion)version1Object;
+            var version2 = (SimpleVersion)version2Object;
+
+            Assert.Equal(expectedSign, Comparer<SimpleVersion>.Default.Compare(version1, version2));
+            Assert.Equal(expectedSign, Math.Sign(version1.CompareTo(version2)));
+        }
+
+        [Theory]
+        [MemberData(nameof(Comparison_TestData))]
+        public void ComparisonOperators_ReturnExpected(object version1Object, object version2Object, int expectedSign)
+        {
+            var version1 = (SimpleVersion)version1Object;
+            var version2 = (SimpleVersion)version2Object;
+
+            if (expectedSign < 0)
+            {
+                Assert.True(version1 < version2);
+                Assert.True(version1 <= version2);
+                Assert.False(version1 == version2);
+                Assert.False(version1 >= version2);
+                Assert.False(version1 > version2);
+                Assert.True(version1 != version2);
+            }
+            else if (expectedSign == 0)
+            {
+                Assert.False(version1 < version2);
+                Assert.True(version1 <= version2);
+                Assert.True(version1 == version2);
+                Assert.True(version1 >= version2);
+                Assert.False(version1 > version2);
+                Assert.False(version1 != version2);
+            }
+            else
+            {
+                Assert.False(version1 < version2);
+                Assert.False(version1 <= version2);
+                Assert.False(version1 == version2);
+                Assert.True(version1 >= version2);
+                Assert.True(version1 > version2);
+                Assert.True(version1 != version2);
+            }
+        }
+
+        public static IEnumerable<object[]> Equals_TestData()
+        {
+            yield return new object[] { new SimpleVersion(2, 3), new SimpleVersion(2, 3), true };
+            yield return new object[] { new SimpleVersion(2, 3), new SimpleVersion(2, 4), false };
+            yield return new object[] { new SimpleVersion(2, 3), new SimpleVersion(3, 3), false };
+
+            yield return new object[] { new SimpleVersion(2, 3, 4), new SimpleVersion(2, 3, 4), true };
+            yield return new object[] { new SimpleVersion(2, 3, 4), new SimpleVersion(2, 3, 5), false };
+            yield return new object[] { new SimpleVersion(2, 3, 4), new SimpleVersion(2, 3), false };
+
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), new SimpleVersion(2, 3, 4, 5), true };
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), new SimpleVersion(2, 3, 4, 6), false };
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), new SimpleVersion(2, 3), false };
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), new SimpleVersion(2, 3, 4), false };
+
+            yield return new object[] { new SimpleVersion(2, 3, 0), new SimpleVersion(2, 3), true };
+            yield return new object[] { new SimpleVersion(2, 3, 4, 0), new SimpleVersion(2, 3, 4), true };
+
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), new TimeSpan(), false };
+            yield return new object[] { new SimpleVersion(2, 3, 4, 5), null, false };
+        }
+
+        [Theory]
+        [MemberData(nameof(Equals_TestData))]
+        public static void Equals_Other_ReturnsExpected(object version1Object, object version2Object, bool expected)
+        {
+            var version1 = (SimpleVersion)version1Object;
+
+            if (version2Object is SimpleVersion version2)
+            {
+                Assert.Equal(expected, version1.Equals(version2));
+                Assert.Equal(expected, version1 == version2);
+                Assert.Equal(!expected, version1 != version2);
+            }
+
+            Assert.Equal(expected, version1.Equals(version2Object));
+
+            if (version2Object != null)
+            {
+                Assert.Equal(expected, version1Object.GetHashCode() == version2Object.GetHashCode());
+            }
+        }
+
+        public static IEnumerable<object[]> Parse_Valid_TestData()
+        {
+            foreach (var prefix in new[] { "", "v",  "V"})
+            {
+                foreach (var suffix in new[] { "", "-pre", "-pre+metadata", "+metadata"})
+                {
+                    yield return new object[] { $"{prefix}1{suffix}", new SimpleVersion(1) };
+                    yield return new object[] { $"{prefix}1.2{suffix}", new SimpleVersion(1, 2) };
+                    yield return new object[] { $"{prefix}1.2.3{suffix}", new SimpleVersion(1, 2, 3) };
+                    yield return new object[] { $"{prefix}1.2.3.4{suffix}", new SimpleVersion(1, 2, 3, 4) };
+                    yield return new object[] { $"{prefix}2147483647.2147483647.2147483647.2147483647{suffix}", new SimpleVersion(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue) };
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_Valid_TestData))]
+        public static void Parse_ValidInput_ReturnsExpected(string input, object expected)
+        {
+            Assert.Equal(expected, SimpleVersion.Parse(input));
+        }
+
+        public static IEnumerable<object[]> Parse_Invalid_TestData()
+        {
+            yield return new object[] { null, typeof(ArgumentNullException) }; // Input is null
+
+            yield return new object[] { "", typeof(FormatException) }; // Input is empty
+            yield return new object[] { "1,2,3,4", typeof(FormatException) }; // Input contains invalid separator
+            yield return new object[] { "1.2.3.4.5", typeof(FormatException) }; // Input has more than 4 version components
+
+            yield return new object[] { "1." , typeof(FormatException) }; // Input contains empty component
+            yield return new object[] { "1.2,", typeof(FormatException) }; // Input contains empty component
+            yield return new object[] { "1.2.3.", typeof(FormatException) }; // Input contains empty component
+            yield return new object[] { "1.2.3.4.", typeof(FormatException) }; // Input contains empty component
+
+            yield return new object[] { "NotAVersion", typeof(FormatException) }; // Input contains non-numeric value
+            yield return new object[] { "b.2.3.4", typeof(FormatException) }; // Input contains non-numeric value
+            yield return new object[] { "1.b.3.4", typeof(FormatException) }; // Input contains non-numeric value
+            yield return new object[] { "1.2.b.4", typeof(FormatException) }; // Input contains non-numeric value
+            yield return new object[] { "1.2.3.b", typeof(FormatException) }; // Input contains non-numeric value
+
+            yield return new object[] { "2147483648.2.3.4", typeof(FormatException) }; // Input contains a value > int.MaxValue
+            yield return new object[] { "1.2147483648.3.4", typeof(FormatException) }; // Input contains a value > int.MaxValue
+            yield return new object[] { "1.2.2147483648.4", typeof(FormatException) }; // Input contains a value > int.MaxValue
+            yield return new object[] { "1.2.3.2147483648", typeof(FormatException) }; // Input contains a value > int.MaxValue
+
+            // System.Version allows whitespace around components, but we don't
+            yield return new object[] { "2  .3.    4.  \t\r\n15  ", typeof(FormatException) };
+            yield return new object[] { "   2  .3.    4.  \t\r\n15  ", typeof(FormatException) };
+
+            // System.Version rejects these because they have negative values, but SimpleVersion strips interprest as semver prerelease to strip
+            // They are still invalid because the stripping leaves a empty components behind which are also not allowed as above.
+            yield return new object[] { "-1.2.3.4", typeof(FormatException) };
+            yield return new object[] { "1.-2.3.4", typeof(FormatException) };
+            yield return new object[] { "1.2.-3.4", typeof(FormatException) };
+            yield return new object[] { "1.2.3.-4", typeof(FormatException) };
+
+            // System.Version treats this as 1.2.3.4, but SimpleVersion interprets as semver metadata to ignore yielding invalid empty string
+            // System.Version parses allowing leading sign, but we treat both sign indicators as beginning of semver part to strip.
+            yield return new object[] { "+1.+2.+3.+4", typeof(FormatException) };
+
+            // Only one 'v' allowed as prefix
+            yield return new object[] { "vv1.2.3.4", typeof(FormatException) };
+        }
+
+        [Theory]
+        [MemberData(nameof(Parse_Invalid_TestData))]
+        public static void Parse_InvalidInput_ThrowsException(string input, Type exceptionType)
+        {
+            Assert.Throws(exceptionType, () => SimpleVersion.Parse(input));
+        }
+
+        public static IEnumerable<object[]> ToString_TestData()
+        {
+            yield return new object[] { new SimpleVersion(1), "1.0.0.0"};
+            yield return new object[] { new SimpleVersion(1, 2), "1.2.0.0" };
+            yield return new object[] { new SimpleVersion(1, 2, 3), "1.2.3.0" };
+            yield return new object[] { new SimpleVersion(1, 2, 3, 4), "1.2.3.4" };
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_TestData))]
+        public static void ToString_Invoke_ReturnsExpected(object versionObject, string expected)
+        {
+            var version = (SimpleVersion)versionObject;
+
+            Assert.Equal(expected, version.ToString());
+        }
+
+        private static void VerifyVersion(SimpleVersion version, int major, int minor, int build, int revision)
+        {
+            Assert.Equal(major, version.Major);
+            Assert.Equal(minor, version.Minor);
+            Assert.Equal(build, version.Build);
+            Assert.Equal(revision, version.Revision);
+        }
+    }
+}

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3865,6 +3865,54 @@ namespace Microsoft.Build.Evaluation
                                 return true;
                             }
                         }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionEquals), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionEquals(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionNotEquals), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionNotEquals(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionGreaterThan), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionGreaterThan(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionGreaterThanOrEquals), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionGreaterThanOrEquals(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionLessThan), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionLessThan(arg0, arg1);
+                                return true;
+                            }
+                        }
+                        else if (string.Equals(_methodMethodName, nameof(IntrinsicFunctions.VersionLessThanOrEquals), StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (TryGetArgs(args, out string arg0, out string arg1))
+                            {
+                                returnVal = IntrinsicFunctions.VersionLessThanOrEquals(arg0, arg1);
+                                return true;
+                            }
+                        }
                     }
                     else if (_receiverType == typeof(Path))
                     {

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.Build.Utilities;
 using Microsoft.Win32;
 
 // Needed for DoesTaskHostExistForParameters
@@ -447,6 +448,36 @@ namespace Microsoft.Build.Evaluation
         internal static bool IsOsBsdLike()
         {
             return NativeMethodsShared.IsBSD;
+        }
+
+        internal static bool VersionEquals(string a, string b)
+        {
+            return SimpleVersion.Parse(a) == SimpleVersion.Parse(b);
+        }
+
+        internal static bool VersionNotEquals(string a, string b)
+        {
+            return SimpleVersion.Parse(a) != SimpleVersion.Parse(b);
+        }
+
+        internal static bool VersionGreaterThan(string a, string b)
+        {
+            return SimpleVersion.Parse(a) > SimpleVersion.Parse(b);
+        }
+
+        internal static bool VersionGreaterThanOrEquals(string a, string b)
+        {
+            return SimpleVersion.Parse(a) >= SimpleVersion.Parse(b);
+        }
+
+        internal static bool VersionLessThan(string a, string b)
+        {
+            return SimpleVersion.Parse(a) < SimpleVersion.Parse(b);
+        }
+
+        internal static bool VersionLessThanOrEquals(string a, string b)
+        {
+            return SimpleVersion.Parse(a) <= SimpleVersion.Parse(b);
         }
 
         public static string GetCurrentToolsDirectory()

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -647,6 +647,7 @@
     <Compile Include="Utilities\Utilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="Utilities\SimpleVersion.cs" />
     <Compile Include="Xml\ProjectXmlUtilities.XmlElementChildIterator.cs" />
     <Compile Include="Xml\ProjectXmlUtilities.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1801,6 +1801,9 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </comment>
   </data>
+  <data name="InvalidVersionFormat" xml:space="preserve">
+    <value>Version string was not in a correct format.</value>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Podrobnost protokolování je nastavená na: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Die Ausführlichkeit der Protokollierung ist auf "{0}" festgelegt.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -82,6 +82,11 @@
         <target state="new">MSB4255: The following input result cache files do not exist: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="new">Logging verbosity is set to: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">El nivel de detalle de registro está establecido en {0}.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">La verbosité de la journalisation a la valeur {0}.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Il livello di dettaglio della registrazione è impostato su: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">ログの詳細度は次のように設定されています: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">로깅의 세부 정보 표시가 {0}(으)로 설정되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Szczegółowość rejestrowania została ustawiona na: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -81,6 +81,11 @@
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">O detalhamento do log está definido como: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Уровень детализации журнала: {0}.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">Günlük kaydı ayrıntı düzeyi {0} olarak ayarlandı.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">日志记录详细程度设置为: {0}。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidVersionFormat">
+        <source>Version string was not in a correct format.</source>
+        <target state="new">Version string was not in a correct format.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="LogLoggerVerbosity">
         <source>Logging verbosity is set to: {0}.</source>
         <target state="translated">記錄詳細程度設定為: {0}。</target>

--- a/src/Build/Utilities/SimpleVersion.cs
+++ b/src/Build/Utilities/SimpleVersion.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Shared;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Microsoft.Build.Utilities
+{
+    /// <summary>
+    /// Simple replacement for System.Version used to implement version
+    /// comparison intrinic property functions.
+    ///
+    /// Allows major version only (e.g. "3" is 3.0.0.0), ignores leading 'v'
+    /// (e.g. "v3.0" is 3.0.0.0).
+    ///
+    /// Ignores semver prerelease and metadata portions (e.g. "1.0.0-preview+info"
+    /// is 1.0.0.0).
+    ///
+    /// Treats unspecified components as 0 (e.g. x == x.0 == x.0.0 == x.0.0.0).
+    ///
+    /// Unlike System.Version, does not tolerate whitespace, and '+' is ignored as
+    /// semver metadata as described above, not tolerated as positive sign of integer
+    /// component.
+    /// <summary>
+    /// <remarks>
+    /// Tolerating leading 'v' allows using $(TargetFrameworkVersion) directly.
+    ///
+    /// Ignoring semver portions allows, for example, checking >= major.minor
+    /// while still in development of that release.
+    ///
+    /// Implemented as a struct to avoid heap allocation. Parsing is done
+    /// without heap allocation at all on .NET Core. However, on .NET Framework,
+    /// the integer component substrings are allocated as there is no int.Parse
+    /// on span there.
+    /// </remarks>
+    internal readonly struct SimpleVersion : IEquatable<SimpleVersion>, IComparable<SimpleVersion>
+    {
+        public readonly int Major;
+        public readonly int Minor;
+        public readonly int Build;
+        public readonly int Revision;
+
+        public SimpleVersion(int major, int minor = 0, int build = 0, int revision = 0)
+        {
+            if (major < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(major));
+            }
+
+            if (minor < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minor));
+            }
+
+            if (build < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(build));
+            }
+
+            if (revision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(revision));
+            }
+
+            Major = major;
+            Minor = minor;
+            Build = build;
+            Revision = revision;
+        }
+
+        public bool Equals(SimpleVersion other)
+        {
+            return Major == other.Major &&
+                   Minor == other.Minor &&
+                   Build == other.Build &&
+                   Revision == other.Revision;
+        }
+
+        public int CompareTo(SimpleVersion other)
+        {
+            return Major != other.Major ? (Major > other.Major ? 1 : -1) :
+                   Minor != other.Minor ? (Minor > other.Minor ? 1 : -1) :
+                   Build != other.Build ? (Build > other.Build ? 1 : -1) :
+                   Revision != other.Revision ? (Revision > other.Revision ? 1 : -1) :
+                   0;
+        }
+
+        public override bool Equals(object obj) => obj is SimpleVersion v && Equals(v);
+        public override int GetHashCode() => (Major, Minor, Build, Revision).GetHashCode();
+        public override string ToString() => FormattableString.Invariant($"{Major}.{Minor}.{Build}.{Revision}");
+
+        public static bool operator ==(SimpleVersion a, SimpleVersion b) => a.Equals(b);
+        public static bool operator !=(SimpleVersion a, SimpleVersion b) => !a.Equals(b);
+        public static bool operator <(SimpleVersion a, SimpleVersion b) => a.CompareTo(b) < 0;
+        public static bool operator <=(SimpleVersion a, SimpleVersion b) => a.CompareTo(b) <= 0;
+        public static bool operator >(SimpleVersion a, SimpleVersion b) => a.CompareTo(b) > 0;
+        public static bool operator >=(SimpleVersion a, SimpleVersion b) => a.CompareTo(b) >= 0;
+
+        public static SimpleVersion Parse(string input)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var span = RemoveTrivia(input);
+
+            int minor = 0, build = 0, revision = 0;
+
+            if (ParseComponent(ref span, out int major) &&
+                ParseComponent(ref span, out minor) &&
+                ParseComponent(ref span, out build) &&
+                ParseComponent(ref span, out revision))
+            {
+                // More than 4 components (too many dots)
+                throw InvalidVersionFormat();
+            }
+
+            return new SimpleVersion(major, minor, build, revision);
+        }
+
+        private static readonly char[] s_semverSeparators = new char[] { '-', '+' };
+
+        private static ReadOnlySpan<char> RemoveTrivia(string input)
+        {
+            int startIndex = 0;
+            int endIndex = input.Length;
+
+            if (input.Length > 0 && (input[0] == 'v' || input[0] == 'V'))
+            {
+                startIndex = 1;
+            }
+
+            int separatorIndex = input.IndexOfAny(s_semverSeparators, startIndex);
+
+            if (separatorIndex >= 0)
+            {
+                endIndex = separatorIndex;
+            }
+
+            return input.AsSpan().Slice(startIndex, endIndex - startIndex);
+        }
+
+        private static bool ParseComponent(ref ReadOnlySpan<char> span, out int value)
+        {
+            int dotIndex = span.IndexOf('.');
+            if (dotIndex < 0)
+            {
+                value = ParseComponent(span);
+                return false;
+            }
+            else
+            {
+                value = ParseComponent(span.Slice(0, dotIndex));
+                span = span.Slice(dotIndex + 1);
+                return true;
+            }
+        }
+
+        private static int ParseComponent(ReadOnlySpan<char> span)
+        {
+        #if NETFRAMEWORK
+            // Cannot parse int from span on .NET Framework, so allocate the substring
+            var spanOrString = span.ToString();
+        #else
+            var spanOrString = span;
+        #endif
+
+            if (!int.TryParse(spanOrString, NumberStyles.None, CultureInfo.InvariantCulture, out int value))
+            {
+                throw InvalidVersionFormat();
+            }
+
+            // Cannot parse as negative using NumberStyles.None. Also, +/- would have
+            // been stripped as semver trivia earlier.
+            Debug.Assert(value >= 0);
+
+            return value;
+        }
+
+        private static Exception InvalidVersionFormat()
+        {
+            return new FormatException(ResourceUtilities.GetResourceString(nameof(InvalidVersionFormat)));
+        }
+    }
+}


### PR DESCRIPTION
Usage: 
```
$([MSBuild]::VersionEquals(a, b))
$([MSBuild]::VersionNotEquals(a, b))
$([MSBuild]::VersionLessThan(a, b))
$([MSBuild]::VersionLessThanOrEquals(a, b))
$([MSBuild]::VersionLessThan(a, b))
$([MSBuild]::VersionGreaterThanOrEquals(a, b))
```

Versions are parsed like System.Version, with the following exceptions:

 * Leading v or V is ignored. Allows comparison to $(TargetFrameworkVersion)

 * Everything from first '-' or '+' to end of string is ignored. Allows passing in semantic versions, though the order is not the same as semver. Instead, prerelease specified and build metadata do not have any sorting weight. This can be useful, for example, to turn on a feature for >= x.y and have it kick in on x.y.z-pre.

 * Remaining part of string from above is parsed with Version.Parse, then normalized to have 4 explicit parts to make x == x.0 == x.0.0 == x.0.0.0.

 * Whitespace is not allowed in integer components

 * major version only is valid ("3" is equal to "3.0.0.0")

 * `+`  is not allowed as positive sign in integer components (it is treated as semver metadata and ignored per above)

The parser is adapted from System.Version source code, but simplified and tweaked to handle quirks above, with trivial opportunities to improve perf / reduce allocations taken. Tests are also adapted from corefx.

Fix #3212 
