### PR TITLE
Avoid a first-chance exception in DeleteNoThrow.

### DIFF
--- a/src/Shared/FileUtilities.cs
+++ b/src/Shared/FileUtilities.cs
@@ -754,7 +754,11 @@ namespace Microsoft.Build.Shared
         {
             try
             {
-                File.Delete(FixFilePath(path));
+                path = FixFilePath(path);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
             }
             catch (Exception ex) when (ExceptionHandling.IsIoRelatedException(ex))
             {


### PR DESCRIPTION
It makes debugging unit-tests with first-chance exceptions a bit better.