### PR TITLE
Normalize on Debug case for CI script

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-configuration="debug"
+configuration="Debug"
 host_type="core"
 build_stage1=true
 properties=
@@ -95,4 +95,3 @@ export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 # - Do run tests
 # - Don't try to create a bootstrap deployment
 . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties
-


### PR DESCRIPTION
Inside the CI script, we were specifying `debug` as the configuration, but in
the YAML we copied up the `Debug` directory. That worked because somewhere in
the guts of things, test logs got emitted to `Debug`, but didn't actually
capture the build log. Specifying with a capital letter should put everything
in the same folder for happy upload.