### PR TITLE
Fixes ClickOnce problem

### DIFF
--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -1599,6 +1599,10 @@ namespace Microsoft.Build.Construction
                 XmlDocument.Save(projectWriter);
             }
 
+            if (DateTime.Now.CompareTo(_lastWriteTimeWhenRead) > 0)
+            {
+                _lastWriteTimeWhenRead = DateTime.Now;
+            }
             _versionOnDisk = Version;
         }
 


### PR DESCRIPTION
Fixes #4824
It fixes it by essentially forcing a rebuild of all project files if this save method is ever called. That is not optimal. An alternative solution proposed is to write a special version of Save in ProjectRootElement and have users call that instead. This version is simpler but not as efficient.