### PR TITLE
Enable logging messages created before BuildManager.BeginBuild

### DIFF
--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -927,6 +927,7 @@ namespace Microsoft.Build.Execution
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
+        public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters, System.Collections.Generic.IEnumerable<Microsoft.Build.Execution.BuildManager.DeferredBuildMessage> deferredBuildMessages) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Graph.GraphBuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Graph.GraphBuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
@@ -940,6 +941,13 @@ namespace Microsoft.Build.Execution
         public Microsoft.Build.Graph.GraphBuildSubmission PendBuildRequest(Microsoft.Build.Graph.GraphBuildRequestData requestData) { throw null; }
         public void ResetCaches() { }
         public void ShutdownAllNodes() { }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct DeferredBuildMessage
+        {
+            public DeferredBuildMessage(string text, Microsoft.Build.Framework.MessageImportance importance) { throw null;}
+            public Microsoft.Build.Framework.MessageImportance Importance { get { throw null; } }
+            public string Text { get { throw null; } }
+        }
     }
     public partial class BuildParameters
     {

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -923,6 +923,7 @@ namespace Microsoft.Build.Execution
         public BuildManager(string hostName) { }
         public static Microsoft.Build.Execution.BuildManager DefaultBuildManager { get { throw null; } }
         public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters) { }
+        public void BeginBuild(Microsoft.Build.Execution.BuildParameters parameters, System.Collections.Generic.IEnumerable<Microsoft.Build.Execution.BuildManager.DeferredBuildMessage> deferredBuildMessages) { }
         public Microsoft.Build.Execution.BuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
         public Microsoft.Build.Graph.GraphBuildResult Build(Microsoft.Build.Execution.BuildParameters parameters, Microsoft.Build.Graph.GraphBuildRequestData requestData) { throw null; }
         public Microsoft.Build.Execution.BuildResult BuildRequest(Microsoft.Build.Execution.BuildRequestData requestData) { throw null; }
@@ -936,6 +937,13 @@ namespace Microsoft.Build.Execution
         public Microsoft.Build.Graph.GraphBuildSubmission PendBuildRequest(Microsoft.Build.Graph.GraphBuildRequestData requestData) { throw null; }
         public void ResetCaches() { }
         public void ShutdownAllNodes() { }
+        [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        public partial struct DeferredBuildMessage
+        {
+            public DeferredBuildMessage(string text, Microsoft.Build.Framework.MessageImportance importance) { throw null;}
+            public Microsoft.Build.Framework.MessageImportance Importance { get { throw null; } }
+            public string Text { get { throw null; } }
+        }
     }
     public partial class BuildParameters
     {

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -944,6 +944,68 @@ namespace Microsoft.Build.UnitTests.BackEnd
             _logger.AssertLogContains("[errormessage]");
         }
 
+        [Fact]
+        public void DeferredMessageShouldBeLogged()
+        {
+            string contents = CleanupFileContents(@"
+              <Project>
+                 <Target Name='Build'>
+                     <Message Text='[Message]' Importance='high'/>
+                     <Warning Text='[Warn]'/>	
+                </Target>
+              </Project>
+            ");
+
+            MockLogger logger;
+
+            const string highMessage = "deferred[High]";
+            const string normalMessage = "deferred[Normal]";
+            const string lowMessage = "deferred[Low]";
+
+            using (var buildManagerSession = new Helpers.BuildManagerSession(
+                _env,
+                deferredMessages: new[]
+                {
+                    new BuildManager.DeferredBuildMessage(highMessage, MessageImportance.High),
+                    new BuildManager.DeferredBuildMessage(normalMessage, MessageImportance.Normal),
+                    new BuildManager.DeferredBuildMessage(lowMessage, MessageImportance.Low)
+                }))
+            {
+                var result = buildManagerSession.BuildProjectFile(_env.CreateFile("build.proj", contents).Path);
+
+                result.OverallResult.ShouldBe(BuildResultCode.Success);
+
+                logger = buildManagerSession.Logger;
+            }
+
+            logger.AssertLogContains("[Warn]");
+            logger.AssertLogContains("[Message]");
+
+            logger.AssertLogContains(highMessage);
+            logger.AssertLogContains(normalMessage);
+            logger.AssertLogContains(lowMessage);
+
+            var deferredMessages = logger.BuildMessageEvents.Where(e => e.Message.StartsWith("deferred")).ToArray();
+
+            deferredMessages.Length.ShouldBe(3);
+
+            deferredMessages[0].Message.ShouldBe(highMessage);
+            deferredMessages[0].Importance.ShouldBe(MessageImportance.High);
+            deferredMessages[1].Message.ShouldBe(normalMessage);
+            deferredMessages[1].Importance.ShouldBe(MessageImportance.Normal);
+            deferredMessages[2].Message.ShouldBe(lowMessage);
+            deferredMessages[2].Importance.ShouldBe(MessageImportance.Low);
+
+            logger.BuildStartedEvents.Count.ShouldBe(1);
+            logger.BuildFinishedEvents.Count.ShouldBe(1);
+            logger.ProjectStartedEvents.Count.ShouldBe(1);
+            logger.ProjectFinishedEvents.Count.ShouldBe(1);
+            logger.TargetStartedEvents.Count.ShouldBe(1);
+            logger.TargetFinishedEvents.Count.ShouldBe(1);
+            logger.TaskStartedEvents.Count.ShouldBe(2);
+            logger.TaskFinishedEvents.Count.ShouldBe(2);
+        }
+
         /// <summary>
         /// A build with a message, error and warning, verify that 
         /// we only get errors, warnings, and project started and finished when OnlyLogCriticalEvents is true

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -233,6 +233,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private DateTime _instantiationTimeUtc;
 
+        private IEnumerable<DeferredBuildMessage> _deferredBuildMessages;
+
 #if DEBUG
         /// <summary>
         /// <code>true</code> to wait for a debugger to be attached, otherwise <code>false</code>.
@@ -293,12 +295,12 @@ namespace Microsoft.Build.Execution
         private enum BuildManagerState
         {
             /// <summary>
-            /// This is the default state.  <see cref="BuildManager.BeginBuild"/> may be called in this state.  All other methods raise InvalidOperationException
+            /// This is the default state.  <see cref="BeginBuild(BuildParameters)"/> may be called in this state.  All other methods raise InvalidOperationException
             /// </summary>
             Idle,
 
             /// <summary>
-            /// This is the state the BuildManager is in after <see cref="BuildManager.BeginBuild"/> has been called but before <see cref="BuildManager.EndBuild"/> has been called.
+            /// This is the state the BuildManager is in after <see cref="BeginBuild(BuildParameters)"/> has been called but before <see cref="EndBuild"/> has been called.
             /// <see cref="BuildManager.PendBuildRequest(Microsoft.Build.Execution.BuildRequestData)"/>, <see cref="BuildManager.BuildRequest(Microsoft.Build.Execution.BuildRequestData)"/>, <see cref="BuildManager.PendBuildRequest(GraphBuildRequestData)"/>, <see cref="BuildManager.BuildRequest(GraphBuildRequestData)"/>, and <see cref="BuildManager.EndBuild"/> may be called in this state.
             /// </summary>
             Building,
@@ -359,6 +361,36 @@ namespace Microsoft.Build.Execution
         LegacyThreadingData IBuildComponentHost.LegacyThreadingData => _legacyThreadingData;
 
         /// <summary>
+        /// <see cref="BuildManager.BeginBuild(BuildParameters,IEnumerable{DeferredBuildMessage})"/>
+        /// </summary>
+        public readonly struct DeferredBuildMessage
+        {
+            public MessageImportance Importance { get; }
+
+            public string Text { get; }
+
+            public DeferredBuildMessage(string text, MessageImportance importance)
+            {
+                Importance = importance;
+                Text = text;
+            }
+        }
+
+        /// <summary>
+        /// Prepares the BuildManager to receive build requests.
+        /// </summary>
+        /// <param name="parameters">The build parameters.  May be null.</param>
+        /// <param name="deferredBuildMessages"> Build messages to be logged before the build begins. </param>
+        /// <exception cref="InvalidOperationException">Thrown if a build is already in progress.</exception>
+        public void BeginBuild(BuildParameters parameters, IEnumerable<DeferredBuildMessage> deferredBuildMessages)
+        {
+            // deferredBuildMessages cannot be an optional parameter on a single BeginBuild method because it would break binary compatibility.
+            _deferredBuildMessages = deferredBuildMessages;
+            BeginBuild(parameters);
+            _deferredBuildMessages = null;
+        }
+
+        /// <summary>
         /// Prepares the BuildManager to receive build requests.
         /// </summary>
         /// <param name="parameters">The build parameters.  May be null.</param>
@@ -399,6 +431,8 @@ namespace Microsoft.Build.Execution
                 _nodeManager = ((IBuildComponentHost)this).GetComponent(BuildComponentType.NodeManager) as INodeManager;
 
                 var loggingService = InitializeLoggingService();
+
+                LogDeferredMessages(loggingService, _deferredBuildMessages);
 
                 InitializeCaches();
 
@@ -2299,6 +2333,19 @@ namespace Microsoft.Build.Execution
             }
 
             return loggingService;
+        }
+
+        private static void LogDeferredMessages(ILoggingService loggingService, IEnumerable<DeferredBuildMessage> deferredBuildMessages)
+        {
+            if (deferredBuildMessages == null)
+            {
+                return;
+            }
+
+            foreach (var message in deferredBuildMessages)
+            {
+                loggingService.LogCommentFromText(BuildEventContext.Invalid, message.Importance, message.Text);
+            }
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1869,7 +1869,8 @@ namespace Microsoft.Build.UnitTests
                 TestEnvironment env,
                 BuildParameters buildParametersPrototype = null,
                 bool enableNodeReuse = false,
-                bool shutdownInProcNode = true)
+                bool shutdownInProcNode = true,
+                IEnumerable<BuildManager.DeferredBuildMessage> deferredMessages = null)
             {
                 _env = env;
 
@@ -1886,7 +1887,7 @@ namespace Microsoft.Build.UnitTests
                 actualBuildParameters.EnableNodeReuse = enableNodeReuse;
 
                 _buildManager = new BuildManager();
-                _buildManager.BeginBuild(actualBuildParameters);
+                _buildManager.BeginBuild(actualBuildParameters, deferredMessages);
             }
 
             public BuildResult BuildProjectFile(string projectFile, string[] entryTargets = null)


### PR DESCRIPTION
Should enable https://github.com/microsoft/msbuild/pull/5007 to log places where msbuild searches for command line arguments.