### PR TITLE
Copy in-SDK MSBuild extensions to bootstrap

### DIFF
--- a/eng/BootStrapMSBuild.targets
+++ b/eng/BootStrapMSBuild.targets
@@ -170,12 +170,14 @@
          probably not count as a link in the cycle. -->
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish" BuildInParallel="$(BuildInParallel)" />
 
-    <!-- Copy all items from the publish folder to the bootstrap folder.  We might be able to just use the published
-         version as the bootstrapped version, but the extra separation here seems like it could be valuable. -->
     <ItemGroup>
+      <!-- Copy all items from the publish folder to the bootstrap folder.  We might be able to just use the published
+            version as the bootstrapped version, but the extra separation here seems like it could be valuable. -->
       <DeployedItems Include="$(PublishDir)\**\*.*" />
+
       <NuGetSdkResolverManifest Include= "$(RepoRoot)src\MSBuild\SdkResolvers\Standalone\Microsoft.Build.NuGetSdkResolver.xml" />
       <InstalledSdks Include="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Sdks\**\*.*" />
+      <InstalledExtensions Include="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Current\**\*.*" Exclude="$(DOTNET_INSTALL_DIR)\sdk\$(DotNetCliVersion)\Current\Microsoft.Common.props" />
     </ItemGroup>
     <Copy SourceFiles="@(DeployedItems)"
           DestinationFolder="$(BootstrapDestination)%(RecursiveDir)" />
@@ -185,6 +187,10 @@
 
     <Copy SourceFiles="@(InstalledSdks)"
           DestinationFiles="@(InstalledSdks -> '$(BootstrapDestination)Sdks\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <Copy SourceFiles="@(InstalledExtensions)"
+          DestinationFolder="$(BootstrapDestination)Current\%(RecursiveDir)" />
+
     <Copy SourceFiles="@(_NuGetRuntimeDependencies)"
           DestinationFolder="$(BootstrapDestination)" />
   </Target>


### PR DESCRIPTION
The second-stage build was intermittently failing on Linux because NuGet's
solution-restore logic wasn't being used. It wasn't being used because it
depends on being placed in `SolutionFile/ImportAfter`, but it wasn't being
copied from the last-known-good SDK to the bootstrap folder.

Fixes #4971 by copying `Current\**` (except the might-have-been-updated
`Microsoft.Common.props` which is already there) into the bootstrap folder
on Core.