### PR TITLE
Implement feature that allows tasks to get the global properties

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
     {
-        System.Collections.Generic.Dictionary<string, string> GetGlobalProperties();
+        System.Collections.Generic.IDictionary<string, string> GetGlobalProperties();
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
     {
-        System.Collections.Generic.IDictionary<string, string> GetGlobalProperties();
+        System.Collections.Generic.IReadOnlyDictionary<string, string> GetGlobalProperties();
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -193,6 +193,10 @@ namespace Microsoft.Build.Framework
     {
         void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties);
     }
+    public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
+    {
+        System.Collections.Generic.Dictionary<string, string> GetGlobalProperties();
+    }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {
         void Cancel();

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
     {
-        System.Collections.Generic.Dictionary<string, string> GetGlobalProperties();
+        System.Collections.Generic.IDictionary<string, string> GetGlobalProperties();
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Framework
     }
     public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
     {
-        System.Collections.Generic.IDictionary<string, string> GetGlobalProperties();
+        System.Collections.Generic.IReadOnlyDictionary<string, string> GetGlobalProperties();
     }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -193,6 +193,10 @@ namespace Microsoft.Build.Framework
     {
         void LogTelemetry(string eventName, System.Collections.Generic.IDictionary<string, string> properties);
     }
+    public partial interface IBuildEngine6 : Microsoft.Build.Framework.IBuildEngine, Microsoft.Build.Framework.IBuildEngine2, Microsoft.Build.Framework.IBuildEngine3, Microsoft.Build.Framework.IBuildEngine4, Microsoft.Build.Framework.IBuildEngine5
+    {
+        System.Collections.Generic.Dictionary<string, string> GetGlobalProperties();
+    }
     public partial interface ICancelableTask : Microsoft.Build.Framework.ITask
     {
         void Cancel();

--- a/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/net/Microsoft.Build.Utilities.Core.cs
@@ -351,6 +351,7 @@ namespace Microsoft.Build.Utilities
         public Microsoft.Build.Framework.IBuildEngine3 BuildEngine3 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine4 BuildEngine4 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
         protected string HelpKeywordPrefix { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
         public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }

--- a/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
+++ b/ref/Microsoft.Build.Utilities.Core/netstandard/Microsoft.Build.Utilities.Core.cs
@@ -196,6 +196,7 @@ namespace Microsoft.Build.Utilities
         public Microsoft.Build.Framework.IBuildEngine3 BuildEngine3 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine4 BuildEngine4 { get { throw null; } }
         public Microsoft.Build.Framework.IBuildEngine5 BuildEngine5 { get { throw null; } }
+        public Microsoft.Build.Framework.IBuildEngine6 BuildEngine6 { get { throw null; } }
         protected string HelpKeywordPrefix { get { throw null; } set { } }
         public Microsoft.Build.Framework.ITaskHost HostObject { get { throw null; } set { } }
         public Microsoft.Build.Utilities.TaskLoggingHelper Log { get { throw null; } }

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
                 null,
-                    null);
+                null);
 
             IDictionary<string, object> parameters = new Dictionary<string, object>();
             TaskHostConfiguration config3 = new TaskHostConfiguration(
@@ -204,7 +204,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
                 parameters,
-                    null);
+                null);
 
             IDictionary<string, object> parameters2 = new Dictionary<string, object>();
             parameters2.Add("Text", "Hello!");
@@ -228,7 +228,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
                 parameters2,
-                    null);
+                null);
         }
 
         /// <summary>

--- a/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHostConfiguration_Tests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     _continueOnErrorDefault,
                     null,
                     @"c:\my tasks\mytask.dll",
+                    null,
                     null);
             }
            );
@@ -79,6 +80,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     _continueOnErrorDefault,
                     String.Empty,
                     @"c:\my tasks\mytask.dll",
+                    null,
                     null);
             }
            );
@@ -105,6 +107,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     @"c:\my project\myproj.proj",
                     _continueOnErrorDefault,
                     "TaskName",
+                    null,
                     null,
                     null);
             }
@@ -135,6 +138,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     _continueOnErrorDefault,
                     "TaskName",
                     String.Empty,
+                    null,
                     null);
             }
            );
@@ -162,7 +166,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
+                null,
                 null);
+
             TaskHostConfiguration config2 = new TaskHostConfiguration(
                 1,
                 Directory.GetCurrentDirectory(),
@@ -178,7 +184,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                null);
+                null,
+                    null);
 
             IDictionary<string, object> parameters = new Dictionary<string, object>();
             TaskHostConfiguration config3 = new TaskHostConfiguration(
@@ -196,7 +203,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                parameters);
+                parameters,
+                    null);
 
             IDictionary<string, object> parameters2 = new Dictionary<string, object>();
             parameters2.Add("Text", "Hello!");
@@ -219,7 +227,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                parameters2);
+                parameters2,
+                    null);
         }
 
         /// <summary>
@@ -228,6 +237,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TestTranslationWithNullDictionary()
         {
+            var expectedGlobalProperties = new Dictionary<string, string>
+            {
+                ["Property1"] = "Value1",
+                ["Property2"] = "Value2"
+            };
+
             TaskHostConfiguration config = new TaskHostConfiguration(
                 1,
                 Directory.GetCurrentDirectory(),
@@ -243,7 +258,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                null);
+                null,
+                expectedGlobalProperties);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -255,6 +271,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
             Assert.Equal(config.TaskLocation, deserializedConfig.TaskLocation);
 #endif
             Assert.Null(deserializedConfig.TaskParameters);
+
+            Assert.Equal(expectedGlobalProperties, deserializedConfig.GlobalProperties);
         }
 
         /// <summary>
@@ -278,7 +296,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                new Dictionary<string, object>());
+                new Dictionary<string, object>(),
+                new Dictionary<string, string>());
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -291,6 +310,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
 #endif
             Assert.NotNull(deserializedConfig.TaskParameters);
             Assert.Equal(config.TaskParameters.Count, deserializedConfig.TaskParameters.Count);
+
+            Assert.NotNull(deserializedConfig.GlobalProperties);
+            Assert.Equal(config.GlobalProperties.Count, deserializedConfig.GlobalProperties.Count);
         }
 
         /// <summary>
@@ -317,7 +339,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                parameters);
+                parameters,
+                null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -357,7 +380,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                parameters);
+                parameters,
+                null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());
@@ -396,7 +420,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                 _continueOnErrorDefault,
                 "TaskName",
                 @"c:\MyTasks\MyTask.dll",
-                parameters);
+                parameters,
+                null);
 
             ((ITranslatable)config).Translate(TranslationHelpers.GetWriteTranslator());
             INodePacket packet = TaskHostConfiguration.FactoryForDeserialization(TranslationHelpers.GetReadTranslator());

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -652,8 +652,8 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
-        public Dictionary<string, string> GetGlobalProperties()
+        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public IDictionary<string, string> GetGlobalProperties()
         {
             return _requestEntry.RequestConfiguration.GlobalProperties.ToDictionary();
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Build.BackEnd
 #if FEATURE_APPDOMAIN
         MarshalByRefObject,
 #endif
-        IBuildEngine5
+        IBuildEngine6
     {
         /// <summary>
         /// True if the "secret" environment variable MSBUILDNOINPROCNODE is set. 
@@ -643,6 +643,19 @@ namespace Microsoft.Build.BackEnd
 
                 _taskLoggingContext.LoggingService.LogTelemetry(_taskLoggingContext.BuildEventContext, eventName, properties);
             }
+        }
+
+        #endregion
+
+        #region IBuildEngine6 Members
+
+        /// <summary>
+        /// Gets the global properties for the current project.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public Dictionary<string, string> GetGlobalProperties()
+        {
+            return _requestEntry.RequestConfiguration.GlobalProperties.ToDictionary();
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -652,8 +652,8 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
-        public IDictionary<string, string> GetGlobalProperties()
+        /// <returns>An <see cref="IReadOnlyDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public IReadOnlyDictionary<string, string> GetGlobalProperties()
         {
             return _requestEntry.RequestConfiguration.GlobalProperties.ToDictionary();
         }

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -273,7 +273,8 @@ namespace Microsoft.Build.BackEnd
                         BuildEngine.ContinueOnError,
                         _taskType.Type.FullName,
                         AssemblyUtilities.GetAssemblyLocation(_taskType.Type.GetTypeInfo().Assembly),
-                        _setParameters
+                        _setParameters,
+                        new Dictionary<string, string>(_buildComponentHost.BuildParameters.GlobalProperties)
                     );
 
             try

--- a/src/Framework/IBuildEngine6.cs
+++ b/src/Framework/IBuildEngine6.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// This interface extends <see cref="IBuildEngine5" /> to allow tasks to get the current project's global properties.
+    /// </summary>
+    public interface IBuildEngine6 : IBuildEngine5
+    {
+        /// <summary>
+        /// Gets the global properties for the current project.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
+        Dictionary<string, string> GetGlobalProperties();
+    }
+}

--- a/src/Framework/IBuildEngine6.cs
+++ b/src/Framework/IBuildEngine6.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
-        IDictionary<string, string> GetGlobalProperties();
+        /// <returns>An <see cref="IReadOnlyDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        IReadOnlyDictionary<string, string> GetGlobalProperties();
     }
 }

--- a/src/Framework/IBuildEngine6.cs
+++ b/src/Framework/IBuildEngine6.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.Framework
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
-        Dictionary<string, string> GetGlobalProperties();
+        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        IDictionary<string, string> GetGlobalProperties();
     }
 }

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.CommandLine
 #if CLR2COMPATIBILITY
         IBuildEngine3
 #else
-        IBuildEngine5
+        IBuildEngine6
 #endif
     {
         /// <summary>
@@ -438,6 +438,19 @@ namespace Microsoft.Build.CommandLine
                 EventName = eventName,
                 Properties = properties == null ? new Dictionary<string, string>() : new Dictionary<string, string>(properties),
             });
+        }
+
+        #endregion
+
+        #region IBuildEngine6 Implementation
+
+        /// <summary>
+        /// Gets the global properties for the current project.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public Dictionary<string, string> GetGlobalProperties()
+        {
+            return new Dictionary<string, string>(_currentConfiguration.GlobalProperties);
         }
 
         #endregion

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -447,8 +447,8 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>A <see cref="Dictionary{String, String}" /> containing the global properties of the current project.</returns>
-        public Dictionary<string, string> GetGlobalProperties()
+        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public IDictionary<string, string> GetGlobalProperties()
         {
             return new Dictionary<string, string>(_currentConfiguration.GlobalProperties);
         }

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -447,8 +447,8 @@ namespace Microsoft.Build.CommandLine
         /// <summary>
         /// Gets the global properties for the current project.
         /// </summary>
-        /// <returns>An <see cref="IDictionary{String, String}" /> containing the global properties of the current project.</returns>
-        public IDictionary<string, string> GetGlobalProperties()
+        /// <returns>An <see cref="IReadOnlyDictionary{String, String}" /> containing the global properties of the current project.</returns>
+        public IReadOnlyDictionary<string, string> GetGlobalProperties()
         {
             return new Dictionary<string, string>(_currentConfiguration.GlobalProperties);
         }

--- a/src/Shared/TaskHostConfiguration.cs
+++ b/src/Shared/TaskHostConfiguration.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private Dictionary<string, TaskParameter> _taskParameters;
 
+        private Dictionary<string, string> _globalParameters;
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -119,7 +121,8 @@ namespace Microsoft.Build.BackEnd
                 bool continueOnError,
                 string taskName,
                 string taskLocation,
-                IDictionary<string, object> taskParameters
+                IDictionary<string, object> taskParameters,
+                Dictionary<string, string> globalParameters
             )
         {
             ErrorUtilities.VerifyThrowInternalLength(taskName, "taskName");
@@ -159,6 +162,8 @@ namespace Microsoft.Build.BackEnd
                     _taskParameters[parameter.Key] = new TaskParameter(parameter.Value);
                 }
             }
+
+            _globalParameters = globalParameters ?? new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -302,6 +307,16 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Gets the global properties for the current project.
+        /// </summary>
+        public Dictionary<string, string> GlobalProperties
+        {
+            [DebuggerStepThrough]
+            get
+            { return _globalParameters; }
+        }
+
+        /// <summary>
         /// The NodePacketType of this NodePacket
         /// </summary>
         public NodePacketType Type
@@ -332,6 +347,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _taskLocation);
             translator.TranslateDictionary(ref _taskParameters, StringComparer.OrdinalIgnoreCase, TaskParameter.FactoryForDeserialization);
             translator.Translate(ref _continueOnError);
+            translator.TranslateDictionary(ref _globalParameters, StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.UnitTests
      * is somewhat of a no-no for task assemblies.
      * 
      **************************************************************************/
-    internal sealed class MockEngine : IBuildEngine5
+    internal sealed class MockEngine : IBuildEngine6
     {
         private readonly object _lockObj = new object();  // Protects _log, _output
         private readonly ITestOutputHelper _output;
@@ -52,6 +52,8 @@ namespace Microsoft.Build.UnitTests
         internal int Errors { get; set; }
 
         public BuildErrorEventArgs[] ErrorEvents => _errorEvents.ToArray();
+
+        public Dictionary<string, string> GlobalProperties { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         internal MockLogger MockLogger { get; }
 
@@ -169,6 +171,11 @@ namespace Microsoft.Build.UnitTests
                 _output?.WriteLine(message);
                 _log.AppendLine(message);
             }
+        }
+
+        public Dictionary<string, string> GetGlobalProperties()
+        {
+            return GlobalProperties;
         }
 
         public bool ContinueOnError => false;

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        public IDictionary<string, string> GetGlobalProperties()
+        public IReadOnlyDictionary<string, string> GetGlobalProperties()
         {
             return GlobalProperties;
         }

--- a/src/Shared/UnitTests/MockEngine.cs
+++ b/src/Shared/UnitTests/MockEngine.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Build.UnitTests
             }
         }
 
-        public Dictionary<string, string> GetGlobalProperties()
+        public IDictionary<string, string> GetGlobalProperties()
         {
             return GlobalProperties;
         }

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1296,11 +1296,11 @@ namespace Microsoft.Build.UnitTests
         /// Build a project with the provided content in memory.
         /// Assert that it succeeded, and return the mock logger with the output.
         /// </summary>
-        internal static MockLogger BuildProjectWithNewOMExpectSuccess(string content)
+        internal static MockLogger BuildProjectWithNewOMExpectSuccess(string content, Dictionary<string, string> globalProperties = null)
         {
             MockLogger logger;
             bool result;
-            BuildProjectWithNewOM(content, out logger, out result, false);
+            BuildProjectWithNewOM(content, out logger, out result, false, globalProperties);
             Assert.True(result);
 
             return logger;
@@ -1309,12 +1309,12 @@ namespace Microsoft.Build.UnitTests
         /// <summary>
         /// Build a project in memory using the new OM
         /// </summary>
-        private static void BuildProjectWithNewOM(string content, out MockLogger logger, out bool result, bool allowTaskCrash)
+        private static void BuildProjectWithNewOM(string content, out MockLogger logger, out bool result, bool allowTaskCrash, Dictionary<string, string> globalProperties = null)
         {
             // Replace the crazy quotes with real ones
             content = ObjectModelHelpers.CleanupFileContents(content);
 
-            Project project = new Project(XmlReader.Create(new StringReader(content)));
+            Project project = new Project(XmlReader.Create(new StringReader(content)), globalProperties, toolsVersion: null);
             logger = new MockLogger();
             logger.AllowTaskCrashes = allowTaskCrash;
             List<ILogger> loggers = new List<ILogger>();

--- a/src/Utilities/Task.cs
+++ b/src/Utilities/Task.cs
@@ -70,19 +70,24 @@ namespace Microsoft.Build.Utilities
         public IBuildEngine2 BuildEngine2 => (IBuildEngine2)BuildEngine;
 
         /// <summary>
-        /// Retrieves the IBuildEngine3 version of the build engine interface provided by the host.
+        /// Retrieves the <see cref="IBuildEngine3" /> version of the build engine interface provided by the host.
         /// </summary>
         public IBuildEngine3 BuildEngine3 => (IBuildEngine3)BuildEngine;
 
         /// <summary>
-        /// Retrieves the IBuildEngine4 version of the build engine interface provided by the host.
+        /// Retrieves the <see cref="IBuildEngine4" /> version of the build engine interface provided by the host.
         /// </summary>
         public IBuildEngine4 BuildEngine4 => (IBuildEngine4)BuildEngine;
 
         /// <summary>
-        /// Retrieves the IBuildEngine5 version of the build engine interface provided by the host.
+        /// Retrieves the <see cref="IBuildEngine5" /> version of the build engine interface provided by the host.
         /// </summary>
         public IBuildEngine5 BuildEngine5 => (IBuildEngine5)BuildEngine;
+
+        /// <summary>
+        /// Retrieves the <see cref="IBuildEngine6" /> version of the build engine interface provided by the host.
+        /// </summary>
+        public IBuildEngine6 BuildEngine6 => (IBuildEngine6)BuildEngine;
 
         /// <summary>
         /// The build engine sets this property if the host IDE has associated a host object with this particular task.


### PR DESCRIPTION
This is an implementation of https://github.com/microsoft/msbuild/issues/4925 which allows tasks to get the current project's global properties.

I added an `IBuildEngine6` and plumbed the global properties to the appropriate task hosts.