### PR TITLE
Pass MSBuild Task Id via project's ParentProjectBuildEventContext

### DIFF
--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1137,7 +1137,7 @@ namespace Microsoft.Build.BackEnd
                             configurationId: request.Config.ConfigurationId,
                             escapedTargets: request.Targets,
                             hostServices: issuingEntry.Request.HostServices,
-                            parentBuildEventContext: issuingEntry.Request.BuildEventContext,
+                            parentBuildEventContext: issuingEntry.Request.CurrentMSBuildTask ?? issuingEntry.Request.BuildEventContext,
                             parentRequest: issuingEntry.Request,
                             buildRequestDataFlags: buildRequestDataFlags,
                             requestedProjectState: null,

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -1137,7 +1137,7 @@ namespace Microsoft.Build.BackEnd
                             configurationId: request.Config.ConfigurationId,
                             escapedTargets: request.Targets,
                             hostServices: issuingEntry.Request.HostServices,
-                            parentBuildEventContext: issuingEntry.Request.CurrentMSBuildTask ?? issuingEntry.Request.BuildEventContext,
+                            parentBuildEventContext: issuingEntry.Request.CurrentTaskContext ?? issuingEntry.Request.BuildEventContext,
                             parentRequest: issuingEntry.Request,
                             buildRequestDataFlags: buildRequestDataFlags,
                             requestedProjectState: null,

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -421,6 +421,11 @@ namespace Microsoft.Build.BackEnd
                     if (requirements != null)
                     {
                         TaskLoggingContext taskLoggingContext = _targetLoggingContext.LogTaskBatchStarted(_projectFullPath, _targetChildInstance);
+                        if (taskLoggingContext.TaskName == "MSBuild")
+                        {
+                            _buildRequestEntry.Request.CurrentMSBuildTask = taskLoggingContext.BuildEventContext;
+                        }
+
                         try
                         {
                             if (
@@ -462,6 +467,8 @@ namespace Microsoft.Build.BackEnd
                         }
                         finally
                         {
+                            _buildRequestEntry.Request.CurrentMSBuildTask = null;
+
                             // Flag the completion of the task.
                             taskLoggingContext.LogTaskBatchFinished(_projectFullPath, taskResult.ResultCode == WorkUnitResultCode.Success || taskResult.ResultCode == WorkUnitResultCode.Skipped);
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -421,10 +421,7 @@ namespace Microsoft.Build.BackEnd
                     if (requirements != null)
                     {
                         TaskLoggingContext taskLoggingContext = _targetLoggingContext.LogTaskBatchStarted(_projectFullPath, _targetChildInstance);
-                        if (taskLoggingContext.TaskName == "MSBuild")
-                        {
-                            _buildRequestEntry.Request.CurrentMSBuildTask = taskLoggingContext.BuildEventContext;
-                        }
+                        _buildRequestEntry.Request.CurrentTaskContext = taskLoggingContext.BuildEventContext;
 
                         try
                         {
@@ -467,7 +464,7 @@ namespace Microsoft.Build.BackEnd
                         }
                         finally
                         {
-                            _buildRequestEntry.Request.CurrentMSBuildTask = null;
+                            _buildRequestEntry.Request.CurrentTaskContext = null;
 
                             // Flag the completion of the task.
                             taskLoggingContext.LogTaskBatchFinished(_projectFullPath, taskResult.ResultCode == WorkUnitResultCode.Success || taskResult.ResultCode == WorkUnitResultCode.Skipped);

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -268,6 +268,8 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        public BuildEventContext CurrentMSBuildTask { get; set; }
+
         /// <summary>
         /// The set of flags specified in the BuildRequestData for this request.
         /// </summary>

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -270,12 +270,10 @@ namespace Microsoft.Build.BackEnd
 
         /// <summary>
         /// The <see cref="BuildEventContext" /> of the currently executing task, if any.
-        /// Used to correlate a project's build with the parent MSBuild task that spawned it.
-        /// Note that it's not exhaustive and won't be set if a build is spawned via
-        /// IBuildEngine* APIs, but since those are uncommon we still get a good correlation
-        /// in the common case.
+        /// Used to correlate a project's build with the parent task that spawned it
+        /// (usually the MSBuild task).
         /// </summary>
-        public BuildEventContext CurrentMSBuildTask { get; set; }
+        public BuildEventContext CurrentTaskContext { get; set; }
 
         /// <summary>
         /// The set of flags specified in the BuildRequestData for this request.

--- a/src/Build/BackEnd/Shared/BuildRequest.cs
+++ b/src/Build/BackEnd/Shared/BuildRequest.cs
@@ -268,6 +268,13 @@ namespace Microsoft.Build.BackEnd
             }
         }
 
+        /// <summary>
+        /// The <see cref="BuildEventContext" /> of the currently executing task, if any.
+        /// Used to correlate a project's build with the parent MSBuild task that spawned it.
+        /// Note that it's not exhaustive and won't be set if a build is spawned via
+        /// IBuildEngine* APIs, but since those are uncommon we still get a good correlation
+        /// in the common case.
+        /// </summary>
         public BuildEventContext CurrentMSBuildTask { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This is based on @MarkKharitonov's fix https://github.com/microsoft/msbuild/pull/4142 for https://github.com/Microsoft/MSBuild/issues/3939. Same change but rebases on latest and adds a unit-test.

@rainersigwald I've played with Mark's change and thought about it, and I think the best thing to do is to take Mark's change as is. I agree that it doesn't capture scenarios where a project's build is spawned via IBuildEngine* APIs and not via the MSBuild task, but we don't care about those as much. Even if we just cover the MSBuild task like this, it will be a huge improvement that covers most if not all scenarios that we really care about.

It's pretty low-risk and non-invasive. I've checked that in this expression:
```
issuingEntry.Request.CurrentMSBuildTask ?? issuingEntry.Request.BuildEventContext
```

all the fields on the build event context are the same, except `BuildRequestId`, `TargetId`and `TaskId`. Since `BuildRequestId` is just `GetHashCode()` I'm not worried about it. `TargetId` and `TaskId` acquire meaningful values instead of being set to -1. I've verified that the valid task id is propagated all the way to the `ParentProjectBuildEventContext` for the project being built. I've added a unit-test to validate that.

I've also made a change in the binlog viewer to take advantage of this if present. It is a major improvement that will significantly clean up the tree and get rid of most low-relevance "project builds", or rather reparent them where they belong and get them out of the way.

![image](https://user-images.githubusercontent.com/679326/71608407-062c0d00-2b36-11ea-832e-557e2929d299.png)
