### PR TITLE
Allow qualified metadata references in the Update item operation

### DIFF
--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -2111,8 +2111,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             Assert.Empty(items);
         }
-		
-		[Fact]
+        
+        [Fact]
         public void RemoveShouldRespectCondition()
         {
             var projectContents = ObjectModelHelpers.FormatProjectContentsWithItemGroupFragment(
@@ -2371,6 +2371,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                               <i2 Update='a;b'>
                                   <m1>%(Identity)</m1>
                                   <m2>%(m1)@(i1 -> '%(m1)')</m2>
+                                  <m3 Condition='%(Identity) == a'>value</m3>
+                                  <m4 Condition='%(m1) == b'>%(m1)</m4>
                               </i2>";
 
             IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
@@ -2386,17 +2388,276 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             {
                 {"m1", "a"},
                 {"m2", "ax"},
+                {"m3", "value"},
             };
 
             var expectedMetadataB = new Dictionary<string, string>
             {
                 {"m1", "b"},
                 {"m2", "bx"},
+                {"m4", "b"},
             };
 
             ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataX, items[0]);
             ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataA, items[1]);
             ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataB, items[2]);
+        }
+
+        [Fact]
+        public void UpdateShouldImportMetadataFromReferencedItem()
+        {
+            string content = @"
+                              <from Include='a;b'>
+                                  <m1>%(Identity)-m1</m1>
+                                  <m2>%(Identity)-m2</m2>
+                              </from>
+
+                              <to Include='a;b;c'>
+                                  <m1>m1_contents</m1>
+                                  <m2>m2_contents</m2>
+                              </to>
+
+                              <to Update='@(from)'>
+                                  <m2>%(m2);%(to.m2);%(from.m2)</m2>
+                                  <m3 Condition=`'%(Identity);%(to.Identity);%(from.m1)' == 'a;a;a-m1'`>%(from.m1)</m3>
+                                  <m4 Condition=`'%(from.m1)' == 'b-m1'`>%(m1)</m4>
+                              </to>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
+
+            var expectedMetadataA = new Dictionary<string, string>
+            {
+                {"m1", "m1_contents"},
+                {"m2", "m2_contents;m2_contents;a-m2"},
+                {"m3", "a-m1"},
+            };
+
+            var expectedMetadataB = new Dictionary<string, string>
+            {
+                {"m1", "m1_contents"},
+                {"m2", "m2_contents;m2_contents;b-m2"},
+                {"m4", "m1_contents"},
+            };
+
+            var expectedMetadataC = new Dictionary<string, string>
+            {
+                {"m1", "m1_contents"},
+                {"m2", "m2_contents"}
+            };
+
+            items[2].ItemType.ShouldBe("to");
+
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataA, items[2]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataB, items[3]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataC, items[4]);
+        }
+
+        [Fact]
+        public void UpdateFromReferencedItemShouldBeCaseInsensitive()
+        {
+            string content = @"
+                              <from Include='a'>
+                                  <metadata>m1_contents</metadata>
+                              </from>
+
+                              <to Include='a' />
+
+                              <to Update='@(FrOm)' m='%(fRoM.MetaDATA)' />";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
+
+            var expectedMetadataA = new Dictionary<string, string>
+            {
+                {"m", "m1_contents"},
+            };
+
+            items[1].ItemType.ShouldBe("to");
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataA, items[1]);
+        }
+
+        [Fact]
+        public void UndeclaredQualifiedMetadataReferencesInUpdateShouldResolveToEmptyStrings()
+        {
+            string content = @"
+                              <from1 Include='a'>
+                                  <metadata>m1_contents</metadata>
+                              </from1>
+
+                              <from2 Include='a'>
+                                  <metadata2>m1_contents</metadata2>
+                              </from2>
+
+                              <to Include='a' />
+
+                              <to Update='@(from1)' m1='%(nonexistent.metadata)' m2='%(from2.metadata2)'/>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
+
+            var expectedMetadataA = new Dictionary<string, string>
+            {
+                { "m1", string.Empty },
+                { "m2", string.Empty },
+            };
+
+            items[2].ItemType.ShouldBe("to");
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataA, items[2]);
+        }
+
+        [Fact]
+        public void UpdateShouldImportMetadataFromMultipleReferencedItems()
+        {
+            string content = @"
+                              <from1 Include='x.cs;y.cs'>
+                                  <m1>%(Identity)-m1</m1>
+                              </from1>
+
+                              <from2 Include='1;2'>
+                                  <m2>%(Identity)-m2</m2>
+                              </from2>
+
+                              <to Include='x.cs;2;ccc;1;d;y.cs'>
+                                  <m3>m3_contents</m3>
+                              </to>
+
+                              <to Update='@(from1);d;c*c;*.cs;@(from2)'>
+                                  <m3>%(from1.m1);%(from2.m2)</m3>
+                                  <m4>%(from1.m2);%(from2.m1)</m4>
+                                  <m5>%(Identity)</m5>
+                                  <m6 Condition='%(Identity) == 1'>%(from2.m2)</m6>
+                              </to>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
+
+            var expectedMetadataX = new Dictionary<string, string>
+            {
+                {"m3", "x.cs-m1;"},
+                {"m4", ";"},
+                {"m5", "x.cs"},
+            };
+
+            var expectedMetadata2 = new Dictionary<string, string>
+            {
+                {"m3", ";2-m2"},
+                {"m4", ";"},
+                {"m5", "2"},
+            };
+
+            var expectedMetadataCCC = new Dictionary<string, string>
+            {
+                {"m3", ";"},
+                {"m4", ";"},
+                {"m5", "ccc"},
+            };
+
+            var expectedMetadata1 = new Dictionary<string, string>
+            {
+                {"m3", ";1-m2"},
+                {"m4", ";"},
+                {"m5", "1"},
+                {"m6", "1-m2"},
+            };
+
+            var expectedMetadataD = new Dictionary<string, string>
+            {
+                {"m3", ";"},
+                {"m4", ";"},
+                {"m5", "d"},
+            };
+
+            var expectedMetadataY = new Dictionary<string, string>
+            {
+                {"m3", "y.cs-m1;"},
+                {"m4", ";"},
+                {"m5", "y.cs"},
+            };
+
+            items[4].ItemType.ShouldBe("to");
+
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataX, items[4]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata2, items[5]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataCCC, items[6]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata1, items[7]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataD, items[8]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataY, items[9]);
+        }
+
+        [Fact]
+        public void UpdateFromReferencedItemsWithDuplicatesShouldUseLastItemFromEachItemType()
+        {
+            using var env = TestEnvironment.Create();
+
+            env.SetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS", "1");
+
+            string content = @"
+                              <to Include='a;b;c'/>
+
+                              <from1 Include='b;a;b'>
+                                  <!-- %(Identity) forces re-evaluating each metadata for each item, leading to different DateTime ticks -->
+                                  <m>from1:%(Identity):$([System.DateTime]::Now.Ticks)</m>
+                              </from1>
+
+                              <from2 Include='a;c;a'>
+                                  <!-- %(Identity) forces re-evaluating each metadata for each item, leading to different DateTime ticks -->
+                                  <m>from2:%(Identity):$([System.DateTime]::Now.Ticks)</m>
+                              </from2>
+
+                              <to Update='@(from1);@(from2)'>
+                                  <m1 Condition='%(from1.Identity) == b'>%(from1.m);%(from2.m)</m1>
+                                  <m2 Condition='%(Identity) == a'>%(from1.m);%(from2.m)</m2>
+                              </to>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, true);
+
+            var lastItemMetadataForBFrom1 = LastItemMetadata("from1", "b");
+            var lastItemMetadataForAFrom1 = LastItemMetadata("from1", "a");
+            var lastItemMetadataForAFrom2 = LastItemMetadata("from2", "a");
+
+            var expectedMetadataB = new Dictionary<string, string>
+            {
+                {"m1", $"{lastItemMetadataForBFrom1};"},
+            };
+
+            var expectedMetadataA = new Dictionary<string, string>()
+            {
+                {"m2", $"{lastItemMetadataForAFrom1};{lastItemMetadataForAFrom2}"},
+            };
+
+            var expectedMetadataC = new Dictionary<string, string>();
+
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataA, items[0]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataB, items[1]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataC, items[2]);
+
+            string LastItemMetadata(string itemType, string itemValue)
+            {
+                var lastItemMetadata = items.Last(i => i.ItemType.Equals(itemType) && i.EvaluatedInclude.Equals(itemValue)).GetMetadataValue("m");
+
+                lastItemMetadata.ShouldNotBeNullOrEmpty();
+
+                return lastItemMetadata;
+            }
+        }
+
+        [Fact]
+        public void UpdateFromReferenceItemAndNoMetadataNOOPS()
+        {
+            string content = @"
+                              <to Include='a'/>
+
+                              <from Include='a'>
+                                  <m>m_contents</m>
+                              </from>
+
+                              <to Update='@(from)' />";
+
+            var items = ObjectModelHelpers.GetItemsFromFragment(content, true).Where(i => i.ItemType.Equals("to")).ToArray();
+
+            items.ShouldNotBeEmpty();
+
+            foreach (var item in items)
+            {
+                ObjectModelHelpers.AssertItemHasMetadata(null, item);
+            }
         }
 
         [Fact]
@@ -2642,6 +2903,42 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         {
             var formattedProjectContents = string.Format(projectContents, include, update, remove);
             ObjectModelHelpers.AssertItemEvaluationFromProject(formattedProjectContents, new string[0], expectedInclude, expectedMetadata);
+        }
+
+        [Fact]
+        public void UpdateAndRemoveShouldNotUseGlobMatchingOnEscapedGlobsFromReferencedItems()
+        {
+            var project = @"
+                    <Project>
+                        <ItemGroup>
+                            <!-- %2A is an escaped '*' character -->
+                            <from1 Include='%2A.cs' />
+                            <from2 Include='%2A.js' />
+                            <i Include='1.cs;2.js' />
+
+                            <i Update='@(from1)'>
+                               <m>updated</m>
+                            </i>
+
+                            <i Remove='@(from2)'/>
+                        </ItemGroup>
+                    </Project>
+                ";
+
+            ObjectModelHelpers.AssertItemEvaluationFromGenericItemEvaluator(
+                (p, c) =>
+                {
+                    return new Project(p, new Dictionary<string, string>(), MSBuildConstants.CurrentToolsVersion, c)
+                        .Items
+                        .Where(i => i.ItemType.Equals("i"))
+                        .Select(i => (ObjectModelHelpers.TestItem) new ObjectModelHelpers.ProjectItemTestItemAdapter(i))
+                        .ToList();
+                },
+                project,
+                inputFiles: new string[0],
+                expectedInclude: new[] { "1.cs", "2.js" },
+                expectedMetadataPerItem: null
+                );
         }
 
         [Theory]

--- a/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/ProjectItem_Tests.cs
@@ -2557,11 +2557,16 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                                   <m2>%(Identity)-m2</m2>
                               </from2>
 
+                              <from3 Include='1;2'>
+                                  <m3>%(Identity)-m3</m3>
+                              </from3>
+
                               <to Include='x.cs;2;ccc;1;d;y.cs'>
                                   <m3>m3_contents</m3>
                               </to>
 
-                              <to Update='@(from1);d;c*c;*.cs;@(from2)'>
+                              <to Update='@(from1);d;c*c;*.cs;@(from2);@(from3)'>
+                                  <m2>%(from2.m2);%(from3.m3)</m2>
                                   <m3>%(from1.m1);%(from2.m2)</m3>
                                   <m4>%(from1.m2);%(from2.m1)</m4>
                                   <m5>%(Identity)</m5>
@@ -2572,6 +2577,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadataX = new Dictionary<string, string>
             {
+                {"m2", ";"},
                 {"m3", "x.cs-m1;"},
                 {"m4", ";"},
                 {"m5", "x.cs"},
@@ -2579,6 +2585,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadata2 = new Dictionary<string, string>
             {
+                {"m2", "2-m2;2-m3"},
                 {"m3", ";2-m2"},
                 {"m4", ";"},
                 {"m5", "2"},
@@ -2586,6 +2593,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadataCCC = new Dictionary<string, string>
             {
+                {"m2", ";"},
                 {"m3", ";"},
                 {"m4", ";"},
                 {"m5", "ccc"},
@@ -2593,6 +2601,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadata1 = new Dictionary<string, string>
             {
+                {"m2", "1-m2;1-m3"},
                 {"m3", ";1-m2"},
                 {"m4", ";"},
                 {"m5", "1"},
@@ -2601,6 +2610,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadataD = new Dictionary<string, string>
             {
+                {"m2", ";"},
                 {"m3", ";"},
                 {"m4", ";"},
                 {"m5", "d"},
@@ -2608,19 +2618,21 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expectedMetadataY = new Dictionary<string, string>
             {
+                {"m2", ";"},
                 {"m3", "y.cs-m1;"},
                 {"m4", ";"},
                 {"m5", "y.cs"},
             };
 
-            items[4].ItemType.ShouldBe("to");
+            items[5].ItemType.ShouldBe("from3");
+            items[6].ItemType.ShouldBe("to");
 
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataX, items[4]);
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata2, items[5]);
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataCCC, items[6]);
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata1, items[7]);
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataD, items[8]);
-            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataY, items[9]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataX, items[6]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata2, items[7]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataCCC, items[8]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadata1, items[9]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataD, items[10]);
+            ObjectModelHelpers.AssertItemHasMetadata(expectedMetadataY, items[11]);
         }
 
         [Fact]

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2501,13 +2501,13 @@ namespace Microsoft.Build.Evaluation
             {
                 var includeItemspec = new EvaluationItemSpec(itemElement.Include, _data.Expander, itemElement.IncludeLocation, itemElement.ContainingProject.DirectoryPath);
 
-                ImmutableArray<ItemFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment).ToImmutableArray();
+                ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment).ToImmutableArray();
                 if (includeGlobFragments.Length == 0)
                 {
                     return null;
                 }
 
-                ImmutableArray<string> includeGlobStrings = includeGlobFragments.Select(f => f.ItemSpecFragment).ToImmutableArray();
+                ImmutableArray<string> includeGlobStrings = includeGlobFragments.Select(f => f.TextFragment).ToImmutableArray();
                 var includeGlob = new CompositeGlob(includeGlobFragments.Select(f => f.ToMSBuildGlob()));
 
                 IEnumerable<string> excludeFragmentStrings = Enumerable.Empty<string>();
@@ -2751,7 +2751,7 @@ namespace Microsoft.Build.Evaluation
             {
                 provenance = Provenance.Undefined;
 
-                IEnumerable<ItemFragment> fragmentsMatchingItem = itemSpec.FragmentsMatchingItem(itemToMatch, out int occurrences);
+                IEnumerable<ItemSpecFragment> fragmentsMatchingItem = itemSpec.FragmentsMatchingItem(itemToMatch, out int occurrences);
                 foreach (var fragment in fragmentsMatchingItem)
                 {
                     if (fragment is ValueFragment)

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -30,7 +30,7 @@ using Microsoft.Build.ObjectModelRemoting;
 using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Build.Utilities;
 using EvaluationItemSpec = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
-using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemExpressionFragment<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>;
+using EvaluationItemExpressionFragment = Microsoft.Build.Evaluation.ItemSpec<Microsoft.Build.Evaluation.ProjectProperty, Microsoft.Build.Evaluation.ProjectItem>.ItemExpressionFragment;
 using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 using System.Data.OleDb;
 

--- a/src/Build/Evaluation/ItemSpec.cs
+++ b/src/Build/Evaluation/ItemSpec.cs
@@ -10,30 +10,133 @@ using Microsoft.Build.Shared.EscapingStringExtensions;
 
 namespace Microsoft.Build.Evaluation
 {
-
     /// <summary>
-    /// Represents the elements of an item specification string (e.g. Include="*.cs;foo;@(i)") and 
-    /// provides some operations over them (like matching items against a given ItemSpec)
+    ///     Represents the elements of an item specification string (e.g. Include="*.cs;foo;@(i)") and
+    ///     provides some operations over them (like matching items against a given ItemSpec)
     /// </summary>
     internal class ItemSpec<P, I>
         where P : class, IProperty
         where I : class, IItem, IMetadataTable
     {
+        internal readonly struct ReferencedItem
+        {
+            public I Item { get; }
+            public ValueFragment ItemAsValueFragment { get; }
+
+            public ReferencedItem(I item, ValueFragment itemAsValueFragment)
+            {
+                Item = item;
+                ItemAsValueFragment = itemAsValueFragment;
+            }
+        }
+
+        internal class ItemExpressionFragment : ItemSpecFragment
+        {
+            private readonly ItemSpec<P, I> _containingItemSpec;
+            private Expander<P, I> _expander;
+
+            private IMSBuildGlob _msbuildGlob;
+
+            private List<ReferencedItem> _referencedItems;
+            public ExpressionShredder.ItemExpressionCapture Capture { get; }
+
+            public List<ReferencedItem> ReferencedItems
+            {
+                get
+                {
+                    InitReferencedItemsIfNecessary();
+                    return _referencedItems;
+                }
+            }
+
+            protected override IMSBuildGlob MsBuildGlob
+            {
+                get
+                {
+                    if (InitReferencedItemsIfNecessary() || _msbuildGlob == null)
+                    {
+                        _msbuildGlob = CreateMsBuildGlob();
+                    }
+
+                    return _msbuildGlob;
+                }
+            }
+
+            public ItemExpressionFragment(
+                ExpressionShredder.ItemExpressionCapture capture,
+                string textFragment,
+                ItemSpec<P, I> containingItemSpec,
+                string projectDirectory)
+                : base(textFragment, projectDirectory)
+            {
+                Capture = capture;
+
+                _containingItemSpec = containingItemSpec;
+                _expander = _containingItemSpec.Expander;
+            }
+
+            public override int MatchCount(string itemToMatch)
+            {
+                return ReferencedItems.Count(v => v.ItemAsValueFragment.MatchCount(itemToMatch) > 0);
+            }
+
+            public override bool IsMatch(string itemToMatch)
+            {
+                return ReferencedItems.Any(v => v.ItemAsValueFragment.IsMatch(itemToMatch));
+            }
+
+            public override IMSBuildGlob ToMSBuildGlob()
+            {
+                return MsBuildGlob;
+            }
+
+            protected override IMSBuildGlob CreateMsBuildGlob()
+            {
+                return new CompositeGlob(ReferencedItems.Select(i => i.ItemAsValueFragment.ToMSBuildGlob()));
+            }
+
+            private bool InitReferencedItemsIfNecessary()
+            {
+                // cache referenced items as long as the expander does not change
+                // reference equality works for now since the expander cannot mutate its item state (hopefully it stays that way)
+                if (_referencedItems == null || _expander != _containingItemSpec.Expander)
+                {
+                    _expander = _containingItemSpec.Expander;
+
+                    List<Pair<string, I>> itemsFromCapture;
+                    bool throwaway;
+                    _expander.ExpandExpressionCapture(
+                        Capture,
+                        _containingItemSpec.ItemSpecLocation,
+                        ExpanderOptions.ExpandItems,
+                        false /* do not include null expansion results */,
+                        out throwaway,
+                        out itemsFromCapture);
+                    _referencedItems =
+                        itemsFromCapture.Select(i => new ReferencedItem(i.Value, new ValueFragment(i.Key, ProjectDirectory))).ToList();
+
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
         public string ItemSpecString { get; }
 
         /// <summary>
-        /// The fragments that compose an item spec string (values, globs, item references)
+        ///     The fragments that compose an item spec string (values, globs, item references)
         /// </summary>
-        public List<ItemFragment> Fragments { get; }
+        public List<ItemSpecFragment> Fragments { get; }
 
         /// <summary>
-        /// The expander needs to have a default item factory set.
+        ///     The expander needs to have a default item factory set.
         /// </summary>
         // todo Make this type immutable. Dealing with an Expander change is painful. See the ItemExpressionFragment
-        public Expander<P, I> Expander { get; set; }
+            public Expander<P, I> Expander { get; set; }
 
         /// <summary>
-        /// The xml attribute where this itemspec comes from
+        ///     The xml attribute where this itemspec comes from
         /// </summary>
         public IElementLocation ItemSpecLocation { get; }
 
@@ -42,7 +145,12 @@ namespace Microsoft.Build.Evaluation
         /// <param name="itemSpecLocation">The xml location the itemspec comes from</param>
         /// <param name="projectDirectory">The directory that the project is in.</param>
         /// <param name="expandProperties">Expand properties before breaking down fragments. Defaults to true</param>
-        public ItemSpec(string itemSpec, Expander<P, I> expander, IElementLocation itemSpecLocation, string projectDirectory, bool expandProperties = true)
+        public ItemSpec(
+            string itemSpec,
+            Expander<P, I> expander,
+            IElementLocation itemSpecLocation,
+            string projectDirectory,
+            bool expandProperties = true)
         {
             ItemSpecString = itemSpec;
             Expander = expander;
@@ -51,20 +159,23 @@ namespace Microsoft.Build.Evaluation
             Fragments = BuildItemFragments(itemSpecLocation, projectDirectory, expandProperties);
         }
 
-        private List<ItemFragment> BuildItemFragments(IElementLocation itemSpecLocation, string projectDirectory, bool expandProperties)
+        private List<ItemSpecFragment> BuildItemFragments(IElementLocation itemSpecLocation, string projectDirectory, bool expandProperties)
         {
             //  Code corresponds to Evaluator.CreateItemsFromInclude
             var evaluatedItemspecEscaped = ItemSpecString;
 
             if (string.IsNullOrEmpty(evaluatedItemspecEscaped))
             {
-                return new List<ItemFragment>();
+                return new List<ItemSpecFragment>();
             }
 
             // STEP 1: Expand properties in Include
             if (expandProperties)
             {
-                evaluatedItemspecEscaped = Expander.ExpandIntoStringLeaveEscaped(ItemSpecString, ExpanderOptions.ExpandProperties, itemSpecLocation);
+                evaluatedItemspecEscaped = Expander.ExpandIntoStringLeaveEscaped(
+                    ItemSpecString,
+                    ExpanderOptions.ExpandProperties,
+                    itemSpecLocation);
             }
 
             var semicolonCount = 0;
@@ -77,7 +188,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             // estimate the number of fragments with the number of semicolons. This is will overestimate in case of transforms with semicolons, but won't underestimate.
-            var fragments = new List<ItemFragment>(semicolonCount + 1);
+            var fragments = new List<ItemSpecFragment>(semicolonCount + 1);
 
             // STEP 2: Split Include on any semicolons, and take each split in turn
             if (evaluatedItemspecEscaped.Length > 0)
@@ -88,7 +199,11 @@ namespace Microsoft.Build.Evaluation
                 {
                     // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                     bool isItemListExpression;
-                    var itemReferenceFragment = ProcessItemExpression(splitEscaped, itemSpecLocation, projectDirectory, out isItemListExpression);
+                    var itemReferenceFragment = ProcessItemExpression(
+                        splitEscaped,
+                        itemSpecLocation,
+                        projectDirectory,
+                        out isItemListExpression);
 
                     if (isItemListExpression)
                     {
@@ -106,7 +221,6 @@ namespace Microsoft.Build.Evaluation
                         // todo: file-system assumption on legal path characters: https://github.com/Microsoft/msbuild/issues/781
                         if (containsEscapedWildcards && containsRealWildcards)
                         {
-
                             // Just return the original string.
                             fragments.Add(new ValueFragment(splitEscaped, projectDirectory));
                         }
@@ -132,7 +246,11 @@ namespace Microsoft.Build.Evaluation
             return fragments;
         }
 
-        private ItemExpressionFragment ProcessItemExpression(string expression, IElementLocation elementLocation, string projectDirectory, out bool isItemListExpression)
+        private ItemExpressionFragment ProcessItemExpression(
+            string expression,
+            IElementLocation elementLocation,
+            string projectDirectory,
+            out bool isItemListExpression)
         {
             isItemListExpression = false;
 
@@ -142,7 +260,10 @@ namespace Microsoft.Build.Evaluation
                 return null;
             }
 
-            var capture = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(expression, ExpanderOptions.ExpandItems, elementLocation);
+            var capture = Expander<P, I>.ExpandSingleItemVectorExpressionIntoExpressionCapture(
+                expression,
+                ExpanderOptions.ExpandItems,
+                elementLocation);
 
             if (capture == null)
             {
@@ -155,33 +276,36 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Return true if the given <paramref name="item"/> matches this itemspec
+        ///     Return true if the given <paramref name="item" /> matches this itemspec
         /// </summary>
         /// <param name="item">The item to attempt to find a match for.</param>
         public bool MatchesItem(I item)
         {
             // Avoid unnecessary LINQ/Func/Enumerator allocations on this path, this is called a lot
 
-            string evaluatedInclude = item.EvaluatedInclude;
-            foreach (ItemFragment fragment in Fragments)
+            var evaluatedInclude = item.EvaluatedInclude;
+            foreach (var fragment in Fragments)
             {
                 if (fragment.IsMatch(evaluatedInclude))
+                {
                     return true;
+                }
             }
 
             return false;
         }
 
         /// <summary>
-        /// Return the fragments that match against the given <paramref name="itemToMatch"/>
+        ///     Return the fragments that match against the given <paramref name="itemToMatch" />
         /// </summary>
         /// <param name="itemToMatch">The item to match.</param>
         /// <param name="matches">
-        /// Total number of matches. Some fragments match more than once (item expression may contain multiple instances of <paramref name="itemToMatch"/>)
+        ///     Total number of matches. Some fragments match more than once (item expression may contain multiple instances of
+        ///     <paramref name="itemToMatch" />)
         /// </param>
-        public IEnumerable<ItemFragment> FragmentsMatchingItem(string itemToMatch, out int matches)
+        public IEnumerable<ItemSpecFragment> FragmentsMatchingItem(string itemToMatch, out int matches)
         {
-            var result = new List<ItemFragment>(Fragments.Count());
+            var result = new List<ItemSpecFragment>(Fragments.Count());
             matches = 0;
 
             foreach (var fragment in Fragments)
@@ -199,7 +323,7 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
-        /// Return an MSBuildGlob that represents this ItemSpec.
+        ///     Return an MSBuildGlob that represents this ItemSpec.
         /// </summary>
         public IMSBuildGlob ToMSBuildGlob()
         {
@@ -209,7 +333,6 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         ///     Returns all the fragment strings that represent it.
         ///     "1;*;2;@(foo)" gets returned as ["1", "2", "*", "a", "b"], given that @(foo)=["a", "b"]
-        /// 
         ///     Order is not preserved. Globs are not expanded. Item expressions get replaced with their referring item instances.
         /// </summary>
         public IEnumerable<string> FlattenFragmentsAsStrings()
@@ -218,7 +341,7 @@ namespace Microsoft.Build.Evaluation
             {
                 if (fragment is ValueFragment || fragment is GlobFragment)
                 {
-                    yield return fragment.ItemSpecFragment;
+                    yield return fragment.TextFragment;
                 }
                 else if (fragment is ItemExpressionFragment)
                 {
@@ -226,7 +349,7 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (var referencedItem in itemExpression.ReferencedItems)
                     {
-                        yield return referencedItem.ItemAsValueFragment.ItemSpecFragment;
+                        yield return referencedItem.ItemAsValueFragment.TextFragment;
                     }
                 }
                 else
@@ -235,128 +358,30 @@ namespace Microsoft.Build.Evaluation
                 }
             }
         }
-        
+
         public override string ToString()
         {
             return ItemSpecString;
         }
-
-        internal readonly struct ReferencedItem
-        {
-            public I Item { get; }
-            public ValueFragment ItemAsValueFragment { get; }
-
-            public ReferencedItem(I item, ValueFragment itemAsValueFragment)
-            {
-                Item = item;
-                ItemAsValueFragment = itemAsValueFragment;
-            }
-        }
-
-        internal class ItemExpressionFragment : ItemFragment
-        {
-        public ExpressionShredder.ItemExpressionCapture Capture { get; }
-
-        private readonly ItemSpec<P, I> _containingItemSpec;
-        private Expander<P, I> _expander;
-
-        private List<ReferencedItem> _referencedItems;
-
-        public List<ReferencedItem> ReferencedItems
-        {
-            get
-            {
-                InitReferencedItemsIfNecessary();
-                return _referencedItems;
-            }
-        }
-
-        private IMSBuildGlob _msbuildGlob;
-        protected override IMSBuildGlob MsBuildGlob
-        {
-            get
-            {
-                if (InitReferencedItemsIfNecessary() || _msbuildGlob == null)
-                {
-                    _msbuildGlob = CreateMsBuildGlob();
-                }
-
-                return _msbuildGlob;
-            }
-        }
-
-        public ItemExpressionFragment(ExpressionShredder.ItemExpressionCapture capture, string itemSpecFragment, ItemSpec<P, I> containingItemSpec, string projectDirectory)
-            : base(itemSpecFragment, projectDirectory)
-        {
-            Capture = capture;
-
-            _containingItemSpec = containingItemSpec;
-            _expander = _containingItemSpec.Expander;
-        }
-
-        public override int MatchCount(string itemToMatch)
-        {
-
-            return ReferencedItems.Count(v => v.ItemAsValueFragment.MatchCount(itemToMatch) > 0);
-        }
-
-        public override bool IsMatch(string itemToMatch)
-        {
-
-            return ReferencedItems.Any(v => v.ItemAsValueFragment.IsMatch(itemToMatch));
-        }
-
-        public override IMSBuildGlob ToMSBuildGlob()
-        {
-            return MsBuildGlob;
-        }
-
-        protected override IMSBuildGlob CreateMsBuildGlob()
-        {
-            return new CompositeGlob(ReferencedItems.Select(i => i.ItemAsValueFragment.ToMSBuildGlob()));
-        }
-
-        private bool InitReferencedItemsIfNecessary()
-        {
-            // cache referenced items as long as the expander does not change
-            // reference equality works for now since the expander cannot mutate its item state (hopefully it stays that way)
-            if (_referencedItems == null || _expander != _containingItemSpec.Expander)
-            {
-                _expander = _containingItemSpec.Expander;
-
-                List<Pair<string, I>> itemsFromCapture;
-                bool throwaway;
-                _expander.ExpandExpressionCapture(
-                    Capture,
-                    _containingItemSpec.ItemSpecLocation,
-                    ExpanderOptions.ExpandItems,
-                    false /* do not include null expansion results */,
-                    out throwaway,
-                    out itemsFromCapture);
-                _referencedItems = itemsFromCapture.Select(i => new ReferencedItem(i.Value, new ValueFragment(i.Key, ProjectDirectory))).ToList();
-
-                return true;
-            }
-
-            return false;
-        }
-    }
     }
 
-    internal abstract class ItemFragment
+    internal abstract class ItemSpecFragment
     {
-        /// <summary>
-        /// The substring from the original itemspec representing this fragment
-        /// </summary>
-        public string ItemSpecFragment { get; }
-
-        /// <summary>
-        /// Path of the project the itemspec is coming from
-        /// </summary>
-        protected string ProjectDirectory { get; }
+        private FileSpecMatcherTester _fileMatcher;
 
         private bool _fileMatcherInitialized;
-        private FileSpecMatcherTester _fileMatcher;
+
+        private IMSBuildGlob _msbuildGlob;
+
+        /// <summary>
+        ///     The substring from the original itemspec representing this fragment
+        /// </summary>
+        public string TextFragment { get; }
+
+        /// <summary>
+        ///     Path of the project the itemspec is coming from
+        /// </summary>
+        protected string ProjectDirectory { get; }
 
         // not a Lazy to reduce memory
         private FileSpecMatcherTester FileMatcher
@@ -375,8 +400,6 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        private IMSBuildGlob _msbuildGlob;
-
         // not a Lazy to reduce memory
         protected virtual IMSBuildGlob MsBuildGlob
         {
@@ -391,16 +414,21 @@ namespace Microsoft.Build.Evaluation
             }
         }
 
-        protected ItemFragment(string itemSpecFragment, string projectDirectory)
+        protected ItemSpecFragment(string textFragment, string projectDirectory)
         {
-            ItemSpecFragment = itemSpecFragment;
+            TextFragment = textFragment;
             ProjectDirectory = projectDirectory;
         }
 
-        /// <returns>The number of times the <param name="itemToMatch"></param> appears in this fragment</returns>
+        /// <returns>The number of times the
+        ///     <param name="itemToMatch"></param>
+        ///     appears in this fragment
+        /// </returns>
         public virtual int MatchCount(string itemToMatch)
         {
-            return IsMatch(itemToMatch) ? 1 : 0;
+            return IsMatch(itemToMatch)
+                ? 1
+                : 0;
         }
 
         public virtual bool IsMatch(string itemToMatch)
@@ -415,27 +443,27 @@ namespace Microsoft.Build.Evaluation
 
         protected virtual IMSBuildGlob CreateMsBuildGlob()
         {
-            return Globbing.MSBuildGlob.Parse(ProjectDirectory, ItemSpecFragment.Unescape());
+            return MSBuildGlob.Parse(ProjectDirectory, TextFragment.Unescape());
         }
 
         private FileSpecMatcherTester CreateFileSpecMatcher()
         {
-            return FileSpecMatcherTester.Parse(ProjectDirectory, ItemSpecFragment);
+            return FileSpecMatcherTester.Parse(ProjectDirectory, TextFragment);
         }
     }
 
-    internal class ValueFragment : ItemFragment
+    internal class ValueFragment : ItemSpecFragment
     {
-        public ValueFragment(string itemSpecFragment, string projectDirectory)
-            : base(itemSpecFragment, projectDirectory)
+        public ValueFragment(string textFragment, string projectDirectory)
+            : base(textFragment, projectDirectory)
         {
         }
     }
 
-    internal class GlobFragment : ItemFragment
+    internal class GlobFragment : ItemSpecFragment
     {
-        public GlobFragment(string itemSpecFragment, string projectDirectory)
-            : base(itemSpecFragment, projectDirectory)
+        public GlobFragment(string textFragment, string projectDirectory)
+            : base(textFragment, projectDirectory)
         {
         }
     }

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Build.Evaluation
 
             protected override void MutateItems(ImmutableList<I> items)
             {
-                DecorateItemsWithMetadata(items, _metadata);
+                DecorateItemsWithMetadata(items.Select(i => new ItemBatchingContext(i)), _metadata);
             }
 
             protected override void SaveItems(ImmutableList<I> items, ImmutableList<ItemData>.Builder listBuilder)

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -63,23 +63,23 @@ namespace Microsoft.Build.Evaluation
                     if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemReferenceFragment)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
-                        bool throwaway;
                         var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            itemReferenceFragment.Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
-                            false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
+                            itemReferenceFragment.Capture,
+                            _evaluatorData,
+                            _itemFactory,
+                            ExpanderOptions.ExpandItems,
+                            includeNullEntries: false,
+                            isTransformExpression: out _,
+                            elementLocation: _itemElement.IncludeLocation);
 
-                        if (excludeTester != null)
-                        {
-                            itemsToAdd.AddRange(itemsFromExpression.Where(item => !excludeTester.Value(item.EvaluatedInclude)));
-                        }
-                        else
-                        {
-                            itemsToAdd.AddRange(itemsFromExpression);
-                        }
+                        itemsToAdd.AddRange(
+                            excludeTester != null
+                                ? itemsFromExpression.Where(item => !excludeTester.Value(item.EvaluatedInclude))
+                                : itemsFromExpression);
                     }
-                    else if (fragment is ValueFragment)
+                    else if (fragment is ValueFragment valueFragment)
                     {
-                        string value = ((ValueFragment)fragment).TextFragment;
+                        string value = valueFragment.TextFragment;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(EscapingUtilities.UnescapeAll(value)))
@@ -88,9 +88,9 @@ namespace Microsoft.Build.Evaluation
                             itemsToAdd.Add(item);
                         }
                     }
-                    else if (fragment is GlobFragment)
+                    else if (fragment is GlobFragment globFragment)
                     {
-                        string glob = ((GlobFragment)fragment).TextFragment;
+                        string glob = globFragment.TextFragment;
 
                         if (excludePatternsForGlobs == null)
                         {
@@ -132,9 +132,9 @@ namespace Microsoft.Build.Evaluation
             private static ISet<string> BuildExcludePatternsForGlobs(ImmutableHashSet<string> globsToIgnore, ImmutableList<string>.Builder excludePatterns)
             {
                 var anyExcludes = excludePatterns.Count > 0;
-                var anyGlobstoIgnore = globsToIgnore.Count > 0;
+                var anyGlobsToIgnore = globsToIgnore.Count > 0;
 
-                if (anyGlobstoIgnore && anyExcludes)
+                if (anyGlobsToIgnore && anyExcludes)
                 {
                     return excludePatterns.Concat(globsToIgnore).ToImmutableHashSet();
                 }
@@ -161,7 +161,7 @@ namespace Microsoft.Build.Evaluation
             public int ElementOrder { get; set; }
             public string RootDirectory { get; set; }
 
-            public ImmutableList<string>.Builder Excludes { get; set; } = ImmutableList.CreateBuilder<string>();
+            public ImmutableList<string>.Builder Excludes { get; } = ImmutableList.CreateBuilder<string>();
 
             public IncludeOperationBuilder(ProjectItemElement itemElement, bool conditionResult) : base(itemElement, conditionResult)
             {

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is ValueFragment)
                     {
-                        string value = ((ValueFragment)fragment).ItemSpecFragment;
+                        string value = ((ValueFragment)fragment).TextFragment;
 
                         if (excludeTester == null ||
                             !excludeTester.Value(EscapingUtilities.UnescapeAll(value)))
@@ -90,7 +90,7 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (fragment is GlobFragment)
                     {
-                        string glob = ((GlobFragment)fragment).ItemSpecFragment;
+                        string glob = ((GlobFragment)fragment).TextFragment;
 
                         if (excludePatternsForGlobs == null)
                         {

--- a/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.IncludeOperation.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Build.Evaluation
 
                 foreach (var fragment in _itemSpec.Fragments)
                 {
-                    if (fragment is ItemExpressionFragment<P, I>)
+                    if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemReferenceFragment)
                     {
                         // STEP 3: If expression is "@(x)" copy specified list with its metadata, otherwise just treat as string
                         bool throwaway;
                         var itemsFromExpression = _expander.ExpandExpressionCaptureIntoItems(
-                            ((ItemExpressionFragment<P, I>)fragment).Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
+                            itemReferenceFragment.Capture, _evaluatorData, _itemFactory, ExpanderOptions.ExpandItems,
                             false /* do not include null expansion results */, out throwaway, _itemElement.IncludeLocation);
 
                         if (excludeTester != null)

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -48,16 +48,21 @@ namespace Microsoft.Build.Evaluation
 
             protected EngineFileUtilities EngineFileUtilities => _lazyEvaluator.EngineFileUtilities;
 
-            public virtual void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
+            public void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
                 MSBuildEventSource.Log.ApplyLazyItemOperationsStart(_itemElement.ItemType);
                 using (_lazyEvaluator._evaluationProfiler.TrackElement(_itemElement))
                 {
-                    var items = SelectItems(listBuilder, globsToIgnore);
-                    MutateItems(items);
-                    SaveItems(items, listBuilder);
+                    ApplyImpl(listBuilder, globsToIgnore);
                 }
                 MSBuildEventSource.Log.ApplyLazyItemOperationsStop(_itemElement.ItemType);
+            }
+
+            protected virtual void ApplyImpl(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
+            {
+                var items = SelectItems(listBuilder, globsToIgnore);
+                MutateItems(items);
+                SaveItems(items, listBuilder);
             }
 
             /// <summary>

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -110,9 +110,6 @@ namespace Microsoft.Build.Evaluation
 
                 public IMetadataTable GetMetadataTable()
                 {
-                    // todo avoid this by adding a generic type constraint that items must also be metadata tables
-                    ErrorUtilities.VerifyThrow(OperationItem is IMetadataTable, "OperationItem is assumed to be an IMetadataTable.");
-
                     return CapturedItems == null
                         ? (IMetadataTable) OperationItem
                         : new ItemOperationMetadataTable(OperationItem, CapturedItems);

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -83,8 +83,7 @@ namespace Microsoft.Build.Evaluation
 
             private IList<I> GetReferencedItems(string itemType, ImmutableHashSet<string> globsToIgnore)
             {
-                LazyItemList itemList;
-                if (_referencedItemLists.TryGetValue(itemType, out itemList))
+                if (_referencedItemLists.TryGetValue(itemType, out var itemList))
                 {
                     return itemList.GetMatchedItems(globsToIgnore);
                 }
@@ -163,13 +162,13 @@ namespace Microsoft.Build.Evaluation
                 {
                     if (itemType == null || itemType.Equals(_operationItem.Key, StringComparison.OrdinalIgnoreCase))
                     {
-                        return getEscapedValueFunc((IMetadataTable) _operationItem, itemType, name);
+                        return getEscapedValueFunc(_operationItem, itemType, name);
                     }
                     else if (_capturedItems.ContainsKey(itemType))
                     {
                         var item = _capturedItems[itemType];
 
-                        return getEscapedValueFunc((IMetadataTable) item, itemType, name);
+                        return getEscapedValueFunc(item, itemType, name);
                     }
                     else
                     {

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Evaluation
                 {
                     OperationItem = operationItem;
 
-                    CapturedItems = capturedItems != null && capturedItems.Count == 0
+                    CapturedItems = capturedItems == null || capturedItems.Count == 0
                         ? null
                         : capturedItems;
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Build.Evaluation
                     return builder;
                 }
 
-                var globs = _itemSpec.Fragments.OfType<GlobFragment>().Select(g => g.ItemSpecFragment);
+                var globs = _itemSpec.Fragments.OfType<GlobFragment>().Select(g => g.TextFragment);
 
                 builder.UnionWith(globs);
 

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -31,7 +32,7 @@ namespace Microsoft.Build.Evaluation
 
                 ItemSpecMatchesItem matchItemspec;
 
-                if (ItemSpecOnlyReferencesOneItemType(_itemSpec, _itemElement.ItemType))
+                if (ItemspecContainsASingleItemReference(_itemSpec, _itemElement.ItemType))
                 {
                     // Perf optimization: If the Update operation references itself (e.g. <I Update="@(I)"/>)
                     // then all items are updated and matching is not necessary
@@ -42,7 +43,9 @@ namespace Microsoft.Build.Evaluation
                     matchItemspec = (itemSpec, item) => itemSpec.MatchesItem(item);
                 }
 
-                var matchedItems = ImmutableList.CreateBuilder<I>();
+                var matchedItems = ImmutableList.CreateBuilder<ItemBatchingContext>();
+
+                var itemFragments = _itemSpec.Fragments.OfType<ItemExpressionFragment<P, I>>().ToArray();
 
                 for (int i = 0; i < listBuilder.Count; i++)
                 {
@@ -56,14 +59,29 @@ namespace Microsoft.Build.Evaluation
                         var clonedItemData = listBuilder[i].Clone(_itemFactory, _itemElement);
                         listBuilder[i] = clonedItemData;
 
-                        matchedItems.Add(clonedItemData.Item);
+                        var matchingItems = new Dictionary<string, IItem>(StringComparer.OrdinalIgnoreCase);
+
+                        // todo: do this only when there's qualified metadata references (ExpressionShredder.GetReferencedItemNamesAndMetadata)
+                        // todo: don't match twice for item references, add Itemspec API to return matched items. Or separate fragments without adding new API
+                        foreach (var itemFragment in itemFragments)
+                        {
+                            foreach (var item in itemFragment.ReferencedItems)
+                            {
+                                if (item.ItemAsValueFragment.IsMatch(itemData.Item.EvaluatedInclude))
+                                {
+                                    matchingItems[item.Item.Key] = item.Item;
+                                }
+                            }
+                        }
+
+                        matchedItems.Add(new ItemBatchingContext(clonedItemData.Item, matchingItems));
                     }
                 }
 
                 DecorateItemsWithMetadata(matchedItems.ToImmutableList(), _metadata);
             }
 
-            private static bool ItemSpecOnlyReferencesOneItemType(ItemSpec<P, I> itemSpec, string itemType)
+            private static bool ItemspecContainsASingleItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
             {
                 if (itemSpec.Fragments.Count != 1)
                 {
@@ -76,7 +94,7 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                if (!itemExpressionFragment.Capture.ItemType.Equals(itemType, StringComparison.OrdinalIgnoreCase))
+                if (!itemExpressionFragment.Capture.ItemType.Equals(referencedItemType, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Evaluation
 
             delegate bool ItemSpecMatchesItem(ItemSpec<P, I> itemSpec, I item);
 
-            public override void Apply(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
+            protected override void ApplyImpl(ImmutableList<ItemData>.Builder listBuilder, ImmutableHashSet<string> globsToIgnore)
             {
                 if (!_conditionResult)
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Build.Construction;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -51,7 +52,9 @@ namespace Microsoft.Build.Evaluation
                     // then all items are updated and matching is not necessary
                     matchItemspec = (itemSpec, item) => new MatchResult(true, null);
                 }
-                else if (ItemSpecContainsItemReferences(_itemSpec) && QualifiedMetadataReferencesExist(_metadata, out needToExpandMetadataForEachItem))
+                else if (ItemSpecContainsItemReferences(_itemSpec)
+                         && QualifiedMetadataReferencesExist(_metadata, out needToExpandMetadataForEachItem)
+                         && !Traits.Instance.EscapeHatches.DoNotExpandQualifiedMetadataInUpdateOperation)
                 {
                     var itemReferenceFragments = _itemSpec.Fragments.OfType<ItemSpec<P,I>.ItemExpressionFragment>().ToArray();
                     var nonItemReferenceFragments = _itemSpec.Fragments.Where(f => !(f is ItemSpec<P,I>.ItemExpressionFragment)).ToArray();

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -527,7 +527,7 @@ namespace Microsoft.Build.Evaluation
         {
             builder.ItemSpec = new ItemSpec<P, I>(itemSpec, _outerExpander, itemSpecLocation, rootDirectory);
 
-            foreach (ItemFragment fragment in builder.ItemSpec.Fragments)
+            foreach (ItemSpecFragment fragment in builder.ItemSpec.Fragments)
             {
                 if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemExpression)
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -529,8 +529,7 @@ namespace Microsoft.Build.Evaluation
 
             foreach (ItemFragment fragment in builder.ItemSpec.Fragments)
             {
-                ItemExpressionFragment<P, I> itemExpression = fragment as ItemExpressionFragment<P, I>;
-                if (itemExpression != null)
+                if (fragment is ItemSpec<P, I>.ItemExpressionFragment itemExpression)
                 {
                     AddReferencedItemLists(builder, itemExpression.Capture);
                 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -100,6 +100,12 @@ namespace Microsoft.Build.Utilities
         public readonly bool DoNotSendDeferredMessagesToBuildManager = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildDoNotSendDeferredMessagesToBuildManager"));
 
         /// <summary>
+        /// https://github.com/microsoft/msbuild/pull/4975 started expanding qualified metadata in Update operations. Before they'd expand to empty strings.
+        /// This escape hatch turns back the old empty string behavior.
+        /// </summary>
+        public readonly bool DoNotExpandQualifiedMetadataInUpdateOperation = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildDoNotExpandQualifiedMetadataInUpdateOperation"));
+
+        /// <summary>
         /// Force whether Project based evaluations should evaluate elements with false conditions.
         /// </summary>
         public readonly bool? EvaluateElementsWithFalseConditionInProjectEvaluation = ParseNullableBoolFromEnvironmentVariable("MSBUILDEVALUATEELEMENTSWITHFALSECONDITIONINPROJECTEVALUATION");

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -420,11 +420,14 @@ namespace Microsoft.Build.UnitTests
 
         internal static void AssertItemHasMetadata(Dictionary<string, string> expected, TestItem item)
         {
-            Assert.Equal(expected.Keys.Count, item.DirectMetadataCount);
+            expected ??= new Dictionary<string, string>();
+
+            item.DirectMetadataCount.ShouldBe(expected.Keys.Count);
 
             foreach (var key in expected.Keys)
             {
-                Assert.Equal(expected[key], item.GetMetadataValue(key));
+                item.GetMetadataValue(key).ShouldBe(expected[key]);
+
             }
         }
 


### PR DESCRIPTION
Resolves #[1655411 ](https://dev.azure.com/mseng/1ES/_workitems/edit/1655411), #[1649689](https://dev.azure.com/mseng/1ES/_workitems/edit/1649689)

This allows users to import and map metadata between two or more item types.

- Example:
```xml
   <I Update="@(Foo);*.cs;@(Bar)" M1="%(Foo.M1)" M2="%(Bar.X2)">
      <M3 Condition="'%(Foo.M3)'' == 'something' ">%(M1)</M3>
   </I>
```
- Each matching item (i.e. each item that needs uptading) now carries a context of captured item instances from all matching referenced item types in the `Update` expression.
- Unqualified metadata (`%(M)`) binds to the operation item type (i.e. type that gets updated). Qualified metadata (`%(Foo.M)`) binds inside the set of captured item types from the `Update` expression.
- If an item matches multiple times within and between multiple referenced items:
  - The last occurrence from each containing item type gets captured (so one captured item per item type)
  - This matches the behaviour of task item batching under targets. If we ever unify batching between evaluation and target items, there will hopefully be no semantic conflicts with this new form of Update.
- Where one can put `%()` references:
  - Metadata
  - Metadata conditions
- Breaking changes
```xml
    <ItemGroup>
        <OldUpdateBehaviour Include="a" M1="1" M2="x"/>
        <Subset Include="a" M1="newM1"/>
        <OldUpdateBehaviour Update="@(Subset)" M1="%(Subset.M1)" M2="%(Subset.M1)"/>
    </ItemGroup>
    <Target Name="Build">
        <Message Importance="High" Text="@(OldUpdateBehaviour) : M1 = [%(M1)] M2 = [%(M2)]"/>
    </Target>
```
Today this outputs: 
      `a : M1 = [] M2 = []`
After the change it will output: 
       `a : M1 = [newM1] M2 = [newM1]`

TODO:
- [x] investigate perf
- [x] finish some of the code todos