### PR TITLE
Expose project imports on ProjectInstance

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1101,8 +1101,8 @@ namespace Microsoft.Build.Execution
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> Imports { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> ImportsIncludingDuplicates { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportPaths { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportPathsIncludingDuplicates { get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }
         public bool IsImmutable { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectItemDefinitionInstance> ItemDefinitions { get { throw null; } }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -1101,6 +1101,8 @@ namespace Microsoft.Build.Execution
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> Imports { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportsIncludingDuplicates { get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }
         public bool IsImmutable { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectItemDefinitionInstance> ItemDefinitions { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1095,6 +1095,8 @@ namespace Microsoft.Build.Execution
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> Imports { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportsIncludingDuplicates { get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }
         public bool IsImmutable { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectItemDefinitionInstance> ItemDefinitions { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -1095,8 +1095,8 @@ namespace Microsoft.Build.Execution
         public int EvaluationId { get { throw null; } set { } }
         public string FullPath { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, string> GlobalProperties { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> Imports { get { throw null; } }
-        public System.Collections.Generic.IReadOnlyList<string> ImportsIncludingDuplicates { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportPaths { get { throw null; } }
+        public System.Collections.Generic.IReadOnlyList<string> ImportPathsIncludingDuplicates { get { throw null; } }
         public System.Collections.Generic.List<string> InitialTargets { get { throw null; } }
         public bool IsImmutable { get { throw null; } }
         public System.Collections.Generic.IDictionary<string, Microsoft.Build.Execution.ProjectItemDefinitionInstance> ItemDefinitions { get { throw null; } }

--- a/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectInstance_Internal_Tests.cs
@@ -802,7 +802,7 @@ namespace Microsoft.Build.UnitTests.OM.Instance
         [InlineData(false, ProjectLoadSettings.RecordDuplicateButNotCircularImports)]
         [InlineData(true, ProjectLoadSettings.Default)]
         [InlineData(true, ProjectLoadSettings.RecordDuplicateButNotCircularImports)]
-        public void GetImportsAndImportsIncludingDuplicates(bool useDirectConstruction, ProjectLoadSettings projectLoadSettings)
+        public void GetImportPathsAndImportPathsIncludingDuplicates(bool useDirectConstruction, ProjectLoadSettings projectLoadSettings)
         {
             try
             {
@@ -839,13 +839,13 @@ namespace Microsoft.Build.UnitTests.OM.Instance
                     ? new ProjectInstance(rootElement, globalProperties: null, toolsVersion: null, buildParameters, projectCollection.LoggingService, buildEventContext, sdkResolverService: null, 0)
                     : new Project(rootElement, globalProperties: null, toolsVersion: null, projectCollection, projectLoadSettings).CreateProjectInstance();
 
-                string[] expectedImports = new string[] { import1Path, import2Path, import3Path };
-                string[] expectedImportsIncludingDuplicates = projectLoadSettings.HasFlag(ProjectLoadSettings.RecordDuplicateButNotCircularImports)
+                string[] expectedImportPaths = new string[] { import1Path, import2Path, import3Path };
+                string[] expectedImportPathsIncludingDuplicates = projectLoadSettings.HasFlag(ProjectLoadSettings.RecordDuplicateButNotCircularImports)
                     ? new string[] { import1Path, import2Path, import3Path, import2Path, import1Path }
-                    : expectedImports;
+                    : expectedImportPaths;
 
-                Helpers.AssertListsValueEqual(expectedImports, projectInstance.Imports.ToList());
-                Helpers.AssertListsValueEqual(expectedImportsIncludingDuplicates, projectInstance.ImportsIncludingDuplicates.ToList());
+                Helpers.AssertListsValueEqual(expectedImportPaths, projectInstance.ImportPaths.ToList());
+                Helpers.AssertListsValueEqual(expectedImportPathsIncludingDuplicates, projectInstance.ImportPathsIncludingDuplicates.ToList());
             }
             finally
             {


### PR DESCRIPTION
Currently the only reason QuickBuild and [MSBuildPrediction](https://github.com/Microsoft/MSBuildPrediction) use `Project` instead of `ProjectInstance` is because imports are not exposed through the `ProjectInstance`. This would allow both to avoid `Project` and use `ProjectInstance` directly.

Note that I decided to just expose full paths and not the `ResolvedImport` because `ResolvedImport` is not currently translatable as it contains a pretty deep object graph which also isn't translatable. Instead of implementing `ITranslatable` on a whole bunch of stuff (including XML...), I decided to simplify and only expose the full file paths.