### PR TITLE
Update System.Text.Json to 4.7.0

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -39,7 +39,7 @@
     <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
-    <PackageReference Update="System.Text.Json" Version="4.6.0" />
+    <PackageReference Update="System.Text.Json" Version="4.7.0" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Update="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Update="System.Xml.XPath" Version="4.3.0" />


### PR DESCRIPTION
As part of allowing System.Text.Json to be used in VS