### PR TITLE
Filtering for duplicate content files with referencing projects

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4472,9 +4472,22 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SkipNonexistentTargets="true"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
-      <Output TaskParameter="TargetOutputs" ItemName="_AllChildProjectItemsWithTargetPath"/>
+      <Output TaskParameter="TargetOutputs" ItemName="_UnfilteredAllChildProjectItemsWithTargetPath"/>
 
     </MSBuild>
+    
+    <!-- Filter out dependency items that could overwrite referencer content -->
+    <CreateItem Include="@(_UnfilteredAllChildProjectItemsWithTargetPath)"  AdditionalMetadata="ParentContent=%(ContentWithTargetPath.Identity)">
+        <Output TaskParameter="Include" ItemName="_FilteredChildProjectItemsWithTargetPath"/>
+    </CreateItem>
+    <ItemGroup>
+      <_ParentChildContentDuplicates Include="@(_FilteredChildProjectItemsWithTargetPath)" Condition="'%(_FilteredChildProjectItemsWithTargetPath.TargetPath)'=='%(ParentContent)'" />
+      <_FilteredChildProjectItemsWithTargetPath Remove="@(_ParentChildContentDuplicates)" />
+      <_FilteredChildProjectItemsWithTargetPath>
+        <ParentContent></ParentContent> <!-- Remove unnecessary metadata -->
+      </_FilteredChildProjectItemsWithTargetPath>
+      <_AllChildProjectItemsWithTargetPath Include="@(_FilteredChildProjectItemsWithTargetPath->Distinct())" />
+    </ItemGroup>
 
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
@@ -4484,7 +4497,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
-      <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
+      <_AllChildProjectItemsWithTargetPath            Remove="@(_AllChildProjectItemsWithTargetPath)"/>
+      <_UnfilteredAllChildProjectItemsWithTargetPath  Remove="@(_UnfilteredAllChildProjectItemsWithTargetPath)"/>
+      <_FilteredChildProjectItemsWithTargetPath       Remove="@(_FilteredChildProjectItemsWithTargetPath)"/>
+      <_ParentChildContentDuplicates                  Remove="@(_ParentChildContentDuplicates)"/>
     </ItemGroup>
 
     <!-- Copy paste _GetCopyToOutputDirectoryItemsFromThisProject but keep the items that came from other projects via ProjectReference's OutputItemType metadata -->

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4569,7 +4569,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
     </CallTarget>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(IgnoreConflictingTransitiveContent)' == 'false' or ('$(IgnoreConflictingTransitiveContent)' == '' and '$(MSBuildRuntimeType)' == 'Core')">
       <_TransitiveItemsToCopyToOutputDirectory Remove="@(_ThisProjectItemsToCopyToOutputDirectory)" MatchOnMetadata="TargetPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4472,22 +4472,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SkipNonexistentTargets="true"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
-      <Output TaskParameter="TargetOutputs" ItemName="_UnfilteredAllChildProjectItemsWithTargetPath"/>
+      <Output TaskParameter="TargetOutputs" ItemName="_AllChildProjectItemsWithTargetPath"/>
 
     </MSBuild>
-    
-    <!-- Filter out dependency items that could overwrite referencer content -->
-    <CreateItem Include="@(_UnfilteredAllChildProjectItemsWithTargetPath)"  AdditionalMetadata="ParentContent=%(ContentWithTargetPath.Identity)">
-        <Output TaskParameter="Include" ItemName="_FilteredChildProjectItemsWithTargetPath"/>
-    </CreateItem>
-    <ItemGroup>
-      <_ParentChildContentDuplicates Include="@(_FilteredChildProjectItemsWithTargetPath)" Condition="'%(_FilteredChildProjectItemsWithTargetPath.TargetPath)'=='%(ParentContent)'" />
-      <_FilteredChildProjectItemsWithTargetPath Remove="@(_ParentChildContentDuplicates)" />
-      <_FilteredChildProjectItemsWithTargetPath>
-        <ParentContent></ParentContent> <!-- Remove unnecessary metadata -->
-      </_FilteredChildProjectItemsWithTargetPath>
-      <_AllChildProjectItemsWithTargetPath Include="@(_FilteredChildProjectItemsWithTargetPath->Distinct())" />
-    </ItemGroup>
 
     <!-- Target outputs must be full paths because they will be consumed by a different project. -->
     <ItemGroup>
@@ -4497,10 +4484,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
     <!-- Remove items which we will never again use - they just sit around taking up memory otherwise -->
     <ItemGroup>
-      <_AllChildProjectItemsWithTargetPath            Remove="@(_AllChildProjectItemsWithTargetPath)"/>
-      <_UnfilteredAllChildProjectItemsWithTargetPath  Remove="@(_UnfilteredAllChildProjectItemsWithTargetPath)"/>
-      <_FilteredChildProjectItemsWithTargetPath       Remove="@(_FilteredChildProjectItemsWithTargetPath)"/>
-      <_ParentChildContentDuplicates                  Remove="@(_ParentChildContentDuplicates)"/>
+      <_AllChildProjectItemsWithTargetPath       Remove="@(_AllChildProjectItemsWithTargetPath)"/>
     </ItemGroup>
 
     <!-- Copy paste _GetCopyToOutputDirectoryItemsFromThisProject but keep the items that came from other projects via ProjectReference's OutputItemType metadata -->
@@ -4584,6 +4568,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <CallTarget Targets="_GetCopyToOutputDirectoryItemsFromThisProject">
       <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
     </CallTarget>
+
+    <ItemGroup>
+      <_TransitiveItemsToCopyToOutputDirectory Remove="@(_ThisProjectItemsToCopyToOutputDirectory)" MatchOnMetadata="TargetPath" MatchOnMetadataOptions="PathLike" />
+    </ItemGroup>
 
     <ItemGroup>
       <_TransitiveItemsToCopyToOutputDirectoryAlways               KeepDuplicates=" '$(_GCTODIKeepDuplicates)' != 'false' " KeepMetadata="$(_GCTODIKeepMetadata)" Include="@(_TransitiveItemsToCopyToOutputDirectory->'%(FullPath)')" Condition="'%(_TransitiveItemsToCopyToOutputDirectory.CopyToOutputDirectory)'=='Always'"/>

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4569,7 +4569,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
     </CallTarget>
 
-    <ItemGroup Condition="'$(IgnoreConflictingTransitiveContent)' == 'false' or ('$(IgnoreConflictingTransitiveContent)' == '' and '$(MSBuildRuntimeType)' == 'Core')">
+    <ItemGroup Condition="'$(IgnoreConflictingTransitiveContent)' == 'false'">
       <_TransitiveItemsToCopyToOutputDirectory Remove="@(_ThisProjectItemsToCopyToOutputDirectory)" MatchOnMetadata="TargetPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4569,7 +4569,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
     </CallTarget>
 
-    <ItemGroup Condition="'$(IgnoreConflictingTransitiveContent)' == 'false'">
+    <ItemGroup Condition="'$(CopyConflictingTransitiveContent)' == 'true'">
       <_TransitiveItemsToCopyToOutputDirectory Remove="@(_ThisProjectItemsToCopyToOutputDirectory)" MatchOnMetadata="TargetPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
 

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4569,7 +4569,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="TargetOutputs" ItemName="_ThisProjectItemsToCopyToOutputDirectory" />
     </CallTarget>
 
-    <ItemGroup Condition="'$(CopyConflictingTransitiveContent)' == 'true'">
+    <ItemGroup Condition="'$(CopyConflictingTransitiveContent)' == 'false'">
       <_TransitiveItemsToCopyToOutputDirectory Remove="@(_ThisProjectItemsToCopyToOutputDirectory)" MatchOnMetadata="TargetPath" MatchOnMetadataOptions="PathLike" />
     </ItemGroup>
 


### PR DESCRIPTION
Addressing the issue of dependency content files overwriting the referencing project's content files of the same name (see dotnet/sdk#3871). 
Test coverage in the SDK [here](https://github.com/sfoslund/sdk/blob/CopyAppSettingsIssue/src/Tests/Microsoft.NET.Build.Tests/GivenThatWeWantToReferenceAProject.cs#L138). 