### PR TITLE
Normalize the path before opening an app.config file.

### DIFF
--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Tasks
 
                 // it's important to normalize the path as it may contain two slashes
                 // see https://github.com/microsoft/msbuild/issues/4335 for details.
-                appConfigFile = Path.GetFullPath(appConfigFile);
+                appConfigFile = FileUtilities.NormalizePath(appConfigFile);
 
                 reader = XmlReader.Create(appConfigFile, readerSettings);
                 Read(reader);

--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Shared;
@@ -23,6 +24,11 @@ namespace Microsoft.Build.Tasks
             try
             {
                 var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+
+                // it's important to normalize the path as it may contain two slashes
+                // see https://github.com/microsoft/msbuild/issues/4335 for details.
+                appConfigFile = Path.GetFullPath(appConfigFile);
+
                 reader = XmlReader.Create(appConfigFile, readerSettings);
                 Read(reader);
             }


### PR DESCRIPTION
Fixes https://github.com/microsoft/msbuild/issues/4335