### PR TITLE
RAR: Prefer the .dll extension first when resolving assemblies.

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -578,8 +578,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         Put the most likely extensions first for reference resolution speed.
         -->
     <AllowedReferenceAssemblyFileExtensions Condition=" '$(AllowedReferenceAssemblyFileExtensions)' == '' ">
-      .winmd;
       .dll;
+      .winmd;
       .exe
     </AllowedReferenceAssemblyFileExtensions>
 


### PR DESCRIPTION
RAR: Reorders the AllowedReferenceAssemblyFileExtensions to place .dll first and .winmd second. Statistically the vast majority of references are to .dll files.

We avoid a large amount of File.Exists checks if we try the .dll first.

Even on a small simple build (30 projects) the difference is noticeable:

.winmd first:
========

.binlog size: 14,685 KB
"Considered .winmd" messages: 2217
"Considered but it didn't exist": 6151

.dll first:
=====

.binlog size: 14,221 KB
"Considered .winmd" messages: 700
"Considered but it didn't exist": 4634

Reduction in the number of log entries will also indirectly translate in a slight reduction of build times, slight reduction of file system access operations (File.Exists checks). It also declutters the logs.