### PR TITLE
Permit DownloadFile to skip unchanged files Fixes #4860

### DIFF
--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -252,8 +252,6 @@ namespace Microsoft.Build.Tasks.UnitTests
             {
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
 
-                testEnvironment.CreateFile(folder, "foo.txt", "C197675A3CC64CAA80680128CF4578C9");
-
                 DownloadFile downloadFile = new DownloadFile
                 {
                     BuildEngine = _mockEngine,
@@ -264,7 +262,7 @@ namespace Microsoft.Build.Tasks.UnitTests
                         {
                             Headers =
                             {
-                                LastModified = DateTimeOffset.UtcNow
+                                LastModified = DateTimeOffset.UtcNow.AddDays(-1)
                             }
                         },
                         RequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://success/foo.txt")
@@ -272,6 +270,8 @@ namespace Microsoft.Build.Tasks.UnitTests
                     SkipUnchangedFiles = true,
                     SourceUrl = "http://success/foo.txt"
                 };
+
+                testEnvironment.CreateFile(folder, "foo.txt", "C197675A3CC64CAA80680128CF4578C9");
 
                 downloadFile.Execute().ShouldBeTrue();
 

--- a/src/Tasks/DownloadFile.cs
+++ b/src/Tasks/DownloadFile.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Build.Tasks
                    && destinationFile.Exists
                    && destinationFile.Length == response.Content.Headers.ContentLength
                    && response.Content.Headers.LastModified.HasValue
-                   && destinationFile.LastWriteTimeUtc < response.Content.Headers.LastModified.Value.UtcDateTime;
+                   && destinationFile.LastWriteTimeUtc > response.Content.Headers.LastModified.Value.UtcDateTime;
         }
     }
 }


### PR DESCRIPTION
The check as to whether a file has changed compares time stamps, but returns that a file has not changed from the original if its time stamp is before when the original was last modified. This is the opposite of the desired behavior.

Fixes #4860