### PR TITLE
Upload symbols in official build

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -147,6 +147,13 @@ stages:
         ArtifactName: logs
       condition: succeededOrFailed()
 
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: symbols'
+      inputs:
+        PathtoPublish: 'artifacts\bin\**\*.pdb'
+        ArtifactName: symbols
+      condition: succeededOrFailed()
+
     # Publishes setup VSIXes to a drop.
     # Note: The insertion tool looks for the display name of this task in the logs.
     - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1


### PR DESCRIPTION
This works around any future recurrence of dotnet/arcade#2531 by
giving us symbols to manually upload if we have to.