### PR TITLE
Enable ResolveNonMSBuildProjectOutput on .NET Core

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -653,6 +653,16 @@ namespace Microsoft.Build.Tasks
         public bool SuppressAutoClosePasswordPrompt { get { throw null; } set { } }
         public override bool Execute() { throw null; }
     }
+    public partial class ResolveNonMSBuildProjectOutput : Microsoft.Build.Tasks.ResolveProjectBase
+    {
+        public ResolveNonMSBuildProjectOutput() { }
+        public string PreresolvedProjectOutputs { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] ResolvedOutputPaths { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] UnresolvedProjectReferences { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+    }
     public abstract partial class ResolveProjectBase : Microsoft.Build.Tasks.TaskExtension
     {
         protected ResolveProjectBase() { }

--- a/src/Tasks.UnitTests/AssignProjectConfiguration_Tests.cs
+++ b/src/Tasks.UnitTests/AssignProjectConfiguration_Tests.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
@@ -20,6 +21,13 @@ namespace Microsoft.Build.UnitTests
     /// </summary>
     sealed public class AssignProjectConfiguration_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public AssignProjectConfiguration_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         private void TestResolveHelper(string itemSpec, string projectGuid, string package, string name,
             Hashtable pregenConfigurations, bool expectedResult,
             string expectedFullConfiguration, string expectedConfiguration, string expectedPlatform)
@@ -257,7 +265,7 @@ namespace Microsoft.Build.UnitTests
             // but they are ignored anyway, and the rest is identical
             string xmlString = ResolveNonMSBuildProjectOutput_Tests.CreatePregeneratedPathDoc(pregenConfigurations);
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             AssignProjectConfiguration rpc = new AssignProjectConfiguration();
             rpc.BuildEngine = engine;
             rpc.SolutionConfigurationContents = xmlString;

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -124,7 +124,6 @@
     <Compile Remove="AssemblyDependency\VerifyTargetFrameworkHigherThanRedist.cs" />
     <Compile Remove="AssemblyDependency\WinMDTests.cs" />
     <Compile Remove="ResolveComReference_Tests.cs" />
-    <Compile Remove="ResolveNonMSBuildProjectOutput_Tests.cs" />
     <Compile Remove="ResolveSDKReference_Tests.cs" />
     <Compile Remove="SdkToolsPathUtility_Tests.cs" />
     <Compile Remove="SGen_Tests.cs" />

--- a/src/Tasks.UnitTests/ResolveNonMSBuildProjectOutput_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveNonMSBuildProjectOutput_Tests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.IO;
 using System.Text;
 using System.Linq;
 using System.Xml;
@@ -127,32 +128,32 @@ namespace Microsoft.Build.UnitTests
 
             // non matching project in string
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
             TestResolveHelper("MCDep1.vcproj", "{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}", "MCDep1",
                 projectOutputs, false, null);
 
             // matching project in string
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\correct.dll");
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "correct.dll"));
             TestResolveHelper("MCDep1.vcproj", "{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}", "MCDep1",
-                projectOutputs, true, @"obj\correct.dll");
+                projectOutputs, true, Path.Combine("obj", "correct.dll"));
 
             // multiple non matching projects in string
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
             TestResolveHelper("MCDep1.vcproj", "{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}", "MCDep1",
                 projectOutputs, false, null);
 
             // multiple non matching projects in string, one matching
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\correct.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "correct.dll"));
             TestResolveHelper("MCDep1.vcproj", "{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}", "MCDep1",
-                projectOutputs, true, @"obj\correct.dll");
+                projectOutputs, true, Path.Combine("obj", "correct.dll"));
         }
 
         private void TestUnresolvedReferencesHelper(ArrayList projectRefs, Hashtable pregenOutputs,
@@ -217,16 +218,16 @@ namespace Microsoft.Build.UnitTests
 
             // 1. multiple project refs, none resolvable
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", @"obj\managed.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\unmanaged.dll");
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", Path.Combine("obj", "managed.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "unmanaged.dll"));
 
-            TestUnresolvedReferencesHelper(projectRefs, projectOutputs, path => (path == @"obj\managed.dll"), out unresolvedOutputs, out resolvedOutputs);
+            TestUnresolvedReferencesHelper(projectRefs, projectOutputs, path => (path == Path.Combine("obj", "managed.dll")), out unresolvedOutputs, out resolvedOutputs);
 
             Assert.NotNull(resolvedOutputs);
-            Assert.True(resolvedOutputs.Contains(@"obj\managed.dll"));
-            Assert.True(resolvedOutputs.Contains(@"obj\unmanaged.dll"));
-            Assert.Equal("true", ((ITaskItem)resolvedOutputs[@"obj\managed.dll"]).GetMetadata("ManagedAssembly"));
-            Assert.NotEqual("true", ((ITaskItem)resolvedOutputs[@"obj\unmanaged.dll"]).GetMetadata("ManagedAssembly"));
+            Assert.True(resolvedOutputs.Contains(Path.Combine("obj", "managed.dll")));
+            Assert.True(resolvedOutputs.Contains(Path.Combine("obj", "unmanaged.dll")));
+            Assert.Equal("true", ((ITaskItem)resolvedOutputs[Path.Combine("obj", "managed.dll")]).GetMetadata("ManagedAssembly"));
+            Assert.NotEqual("true", ((ITaskItem)resolvedOutputs[Path.Combine("obj", "unmanaged.dll")]).GetMetadata("ManagedAssembly"));
         }
 
         /// <summary>
@@ -249,9 +250,9 @@ namespace Microsoft.Build.UnitTests
 
             // 1. multiple project refs, none resolvable
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
 
             TestUnresolvedReferencesHelper(projectRefs, projectOutputs, out unresolvedOutputs, out resolvedOutputs);
 
@@ -262,38 +263,38 @@ namespace Microsoft.Build.UnitTests
 
             // 2. multiple project refs, one resolvable
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\correct.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "correct.dll"));
 
             TestUnresolvedReferencesHelper(projectRefs, projectOutputs, out unresolvedOutputs, out resolvedOutputs);
 
             Assert.Single(resolvedOutputs); // "One resolved ref expected for case 2"
-            Assert.True(resolvedOutputs.ContainsKey(@"obj\correct.dll"));
+            Assert.True(resolvedOutputs.ContainsKey(Path.Combine("obj", "correct.dll")));
             Assert.Single(unresolvedOutputs); // "One unresolved ref expected for case 2"
             Assert.Equal(unresolvedOutputs["MCDep1.vcproj"], projectRefs[0]);
 
             // 3. multiple project refs, all resolvable
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\correct.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", @"obj\correct2.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "correct.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", Path.Combine("obj", "correct2.dll"));
 
             TestUnresolvedReferencesHelper(projectRefs, projectOutputs, out unresolvedOutputs, out resolvedOutputs);
 
             Assert.Equal(2, resolvedOutputs.Count); // "Two resolved refs expected for case 3"
-            Assert.True(resolvedOutputs.ContainsKey(@"obj\correct.dll"));
-            Assert.True(resolvedOutputs.ContainsKey(@"obj\correct2.dll"));
+            Assert.True(resolvedOutputs.ContainsKey(Path.Combine("obj", "correct.dll")));
+            Assert.True(resolvedOutputs.ContainsKey(Path.Combine("obj", "correct2.dll")));
             Assert.Empty(unresolvedOutputs); // "No unresolved refs expected for case 3"
 
             // 4. multiple project refs, all failed to resolve
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
             projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"");
             projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", @"");
 
@@ -304,23 +305,23 @@ namespace Microsoft.Build.UnitTests
 
             // 5. multiple project refs, one resolvable, one failed to resolve
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
-            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", @"obj\correct.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
+            projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-34CFC76F37C5}", Path.Combine("obj", "correct.dll"));
             projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", @"");
 
             TestUnresolvedReferencesHelper(projectRefs, projectOutputs, out unresolvedOutputs, out resolvedOutputs);
 
             Assert.Single(resolvedOutputs); // "One resolved ref expected for case 5"
-            Assert.True(resolvedOutputs.ContainsKey(@"obj\correct.dll"));
+            Assert.True(resolvedOutputs.ContainsKey(Path.Combine("obj", "correct.dll")));
             Assert.Empty(unresolvedOutputs); // "No unresolved refs expected for case 5"
 
             // 6. multiple project refs, one unresolvable, one failed to resolve
             projectOutputs = new Hashtable();
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", @"obj\wrong.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", @"obj\wrong2.dll");
-            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", @"obj\wrong3.dll");
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111111}", Path.Combine("obj", "wrong.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111112}", Path.Combine("obj", "wrong2.dll"));
+            projectOutputs.Add("{11111111-1111-1111-1111-111111111113}", Path.Combine("obj", "wrong3.dll"));
             projectOutputs.Add("{2F6BBCC3-7111-4116-A68B-000000000000}", @"");
 
             TestUnresolvedReferencesHelper(projectRefs, projectOutputs, out unresolvedOutputs, out resolvedOutputs);

--- a/src/Tasks.UnitTests/ResolveNonMSBuildProjectOutput_Tests.cs
+++ b/src/Tasks.UnitTests/ResolveNonMSBuildProjectOutput_Tests.cs
@@ -10,12 +10,20 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests
 {
     sealed public class ResolveNonMSBuildProjectOutput_Tests
     {
         private const string attributeProject = "Project";
+
+        private readonly ITestOutputHelper _output;
+
+        public ResolveNonMSBuildProjectOutput_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         static internal ITaskItem CreateReferenceItem(string itemSpec, string projectGuid, string package, string name)
         {
@@ -170,7 +178,7 @@ namespace Microsoft.Build.UnitTests
 
             string xmlString = CreatePregeneratedPathDoc(pregenOutputs);
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             ResolveNonMSBuildProjectOutput rvpo = new ResolveNonMSBuildProjectOutput();
             rvpo.GetAssemblyName = pretendGetAssemblyName;
             rvpo.BuildEngine = engine;
@@ -332,14 +340,14 @@ namespace Microsoft.Build.UnitTests
             taskItems[0] = new TaskItem("projectReference");
             taskItems[0].SetMetadata(attributeProject, "{invalid guid}");
 
-            MockEngine engine = new MockEngine();
+            MockEngine engine = new MockEngine(_output);
             rvpo.BuildEngine = engine;
             Assert.True(rvpo.VerifyProjectReferenceItems(taskItems, false /* treat problems as warnings */));
             Assert.Equal(1, engine.Warnings);
             Assert.Equal(0, engine.Errors);
             engine.AssertLogContains("MSB3107");
 
-            engine = new MockEngine();
+            engine = new MockEngine(_output);
             rvpo.BuildEngine = engine;
             Assert.False(rvpo.VerifyProjectReferenceItems(taskItems, true /* treat problems as errors */));
             Assert.Equal(0, engine.Warnings);

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -474,6 +474,9 @@
     <Compile Include="ResolveKeySource.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="ResolveNonMSBuildProjectOutput.cs">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="ResolveProjectBase.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -617,9 +620,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveNativeReference.cs" Condition="'$(MonoBuild)' != 'true'">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="ResolveNonMSBuildProjectOutput.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveSDKReference.cs" />


### PR DESCRIPTION
This task isn't required in normal operation on .NET Core, but
compiles and runs just fine so there's no reason to have a discrepancy.

Fixes #4770.