### PR TITLE
Allow tracking of global/environment property reads

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
     {
         protected ExternalProjectFinishedEventArgs() { }
@@ -406,6 +412,23 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+        public string PropertySource { get { throw null; } set { } }
+        public string PropertyValue { get { throw null; } set { } }
+    }
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string Location { get { throw null; } set { } }
+        public string NewValue { get { throw null; } set { } }
+        public string PreviousValue { get { throw null; } set { } }
+        public string PropertyName { get { throw null; } set { } }
+    }
     public enum RegisteredTaskObjectLifetime
     {
         AppDomain = 1,
@@ -566,6 +589,12 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+    }
 }
 namespace Microsoft.Build.Framework.Profiler
 {

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Build.Framework
         protected CustomBuildEventArgs(string message, string helpKeyword, string senderName, System.DateTime eventTimestamp, params object[] messageArgs) { }
     }
     public delegate void CustomBuildEventHandler(object sender, Microsoft.Build.Framework.CustomBuildEventArgs e);
+    public partial class EnvironmentVariableReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public EnvironmentVariableReadEventArgs() { }
+        public EnvironmentVariableReadEventArgs(string environmentVariableName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string EnvironmentVariableName { get { throw null; } set { } }
+    }
     public partial class ExternalProjectFinishedEventArgs : Microsoft.Build.Framework.CustomBuildEventArgs
     {
         protected ExternalProjectFinishedEventArgs() { }
@@ -405,6 +411,23 @@ namespace Microsoft.Build.Framework
         public string ToolsVersion { get { throw null; } }
     }
     public delegate void ProjectStartedEventHandler(object sender, Microsoft.Build.Framework.ProjectStartedEventArgs e);
+    public partial class PropertyInitialValueSetEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyInitialValueSetEventArgs() { }
+        public PropertyInitialValueSetEventArgs(string propertyName, string propertyValue, string propertySource, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+        public string PropertySource { get { throw null; } set { } }
+        public string PropertyValue { get { throw null; } set { } }
+    }
+    public partial class PropertyReassignmentEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public PropertyReassignmentEventArgs() { }
+        public PropertyReassignmentEventArgs(string propertyName, string previousValue, string newValue, string location, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string Location { get { throw null; } set { } }
+        public string NewValue { get { throw null; } set { } }
+        public string PreviousValue { get { throw null; } set { } }
+        public string PropertyName { get { throw null; } set { } }
+    }
     public enum RegisteredTaskObjectLifetime
     {
         AppDomain = 1,
@@ -565,6 +588,12 @@ namespace Microsoft.Build.Framework
         public System.Collections.Generic.IDictionary<string, string> Properties { get { throw null; } set { } }
     }
     public delegate void TelemetryEventHandler(object sender, Microsoft.Build.Framework.TelemetryEventArgs e);
+    public partial class UninitializedPropertyReadEventArgs : Microsoft.Build.Framework.BuildMessageEventArgs
+    {
+        public UninitializedPropertyReadEventArgs() { }
+        public UninitializedPropertyReadEventArgs(string propertyName, string message, string helpKeyword=null, string senderName=null, Microsoft.Build.Framework.MessageImportance importance=(Microsoft.Build.Framework.MessageImportance)(2)) { }
+        public string PropertyName { get { throw null; } set { } }
+    }
 }
 namespace Microsoft.Build.Framework.Profiler
 {

--- a/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
+++ b/src/Build.UnitTests/BuildEventArgsSerialization_Tests.cs
@@ -419,6 +419,79 @@ namespace Microsoft.Build.UnitTests
         }
 
         [Fact]
+        public void RoundTripEnvironmentVariableReadEventArgs()
+        {
+            var args = new EnvironmentVariableReadEventArgs(
+                environmentVariableName: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.EnvironmentVariableName,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
+        public void RoundTripPropertyReassignmentEventArgs()
+        {
+            var args = new PropertyReassignmentEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                previousValue: Guid.NewGuid().ToString(),
+                newValue: Guid.NewGuid().ToString(),
+                location: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.PreviousValue,
+                e => e.NewValue,
+                e => e.Location,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
+        public void UninitializedPropertyReadEventArgs()
+        {
+            var args = new UninitializedPropertyReadEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+
+        [Fact]
+        public void PropertyInitialValueEventArgs()
+        {
+            var args = new PropertyInitialValueSetEventArgs(
+                propertyName: Guid.NewGuid().ToString(),
+                propertyValue: Guid.NewGuid().ToString(),
+                propertySource: Guid.NewGuid().ToString(),
+                message: Guid.NewGuid().ToString(),
+                helpKeyword: Guid.NewGuid().ToString(),
+                senderName: Guid.NewGuid().ToString());
+
+            Roundtrip(args,
+                e => e.PropertyName,
+                e => e.PropertyValue,
+                e => e.PropertySource,
+                e => e.Message,
+                e => e.HelpKeyword,
+                e => e.SenderName);
+        }
+        [Fact]
         public void ReadingCorruptedStreamThrows()
         {
             var memoryStream = new MemoryStream();

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -506,9 +506,12 @@ namespace Microsoft.Build.UnitTests.Evaluation
             string testTargetPath = Path.Combine(targetDirectory, "test.proj");
 
             string originalValue = Environment.GetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY");
+            bool originalValue2 = BuildParameters.WarnOnUninitializedProperty;
+
             try
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", null);
+                BuildParameters.WarnOnUninitializedProperty = false;
                 Directory.CreateDirectory(targetDirectory);
                 File.WriteAllText(testTargetPath, testtargets);
 
@@ -524,6 +527,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
             finally
             {
                 Environment.SetEnvironmentVariable("MSBUILDWARNONUNINITIALIZEDPROPERTY", originalValue);
+                BuildParameters.WarnOnUninitializedProperty = originalValue2;
                 FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
             }
         }
@@ -653,55 +657,6 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 Assert.True(result);
                 logger.AssertLogContains("MSB4211");
                 Assert.Equal(2, logger.WarningCount); // "Expected two warnings"
-            }
-            finally
-            {
-                BuildParameters.WarnOnUninitializedProperty = originalValue;
-                FileUtilities.DeleteWithoutTrailingBackslash(targetDirectory, true);
-            }
-        }
-
-        /// <summary>
-        /// Log when a property is being assigned a new value.
-        /// </summary>
-        [Fact]
-        public void LogPropertyAssignments()
-        {
-            string testtargets = ObjectModelHelpers.CleanupFileContents(@"
-                                <Project xmlns='msbuildnamespace'>
-                                     <PropertyGroup>
-                                         <Prop>OldValue</Prop>
-                                         <Prop>NewValue</Prop>
-                                     </PropertyGroup>
-
-                                  <Target Name=""Test""/>
-                                </Project>");
-
-            string tempPath = Path.GetTempPath();
-            string targetDirectory = Path.Combine(tempPath, "LogPropertyAssignments");
-            string testTargetPath = Path.Combine(targetDirectory, "test.proj");
-
-            bool originalValue = BuildParameters.WarnOnUninitializedProperty;
-            try
-            {
-                BuildParameters.WarnOnUninitializedProperty = true;
-                Directory.CreateDirectory(targetDirectory);
-                File.WriteAllText(testTargetPath, testtargets);
-
-                MockLogger logger = new MockLogger();
-                logger.Verbosity = LoggerVerbosity.Diagnostic;
-                ProjectCollection pc = new ProjectCollection();
-                pc.RegisterLogger(logger);
-                Project project = pc.LoadProject(testTargetPath);
-
-                bool result = project.Build();
-                Assert.True(result);
-                logger.AssertLogContains("Evaluation started");
-                logger.AssertLogContains("Property reassignment");
-                logger.AssertLogContains("Evaluation finished");
-                logger.AssertLogContains("Prop");
-                logger.AssertLogContains("OldValue");
-                logger.AssertLogContains("NewValue");
             }
             finally
             {
@@ -4554,6 +4509,305 @@ namespace Microsoft.Build.UnitTests.Evaluation
             project.Build(logger);
             logger.AssertLogContains(
                 ResourceUtilities.FormatResourceStringStripCodeAndKeyword("OM_GlobalProperty", "Foo"));
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingDefault()
+        {
+            // Having nothing defined should default to only logging reassignments
+            this.VerifyPropertyTrackingLoggingScenario(
+                null,
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ShouldBeEmpty();
+
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingPropertyReassignment()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "1",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ShouldBeEmpty();
+
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingNone()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "0",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ShouldBeEmpty();
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingPropertyInitialValue()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "2",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldBeEmpty();
+
+                    IDictionary<string, PropertyInitialValueSetEventArgs> propertyInitialValueMap = logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ToDictionary(piv => piv.PropertyName);
+
+                    // Verify logging of property initial values.
+                    propertyInitialValueMap.ShouldContainKey("Prop");
+                    propertyInitialValueMap["Prop"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["Prop"].PropertyValue.ShouldBe(string.Empty);
+
+                    propertyInitialValueMap.ShouldContainKey("EnvVar");
+                    propertyInitialValueMap["EnvVar"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["EnvVar"].PropertyValue.ShouldBe("It's also Defined!");
+
+                    propertyInitialValueMap.ShouldContainKey("DEFINED_ENVIRONMENT_VARIABLE");
+                    propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertySource.ShouldBe("EnvironmentVariable");
+                    propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertyValue.ShouldBe("It's Defined!");
+
+                    propertyInitialValueMap.ShouldContainKey("NotEnvVarRead");
+                    propertyInitialValueMap["NotEnvVarRead"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["NotEnvVarRead"].PropertyValue.ShouldBe("Overwritten!");
+
+                    propertyInitialValueMap.ShouldContainKey("Prop2");
+                    propertyInitialValueMap["Prop2"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["Prop2"].PropertyValue.ShouldBe("Value1");
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingEnvironmentVariableRead()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "4",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE2");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldNotContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ShouldBeEmpty();
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingUninitializedPropertyRead()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "8",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldContain(p => p.PropertyName == "DOES_NOT_EXIST");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldBeEmpty();
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ShouldBeEmpty();
+                });
+        }
+
+        [Fact]
+        public void VerifyPropertyTrackingLoggingAll()
+        {
+            this.VerifyPropertyTrackingLoggingScenario(
+                "15",
+                logger =>
+                {
+                    logger
+                        .AllBuildEvents
+                        .OfType<UninitializedPropertyReadEventArgs>()
+                        .ShouldContain(p => p.PropertyName == "DOES_NOT_EXIST");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE2");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<EnvironmentVariableReadEventArgs>()
+                        .ShouldNotContain(ev => ev.EnvironmentVariableName == "DEFINED_ENVIRONMENT_VARIABLE");
+
+                    logger
+                        .AllBuildEvents
+                        .OfType<PropertyReassignmentEventArgs>()
+                        .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
+
+                    IDictionary<string, PropertyInitialValueSetEventArgs> propertyInitialValueMap = logger
+                        .AllBuildEvents
+                        .OfType<PropertyInitialValueSetEventArgs>()
+                        .ToDictionary(piv => piv.PropertyName);
+
+                    // Verify logging of property initial values.
+                    propertyInitialValueMap.ShouldContainKey("Prop");
+                    propertyInitialValueMap["Prop"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["Prop"].PropertyValue.ShouldBe(string.Empty);
+
+                    propertyInitialValueMap.ShouldContainKey("EnvVar");
+                    propertyInitialValueMap["EnvVar"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["EnvVar"].PropertyValue.ShouldBe("It's also Defined!");
+
+                    propertyInitialValueMap.ShouldContainKey("DEFINED_ENVIRONMENT_VARIABLE");
+                    propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertySource.ShouldBe("EnvironmentVariable");
+                    propertyInitialValueMap["DEFINED_ENVIRONMENT_VARIABLE"].PropertyValue.ShouldBe("It's Defined!");
+
+                    propertyInitialValueMap.ShouldContainKey("NotEnvVarRead");
+                    propertyInitialValueMap["NotEnvVarRead"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["NotEnvVarRead"].PropertyValue.ShouldBe("Overwritten!");
+
+                    propertyInitialValueMap.ShouldContainKey("Prop2");
+                    propertyInitialValueMap["Prop2"].PropertySource.ShouldBe("Xml");
+                    propertyInitialValueMap["Prop2"].PropertyValue.ShouldBe("Value1");
+                });
+        }
+
+        private void VerifyPropertyTrackingLoggingScenario(string envVarValue, Action<MockLogger> loggerEvaluatorAction)
+        {
+            // The default is that only reassignments are logged.
+
+            string testTargets = ObjectModelHelpers.CleanupFileContents(@"
+                                <Project>
+                                     <PropertyGroup>
+                                         <Prop>$(DOES_NOT_EXIST)</Prop>
+                                         <EnvVar>$(DEFINED_ENVIRONMENT_VARIABLE2)</EnvVar>
+                                         <DEFINED_ENVIRONMENT_VARIABLE>Overwritten!</DEFINED_ENVIRONMENT_VARIABLE>
+                                         <NotEnvVarRead>$(DEFINED_ENVIRONMENT_VARIABLE)</NotEnvVarRead>
+                                         <Prop2>Value1</Prop2>
+                                         <Prop2>Value2</Prop2>
+                                     </PropertyGroup>
+                                     <Target Name='Build' />
+                                </Project>");
+
+            using (TestEnvironment env = TestEnvironment.Create())
+            {
+                if (!string.IsNullOrWhiteSpace(envVarValue))
+                    env.SetEnvironmentVariable("MsBuildLogPropertyTracking", envVarValue);
+
+                env.SetEnvironmentVariable("DEFINED_ENVIRONMENT_VARIABLE", "It's Defined!");
+                env.SetEnvironmentVariable("DEFINED_ENVIRONMENT_VARIABLE2", "It's also Defined!");
+
+                var tempPath = env.CreateFile(Guid.NewGuid().ToString(), testTargets);
+
+                BuildParameters.WarnOnUninitializedProperty = true;
+
+                MockLogger logger = new MockLogger();
+                logger.Verbosity = LoggerVerbosity.Diagnostic;
+                ProjectCollection pc = new ProjectCollection();
+                pc.RegisterLogger(logger);
+                Project project = pc.LoadProject(tempPath.Path);
+
+                project.Build().ShouldBeTrue();
+
+                loggerEvaluatorAction?.Invoke(logger);
+            }
         }
 
 #if FEATURE_HTTP_LISTENER

--- a/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Evaluator_Tests.cs
@@ -4514,7 +4514,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [Fact]
         public void VerifyPropertyTrackingLoggingDefault()
         {
-            // Having nothing defined should default to only logging reassignments
+            // Having nothing defined should default to nothing being logged.
             this.VerifyPropertyTrackingLoggingScenario(
                 null,
                 logger =>
@@ -4532,7 +4532,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                     logger
                         .AllBuildEvents
                         .OfType<PropertyReassignmentEventArgs>()
-                        .ShouldContain(r => r.PropertyName == "Prop2" && r.PreviousValue == "Value1" && r.NewValue == "Value2");
+                        .ShouldBeEmpty();
 
                     logger
                         .AllBuildEvents

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception
         /// </summary>
-        /// <param name="exception">The exception wich is to be logged</param>
+        /// <param name="exception">The exception which is to be logged</param>
         /// <param name="file">The file in which the error occurred</param>
         internal void LogFatalBuildError(Exception exception, BuildEventFileInfo file)
         {

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <summary>
         /// Log an error based on an exception
         /// </summary>
-        /// <param name="exception">The exception which is to be logged</param>
+        /// <param name="exception">The exception to be logged</param>
         /// <param name="file">The file in which the error occurred</param>
         internal void LogFatalBuildError(Exception exception, BuildEventFileInfo file)
         {

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -3961,6 +3961,11 @@ namespace Microsoft.Build.Evaluation
             public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary { get; }
 
             /// <summary>
+            /// A dictionary of all of the properties read from environment variables during evaluation.
+            /// </summary>
+            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => this.Project.ProjectCollection.EnvironmentProperties;
+
+            /// <summary>
             /// List of names of the properties that, while global, are still treated as overridable 
             /// </summary>
             public ISet<string> GlobalPropertiesToTreatAsLocal => _globalPropertiesToTreatAsLocal ?? (_globalPropertiesToTreatAsLocal =
@@ -4334,7 +4339,7 @@ namespace Microsoft.Build.Evaluation
             /// <summary>
             /// Sets a property which is not derived from Xml.
             /// </summary>
-            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public ProjectProperty SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
             {
                 ProjectProperty property = ProjectProperty.Create(Project, name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
                 Properties.Set(property);
@@ -4346,13 +4351,10 @@ namespace Microsoft.Build.Evaluation
 
             /// <summary>
             /// Sets a property derived from Xml.
-            /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
-            /// This would include all properties with the same name that lie above in the logical
-            /// project file, and whose conditions evaluated to true.
-            /// If there are none above this is null.
             /// </summary>
-            public ProjectProperty SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, ProjectProperty predecessor)
+            public ProjectProperty SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
             {
+                ProjectProperty predecessor = GetProperty(propertyElement.Name);
                 ProjectProperty property = ProjectProperty.Create(Project, propertyElement, evaluatedValueEscaped, predecessor);
                 Properties.Set(property);
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -203,8 +203,12 @@ namespace Microsoft.Build.Evaluation
                 buildEventContext,
                 string.IsNullOrEmpty(projectRootElement.ProjectFileLocation.File) ? "(null)" : projectRootElement.ProjectFileLocation.File);
 
-            // Wrap the IEvaluatorData<> object passed in.
-            data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext, Traits.Instance.LogPropertyTracking);
+            // If someone sets the 'MsBuildLogPropertyTracking' environment variable to a non-zero value, wrap property accesses for event reporting.
+            if (Traits.Instance.LogPropertyTracking > 0)
+            {
+                // Wrap the IEvaluatorData<> object passed in.
+                data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext, Traits.Instance.LogPropertyTracking);
+            }
             _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
             // Create containers for the evaluation results
@@ -1337,7 +1341,37 @@ namespace Microsoft.Build.Evaluation
 
                 _expander.UsedUninitializedProperties.CurrentlyEvaluatingPropertyElementName = null;
 
-                _data.SetProperty(propertyElement, evaluatedValue);
+                if (Traits.Instance.LogPropertyTracking == 0)
+                {
+                    P predecessor = _data.GetProperty(propertyElement.Name);
+                    P property = _data.SetProperty(propertyElement, evaluatedValue);
+
+                    if (predecessor != null)
+                    {
+                        LogPropertyReassignment(predecessor, property, propertyElement.Location.LocationString);
+                    }
+                }
+                else
+                {
+                    _data.SetProperty(propertyElement, evaluatedValue);
+                }
+            }
+        }
+
+        private void LogPropertyReassignment(P predecessor, P property, string location)
+        {
+            string newValue = property.EvaluatedValue;
+            string oldValue = predecessor?.EvaluatedValue;
+
+            if (newValue != oldValue)
+            {
+                _evaluationLoggingContext.LogComment(
+                    MessageImportance.Low,
+                    "PropertyReassignment",
+                    property.Name,
+                    newValue,
+                    oldValue,
+                    location);
             }
         }
 

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using ObjectModel = System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
@@ -190,11 +189,22 @@ namespace Microsoft.Build.Evaluation
             int submissionId,
             EvaluationContext evaluationContext,
             bool profileEvaluation,
-            bool interactive)
+            bool interactive,
+            ILoggingService loggingService,
+            BuildEventContext buildEventContext)
         {
             ErrorUtilities.VerifyThrowInternalNull(data, nameof(data));
             ErrorUtilities.VerifyThrowInternalNull(projectRootElementCache, nameof(projectRootElementCache));
+            ErrorUtilities.VerifyThrowInternalNull(loggingService, nameof(loggingService));
+            ErrorUtilities.VerifyThrowInternalNull(buildEventContext, nameof(buildEventContext));
 
+            _evaluationLoggingContext = new EvaluationLoggingContext(
+                loggingService,
+                buildEventContext,
+                string.IsNullOrEmpty(projectRootElement.ProjectFileLocation.File) ? "(null)" : projectRootElement.ProjectFileLocation.File);
+
+            // Wrap the IEvaluatorData<> object passed in.
+            data = new PropertyTrackingEvaluatorDataWrapper<P, I, M, D>(data, _evaluationLoggingContext, Traits.Instance.LogPropertyTracking);
             _evaluationContext = evaluationContext ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
             // Create containers for the evaluation results
@@ -269,27 +279,27 @@ namespace Microsoft.Build.Evaluation
             EvaluationContext evaluationContext = null,
             bool interactive = false)
         {
-            {
-                MSBuildEventSource.Log.EvaluateStart(root.ProjectFileLocation.File);
-                var profileEvaluation = (loadSettings & ProjectLoadSettings.ProfileEvaluation) != 0 || loggingService.IncludeEvaluationProfile;
-                var evaluator = new Evaluator<P, I, M, D>(
-                    data,
-                    root,
-                    loadSettings,
-                    maxNodeCount,
-                    environmentProperties,
-                    itemFactory,
-                    toolsetProvider,
-                    projectRootElementCache,
-                    sdkResolverService,
-                    submissionId,
-                    evaluationContext,
-                    profileEvaluation,
-                    interactive);
+            MSBuildEventSource.Log.EvaluateStart(root.ProjectFileLocation.File);
+            var profileEvaluation = (loadSettings & ProjectLoadSettings.ProfileEvaluation) != 0 || loggingService.IncludeEvaluationProfile;
+            var evaluator = new Evaluator<P, I, M, D>(
+                data,
+                root,
+                loadSettings,
+                maxNodeCount,
+                environmentProperties,
+                itemFactory,
+                toolsetProvider,
+                projectRootElementCache,
+                sdkResolverService,
+                submissionId,
+                evaluationContext,
+                profileEvaluation,
+                interactive,
+                loggingService,
+                buildEventContext);
 
-                evaluator.Evaluate(loggingService, buildEventContext);
-                MSBuildEventSource.Log.EvaluateStop(root.ProjectFileLocation.File);
-            }
+            evaluator.Evaluate();
+            MSBuildEventSource.Log.EvaluateStop(root.ProjectFileLocation.File);
         }
 
         /// <summary>
@@ -576,18 +586,16 @@ namespace Microsoft.Build.Evaluation
         /// Do the evaluation.
         /// Called by the static helper method.
         /// </summary>
-        private void Evaluate(ILoggingService loggingService, BuildEventContext buildEventContext)
+        private void Evaluate()
         {
-            string projectFile;
+            string projectFile = String.IsNullOrEmpty(_projectRootElement.ProjectFileLocation.File) ? "(null)" : _projectRootElement.ProjectFileLocation.File;
             using (_evaluationProfiler.TrackPass(EvaluationPass.TotalEvaluation))
             {
                 ErrorUtilities.VerifyThrow(_data.EvaluationId == BuildEventContext.InvalidEvaluationId, "There is no prior evaluation ID. The evaluator data needs to be reset at this point");
+                _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
 
                 _logProjectImportedEvents = Traits.Instance.EscapeHatches.LogProjectImports;
 
-                ICollection<P> builtInProperties;
-                ICollection<P> environmentProperties;
-                ICollection<P> toolsetProperties;
                 ICollection<P> globalProperties;
 
                 using (_evaluationProfiler.TrackPass(EvaluationPass.InitialProperties))
@@ -595,9 +603,9 @@ namespace Microsoft.Build.Evaluation
                     // Pass0: load initial properties
                     // Follow the order of precedence so that Global properties overwrite Environment properties
                     MSBuildEventSource.Log.EvaluatePass0Start(_projectRootElement.ProjectFileLocation.File);
-                    builtInProperties = AddBuiltInProperties();
-                    environmentProperties = AddEnvironmentProperties();
-                    toolsetProperties = AddToolsetProperties();
+                    AddBuiltInProperties();
+                    AddEnvironmentProperties();
+                    AddToolsetProperties();
                     globalProperties = AddGlobalProperties();
 
                     if (_interactive)
@@ -605,11 +613,6 @@ namespace Microsoft.Build.Evaluation
                         SetBuiltInProperty(ReservedPropertyNames.interactive, "true");
                     }
                 }
-
-                projectFile = String.IsNullOrEmpty(_projectRootElement.ProjectFileLocation.File) ? "(null)" : _projectRootElement.ProjectFileLocation.File;
-
-                _evaluationLoggingContext = new EvaluationLoggingContext(loggingService, buildEventContext, projectFile);
-                _data.EvaluationId = _evaluationLoggingContext.BuildEventContext.EvaluationId;
 
                 _evaluationLoggingContext.LogProjectEvaluationStarted();
 
@@ -1197,7 +1200,7 @@ namespace Microsoft.Build.Evaluation
 
             foreach (ProjectPropertyInstance environmentProperty in _environmentProperties)
             {
-                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, false /* NOT global property */, false /* may NOT be a reserved name */);
+                P property = _data.SetProperty(environmentProperty.Name, ((IProperty)environmentProperty).EvaluatedValueEscaped, isGlobalProperty: false, mayBeReserved: false, isEnvironmentVariable: true);
                 environmentPropertiesList.Add(property);
             }
 
@@ -1334,31 +1337,7 @@ namespace Microsoft.Build.Evaluation
 
                 _expander.UsedUninitializedProperties.CurrentlyEvaluatingPropertyElementName = null;
 
-                P predecessor = _data.GetProperty(propertyElement.Name);
-
-                P property = _data.SetProperty(propertyElement, evaluatedValue, predecessor);
-
-                if (predecessor != null)
-                {
-                    LogPropertyReassignment(predecessor, property, propertyElement.Location.LocationString);
-                }
-            }
-        }
-
-        private void LogPropertyReassignment(P predecessor, P property, string location)
-        {
-            string newValue = property.EvaluatedValue;
-            string oldValue = predecessor.EvaluatedValue;
-
-            if (newValue != oldValue)
-            {
-                _evaluationLoggingContext.LogComment(
-                    MessageImportance.Low,
-                    "PropertyReassignment",
-                    property.Name,
-                    newValue,
-                    oldValue,
-                    location);
+                _data.SetProperty(propertyElement, evaluatedValue);
             }
         }
 
@@ -2375,11 +2354,6 @@ namespace Microsoft.Build.Evaluation
                         : $"{_lastModifiedProject.FullPath};{oldValue.EvaluatedValue}",
                     isGlobalProperty: false,
                     mayBeReserved: false);
-
-                if (oldValue != null)
-                {
-                    LogPropertyReassignment(oldValue, newValue, String.Empty);
-                }
             }
         }
     }

--- a/src/Build/Evaluation/IEvaluatorData.cs
+++ b/src/Build/Evaluation/IEvaluatorData.cs
@@ -206,6 +206,11 @@ namespace Microsoft.Build.Evaluation
         }
 
         /// <summary>
+        /// A dictionary of all of the environment variable properties.
+        /// </summary>
+        PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary { get; }
+
+        /// <summary>
         /// Prepares the data block for a new evaluation pass
         /// </summary>
         void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem);
@@ -263,16 +268,12 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Sets a property which does not come from the Xml.
         /// </summary>
-        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved);
+        P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false);
 
         /// <summary>
         /// Sets a property which comes from the Xml.
-        /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
-        /// This would include all properties with the same name that lie above in the logical
-        /// project file, and whose conditions evaluated to true.
-        /// If there are none above this is null.
         /// </summary>
-        P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor);
+        P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped);
 
         /// <summary>
         /// Retrieves an existing target, if any.

--- a/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.EvaluatorData.cs
@@ -124,6 +124,14 @@ namespace Microsoft.Build.Evaluation
                 }
             }
 
+            public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary
+            {
+                get
+                {
+                    return _wrappedData.EnvironmentVariablePropertiesDictionary;
+                }
+            }
+
             public ISet<string> GlobalPropertiesToTreatAsLocal
             {
                 get
@@ -292,12 +300,12 @@ namespace Microsoft.Build.Evaluation
                 _wrappedData.RecordImportWithDuplicates(importElement, import, versionEvaluated);
             }
 
-            public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, P predecessor)
+            public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
             {
-                return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped, predecessor);
+                return _wrappedData.SetProperty(propertyElement, evaluatedValueEscaped);
             }
 
-            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+            public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
             {
                 return _wrappedData.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved);
             }

--- a/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
+++ b/src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs
@@ -1,0 +1,323 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Shared.FileSystem;
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.BackEnd.Components.Logging;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
+
+namespace Microsoft.Build.Evaluation
+{
+    /// <summary>
+    /// Wraps an existing <see cref="IEvaluatorData{P,I,M,D}"/> allowing the property usage to be tracked.
+    /// </summary>
+    /// <typeparam name="P">The type of properties to be produced.</typeparam>
+    /// <typeparam name="I">The type of items to be produced.</typeparam>
+    /// <typeparam name="M">The type of metadata on those items.</typeparam>
+    /// <typeparam name="D">The type of item definitions to be produced.</typeparam>
+    internal class PropertyTrackingEvaluatorDataWrapper<P, I, M, D> : IEvaluatorData<P, I, M, D>
+        where P : class, IProperty, IEquatable<P>, IValued
+        where I : class, IItem
+        where M : class, IMetadatum
+        where D : class, IItemDefinition<M>
+    {
+        private readonly IEvaluatorData<P, I, M, D> _wrapped;
+        private readonly HashSet<string> _overwrittenEnvironmentVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly EvaluationLoggingContext _evaluationLoggingContext;
+        private readonly PropertyTrackingSetting _settings;
+
+        /// <summary>
+        /// Creates an instance of the PropertyTrackingEvaluatorDataWrapper class.
+        /// </summary>
+        /// <param name="dataToWrap">The underlying <see cref="IEvaluatorData{P,I,M,D}"/> to wrap for property tracking.</param>
+        /// <param name="evaluationLoggingContext">The <see cref="EvaluationLoggingContext"/> used to log relevant events.</param>
+        public PropertyTrackingEvaluatorDataWrapper(IEvaluatorData<P, I, M, D> dataToWrap, EvaluationLoggingContext evaluationLoggingContext, int settingValue)
+        {
+            ErrorUtilities.VerifyThrowInternalNull(dataToWrap, nameof(dataToWrap));
+            ErrorUtilities.VerifyThrowInternalNull(evaluationLoggingContext, nameof(evaluationLoggingContext));
+
+            _wrapped = dataToWrap;
+            _evaluationLoggingContext = evaluationLoggingContext;
+            _settings = (PropertyTrackingSetting)settingValue;
+        }
+
+        #region IEvaluatorData<> members with tracking-related code in them.
+
+        /// <summary>
+        /// Returns a property with the specified name, or null if it was not found.
+        /// </summary>
+        /// <param name="name">The property name.</param>
+        /// <returns>The property.</returns>
+        public P GetProperty(string name)
+        {
+            P prop = _wrapped.GetProperty(name);
+            this.TrackPropertyRead(name, prop);
+            return prop;
+        }
+
+        /// <summary>
+        /// Returns a property with the specified name, or null if it was not found.
+        /// Name is the segment of the provided string with the provided start and end indexes.
+        /// </summary>
+        public P GetProperty(string name, int startIndex, int endIndex)
+        {
+            P prop = _wrapped.GetProperty(name, startIndex, endIndex);
+            this.TrackPropertyRead(name.Substring(startIndex, endIndex - startIndex + 1), prop);
+            return prop;
+        }
+
+        /// <summary>
+        /// Sets a property which does not come from the Xml.
+        /// </summary>
+        public P SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable = false)
+        {
+            P originalProperty = _wrapped.GetProperty(name);
+            P newProperty = _wrapped.SetProperty(name, evaluatedValueEscaped, isGlobalProperty, mayBeReserved, isEnvironmentVariable);
+
+            this.TrackPropertyWrite(
+                originalProperty,
+                newProperty,
+                string.Empty,
+                this.DeterminePropertySource(isGlobalProperty, mayBeReserved, isEnvironmentVariable));
+
+            return newProperty;
+        }
+
+        /// <summary>
+        /// Sets a property which comes from the Xml.
+        /// Predecessor is any immediately previous property that was overridden by this one during evaluation.
+        /// This would include all properties with the same name that lie above in the logical
+        /// project file, and whose conditions evaluated to true.
+        /// If there are none above this is null.
+        /// </summary>
+        public P SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
+        {
+            P originalProperty = _wrapped.GetProperty(propertyElement.Name);
+            P newProperty = _wrapped.SetProperty(propertyElement, evaluatedValueEscaped);
+
+            this.TrackPropertyWrite(
+                originalProperty,
+                newProperty,
+                propertyElement.Location.LocationString,
+                PropertySource.Xml);
+
+            return newProperty;
+        }
+        #endregion
+
+        #region IEvaluatorData<> members that are forwarded directly to wrapped object.
+        public ICollection<I> GetItems(string itemType) => _wrapped.GetItems(itemType);
+        public int EvaluationId { get => _wrapped.EvaluationId; set => _wrapped.EvaluationId = value; }
+        public string Directory => _wrapped.Directory;
+        public TaskRegistry TaskRegistry { get => _wrapped.TaskRegistry; set => _wrapped.TaskRegistry = value; }
+        public Toolset Toolset => _wrapped.Toolset;
+        public string SubToolsetVersion => _wrapped.SubToolsetVersion;
+        public string ExplicitToolsVersion => _wrapped.ExplicitToolsVersion;
+        public PropertyDictionary<ProjectPropertyInstance> GlobalPropertiesDictionary => _wrapped.GlobalPropertiesDictionary;
+        public ISet<string> GlobalPropertiesToTreatAsLocal => _wrapped.GlobalPropertiesToTreatAsLocal;
+        public List<string> InitialTargets { get => _wrapped.InitialTargets; set => _wrapped.InitialTargets = value; }
+        public List<string> DefaultTargets { get => _wrapped.DefaultTargets; set => _wrapped.DefaultTargets = value; }
+        public IDictionary<string, List<TargetSpecification>> BeforeTargets { get => _wrapped.BeforeTargets; set => _wrapped.BeforeTargets = value; }
+        public IDictionary<string, List<TargetSpecification>> AfterTargets { get => _wrapped.AfterTargets; set => _wrapped.AfterTargets = value; }
+        public Dictionary<string, List<string>> ConditionedProperties => _wrapped.ConditionedProperties;
+        public bool ShouldEvaluateForDesignTime => _wrapped.ShouldEvaluateForDesignTime;
+        public bool CanEvaluateElementsWithFalseConditions => _wrapped.CanEvaluateElementsWithFalseConditions;
+        public PropertyDictionary<P> Properties => _wrapped.Properties;
+        public IEnumerable<D> ItemDefinitionsEnumerable => _wrapped.ItemDefinitionsEnumerable;
+        public ItemDictionary<I> Items => _wrapped.Items;
+        public List<ProjectItemElement> EvaluatedItemElements => _wrapped.EvaluatedItemElements;
+        public PropertyDictionary<ProjectPropertyInstance> EnvironmentVariablePropertiesDictionary => _wrapped.EnvironmentVariablePropertiesDictionary;
+        public void InitializeForEvaluation(IToolsetProvider toolsetProvider, IFileSystem fileSystem) => _wrapped.InitializeForEvaluation(toolsetProvider, fileSystem);
+        public void FinishEvaluation() => _wrapped.FinishEvaluation();
+        public void AddItem(I item) => _wrapped.AddItem(item);
+        public void AddItemIgnoringCondition(I item) => _wrapped.AddItemIgnoringCondition(item);
+        public IItemDefinition<M> AddItemDefinition(string itemType) => _wrapped.AddItemDefinition(itemType);
+        public void AddToAllEvaluatedPropertiesList(P property) => _wrapped.AddToAllEvaluatedPropertiesList(property);
+        public void AddToAllEvaluatedItemDefinitionMetadataList(M itemDefinitionMetadatum) => _wrapped.AddToAllEvaluatedItemDefinitionMetadataList(itemDefinitionMetadatum);
+        public void AddToAllEvaluatedItemsList(I item) => _wrapped.AddToAllEvaluatedItemsList(item);
+        public IItemDefinition<M> GetItemDefinition(string itemType) => _wrapped.GetItemDefinition(itemType);
+        public ProjectTargetInstance GetTarget(string targetName) => _wrapped.GetTarget(targetName);
+        public void AddTarget(ProjectTargetInstance target) => _wrapped.AddTarget(target);
+        public void RecordImport(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated, SdkResult sdkResult) => _wrapped.RecordImport(importElement, import, versionEvaluated, sdkResult);
+        public void RecordImportWithDuplicates(ProjectImportElement importElement, ProjectRootElement import, int versionEvaluated) => _wrapped.RecordImportWithDuplicates(importElement, import, versionEvaluated);
+        public string ExpandString(string unexpandedValue) => _wrapped.ExpandString(unexpandedValue);
+        public bool EvaluateCondition(string condition) => _wrapped.EvaluateCondition(condition);
+        #endregion
+
+        #region Private Methods...
+        /// <summary>
+        /// Logic containing what to do when a property is read.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <param name="property">The value of the property that was read (null if there is no value).</param>
+        private void TrackPropertyRead(string name, P property)
+        {
+            // MSBuild looks up a property called "InnerBuildProperty". If that isn't present,
+            // an empty string is returned and it then attempts to look up the value for that property
+            // (which is an empty string). Thus this check.
+            if (string.IsNullOrEmpty(name)) return;
+
+            // If a property matches the name of an environment variable, but has NOT been overwritten by a non-environment-variable property
+            // track it as an environment variable read.
+            if (_wrapped.EnvironmentVariablePropertiesDictionary.Contains(name) && !_overwrittenEnvironmentVariables.Contains(name))
+            {
+                this.TrackEnvironmentVariableRead(name);
+            }
+            else if (property == null)
+            {
+                this.TrackUninitializedPropertyRead(name);
+            }
+        }
+
+        /// <summary>
+        /// Logs an EnvironmentVariableRead event.
+        /// </summary>
+        /// <param name="name">The name of the environment variable read.</param>
+        private void TrackEnvironmentVariableRead(string name)
+        {
+            if ((_settings & PropertyTrackingSetting.EnvironmentVariableRead) != PropertyTrackingSetting.EnvironmentVariableRead) return;
+
+            var args = new EnvironmentVariableReadEventArgs(
+                name,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("EnvironmentVariableRead", name));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        /// <summary>
+        /// Logs an UninitializedPropertyRead event.
+        /// </summary>
+        /// <param name="name">The name of the uninitialized property read.</param>
+        private void TrackUninitializedPropertyRead(string name)
+        {
+            if ((_settings & PropertyTrackingSetting.UninitializedPropertyRead) != PropertyTrackingSetting.UninitializedPropertyRead) return;
+
+            var args = new UninitializedPropertyReadEventArgs(
+                name,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("UninitializedPropertyRead", name));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        private void TrackPropertyWrite(P predecessor, P property, string location, PropertySource source)
+        {
+            string name = property.Name;
+
+            // If this property was an environment variable but no longer is, track it.
+            if (_wrapped.EnvironmentVariablePropertiesDictionary.Contains(name) && source != PropertySource.EnvironmentVariable)
+            {
+                _overwrittenEnvironmentVariables.Add(name);
+            }
+
+            if (predecessor == null)
+            {
+                // If this property had no previous value, then track an initial value.
+                TrackPropertyInitialValueSet(property, source);
+            }
+            else
+            {
+                // There was a previous value, and it might have been changed. Track that.
+                TrackPropertyReassignment(predecessor, property, location);
+            }
+        }
+
+        /// <summary>
+        /// If the property's initial value is set, it logs a PropertyInitialValueSet event.
+        /// </summary>
+        /// <param name="property">The property being set.</param>
+        /// <param name="source">The source of the property.</param>
+        private void TrackPropertyInitialValueSet(P property, PropertySource source)
+        {
+            if ((_settings & PropertyTrackingSetting.PropertyInitialValueSet) != PropertyTrackingSetting.PropertyInitialValueSet) return;
+
+            var args = new PropertyInitialValueSetEventArgs(
+                    property.Name,
+                    property.EvaluatedValue,
+                    source.ToString(),
+                    ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyAssignment", property.Name, property.EvaluatedValue, source)
+                );
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        /// <summary>
+        /// If the property's value has changed, it logs a PropertyReassignment event.
+        /// </summary>
+        /// <param name="predecessor">The property's preceding state. Null if none.</param>
+        /// <param name="property">The property's current state.</param>
+        /// <param name="location">The location of this property's reassignment.</param>
+        private void TrackPropertyReassignment(P predecessor, P property, string location)
+        {
+            if ((_settings & PropertyTrackingSetting.PropertyReassignment) != PropertyTrackingSetting.PropertyReassignment) return;
+
+            string newValue = property.EvaluatedValue;
+            string oldValue = predecessor.EvaluatedValue;
+            if (newValue == oldValue) return;
+
+            var args = new PropertyReassignmentEventArgs(
+                property.Name,
+                oldValue,
+                newValue,
+                location,
+                ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("PropertyReassignment", property.Name, newValue, oldValue, location));
+            args.BuildEventContext = _evaluationLoggingContext.BuildEventContext;
+
+            _evaluationLoggingContext.LogBuildEvent(args);
+        }
+
+        /// <summary>
+        /// Determines the source of a property given the variables SetProperty arguments provided. This logic follows what's in <see cref="Evaluator{P,I,M,D}"/>.
+        /// </summary>
+        private PropertySource DeterminePropertySource(bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable)
+        {
+            if (isEnvironmentVariable)
+            {
+                return PropertySource.EnvironmentVariable;
+            }
+
+            if (isGlobalProperty)
+            {
+                return PropertySource.Global;
+            }
+
+            return mayBeReserved ? PropertySource.BuiltIn : PropertySource.Toolset;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The available sources for a property.
+        /// </summary>
+        private enum PropertySource
+        {
+            Xml,
+            BuiltIn,
+            Global,
+            Toolset,
+            EnvironmentVariable
+        }
+
+        [Flags]
+        private enum PropertyTrackingSetting
+        {
+            None = 0,
+
+            PropertyReassignment = 1,
+            PropertyInitialValueSet = 1 << 1,
+            EnvironmentVariableRead = 1 << 2,
+            UninitializedPropertyRead = 1 << 3,
+
+            All = PropertyReassignment | PropertyInitialValueSet | EnvironmentVariableRead | UninitializedPropertyRead
+        }
+    }
+}

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -976,6 +976,11 @@ namespace Microsoft.Build.Execution
             { return _globalProperties; }
         }
 
+        PropertyDictionary<ProjectPropertyInstance> IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.EnvironmentVariablePropertiesDictionary
+        {
+            get => _environmentVariableProperties;
+        }
+
         /// <summary>
         /// List of names of the properties that, while global, are still treated as overridable 
         /// </summary>
@@ -1413,7 +1418,7 @@ namespace Microsoft.Build.Execution
         /// immutable if we are immutable.
         /// Only called during evaluation, so does not check for immutability.
         /// </summary>
-        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved)
+        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(string name, string evaluatedValueEscaped, bool isGlobalProperty, bool mayBeReserved, bool isEnvironmentVariable)
         {
             // Mutability not verified as this is being populated during evaluation
             ProjectPropertyInstance property = ProjectPropertyInstance.Create(name, evaluatedValueEscaped, mayBeReserved, _isImmutable);
@@ -1426,7 +1431,7 @@ namespace Microsoft.Build.Execution
         /// Predecessor is discarded as it is a design time only artefact.
         /// Only called during evaluation, so does not check for immutability.
         /// </summary>
-        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped, ProjectPropertyInstance predecessor)
+        ProjectPropertyInstance IEvaluatorData<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.SetProperty(ProjectPropertyElement propertyElement, string evaluatedValueEscaped)
         {
             // Mutability not verified as this is being populated during evaluation
             ProjectPropertyInstance property = ProjectPropertyInstance.Create(propertyElement.Name, evaluatedValueEscaped, false /* may not be reserved */, _isImmutable);

--- a/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs
@@ -20,6 +20,10 @@
         ProjectEvaluationFinished,
         ProjectImported,
         ProjectImportArchive,
-        TargetSkipped
+        TargetSkipped,
+        PropertyReassignment,
+        UninitializedPropertyRead,
+        EnvironmentVariableRead,
+        PropertyInitialValueSet,
     }
 }

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -29,10 +29,12 @@ namespace Microsoft.Build.Logging
         // version 5:
         //   - new EvaluationFinished.ProfilerResult
         // version 6:
-        //   -  Ids and parent ids for the evaluation locations
+        //   - Ids and parent ids for the evaluation locations
         // version 7:
-        //   -  Include ProjectStartedEventArgs.GlobalProperties
-        internal const int FileFormatVersion = 7;
+        //   - Include ProjectStartedEventArgs.GlobalProperties
+        // version 8:
+        //   - new record kinds: EnvironmentVariableRead, PropertyReassignment, UninitializedPropertyRead
+        internal const int FileFormatVersion = 8;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -33,8 +33,10 @@ namespace Microsoft.Build.Logging
         // version 7:
         //   - Include ProjectStartedEventArgs.GlobalProperties
         // version 8:
+        //   - This was used in a now-reverted change but is the same as 9.
+        // version 9:
         //   - new record kinds: EnvironmentVariableRead, PropertyReassignment, UninitializedPropertyRead
-        internal const int FileFormatVersion = 8;
+        internal const int FileFormatVersion = 9;
 
         private Stream stream;
         private BinaryWriter binaryWriter;

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs
@@ -112,6 +112,18 @@ namespace Microsoft.Build.Logging
                 case BinaryLogRecordKind.TargetSkipped:
                     result = ReadTargetSkippedEventArgs();
                     break;
+                case BinaryLogRecordKind.EnvironmentVariableRead:
+                    result = ReadEnvironmentVariableReadEventArgs();
+                    break;
+                case BinaryLogRecordKind.PropertyReassignment:
+                    result = ReadPropertyReassignmentEventArgs();
+                    break;
+                case BinaryLogRecordKind.UninitializedPropertyRead:
+                    result = ReadUninitializedPropertyReadEventArgs();
+                    break;
+                case BinaryLogRecordKind.PropertyInitialValueSet:
+                    result = ReadPropertyInitialValueSetEventArgs();
+                    break;
                 default:
                     break;
             }
@@ -505,6 +517,85 @@ namespace Microsoft.Build.Logging
                 fields.Timestamp);
             e.BuildEventContext = fields.BuildEventContext;
             e.ProjectFile = fields.ProjectFile;
+            return e;
+        }
+
+        private BuildEventArgs ReadEnvironmentVariableReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+
+            var environmentVariableName = ReadString();
+
+            var e = new EnvironmentVariableReadEventArgs(
+                environmentVariableName,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyReassignmentEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+            string previousValue = ReadString();
+            string newValue = ReadString();
+            string location = ReadString();
+
+            var e = new PropertyReassignmentEventArgs(
+                propertyName,
+                previousValue,
+                newValue,
+                location,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadUninitializedPropertyReadEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+
+            var e = new UninitializedPropertyReadEventArgs(
+                propertyName,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance);
+            SetCommonFields(e, fields);
+
+            return e;
+        }
+
+        private BuildEventArgs ReadPropertyInitialValueSetEventArgs()
+        {
+            var fields = ReadBuildEventArgsFields();
+            var importance = (MessageImportance)ReadInt32();
+            string propertyName = ReadString();
+            string propertyValue = ReadString();
+            string propertySource = ReadString();
+
+            var e = new PropertyInitialValueSetEventArgs(
+                propertyName,
+                propertyValue,
+                propertySource,
+                fields.Message,
+                fields.HelpKeyword,
+                fields.SenderName,
+                importance);
+            SetCommonFields(e, fields);
+
             return e;
         }
 

--- a/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
+++ b/src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs
@@ -286,6 +286,30 @@ namespace Microsoft.Build.Logging
                 return;
             }
 
+            if (e is PropertyReassignmentEventArgs)
+            {
+                Write((PropertyReassignmentEventArgs)e);
+                return;
+            }
+
+            if (e is UninitializedPropertyReadEventArgs)
+            {
+                Write((UninitializedPropertyReadEventArgs)e);
+                return;
+            }
+
+            if (e is EnvironmentVariableReadEventArgs)
+            {
+                Write((EnvironmentVariableReadEventArgs)e);
+                return;
+            }
+
+            if (e is PropertyInitialValueSetEventArgs)
+            {
+                Write((PropertyInitialValueSetEventArgs)e);
+                return;
+            }
+
             Write(BinaryLogRecordKind.Message);
             WriteMessageFields(e);
         }
@@ -313,6 +337,39 @@ namespace Microsoft.Build.Logging
         {
             Write(BinaryLogRecordKind.CriticalBuildMessage);
             WriteMessageFields(e);
+        }
+
+        private void Write(PropertyReassignmentEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyReassignment);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PreviousValue);
+            Write(e.NewValue);
+            Write(e.Location);
+        }
+
+        private void Write(UninitializedPropertyReadEventArgs e)
+        {
+            Write(BinaryLogRecordKind.UninitializedPropertyRead);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+        }
+
+        private void Write(PropertyInitialValueSetEventArgs e)
+        {
+            Write(BinaryLogRecordKind.PropertyInitialValueSet);
+            WriteMessageFields(e);
+            Write(e.PropertyName);
+            Write(e.PropertyValue);
+            Write(e.PropertySource);
+        }
+
+        private void Write(EnvironmentVariableReadEventArgs e)
+        {
+            Write(BinaryLogRecordKind.EnvironmentVariableRead);
+            WriteMessageFields(e);
+            Write(e.EnvironmentVariableName);
         }
 
         private void Write(TaskCommandLineEventArgs e)

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -162,6 +162,7 @@
     <Compile Include="ObjectModelRemoting\DefinitionObjectsLinks\ProjectItemDefinitionLink.cs" />
     <Compile Include="ObjectModelRemoting\DefinitionObjectsLinks\ProjectItemLink.cs" />
     <Compile Include="ObjectModelRemoting\DefinitionObjectsLinks\ProjectLink.cs" />
+    <Compile Include="Evaluation\PropertyTrackingEvaluatorDataWrapper.cs" />
     <Compile Include="Graph\GraphBuilder.cs" />
     <Compile Include="Graph\ParallelWorkSet.cs" />
     <Compile Include="Graph\ProjectInterpretation.cs" />

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1804,6 +1804,21 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
   <data name="InvalidVersionFormat" xml:space="preserve">
     <value>Version string was not in a correct format.</value>
   </data>
+  <data name="UninitializedPropertyRead" UESanitized="false" Visibility="Public">
+    <value>Read uninitialized property "{0}"</value>
+    <comment>
+    </comment>
+  </data>
+  <data name="EnvironmentVariableRead" UESanitized="false" Visibility="Public">
+    <value>Read environment variable "{0}"</value>
+    <comment>
+    </comment>
+  </data>
+  <data name="PropertyAssignment" UESanitized="false" Visibility="Public">
+    <value>Property initial value: $({0})="{1}" Source: {2}</value>
+    <comment>
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Zadaný výstupní soubor mezipaměti pro výsledky je prázdný.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Při čtení vstupních souborů mezipaměti pro výsledky z cesty {0} byla zjištěna chyba: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Projekt {0} přeskočil omezení izolace grafu v odkazovaném projektu {1}.</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Die angegebene Cachedatei für Ausgabeergebnisse ist leer.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Beim Lesen der Cachedateien für Eingabeergebnisse aus dem Pfad "{0}" wurde ein Fehler festgestellt: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: Das Projekt "{0}" hat Graphisolationseinschränkungen für das referenzierte Projekt "{1}" übersprungen.</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -67,6 +67,11 @@
         <target state="new">MSB4257: The specified output result cache file is empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="new">MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="new">MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: El archivo de caché de resultados de salida especificado está vacío.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Error al leer los archivos de caché de resultados de entrada en la ruta de acceso "{0}": {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: El proyecto "{0}" ha omitido las restricciones de aislamiento de gráficos en el proyecto "{1}" al que se hace referencia.</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Le fichier cache des résultats de sortie spécifié est vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: La lecture des fichiers cache des résultats d'entrée à partir du chemin "{0}" a rencontré une erreur : {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: le projet "{0}" a ignoré les contraintes d'isolement de graphe dans le projet référencé "{1}"</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: il file della cache dei risultati di output specificato è vuoto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: durante la lettura dei file della cache dei risultati di input dal percorso "{0}" è stato rilevato un errore: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: il progetto "{0}" ha ignorato i vincoli di isolamento del grafico nel progetto di riferimento "{1}"</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定された出力結果キャッシュ ファイルは空です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: パス "{0}" から入力結果キャッシュ ファイルを読み取る処理でエラーが発生しました: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: プロジェクト "{0}" は、参照先のプロジェクト "{1}" で、グラフの分離制約をスキップしました</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 지정한 출력 결과 캐시 파일이 비어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: "{0}" 경로에서 입력 결과 캐시 파일을 읽는 중 오류가 발생했습니다. {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 프로젝트 "{0}"에서 참조된 프로젝트 "{1}"의 그래프 격리 제약 조건을 건너뛰었습니다.</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Określony plik wyjściowej pamięci podręcznej wyników jest pusty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: Podczas odczytywania plików wejściowej pamięci podręcznej wyników ze ścieżki „{0}” wystąpił błąd: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: W przypadku projektu „{0}” pominięto ograniczenia izolacji grafu dla przywoływanego projektu „{1}”</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -66,6 +66,11 @@
         <target state="translated">MSB4257: o arquivo de cache do resultado de saída especificado está vazio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: a leitura dos arquivos de cache do resultado de entrada do caminho "{0}" encontrou um erro: {1}</target>
@@ -124,6 +129,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: o projeto "{0}" ignorou as restrições de isolamento do gráfico no projeto referenciado "{1}"</target>
@@ -167,6 +177,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: указанный выходной файл кэша результатов пустой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: произошла ошибка при чтении входных файлов кэша результатов из пути "{0}": {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: проект "{0}" пропустил ограничения изоляции графа в проекте "{1}", на который указывает ссылка.</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: Belirtilen çıkış sonucu önbellek dosyası boş.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: "{0}" yolundan giriş sonucu önbellek dosyaları okunurken bir hatayla karşılaşıldı: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: "{0}" projesi, başvurulan "{1}" projesindeki graf yalıtımı kısıtlamalarını atladı</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定的输出结果缓存文件为空。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: 从路径“{0}”读取输入结果缓存文件时遇到错误: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 项目“{0}”已跳过所引用的项目“{1}”上的图形隔离约束</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">MSB4257: 指定的輸出結果快取檔案是空的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnvironmentVariableRead">
+        <source>Read environment variable "{0}"</source>
+        <target state="new">Read environment variable "{0}"</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingCacheFile">
         <source>MSB4256: Reading input result cache files from path "{0}" encountered an error: {1}</source>
         <target state="translated">MSB4256: 從路徑 "{0}" 讀取輸入結果快取檔案發生錯誤: {1}</target>
@@ -125,6 +130,11 @@
       LOCALIZATION:  Do not localize the following words: ProjectGraph, ProjectReference, ToolsVersion.
     </note>
       </trans-unit>
+      <trans-unit id="PropertyAssignment">
+        <source>Property initial value: $({0})="{1}" Source: {2}</source>
+        <target state="new">Property initial value: $({0})="{1}" Source: {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SkippedConstraintsOnRequest">
         <source>MSB4260: Project "{0}" skipped graph isolation constraints on referenced project "{1}"</source>
         <target state="translated">MSB4260: 專案 "{0}" 已跳過參考專案 "{1}" 上的圖形隔離條件約束</target>
@@ -168,6 +178,11 @@
       {StrBegin="MSB4254:"}
       LOCALIZATION: Do not localize the following words: ProjectReference, MSBuild, task.
     </note>
+      </trans-unit>
+      <trans-unit id="UninitializedPropertyRead">
+        <source>Read uninitialized property "{0}"</source>
+        <target state="new">Read uninitialized property "{0}"</target>
+        <note />
       </trans-unit>
       <trans-unit id="UsingInputCaches">
         <source>Using input build results caches: {0}</source>

--- a/src/Framework/EnvironmentVariableReadEventArgs.cs
+++ b/src/Framework/EnvironmentVariableReadEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// Arguments for the environment variable read event.
+    /// </summary>
+    [Serializable]
+    public class EnvironmentVariableReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+        public EnvironmentVariableReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the EnvironmentVariableReadEventArgs class.
+        /// </summary>
+        /// <param name="environmentVariableName">The name of the environment variable that was read.</param>
+        public EnvironmentVariableReadEventArgs(
+            string environmentVariableName,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.EnvironmentVariableName = environmentVariableName;
+        }
+
+        /// <summary>
+        /// The name of the environment variable that was read.
+        /// </summary>
+        public string EnvironmentVariableName { get; set; }
+    }
+}

--- a/src/Framework/PropertyInitialValueSetEventArgs.cs
+++ b/src/Framework/PropertyInitialValueSetEventArgs.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The argument for a property initial value set event.
+    /// </summary>
+    [Serializable]
+    public class PropertyInitialValueSetEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Creates an instance of the <see cref="PropertyInitialValueSetEventArgs"/> class.
+        /// </summary>
+        public PropertyInitialValueSetEventArgs() { }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="PropertyInitialValueSetEventArgs"/> class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="propertyValue">The value of the property.</param>
+        /// <param name="propertySource">The source of the property.</param>
+        public PropertyInitialValueSetEventArgs(
+            string propertyName,
+            string propertyValue,
+            string propertySource,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PropertyValue = propertyValue;
+            this.PropertySource = propertySource;
+        }
+
+        /// <summary>
+        /// The name of the property.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// The value of the property.
+        /// </summary>
+        public string PropertyValue { get; set; }
+
+        /// <summary>
+        /// The source of the property.
+        /// </summary>
+        public string PropertySource { get; set; }
+    }
+}

--- a/src/Framework/PropertyReassignmentEventArgs.cs
+++ b/src/Framework/PropertyReassignmentEventArgs.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The argument for a property reassignment event.
+    /// </summary>
+    [Serializable]
+    public class PropertyReassignmentEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// Creates an instance of the PropertyReassignmentEventArgs class.
+        /// </summary>
+        public PropertyReassignmentEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the PropertyReassignmentEventArgs class.
+        /// </summary>
+        /// <param name="propertyName">The name of the property whose value was reassigned.</param>
+        /// <param name="previousValue">The previous value of the reassigned property.</param>
+        /// <param name="newValue">The new value of the reassigned property.</param>
+        /// <param name="location">The location of the reassignment.</param>
+        public PropertyReassignmentEventArgs(
+            string propertyName,
+            string previousValue,
+            string newValue,
+            string location,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+            this.PreviousValue = previousValue;
+            this.NewValue = newValue;
+            this.Location = location;
+        }
+
+        /// <summary>
+        /// The name of the property whose value was reassigned.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// The previous value of the reassigned property.
+        /// </summary>
+        public string PreviousValue { get; set; }
+
+        /// <summary>
+        /// The new value of the reassigned property.
+        /// </summary>
+        public string NewValue { get; set; }
+
+        /// <summary>
+        /// The location of the reassignment.
+        /// </summary>
+        public string Location { get; set; }
+    }
+}

--- a/src/Framework/UninitializedPropertyReadEventArgs.cs
+++ b/src/Framework/UninitializedPropertyReadEventArgs.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Build.Framework
+{
+    /// <summary>
+    /// The arguments for an uninitialized property read event.
+    /// </summary>
+    [Serializable]
+    public class UninitializedPropertyReadEventArgs : BuildMessageEventArgs
+    {
+        /// <summary>
+        /// UninitializedPropertyReadEventArgs
+        /// </summary>
+        public UninitializedPropertyReadEventArgs()
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the UninitializedPropertyReadEventArgs class
+        /// </summary>
+        /// <param name="propertyName">The name of the uninitialized property that was read.</param>
+        public UninitializedPropertyReadEventArgs(
+            string propertyName,
+            string message,
+            string helpKeyword = null,
+            string senderName = null,
+            MessageImportance importance = MessageImportance.Low) : base(message, helpKeyword, senderName, importance)
+        {
+            this.PropertyName = propertyName;
+        }
+
+        /// <summary>
+        /// The name of the uninitialized property that was read.
+        /// </summary>
+        public string PropertyName { get; set; }
+    }
+}

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool LogPropertyFunctionsRequiringReflection = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBuildLogPropertyFunctionsRequiringReflection"));
 
+        /// <summary>
+        /// Log property tracking information.
+        /// </summary>
+        public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 1); // Default to logging only property reassignments.
+
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {
             return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Log property tracking information.
         /// </summary>
-        public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 1); // Default to logging only property reassignments.
+        public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 0); // Default to logging nothing via the property tracker.
 
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {


### PR DESCRIPTION
Re-reverting this as a starting point for #3432 and #5015 

…#4461)" (#4663)"

This reverts commit faf5e5d75f737df486e9005c4024738fa723da7d.

