### PR TITLE
Don't log RAR task inputs manually when LogTaskInputs is set.

### DIFF
--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -5,22 +5,23 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
-
-using Microsoft.Build.Execution;
-using Microsoft.Build.Exceptions;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Construction;
-using Microsoft.Build.BackEnd.Logging;
 using System.Globalization;
 using System.Reflection;
 #if FEATURE_APPDOMAIN
 using System.Runtime.Remoting;
 #endif
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Utilities;
 
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 
@@ -145,7 +146,7 @@ namespace Microsoft.Build.BackEnd
             // If this is false, check the environment variable to see if it's there:
             if (!LogTaskInputs)
             {
-                LogTaskInputs = (Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTS") == "1");
+                LogTaskInputs = Traits.Instance.EscapeHatches.LogTaskInputs;
             }
         }
 

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -124,6 +124,23 @@ namespace Microsoft.Build.Utilities
             }
         }
 
+        private bool? _logTaskInputs;
+        public bool LogTaskInputs
+        {
+            get
+            {
+                if (_logTaskInputs == null)
+                {
+                    _logTaskInputs = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTS") == "1";
+                }
+                return _logTaskInputs.Value;
+            }
+            set
+            {
+                _logTaskInputs = value;
+            }
+        }
+
         /// <summary>
         /// Read information only once per file per ResolveAssemblyReference invocation.
         /// </summary>

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// A list of assembly files that can be part of the search and resolution process.
-        /// These must be absolute filesnames, or project-relative filenames.
+        /// These must be absolute filenames, or project-relative filenames.
         ///
         /// Assembly files in this list will be considered when SearchPaths contains
         /// {CandidateAssemblyFiles} as one of the paths to consider.
@@ -1269,6 +1269,12 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void LogInputs()
         {
+            if (Traits.Instance.EscapeHatches.LogTaskInputs)
+            {
+                // the inputs will be logged automatically anyway, avoid duplication in the logs
+                return;
+            }
+
             if (!Silent)
             {
                 Log.LogMessageFromResources(MessageImportance.Low, "ResolveAssemblyReference.LogTaskPropertyFormat", "TargetFrameworkMoniker");


### PR DESCRIPTION
Move the environment variable read to Traits and cache it. Otherwise we would read the environment every time a task is run.

Fixes https://github.com/microsoft/msbuild/issues/4956

From cursory glance there is nothing in the manual `LogInputs()` method that wouldn't be logged automatically. If we are missing something it's probably nothing substantial.