### PR TITLE
Use MSBuildToolsDirectory32 in node handshake communication

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -655,14 +655,10 @@ namespace Microsoft.Build.Internal
         /// <returns>Base Handshake</returns>
         private static long GetBaseHandshakeForContext(TaskHostContext hostContext)
         {
-            // Use the directory, rather than the full path, because this is in Shared and may
-            // be compiled into several different assemblies. We also want to make sure
-            // MSBuildTaskHost.exe gets the same path as MSBuild.exe/Microsoft.Build.dll.
-            string msbuildDirectory = Path.GetDirectoryName(FileUtilities.ExecutingAssemblyPath);
-            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + msbuildDirectory;
+            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
             long nodeHandshakeSalt = GetHandshakeHashCode(salt);
 
-            Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", hostContext={2}, FileVersionHash={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), msbuildDirectory, hostContext, FileVersionHash);
+            Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", hostContext={2}, FileVersionHash={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, hostContext, FileVersionHash);
 
             //FileVersionHash (32 bits) is shifted 8 bits to avoid session ID collision
             //hostContext (4 bits) is shifted just after the FileVersionHash


### PR DESCRIPTION
Use a directory path for the MSBuild "installation" instead of path-to-folder-of-current-assembly to normalize for the `bin`/`bin\amd64` differences that may arise in a single logical installation.

Fixes #4957 
