### PR TITLE
Fix Expander.TryExecuteWellKnownFunction for Add, Multiply and PadLeft.

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3883,6 +3883,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionStringPadLeftComplex()
+        {
+            TestPropertyFunction("$(prop.PadLeft($([MSBuild]::Multiply(1, 2)), '0'))", "prop", "x", "0x");
+        }
+
+        [Fact]
         public void PropertyFunctionStringPadRight1()
         {
             TestPropertyFunction("$(prop.PadRight(2))", "prop", "x", "x ");
@@ -3947,6 +3953,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionMSBuildAddComplex()
+        {
+            TestPropertyFunction("$([MSBuild]::Add($(X), $([MSBuild]::Add(2, 3))))", "X", "7", "12");
+        }
+
+        [Fact]
         public void PropertyFunctionMSBuildSubtract()
         {
             TestPropertyFunction("$([MSBuild]::Subtract($(X), 20100000))", "X", "20100042", "42");
@@ -3956,6 +3968,12 @@ $(
         public void PropertyFunctionMSBuildMultiply()
         {
             TestPropertyFunction("$([MSBuild]::Multiply($(X), 8800))", "X", "2", "17600");
+        }
+
+        [Fact]
+        public void PropertyFunctionMSBuildMultiplyComplex()
+        {
+            TestPropertyFunction("$([MSBuild]::Multiply($(X), $([MSBuild]::Multiply(1, 8800))))", "X", "2", "17600");
         }
 
         [Fact]

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4170,6 +4170,9 @@ namespace Microsoft.Build.Evaluation
             {
                 switch (value)
                 {
+                    case double d:
+                        arg0 = Convert.ToInt32(d);
+                        return arg0 == d;
                     case int i:
                         arg0 = i;
                         return true;
@@ -4178,6 +4181,22 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 arg0 = 0;
+                return false;
+            }
+
+            private static bool TryConvertToDouble(object value, out double arg)
+            {
+                if (value is double unboxed)
+                {
+                    arg = unboxed;
+                    return true;
+                }
+                else if (value is string str && double.TryParse(str, out arg))
+                {
+                    return true;
+                }
+
+                arg = 0;
                 return false;
             }
 
@@ -4217,15 +4236,8 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                if (args[0] is string value0 &&
-                    args[1] is string value1 &&
-                    double.TryParse(value0, out arg0) &&
-                    double.TryParse(value1, out arg1))
-                {
-                    return true;
-                }
-
-                return false;
+                return TryConvertToDouble(args[0], out arg0) &&
+                       TryConvertToDouble(args[1], out arg1);
             }
 
             private static bool TryGetArgs(object[] args, out int arg0, out string arg1)
@@ -4238,11 +4250,9 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                var value0 = args[0] as string;
                 arg1 = args[1] as string;
-                if (value0 != null &&
-                    arg1 != null &&
-                    int.TryParse(value0, out arg0))
+                if (TryConvertToInt(args[0], out arg0) &&
+                    arg1 != null)
                 {
                     return true;
                 }


### PR DESCRIPTION
Turns out the shortcut in Expander for evaluating IntrinsicFunctions.Add, IntrinsicFunctions.Multiply and String.PadLeft wasn't working as expected. Under some conditions we can end up with an array of args where the first arg is a boxed double and the second one is a string.

By following the pattern with TryConvertToInt I introduce TryConvertToDouble. Also use TryConvertToInt in another place which fixes another case.

I've added unit-tests for the scenarios I encountered.

With these changes, there are no more first-chance exceptions when evaluating MSBuild's own solution. The three first-chance exceptions were observed when evaluating:
https://github.com/dotnet/arcade/blob/cc596c55ac68c952d0e052e6ed50334ed170b53a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets#L61
and
https://github.com/dotnet/arcade/blob/cc596c55ac68c952d0e052e6ed50334ed170b53a/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets#L61