### PR TITLE
Small fixes in TaskHostConfiguration_Tests.cs

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -41,13 +41,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     1,
                     Directory.GetCurrentDirectory(),
                     null,
-#if FEATURE_THREAD_CULTURE
                     Thread.CurrentThread.CurrentCulture,
                     Thread.CurrentThread.CurrentUICulture,
-#else
-                    CultureInfo.CurrentCulture,
-                    CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                     null,
 #endif
@@ -73,13 +68,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     1,
                     Directory.GetCurrentDirectory(),
                     null,
-#if FEATURE_THREAD_CULTURE
                     Thread.CurrentThread.CurrentCulture,
                     Thread.CurrentThread.CurrentUICulture,
-#else
-                    CultureInfo.CurrentCulture,
-                    CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                     null,
 #endif
@@ -105,13 +95,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     1,
                     Directory.GetCurrentDirectory(),
                     null,
-#if FEATURE_THREAD_CULTURE
                     Thread.CurrentThread.CurrentCulture,
                     Thread.CurrentThread.CurrentUICulture,
-#else
-                    CultureInfo.CurrentCulture,
-                    CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                     null,
 #endif
@@ -139,13 +124,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     1,
                     Directory.GetCurrentDirectory(),
                     null,
-#if FEATURE_THREAD_CULTURE
                     Thread.CurrentThread.CurrentCulture,
                     Thread.CurrentThread.CurrentUICulture,
-#else
-                    CultureInfo.CurrentCulture,
-                    CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                     null,
 #endif
@@ -171,13 +151,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -192,13 +167,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -215,13 +185,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -243,13 +208,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -272,13 +232,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -312,13 +267,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -396,13 +346,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif
@@ -440,13 +385,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 1,
                 Directory.GetCurrentDirectory(),
                 null,
-#if FEATURE_THREAD_CULTURE
                 Thread.CurrentThread.CurrentCulture,
                 Thread.CurrentThread.CurrentUICulture,
-#else
-                CultureInfo.CurrentCulture,
-                CultureInfo.CurrentCulture,
-#endif
 #if FEATURE_APPDOMAIN
                 null,
 #endif

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(config.TaskName, deserializedConfig.TaskName);
 #if FEATURE_ASSEMBLY_LOADFROM
-            Assert.Equal(config.TaskLocation, config.TaskLocation);
+            Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.Null(deserializedConfig.TaskParameters);
         }
@@ -287,7 +287,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(config.TaskName, deserializedConfig.TaskName);
 #if FEATURE_ASSEMBLY_LOADFROM
-            Assert.Equal(config.TaskLocation, config.TaskLocation);
+            Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.NotNull(deserializedConfig.TaskParameters);
             Assert.Equal(config.TaskParameters.Count, deserializedConfig.TaskParameters.Count);
@@ -326,7 +326,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(config.TaskName, deserializedConfig.TaskName);
 #if FEATURE_ASSEMBLY_LOADFROM
-            Assert.Equal(config.TaskLocation, config.TaskLocation);
+            Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.NotNull(deserializedConfig.TaskParameters);
             Assert.Equal(config.TaskParameters.Count, deserializedConfig.TaskParameters.Count);
@@ -366,7 +366,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(config.TaskName, deserializedConfig.TaskName);
 #if FEATURE_ASSEMBLY_LOADFROM
-            Assert.Equal(config.TaskLocation, config.TaskLocation);
+            Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.NotNull(deserializedConfig.TaskParameters);
             Assert.Equal(config.TaskParameters.Count, deserializedConfig.TaskParameters.Count);
@@ -405,7 +405,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             Assert.Equal(config.TaskName, deserializedConfig.TaskName);
 #if FEATURE_ASSEMBLY_LOADFROM
-            Assert.Equal(config.TaskLocation, config.TaskLocation);
+            Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.NotNull(deserializedConfig.TaskParameters);
             Assert.Equal(config.TaskParameters.Count, deserializedConfig.TaskParameters.Count);

--- a/src/Shared/ThreadPoolExtensions.cs
+++ b/src/Shared/ThreadPoolExtensions.cs
@@ -27,20 +27,12 @@ namespace Microsoft.Build.Shared
                   {
                       if (CultureInfo.CurrentCulture != culture)
                       {
-#if FEATURE_THREAD_CULTURE
                           Thread.CurrentThread.CurrentCulture = culture;
-#else
-                          CultureInfo.CurrentCulture = culture;
-#endif
                       }
 
                       if (CultureInfo.CurrentUICulture != uiCulture)
                       {
-#if FEATURE_THREAD_CULTURE
                           Thread.CurrentThread.CurrentUICulture = uiCulture;
-#else
-                          CultureInfo.CurrentCulture = uiCulture;
-#endif
                       }
 
                       callback(state);
@@ -50,20 +42,12 @@ namespace Microsoft.Build.Shared
                       // Set the culture back to the original one so that if something else reuses this thread then it will not have a culture which it was not expecting.
                       if (CultureInfo.CurrentCulture != originalThreadCulture)
                       {
-#if FEATURE_THREAD_CULTURE
                           Thread.CurrentThread.CurrentCulture = originalThreadCulture;
-#else
-                          CultureInfo.CurrentCulture = originalThreadCulture;
-#endif
                       }
 
                       if (CultureInfo.CurrentUICulture != originalThreadUICulture)
                       {
-#if FEATURE_THREAD_CULTURE
                           Thread.CurrentThread.CurrentUICulture = originalThreadUICulture;
-#else
-                          CultureInfo.CurrentUICulture = originalThreadUICulture;
-#endif
                       }
                   }
               });

--- a/src/Shared/UnitTests/FileUtilities_Tests.cs
+++ b/src/Shared/UnitTests/FileUtilities_Tests.cs
@@ -273,8 +273,6 @@ namespace Microsoft.Build.UnitTests
             });
         }
 
-#if FEATURE_THREAD_CULTURE
-
         [Fact]
         public void HasExtension_UsesOrdinalIgnoreCase()
         {
@@ -292,8 +290,6 @@ namespace Microsoft.Build.UnitTests
                 Thread.CurrentThread.CurrentCulture = currentCulture;
             }
         }
-
-#endif
 
         /// <summary>
         /// Exercises FileUtilities.EnsureTrailingSlash


### PR DESCRIPTION
Noticed these while looking at `AssemblyLoadContext` implementation.