### PR TITLE
Bootstrap build: Remove directory before moving to avoid IO exception

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.ps1
+++ b/eng/cibuild_bootstrapped_msbuild.ps1
@@ -106,6 +106,11 @@ try {
 
   if ($buildStage1)
   {
+    if (Test-Path $Stage1Dir)
+    {
+      Remove-Item -Force -Recurse $Stage1Dir
+    }
+
     Move-Item -Path $ArtifactsDir -Destination $Stage1Dir -Force
   }
 


### PR DESCRIPTION
Avoids errors like:
```
Cannot create a file when that file already exists.

System.IO.IOException: Cannot create a file when that file already exists.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.DirectoryInfo.MoveTo(String destDirName)
   at Microsoft.PowerShell.Commands.FileSystemProvider.MoveDirectoryInfoItem(DirectoryInfo directory, String destination, Boolean force)
at <ScriptBlock>, E:\projects\test-msbuild\eng\cibuild_bootstrapped_msbuild.ps1: line 109
```