### PR TITLE
DownloadFile behaves unexpectedly in the case of OperationCanceledExceptions

### DIFF
--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-configuration="debug"
+configuration="Debug"
 host_type="core"
 build_stage1=true
 properties=
@@ -95,4 +95,3 @@ export DOTNET_HOST_PATH="$_InitializeDotNetCli/dotnet"
 # - Do run tests
 # - Don't try to create a bootstrap deployment
 . "$ScriptRoot/common/build.sh" --restore --build --test --ci --nodereuse false --configuration $configuration /p:CreateBootstrap=false $properties $extra_properties
-

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -301,7 +301,12 @@ namespace Microsoft.Build.Tasks.UnitTests
             await Task.Delay(TimeSpan.FromSeconds(1));
             runaway.IsCompleted.ShouldBeTrue("Task did not cancel");
             if (!runaway.IsCompleted)
+            {
+                // If this task isn't completed now, it never will, so we have an early return here
+                // so that the test fails rather than enter an infinite loop if the assert above doesn't
+                // throw for whatever reason.
                 return;
+            }
 
             var result = await runaway;
             result.ShouldBeFalse(() => _mockEngine.Log);
@@ -359,7 +364,7 @@ namespace Microsoft.Build.Tasks.UnitTests
 
             _mockEngine.Log.ShouldContain("MSB3922", () => _mockEngine.Log);
         }
-        
+
         private class MockHttpContent : HttpContent
         {
             private readonly Func<Stream, Task> _func;

--- a/src/Tasks.UnitTests/DownloadFile_Tests.cs
+++ b/src/Tasks.UnitTests/DownloadFile_Tests.cs
@@ -300,13 +300,6 @@ namespace Microsoft.Build.Tasks.UnitTests
             var runaway = Task.Run(() => downloadFile.Execute());
             await Task.Delay(TimeSpan.FromSeconds(1));
             runaway.IsCompleted.ShouldBeTrue("Task did not cancel");
-            if (!runaway.IsCompleted)
-            {
-                // If this task isn't completed now, it never will, so we have an early return here
-                // so that the test fails rather than enter an infinite loop if the assert above doesn't
-                // throw for whatever reason.
-                return;
-            }
 
             var result = await runaway;
             result.ShouldBeFalse(() => _mockEngine.Log);

--- a/src/Tasks/DownloadFile.cs
+++ b/src/Tasks/DownloadFile.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Build.Tasks
@@ -70,6 +71,11 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
             if (!Uri.TryCreate(SourceUrl, UriKind.Absolute, out Uri uri))
             {
                 Log.LogErrorWithCodeFromResources("DownloadFile.ErrorInvalidUrl", SourceUrl);
@@ -77,36 +83,46 @@ namespace Microsoft.Build.Tasks
             }
 
             int retryAttemptCount = 0;
-            bool canRetry = false;
+            
+            CancellationToken cancellationToken = _cancellationTokenSource.Token;
 
-            do
+            while(true)
             {
                 try
                 {
-                    Download(uri);
+                    await DownloadAsync(uri, cancellationToken);
                     break;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException e) when (e.CancellationToken == cancellationToken)
                 {
+                    // This task is being cancelled, exit the loop
+                    break;
                 }
                 catch (Exception e)
                 {
-                    canRetry = IsRetriable(e, out Exception actualException) && retryAttemptCount++ < Retries;
+                    bool canRetry = IsRetriable(e, out Exception actualException) && retryAttemptCount++ < Retries;
 
                     if (canRetry)
                     {
                         Log.LogWarningWithCodeFromResources("DownloadFile.Retrying", SourceUrl, retryAttemptCount + 1, RetryDelayMilliseconds, actualException.Message);
 
-                        Thread.Sleep(RetryDelayMilliseconds);
-
+                        try
+                        {
+                            await Task.Delay(RetryDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException delayException) when (delayException.CancellationToken == cancellationToken)
+                        {
+                            // This task is being cancelled, exit the loop
+                            break;
+                        }
                     }
                     else
                     {
                         Log.LogErrorWithCodeFromResources("DownloadFile.ErrorDownloading", SourceUrl, actualException.Message);
+                        break;
                     }
                 }
             }
-            while (canRetry);
 
             return !_cancellationTokenSource.IsCancellationRequested && !Log.HasLoggedErrors;
         }
@@ -115,16 +131,13 @@ namespace Microsoft.Build.Tasks
         /// Attempts to download the file.
         /// </summary>
         /// <param name="uri">The parsed <see cref="Uri"/> of the request.</param>
-        private void Download(Uri uri)
+        private async Task DownloadAsync(Uri uri, CancellationToken cancellationToken)
         {
             // The main reason to use HttpClient vs WebClient is because we can pass a message handler for unit tests to mock
             using (var client = new HttpClient(HttpMessageHandler ?? new HttpClientHandler(), disposeHandler: true))
             {
                 // Only get the response without downloading the file so we can determine if the file is already up-to-date
-                using (HttpResponseMessage response = client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, _cancellationTokenSource.Token)
-                                                            .ConfigureAwait(continueOnCapturedContext: false)
-                                                            .GetAwaiter()
-                                                            .GetResult())
+                using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false))
                 {
                     try
                     {
@@ -159,15 +172,16 @@ namespace Microsoft.Build.Tasks
 
                     try
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         using (var target = new FileStream(destinationFile.FullName, FileMode.Create, FileAccess.Write, FileShare.None))
                         {
                             Log.LogMessageFromResources(MessageImportance.High, "DownloadFile.Downloading", SourceUrl, destinationFile.FullName, response.Content.Headers.ContentLength);
 
-                            Task task = response.Content.CopyToAsync(target);
-
-                            task.ConfigureAwait(continueOnCapturedContext: false);
-
-                            task.Wait(_cancellationTokenSource.Token);
+                            using (Stream responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                            {
+                                await responseStream.CopyToAsync(target, 1024, cancellationToken).ConfigureAwait(false);
+                            }
 
                             DownloadedFile = new TaskItem(destinationFile.FullName);
                         }


### PR DESCRIPTION
We have some builds that are calling the DownloadFile task, and they seem to be
silently misbehaving: no errors, just hangs for a few hours and then we have to kill the process.

Looking at the code, there are a few paths through the code that result in either infinite loops or silently downloading nothing and returning success.

In particular, if a server returns a failed response, like a 500, and then the task is cancelled, it enters an infinite loop, because canRetry isn't refreshed in the loop.

Also, if a request times out the first time, where HttpClient.Send throws an OperationCanceledException, the task returns success without downloading anything.

I added tests for these two cases, and they fail without this change.

Hopefully this change is an acceptable one... I tried hard not to change any existing code behaviors (other than infinite loop and silent failure).  This will still fail and not-retry if any request times out, but that was the existing behavior (it just correctly reports and error and returns false now, instead of not downloading the requested file), and perhaps that behavior isn't desirable, in which case, IsRetriable should have a clause for OperationCanceled that returns true.