### PR TITLE
Target protocol with GetTargetPath

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -49,6 +49,8 @@ $filesToCopyToBin = @(
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.CSharp.CurrentVersion.targets"
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.CSharp.targets"
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.targets"
+    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.Before.targets"
+    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.After.targets"
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Net.props"
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.CurrentVersion.props"
     "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.CurrentVersion.targets"

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -293,6 +293,8 @@
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.Common.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.Common.tasks" TargetFramework="%(_TargetFrameworks.Identity)" />
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.Managed.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
+      <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.Managed.Before.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
+      <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.Managed.After.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.CSharp.CrossTargeting.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.CSharp.CurrentVersion.targets" TargetFramework="%(_TargetFrameworks.Identity)" />
       <_OurFiles Include="$(OutputPath)%(_TargetFrameworks.Identity)\Microsoft.CSharp.targets" TargetFramework="%(_TargetFrameworks.Identity)" />

--- a/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
+++ b/src/Package/MSBuild.Engine.Corext/MsBuild.Engine.Corext.nuspec
@@ -45,6 +45,8 @@
     <file src="$X86BinPath$/Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/MSBuild" />
     <file src="$X86BinPath$/MSBuild.rsp" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Managed.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$/Microsoft.Managed.Before.targets" target="v15.0/bin" />
+    <file src="$X86BinPath$/Microsoft.Managed.After.targets" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.CSharp.targets" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.VisualBasic.targets" target="v15.0/bin" />
     <file src="$X86BinPath$/Microsoft.Common.CrossTargeting.targets" target="v15.0/bin" />
@@ -97,6 +99,8 @@
     <file src="$X86BinPath$/Microsoft.Build.CommonTypes.xsd" target="v15.0/bin/amd64/MSBuild" />
     <file src="$X86BinPath$/MSBuild.rsp" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Managed.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/Microsoft.Managed.Before.targets" target="v15.0/bin/amd64" />
+    <file src="$X86BinPath$/Microsoft.Managed.After.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.CSharp.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.VisualBasic.targets" target="v15.0/bin/amd64" />
     <file src="$X86BinPath$/Microsoft.Common.CrossTargeting.targets" target="v15.0/bin/amd64" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -54,6 +54,8 @@ folder InstallDir:\MSBuild\Current\Bin
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
   file source=$(X86BinPath)Microsoft.Managed.targets
+  file source=$(X86BinPath)Microsoft.Managed.Before.targets
+  file source=$(X86BinPath)Microsoft.Managed.After.targets
   file source=$(X86BinPath)Microsoft.CSharp.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.CSharp.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.CSharp.targets
@@ -200,6 +202,8 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Common.targets
   file source=$(X86BinPath)Microsoft.Common.tasks
   file source=$(X86BinPath)Microsoft.Managed.targets
+  file source=$(X86BinPath)Microsoft.Managed.Before.targets
+  file source=$(X86BinPath)Microsoft.Managed.After.targets
   file source=$(X86BinPath)Microsoft.CSharp.CurrentVersion.targets
   file source=$(X86BinPath)Microsoft.CSharp.CrossTargeting.targets
   file source=$(X86BinPath)Microsoft.CSharp.targets

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -708,6 +708,12 @@
     <Content Include="Microsoft.Managed.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Microsoft.Managed.Before.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Microsoft.Managed.After.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Microsoft.CSharp.CurrentVersion.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -841,6 +847,8 @@
       <SubType>Designer</SubType>
     </DataFile>
     <DataFile Include="Microsoft.Managed.targets" />
+    <DataFile Include="Microsoft.Managed.Before.targets" />
+    <DataFile Include="Microsoft.Managed.After.targets" />
     <DataFile Include="Microsoft.CSharp.targets" />
     <DataFile Include="Microsoft.CSharp.CurrentVersion.targets" />
     <DataFile Include="Microsoft.CSharp.CrossTargeting.targets" />

--- a/src/Tasks/Microsoft.CSharp.targets
+++ b/src/Tasks/Microsoft.CSharp.targets
@@ -156,11 +156,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
    </ImportGroup> 
 
-   <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" />
+   <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
 
    <Import Project="$(CSharpTargetsPath)" />
 
-   <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.CSharp.targets imports 
+   <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
+
+   <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.CSharp.targets imports
         Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
         targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
         way instead. --> 

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -58,18 +58,17 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
 
   <ItemGroup>
-      <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true"/>
-      <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true"/>
+    <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
 
-      <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true"/>
-      <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true"/>
+    <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
 
-      <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForRebuildInOuterBuild)' != '' " />
-      <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForRebuildInOuterBuild)' != '' " />
+    <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
 
-      <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
-      <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
-
+    <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
+    <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -1,21 +1,19 @@
 ﻿<!--
 ***********************************************************************************************
-This file is deprecated and left here for back compat reasons. It is replaced by Microsoft.Managed.<Before|After>.targets
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file defines common build logic for all managed languaged: C#, VisualBasic, F#
+It is imported after the common targets have been imported.
 
 Copyright (C) Microsoft Corporation. All rights reserved.
 ***********************************************************************************************
 -->
 
 <Project>
-   <!--
-        We are doing a cross-targeting build if there is a non-empty list of target frameworks specified
-        and there is no current target framework being built individually. In that case, a multitargeting
-        project file like Microsoft.<language>.CrossTargeting.targets gets imported.
-   -->
-   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
-      <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
-   </PropertyGroup>
 
+   <!-- Define crosstargeting for static graph, so it can identify inner and outer build graph nodes -->
    <PropertyGroup>
       <InnerBuildProperty>TargetFramework</InnerBuildProperty>
       <InnerBuildPropertyValues>TargetFrameworks</InnerBuildPropertyValues>
@@ -77,6 +75,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
       <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
       <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
+
   </ItemGroup>
 
 </Project>

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -39,12 +39,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
          Include="$([MSBuild]::Escape('$(MSBuildProjectDirectory)\$(MSBuildProjectName)*_wpftmp$(MSBuildProjectExtension)'))" />
    </ItemGroup>
 
-   <!-- Item copied from Microsoft.Common.Currentversion.targets   -->
-  <PropertyGroup>
-    <_RecursiveTargetForContentCopying>GetCopyToOutputDirectoryItems</_RecursiveTargetForContentCopying>
-    <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
-  </PropertyGroup>
-
   <!--
     Properties for extension of ProjectReferenceTargets.
     Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.

--- a/src/Tasks/Microsoft.Managed.After.targets
+++ b/src/Tasks/Microsoft.Managed.After.targets
@@ -44,8 +44,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
   -->
   <PropertyGroup>
+    <!-- Empty case is for outer builds which do not import the target files that set BuildProjectReferences -->
+    <_MainReferenceTarget Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTarget>
+    <_MainReferenceTarget Condition="'$(_MainReferenceTarget)' == ''">GetTargetPath</_MainReferenceTarget>
+
     <ProjectReferenceTargetsForBuildInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForBuildInOuterBuild)</ProjectReferenceTargetsForBuildInOuterBuild>
-    <ProjectReferenceTargetsForBuild>.projectReferenceTargetsOrDefaultTargets;GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+    <ProjectReferenceTargetsForBuild>$(_MainReferenceTarget);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
 
     <ProjectReferenceTargetsForCleanInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForCleanInOuterBuild)</ProjectReferenceTargetsForCleanInOuterBuild>
     <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>

--- a/src/Tasks/Microsoft.Managed.Before.targets
+++ b/src/Tasks/Microsoft.Managed.Before.targets
@@ -1,0 +1,24 @@
+﻿<!--
+***********************************************************************************************
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file defines common build logic for all managed languaged: C#, VisualBasic, F#
+It is imported before the common targets have been imported.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project>
+   <!--
+        We are doing a cross-targeting build if there is a non-empty list of target frameworks specified
+        and there is no current target framework being built individually. In that case, a multitargeting
+        project file like Microsoft.<language>.CrossTargeting.targets gets imported.
+   -->
+   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
+      <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
+   </PropertyGroup>
+
+</Project>

--- a/src/Tasks/Microsoft.Managed.targets
+++ b/src/Tasks/Microsoft.Managed.targets
@@ -52,8 +52,12 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
   -->
   <PropertyGroup>
+    <!-- Empty case is for outer builds which do not import the target files that set BuildProjectReferences -->
+    <_MainReferenceTarget Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTarget>
+    <_MainReferenceTarget Condition="'$(_MainReferenceTarget)' == ''">GetTargetPath</_MainReferenceTarget>
+
     <ProjectReferenceTargetsForBuildInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForBuildInOuterBuild)</ProjectReferenceTargetsForBuildInOuterBuild>
-    <ProjectReferenceTargetsForBuild>.projectReferenceTargetsOrDefaultTargets;GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
+    <ProjectReferenceTargetsForBuild>$(_MainReferenceTarget);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
 
     <ProjectReferenceTargetsForCleanInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForCleanInOuterBuild)</ProjectReferenceTargetsForCleanInOuterBuild>
     <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>

--- a/src/Tasks/Microsoft.Managed.targets
+++ b/src/Tasks/Microsoft.Managed.targets
@@ -7,39 +7,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 -->
 
 <Project>
-   <!--
-        We are doing a cross-targeting build if there is a non-empty list of target frameworks specified
-        and there is no current target framework being built individually. In that case, a multitargeting
-        project file like Microsoft.<language>.CrossTargeting.targets gets imported.
-   -->
-   <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(TargetFramework)' == ''">
-      <IsCrossTargetingBuild>true</IsCrossTargetingBuild>
-   </PropertyGroup>
 
-   <PropertyGroup>
-      <InnerBuildProperty>TargetFramework</InnerBuildProperty>
-      <InnerBuildPropertyValues>TargetFrameworks</InnerBuildPropertyValues>
-   </PropertyGroup>
-
-   <PropertyGroup Condition="'$(IsGraphBuild)' == 'true'">
-      <!-- Microsoft.Net.Sdk adds all transitive project references to ProjectReference. It does this at build time
-           via a target. This fails the undeclared msbuild reference /isolate constraint, so disable transitive
-           references.
-           Do not disable transitive references if BuildProjectReferences is false. If building references is false,
-           then MSBuild won't try to build the transitive references, which won't trigger undeclared reference constraints.
-          -->
-      <DisableTransitiveProjectReferences Condition="'$(BuildProjectReferences)' != 'false' and '$(DisableTransitiveProjectReferences)' == ''">true</DisableTransitiveProjectReferences>
-   </PropertyGroup>
-
-   <ItemGroup Condition="'$(IsGraphBuild)' == 'true'">
-      <!-- WPF projects generate a project with a random name at build time and then build the project via the IBuildEngine callbacks.
-           Detect WPF, and exclude the generated project from static graph isolation constraint checking.
-           Escape the item to avoid eager evaluation of the wildcards.
-      -->
-      <GraphIsolationExemptReference
-         Condition="'$(UseWPF)' == 'true' or '@(Page)' != '' or '@(ApplicationDefinition)' != '' or '@(XamlPage)' != '' or '@(XamlAppDef)' != ''"
-         Include="$([MSBuild]::Escape('$(MSBuildProjectDirectory)\$(MSBuildProjectName)*_wpftmp$(MSBuildProjectExtension)'))" />
-   </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
 
    <!-- Item copied from Microsoft.Common.Currentversion.targets   -->
   <PropertyGroup>
@@ -47,40 +16,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_RecursiveTargetForContentCopying Condition=" '$(MSBuildCopyContentTransitively)' == 'false' ">_GetCopyToOutputDirectoryItemsFromThisProject</_RecursiveTargetForContentCopying>
   </PropertyGroup>
 
-  <!--
-    Properties for extension of ProjectReferenceTargets.
-    Append any current value which may have been provided in a Directory.Build.props since the intent was likely to append, not prepend.
-  -->
-  <PropertyGroup>
-    <!-- Empty case is for outer builds which do not import the target files that set BuildProjectReferences -->
-    <_MainReferenceTarget Condition="'$(BuildProjectReferences)' == '' or '$(BuildProjectReferences)' == 'true'">.projectReferenceTargetsOrDefaultTargets</_MainReferenceTarget>
-    <_MainReferenceTarget Condition="'$(_MainReferenceTarget)' == ''">GetTargetPath</_MainReferenceTarget>
-
-    <ProjectReferenceTargetsForBuildInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForBuildInOuterBuild)</ProjectReferenceTargetsForBuildInOuterBuild>
-    <ProjectReferenceTargetsForBuild>$(_MainReferenceTarget);GetNativeManifest;$(_RecursiveTargetForContentCopying);$(ProjectReferenceTargetsForBuild)</ProjectReferenceTargetsForBuild>
-
-    <ProjectReferenceTargetsForCleanInOuterBuild>GetTargetFrameworks;$(ProjectReferenceTargetsForCleanInOuterBuild)</ProjectReferenceTargetsForCleanInOuterBuild>
-    <ProjectReferenceTargetsForClean>Clean;$(ProjectReferenceTargetsForClean)</ProjectReferenceTargetsForClean>
-
-    <ProjectReferenceTargetsForRebuildInOuterBuild>$(ProjectReferenceTargetsForCleanInOuterBuild);$(ProjectReferenceTargetsForBuildInOuterBuild);$(ProjectReferenceTargetsForRebuildInOuterBuild)</ProjectReferenceTargetsForRebuildInOuterBuild>
-    <ProjectReferenceTargetsForRebuild>$(ProjectReferenceTargetsForClean);$(ProjectReferenceTargetsForBuild);$(ProjectReferenceTargetsForRebuild)</ProjectReferenceTargetsForRebuild>
-
-    <ProjectReferenceTargetsForPublish>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForPublish)</ProjectReferenceTargetsForPublish>
-    <ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>GetCopyToPublishDirectoryItems;$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)</ProjectReferenceTargetsForGetCopyToPublishDirectoryItems>
-  </PropertyGroup>
-
-  <ItemGroup>
-      <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForBuildInOuterBuild)' != '' " OuterBuild="true"/>
-      <ProjectReferenceTargets Include="Build" Targets="$(ProjectReferenceTargetsForBuild)" Condition=" '$(ProjectReferenceTargetsForBuild)' != '' " />
-
-      <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForCleanInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForCleanInOuterBuild)' != '' " OuterBuild="true"/>
-      <ProjectReferenceTargets Include="Clean" Targets="$(ProjectReferenceTargetsForClean)" Condition=" '$(ProjectReferenceTargetsForClean)' != '' " />
-
-      <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuildInOuterBuild)" Condition=" '$(ProjectReferenceTargetsForRebuildInOuterBuild)' != '' " />
-      <ProjectReferenceTargets Include="Rebuild" Targets="$(ProjectReferenceTargetsForRebuild)" Condition=" '$(ProjectReferenceTargetsForRebuild)' != '' " />
-
-      <ProjectReferenceTargets Include="Publish" Targets="$(ProjectReferenceTargetsForPublish)" Condition=" '$(ProjectReferenceTargetsForPublish)' != '' " />
-      <ProjectReferenceTargets Include="GetCopyToPublishDirectoryItems" Targets="$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)" Condition=" '$(ProjectReferenceTargetsForGetCopyToPublishDirectoryItems)' != '' " />
-  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
 
 </Project>

--- a/src/Tasks/Microsoft.VisualBasic.targets
+++ b/src/Tasks/Microsoft.VisualBasic.targets
@@ -156,11 +156,13 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <Import Project="$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore\*" Condition="'$(ImportByWildcardBefore40MicrosoftNetFrameworkProps)' == 'true' and exists('$(MSBuildExtensionsPath)\4.0\Microsoft.NETFramework.props\ImportBefore')"/>
   </ImportGroup> 
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.Before.targets" />
 
   <Import Project="$(VisualBasicTargetsPath)" />
-  
-  <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.VisualBasic.targets imports 
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.After.targets" />
+
+  <!-- Really should be imported right after Microsoft.NETFramework.props, but because Microsoft.VisualBasic.targets imports
        Microsoft.Common.targets from the current directory rather than using MSBuildToolsPath (which would redirect to our
        targets), and Microsoft.Common.targets does likewise with Microsoft.NETFramework.props, we're stuck doing it this 
        way instead. --> 


### PR DESCRIPTION
Quickbuild calls each project with `BuildProjectReferences=false`, which makes the main p2p target be `GetTargetPath` instead of the default (default target or the `ProjectReference.Targets`). This PR updates the target protocol for static graph to reflect this.

Unfortunately, Microsoft.Managed.targets was imported before the common targets which define `BuildProjectReferences`. So I split it up in before / after imports.