### PR TITLE
Fix nullref in binlog playback when CentralLogger is null

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3519,13 +3519,14 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                if (distributedLoggerRecord.CentralLogger is INodeLogger nodeLogger)
+                var centralLogger = distributedLoggerRecord.CentralLogger;
+                if (centralLogger is INodeLogger nodeLogger)
                 {
                     nodeLogger.Initialize(replayEventSource, cpuCount);
                 }
-                else
+                else if (centralLogger != null)
                 {
-                    distributedLoggerRecord.CentralLogger.Initialize(replayEventSource);
+                    centralLogger.Initialize(replayEventSource);
                 }
             }
 
@@ -3558,7 +3559,11 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                distributedLoggerRecord.CentralLogger.Shutdown();
+                var centralLogger = distributedLoggerRecord.CentralLogger;
+                if (centralLogger != null)
+                {
+                    centralLogger.Shutdown();
+                }
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3559,11 +3559,7 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                var centralLogger = distributedLoggerRecord.CentralLogger;
-                if (centralLogger != null)
-                {
-                    centralLogger.Shutdown();
-                }
+                distributedLoggerRecord.CentralLogger?.Shutdown();
             }
         }
 

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3519,7 +3519,7 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                var centralLogger = distributedLoggerRecord.CentralLogger;
+                ILogger centralLogger = distributedLoggerRecord.CentralLogger;
                 if (centralLogger is INodeLogger nodeLogger)
                 {
                     nodeLogger.Initialize(replayEventSource, cpuCount);


### PR DESCRIPTION
When playing back a .binlog with using -distributedfilelogger there was a crash because CentralLogger was null.

Fixes https://github.com/microsoft/msbuild/issues/4788