### PR TITLE
Add arcade telemetry for build failures in Build-Repo

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -174,6 +174,8 @@ try {
   }
 }
 catch {
+  Write-Host $_
+  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
   Write-PipelineTelemetryError -Category "Build" -Message $_
   ExitWithExitCode 1

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -174,9 +174,8 @@ try {
   }
 }
 catch {
-  Write-Host $_
-  Write-Host $_.Exception
   Write-Host $_.ScriptStackTrace
+  Write-PipelineTelemetryError -Category "Build" -Message $_
   ExitWithExitCode 1
 }
 


### PR DESCRIPTION
Helps us correctly classify build errors as such when running them through Arcade.