### PR TITLE
Ensure directory entries in zips are not created

### DIFF
--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -131,6 +131,15 @@ namespace Microsoft.Build.Tasks
             {
                 FileInfo destinationPath = new FileInfo(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName));
 
+                // Zip archives can have directory entries listed explicitly.
+                // If this entry is a directory we should create the it and move to the next entry.
+                if (Path.GetFileName(destinationPath.FullName).Length == 0)
+                {
+                    // The entry is a directory
+                    Directory.CreateDirectory(destinationPath.FullName);
+                    continue;
+                }
+
                 if (!destinationPath.FullName.StartsWith(destinationDirectory.FullName, StringComparison.OrdinalIgnoreCase))
                 {
                     // ExtractToDirectory() throws an IOException for this but since we're extracting one file at a time

--- a/src/Tasks/Unzip.cs
+++ b/src/Tasks/Unzip.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Build.Tasks
                 FileInfo destinationPath = new FileInfo(Path.Combine(destinationDirectory.FullName, zipArchiveEntry.FullName));
 
                 // Zip archives can have directory entries listed explicitly.
-                // If this entry is a directory we should create the it and move to the next entry.
+                // If this entry is a directory we should create it and move to the next entry.
                 if (Path.GetFileName(destinationPath.FullName).Length == 0)
                 {
                     // The entry is a directory


### PR DESCRIPTION
Ensure that directory entries in zip archives are not attempted to be created as files. Only file entries (and their parent directories) will be created.

Currently using the `<Unzip/>` task with an archive containing directories will fail trying to `File.Open` on a directory.

```
error : Access to the path '/Users/USER/stuff/internalzipdir/' is denied.

at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirectory, Func`2 errorRewriter)
at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode)
at System.IO.FileStream.OpenHandle(FileMode mode, FileShare share, FileOptions options)
at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
at System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
at Microsoft.Build.Tasks.Unzip.Extract(ZipArchive sourceArchive, DirectoryInfo destinationDirectory)
at Microsoft.Build.Tasks.Unzip.Execute()
```

Fixes #3884