### PR TITLE
Detect and switch to UTF-8 codepage in ToolTask with UseCommandProcessor

### DIFF
--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class EncodingUtilities
     {
+        internal static readonly Encoding Utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
         private static Encoding s_currentOemEncoding;
 
         internal const string UseUtf8Always = "ALWAYS";

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Build.Shared
     {
         private static Encoding s_currentOemEncoding;
 
+        internal const string UseUtf8Always = "ALWAYS";
+        internal const string UseUtf8Never = "NEVER";
+        internal const string UseUtf8Detect = "DETECT";
+        internal const string UseUtf8System = "SYSTEM";
+
         /// <summary>
         /// Get the current system locale code page, OEM version. OEM code pages are used for console-based input/output
         /// for historical reasons.

--- a/src/Shared/EncodingUtilities.cs
+++ b/src/Shared/EncodingUtilities.cs
@@ -188,5 +188,59 @@ namespace Microsoft.Build.Shared
                 return false;
             }
         }
+
+        /// <summary>
+        /// Find the encoding for the batch file.
+        /// </summary>
+        /// <remarks>
+        /// The "best" encoding is the current OEM encoding, unless it's not capable of representing
+        /// the characters we plan to put in the file. If it isn't, we can fall back to UTF-8.
+        ///
+        /// Why not always UTF-8? Because tools don't always handle it well. See
+        /// https://github.com/Microsoft/msbuild/issues/397
+        /// </remarks>
+        internal static Encoding BatchFileEncoding(string contents, string encodingSpecification)
+        {
+            if (!NativeMethodsShared.IsWindows)
+            {
+                return EncodingUtilities.Utf8WithoutBom;
+            }
+
+            var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
+
+            // When Windows is configured to use UTF-8 by default, the above returns
+            // a UTF-8-with-BOM encoding, which cmd.exe can't interpret. Force the no-BOM
+            // encoding if the returned encoding would have emitted one (preamble is nonempty).
+            // See https://github.com/Microsoft/msbuild/issues/4268
+            if (defaultEncoding is UTF8Encoding e && e.GetPreamble().Length > 0)
+            {
+                defaultEncoding = EncodingUtilities.Utf8WithoutBom;
+            }
+
+            string useUtf8 = string.IsNullOrEmpty(encodingSpecification) ? EncodingUtilities.UseUtf8Detect : encodingSpecification;
+
+#if FEATURE_OSVERSION
+            // UTF8 is only supported in Windows 7 (6.1) or greater.
+            var windows7 = new Version(6, 1);
+
+            if (Environment.OSVersion.Version < windows7)
+            {
+                useUtf8 = EncodingUtilities.UseUtf8Never;
+            }
+#endif
+
+            switch (useUtf8.ToUpperInvariant())
+            {
+                case EncodingUtilities.UseUtf8Always:
+                    return EncodingUtilities.Utf8WithoutBom;
+                case EncodingUtilities.UseUtf8Never:
+                case EncodingUtilities.UseUtf8System:
+                    return defaultEncoding;
+                default:
+                    return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, contents)
+                        ? defaultEncoding
+                        : EncodingUtilities.Utf8WithoutBom;
+            }
+        }
     }
 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -185,6 +185,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool UseAutoRunWhenLaunchingProcessUnderCmd = Environment.GetEnvironmentVariable("MSBUILDUSERAUTORUNINCMD") == "1";
 
         /// <summary>
+        /// Disables switching codepage to UTF-8 after detection of characters that can't be represented in the current codepage.
+        /// </summary>
+        public readonly bool AvoidUnicodeWhenWritingToolTaskBatch = Environment.GetEnvironmentVariable("MSBUILDAVOIDUNICODE") == "1";
+
+        /// <summary>
         /// Workaround for https://github.com/Microsoft/vstest/issues/1503.
         /// </summary>
         public readonly bool EnsureStdOutForChildNodesIsPrimaryStdout = Environment.GetEnvironmentVariable("MSBUILDENSURESTDOUTFORTASKPROCESSES") == "1";

--- a/src/Tasks.UnitTests/Exec_Tests.cs
+++ b/src/Tasks.UnitTests/Exec_Tests.cs
@@ -856,8 +856,8 @@ namespace Microsoft.Build.UnitTests
             string nonAnsiCharacters = "\u521B\u5EFA";
             string pathWithAnsiCharacters = @"c:\windows\system32\cmd.exe";
 
-            Assert.False(Exec.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
-            Assert.True(Exec.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
+            Assert.False(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, nonAnsiCharacters));
+            Assert.True(EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, pathWithAnsiCharacters));
         }
 
         [Fact]

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void CreateTemporaryBatchFile()
         {
-            var encoding = BatchFileEncoding(Command + WorkingDirectory);
+            var encoding = BatchFileEncoding(Command + WorkingDirectory, UseUtf8Encoding);
 
             // Temporary file with the extension .Exec.bat
             _batchFile = FileUtilities.GetTemporaryFile(".exec.cmd");
@@ -657,7 +657,7 @@ namespace Microsoft.Build.Tasks
         /// Why not always UTF-8? Because tools don't always handle it well. See
         /// https://github.com/Microsoft/msbuild/issues/397
         /// </remarks>
-        private Encoding BatchFileEncoding(string contents)
+        private static Encoding BatchFileEncoding(string contents, string encodingSpecification)
         {
             if (!NativeMethodsShared.IsWindows)
             {
@@ -675,7 +675,7 @@ namespace Microsoft.Build.Tasks
                 defaultEncoding = EncodingUtilities.Utf8WithoutBom;
             }
 
-            string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? EncodingUtilities.UseUtf8Detect : UseUtf8Encoding;
+            string useUtf8 = string.IsNullOrEmpty(encodingSpecification) ? EncodingUtilities.UseUtf8Detect : encodingSpecification;
 
 #if FEATURE_OSVERSION
             // UTF8 is only supported in Windows 7 (6.1) or greater.

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         private void CreateTemporaryBatchFile()
         {
-            var encoding = BatchFileEncoding();
+            var encoding = BatchFileEncoding(Command + WorkingDirectory);
 
             // Temporary file with the extension .Exec.bat
             _batchFile = FileUtilities.GetTemporaryFile(".exec.cmd");
@@ -663,7 +663,7 @@ namespace Microsoft.Build.Tasks
         /// Why not always UTF-8? Because tools don't always handle it well. See
         /// https://github.com/Microsoft/msbuild/issues/397
         /// </remarks>
-        private Encoding BatchFileEncoding()
+        private Encoding BatchFileEncoding(string contents)
         {
             if (!NativeMethodsShared.IsWindows)
             {
@@ -701,7 +701,7 @@ namespace Microsoft.Build.Tasks
                 case UseUtf8System:
                     return defaultEncoding;
                 default:
-                    return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)
+                    return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, contents)
                         ? defaultEncoding
                         : s_utf8WithoutBom;
             }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -646,7 +646,6 @@ namespace Microsoft.Build.Tasks
 
         #endregion
 
-        private static readonly Encoding s_utf8WithoutBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         /// <summary>
         /// Find the encoding for the batch file.
@@ -662,7 +661,7 @@ namespace Microsoft.Build.Tasks
         {
             if (!NativeMethodsShared.IsWindows)
             {
-                return s_utf8WithoutBom;
+                return EncodingUtilities.Utf8WithoutBom;
             }
 
             var defaultEncoding = EncodingUtilities.CurrentSystemOemEncoding;
@@ -673,7 +672,7 @@ namespace Microsoft.Build.Tasks
             // See https://github.com/Microsoft/msbuild/issues/4268
             if (defaultEncoding is UTF8Encoding e && e.GetPreamble().Length > 0)
             {
-                defaultEncoding = s_utf8WithoutBom;
+                defaultEncoding = EncodingUtilities.Utf8WithoutBom;
             }
 
             string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? EncodingUtilities.UseUtf8Detect : UseUtf8Encoding;
@@ -691,14 +690,14 @@ namespace Microsoft.Build.Tasks
             switch (useUtf8.ToUpperInvariant())
             {
                 case EncodingUtilities.UseUtf8Always:
-                    return s_utf8WithoutBom;
+                    return EncodingUtilities.Utf8WithoutBom;
                 case EncodingUtilities.UseUtf8Never:
                 case EncodingUtilities.UseUtf8System:
                     return defaultEncoding;
                 default:
                     return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, contents)
                         ? defaultEncoding
-                        : s_utf8WithoutBom;
+                        : EncodingUtilities.Utf8WithoutBom;
             }
         }
     }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -701,42 +701,9 @@ namespace Microsoft.Build.Tasks
                 case UseUtf8System:
                     return defaultEncoding;
                 default:
-                    return CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)
+                    return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, Command + WorkingDirectory)
                         ? defaultEncoding
                         : s_utf8WithoutBom;
-            }
-        }
-
-        /// <summary>
-        /// Checks to see if a string can be encoded in a specified code page.
-        /// </summary>
-        /// <remarks>Internal for testing purposes.</remarks>
-        /// <param name="codePage">Code page for encoding.</param>
-        /// <param name="stringToEncode">String to encode.</param>
-        /// <returns>True if the string can be encoded in the specified code page.</returns>
-        internal static bool CanEncodeString(int codePage, string stringToEncode)
-        {
-            // We have a System.String that contains some characters. Get a lossless representation
-            // in byte-array form.
-            var unicodeEncoding = new UnicodeEncoding();
-            var unicodeBytes = unicodeEncoding.GetBytes(stringToEncode);
-
-            // Create an Encoding using the desired code page, but throws if there's a
-            // character that can't be represented.
-            var systemEncoding = Encoding.GetEncoding(codePage, EncoderFallback.ExceptionFallback,
-                DecoderFallback.ExceptionFallback);
-
-            try
-            {
-                var oemBytes = Encoding.Convert(unicodeEncoding, systemEncoding, unicodeBytes);
-
-                // If Convert didn't throw, we can represent everything in the desired encoding.
-                return true;
-            }
-            catch (EncoderFallbackException)
-            {
-                // If a fallback encoding was attempted, we need to go to Unicode.
-                return false;
             }
         }
     }

--- a/src/Tasks/Exec.cs
+++ b/src/Tasks/Exec.cs
@@ -43,11 +43,6 @@ namespace Microsoft.Build.Tasks
 
         #region Fields
 
-        private const string UseUtf8Always = "ALWAYS";
-        private const string UseUtf8Never = "NEVER";
-        private const string UseUtf8Detect = "DETECT";
-        private const string UseUtf8System = "SYSTEM";
-
         // Are the encodings for StdErr and StdOut streams valid
         private bool _encodingParametersValid = true;
         private string _workingDirectory;
@@ -681,7 +676,7 @@ namespace Microsoft.Build.Tasks
                 defaultEncoding = s_utf8WithoutBom;
             }
 
-            string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? UseUtf8Detect : UseUtf8Encoding;
+            string useUtf8 = string.IsNullOrEmpty(UseUtf8Encoding) ? EncodingUtilities.UseUtf8Detect : UseUtf8Encoding;
 
 #if FEATURE_OSVERSION
             // UTF8 is only supported in Windows 7 (6.1) or greater.
@@ -689,16 +684,16 @@ namespace Microsoft.Build.Tasks
 
             if (Environment.OSVersion.Version < windows7)
             {
-                useUtf8 = UseUtf8Never;
+                useUtf8 = EncodingUtilities.UseUtf8Never;
             }
 #endif
 
             switch (useUtf8.ToUpperInvariant())
             {
-                case UseUtf8Always:
+                case EncodingUtilities.UseUtf8Always:
                     return s_utf8WithoutBom;
-                case UseUtf8Never:
-                case UseUtf8System:
+                case EncodingUtilities.UseUtf8Never:
+                case EncodingUtilities.UseUtf8System:
                     return defaultEncoding;
                 default:
                     return EncodingUtilities.CanEncodeString(defaultEncoding.CodePage, contents)

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -10,11 +10,19 @@ using Microsoft.Build.UnitTests;
 using Microsoft.Build.Utilities;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     public sealed class ToolTask_Tests
     {
+        private ITestOutputHelper _output;
+
+        public ToolTask_Tests(ITestOutputHelper testOutput)
+        {
+            _output = testOutput;
+        }
+
         private class MyTool : ToolTask, IDisposable
         {
             private string _fullToolName;
@@ -789,5 +797,64 @@ namespace Microsoft.Build.UnitTests
 
             public string ResponseFileCommands { get; private set; }
         }
+
+        [Theory]
+        [InlineData("MSBUILDAVOIDUNICODE", null, false)]
+        [InlineData("MSBUILDAVOIDUNICODE", "0", false)]
+        [InlineData("MSBUILDAVOIDUNICODE", "1", true)]
+        public void ToolTaskCanUseUnicode(string environmentVariableName, string environmentVariableValue, bool expectNormalizationToANSI)
+        {
+            using TestEnvironment testEnvironment = TestEnvironment.Create(_output);
+
+            testEnvironment.SetEnvironmentVariable(environmentVariableName, environmentVariableValue);
+
+            var output = testEnvironment.ExpectFile();
+
+            MockEngine engine = new MockEngine();
+
+            var task = new ToolTaskThatNeedsUnicode
+            {
+                BuildEngine = engine,
+                UseCommandProcessor = true,
+                OutputPath = output.Path,
+            };
+
+            task.Execute();
+
+            File.Exists(output.Path).ShouldBeTrue();
+            if (expectNormalizationToANSI)
+            {
+                File.ReadAllText(output.Path).ShouldContain("lol");
+            }
+            else
+            {
+                File.ReadAllText(output.Path).ShouldContain("łoł");
+            }
+        }
+
+
+        private sealed class ToolTaskThatNeedsUnicode : ToolTask
+        {
+            protected override string ToolName => "cmd.exe";
+
+            [Required]
+            public string OutputPath { get; set; }
+
+            public ToolTaskThatNeedsUnicode()
+            {
+                UseCommandProcessor = true;
+            }
+
+            protected override string GenerateFullPathToTool()
+            {
+                return "cmd.exe";
+            }
+
+            protected override string GenerateCommandLineCommands()
+            {
+                return $"echo łoł > {OutputPath}";
+            }
+        }
+
     }
 }

--- a/src/Utilities.UnitTests/ToolTask_Tests.cs
+++ b/src/Utilities.UnitTests/ToolTask_Tests.cs
@@ -822,13 +822,14 @@ namespace Microsoft.Build.UnitTests
             task.Execute();
 
             File.Exists(output.Path).ShouldBeTrue();
-            if (expectNormalizationToANSI)
+            if (NativeMethodsShared.IsUnixLike // treat all UNIXy OSes as capable of UTF-8 everywhere
+                || !expectNormalizationToANSI)
             {
-                File.ReadAllText(output.Path).ShouldContain("lol");
+                File.ReadAllText(output.Path).ShouldContain("łoł");
             }
             else
             {
-                File.ReadAllText(output.Path).ShouldContain("łoł");
+                File.ReadAllText(output.Path).ShouldContain("lol");
             }
         }
 

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1362,6 +1362,8 @@ namespace Microsoft.Build.Utilities
                         File.AppendAllText(_temporaryBatchFile, "#!/bin/sh\n"); // first line for UNIX is ANSI
                         // This is a hack..!
                         File.AppendAllText(_temporaryBatchFile, AdjustCommandsForOperatingSystem(commandLineCommands), EncodingUtilities.CurrentSystemOemEncoding);
+
+                        commandLineCommands = $"\"{_temporaryBatchFile}\"";
                     }
                     else
                     {

--- a/src/Utilities/ToolTask.cs
+++ b/src/Utilities/ToolTask.cs
@@ -1365,7 +1365,30 @@ namespace Microsoft.Build.Utilities
                     }
                     else
                     {
-                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, EncodingUtilities.CurrentSystemOemEncoding);
+
+                        Encoding encoding;
+
+                        if (Traits.Instance.EscapeHatches.AvoidUnicodeWhenWritingToolTaskBatch)
+                        {
+                            encoding = EncodingUtilities.CurrentSystemOemEncoding;
+                        }
+                        else
+                        {
+                            encoding = EncodingUtilities.BatchFileEncoding(commandLineCommands + _temporaryBatchFile, EncodingUtilities.UseUtf8Detect);
+
+                            if (encoding.CodePage != EncodingUtilities.CurrentSystemOemEncoding.CodePage)
+                            {
+                                // cmd.exe reads the first line in the console CP, 
+                                // which for a new console (as here) is OEMCP
+                                // this string should ideally always be ASCII
+                                // and the same in any OEMCP.
+                                File.AppendAllText(_temporaryBatchFile,
+                                                   $@"%SystemRoot%\System32\chcp.com {encoding.CodePage}>nul{Environment.NewLine}",
+                                                   EncodingUtilities.CurrentSystemOemEncoding);
+                            }
+                        }
+
+                        File.AppendAllText(_temporaryBatchFile, commandLineCommands, encoding);
 
                         string batchFileForCommandLine = _temporaryBatchFile;
 


### PR DESCRIPTION
Fix #4904 using the same detect-and-switch-codepage code as we use in `Exec`.