### PR TITLE
Introduce ExecuteTask ETW

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Build.BackEnd
                 if (MSBuildEventSource.Log.IsEnabled())
                 {
                     startTime = MSBuildEventSource.GetThreadTime();
-                    MSBuildEventSource.Log.ExecuteTaskStart(_taskNode == null ? null : _taskNode.Name);
+                    MSBuildEventSource.Log.ExecuteTaskStart(_taskNode?.Name);
                 }
                 // Loop through each of the batch buckets and execute them one at a time
                 for (int i = 0; i < buckets.Count; i++)
@@ -345,7 +345,8 @@ namespace Microsoft.Build.BackEnd
                 if (MSBuildEventSource.Log.IsEnabled())
                 {
                     long endTime = MSBuildEventSource.GetThreadTime();
-                    MSBuildEventSource.Log.ExecuteTaskStop(_taskNode == null ? null : _taskNode.Name, startTime == -1 || endTime == -1 ? null : string.Empty + (endTime - startTime));
+                    TimeSpan time = TimeSpan.FromMilliseconds(startTime == -1 || endTime == -1 ? -1 : endTime - startTime);
+                    MSBuildEventSource.Log.ExecuteTaskStop(_taskNode?.Name, time.TotalMilliseconds == -1 ? null : string.Empty + time.Duration().Milliseconds);
                 }
                 taskResult = aggregateResult;
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Eventing;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -324,6 +325,8 @@ namespace Microsoft.Build.BackEnd
 
                 WorkUnitResult aggregateResult = new WorkUnitResult();
 
+                // Some tests do not provide an actual taskNode; checking if _taskNode == null prevents those tests from failing.
+                MSBuildEventSource.Log.ExecuteTaskStart(_taskNode == null ? null : _taskNode.Name);
                 // Loop through each of the batch buckets and execute them one at a time
                 for (int i = 0; i < buckets.Count; i++)
                 {
@@ -337,6 +340,8 @@ namespace Microsoft.Build.BackEnd
                         break;
                     }
                 }
+                // Some tests do not provide an actual taskNode; checking if _taskNode == null prevents those tests from failing.
+                MSBuildEventSource.Log.ExecuteTaskStop(_taskNode == null ? null : _taskNode.Name);
 
                 taskResult = aggregateResult;
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -22,6 +22,7 @@ using TaskLoggingContext = Microsoft.Build.BackEnd.Logging.TaskLoggingContext;
 using System.Threading.Tasks;
 using Microsoft.Build.BackEnd.Components.Caching;
 using System.Reflection;
+using Microsoft.Build.Eventing;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -345,6 +346,7 @@ namespace Microsoft.Build.BackEnd
                 IRequestBuilderCallback builderCallback = _requestEntry.Builder as IRequestBuilderCallback;
                 ErrorUtilities.VerifyThrow(_yieldThreadId == -1, "Cannot call Yield() while yielding.");
                 _yieldThreadId = Thread.CurrentThread.ManagedThreadId;
+                MSBuildEventSource.Log.ExecuteTaskYieldStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Yield();
             }
         }
@@ -361,6 +363,7 @@ namespace Microsoft.Build.BackEnd
                 IRequestBuilderCallback builderCallback = _requestEntry.Builder as IRequestBuilderCallback;
                 ErrorUtilities.VerifyThrow(_yieldThreadId != -1, "Cannot call Reacquire() before Yield().");
                 ErrorUtilities.VerifyThrow(_yieldThreadId == Thread.CurrentThread.ManagedThreadId, "Cannot call Reacquire() on thread {0} when Yield() was called on thread {1}", Thread.CurrentThread.ManagedThreadId, _yieldThreadId);
+                MSBuildEventSource.Log.ExecuteTaskYieldStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Reacquire();
                 _yieldThreadId = -1;
             }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -346,7 +346,6 @@ namespace Microsoft.Build.BackEnd
                 IRequestBuilderCallback builderCallback = _requestEntry.Builder as IRequestBuilderCallback;
                 ErrorUtilities.VerifyThrow(_yieldThreadId == -1, "Cannot call Yield() while yielding.");
                 _yieldThreadId = Thread.CurrentThread.ManagedThreadId;
-                MSBuildEventSource.Log.ExecuteTaskStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 MSBuildEventSource.Log.ExecuteTaskYieldStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Yield();
             }
@@ -368,7 +367,6 @@ namespace Microsoft.Build.BackEnd
                 MSBuildEventSource.Log.ExecuteTaskReacquireStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Reacquire();
                 MSBuildEventSource.Log.ExecuteTaskReacquireStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
-                MSBuildEventSource.Log.ExecuteTaskStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 _yieldThreadId = -1;
             }
         }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -346,6 +346,7 @@ namespace Microsoft.Build.BackEnd
                 IRequestBuilderCallback builderCallback = _requestEntry.Builder as IRequestBuilderCallback;
                 ErrorUtilities.VerifyThrow(_yieldThreadId == -1, "Cannot call Yield() while yielding.");
                 _yieldThreadId = Thread.CurrentThread.ManagedThreadId;
+                MSBuildEventSource.Log.ExecuteTaskStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 MSBuildEventSource.Log.ExecuteTaskYieldStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Yield();
             }
@@ -364,7 +365,10 @@ namespace Microsoft.Build.BackEnd
                 ErrorUtilities.VerifyThrow(_yieldThreadId != -1, "Cannot call Reacquire() before Yield().");
                 ErrorUtilities.VerifyThrow(_yieldThreadId == Thread.CurrentThread.ManagedThreadId, "Cannot call Reacquire() on thread {0} when Yield() was called on thread {1}", Thread.CurrentThread.ManagedThreadId, _yieldThreadId);
                 MSBuildEventSource.Log.ExecuteTaskYieldStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
+                MSBuildEventSource.Log.ExecuteTaskReacquireStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 builderCallback.Reacquire();
+                MSBuildEventSource.Log.ExecuteTaskReacquireStop(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
+                MSBuildEventSource.Log.ExecuteTaskStart(_taskLoggingContext.TaskName, _taskLoggingContext.BuildEventContext.TaskId);
                 _yieldThreadId = -1;
             }
         }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -361,6 +361,18 @@ namespace Microsoft.Build.Eventing
             WriteEvent(46, commandLine);
         }
 
+        [Event(47)]
+        public void ExecuteTaskStart(string taskName)
+        {
+            WriteEvent(47, taskName);
+        }
+
+        [Event(48)]
+        public void ExecuteTaskStop(string taskName)
+        {
+            WriteEvent(48, taskName);
+        }
+
         #endregion
     }
 }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -12,13 +12,6 @@ namespace Microsoft.Build.Eventing
     [EventSource(Name = "Microsoft-Build")]
     internal sealed class MSBuildEventSource : EventSource
     {
-        [DllImport("kernel32.dll")]
-        private static extern long GetThreadTimes(IntPtr threadHandle, out long creationTime,
-             out long exitTime, out long kernelTime, out long userTime);
-
-        [DllImport("kernel32.dll")]
-        private static extern IntPtr GetCurrentThread();
-
         /// <summary>
         /// define the singleton instance of the event source
         /// </summary>
@@ -371,31 +364,28 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(47)]
-        public void ExecuteTaskStart(string taskName)
+        public void ExecuteTaskStart(string taskName, int taskID)
         {
-            WriteEvent(47, taskName);
+            WriteEvent(47, taskName, taskID);
         }
 
         [Event(48)]
-        public void ExecuteTaskStop(string taskName, string millisecondsElapsed)
+        public void ExecuteTaskStop(string taskName, int taskID)
         {
-            WriteEvent(48, taskName, millisecondsElapsed);
+            WriteEvent(48, taskName, taskID);
         }
 
-        #endregion
-
-        #region Non-Events
-        [NonEvent]
-        public static long GetThreadTime()
+        [Event(49)]
+        public void ExecuteTaskYieldStart(string taskName, int taskID)
         {
-            long kernelTime, userTime;
-            if (!Convert.ToBoolean(GetThreadTimes(GetCurrentThread(), out _, out _, out kernelTime, out userTime)))
-            {
-                return -1;
-            }
-            return (kernelTime + userTime) / 10000;
+            WriteEvent(49, taskName, taskID);
         }
 
+        [Event(50)]
+        public void ExecuteTaskYieldStop(string taskName, int taskID)
+        {
+            WriteEvent(50, taskName, taskID);
+        }
         #endregion
     }
 }

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -377,9 +377,9 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(48)]
-        public void ExecuteTaskStop(string taskName, string nanosecondsElapsed)
+        public void ExecuteTaskStop(string taskName, string millisecondsElapsed)
         {
-            WriteEvent(48, taskName, nanosecondsElapsed);
+            WriteEvent(48, taskName, millisecondsElapsed);
         }
 
         #endregion
@@ -393,7 +393,7 @@ namespace Microsoft.Build.Eventing
             {
                 return -1;
             }
-            return (kernelTime + userTime) / 10;
+            return (kernelTime + userTime) / 10000;
         }
 
         #endregion

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics.Tracing;
+using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Microsoft.Build.Eventing
 {
@@ -10,6 +12,13 @@ namespace Microsoft.Build.Eventing
     [EventSource(Name = "Microsoft-Build")]
     internal sealed class MSBuildEventSource : EventSource
     {
+        [DllImport("kernel32.dll")]
+        private static extern long GetThreadTimes(IntPtr threadHandle, out long creationTime,
+             out long exitTime, out long kernelTime, out long userTime);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr GetCurrentThread();
+
         /// <summary>
         /// define the singleton instance of the event source
         /// </summary>
@@ -368,9 +377,23 @@ namespace Microsoft.Build.Eventing
         }
 
         [Event(48)]
-        public void ExecuteTaskStop(string taskName)
+        public void ExecuteTaskStop(string taskName, string nanosecondsElapsed)
         {
-            WriteEvent(48, taskName);
+            WriteEvent(48, taskName, nanosecondsElapsed);
+        }
+
+        #endregion
+
+        #region Non-Events
+        [NonEvent]
+        public static long GetThreadTime()
+        {
+            long kernelTime, userTime;
+            if (!Convert.ToBoolean(GetThreadTimes(GetCurrentThread(), out _, out _, out kernelTime, out userTime)))
+            {
+                return -1;
+            }
+            return (kernelTime + userTime) / 10;
         }
 
         #endregion

--- a/src/Framework/MSBuildEventSource.cs
+++ b/src/Framework/MSBuildEventSource.cs
@@ -386,6 +386,18 @@ namespace Microsoft.Build.Eventing
         {
             WriteEvent(50, taskName, taskID);
         }
+
+        [Event(51)]
+        public void ExecuteTaskReacquireStart(string taskName, int taskID)
+        {
+            WriteEvent(51, taskName, taskID);
+        }
+
+        [Event(52)]
+        public void ExecuteTaskReacquireStop(string taskName, int taskID)
+        {
+            WriteEvent(52, taskName, taskID);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
This creates a new eventsource pair: ExecuteTaskStart and ExecuteTaskStop. Together, they allow a user to see the name of a task and how long it took to execute (including exact start and stop time) for each task. Another pair is added to capture how long each of yield and reacquire takes (if relevant).