### PR TITLE
Publish x64 Architecture Symbols

### DIFF
--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,0 +1,12 @@
+<Project>
+    <Target Name="CopyAMD64Symbols" BeforeTargets="Build">
+        <Copy 
+            SourceFiles="$(ArtifactsBinDir)MSBuild\x64\Release\net472\MSBuild.pdb"
+            DestinationFolder="$(ArtifactsSymStoreDirectory)\MSBuild\net472\amd64"
+            />
+        <Copy 
+            SourceFiles="$(ArtifactsBinDir)MSBuildTaskHost\x64\Release\net35\MSBuildTaskHost.pdb"
+            DestinationFolder="$(ArtifactsSymStoreDirectory)\MSBuildTaskHost\net35\amd64"
+            />
+    </Target>
+</Project>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,5 +1,5 @@
 <Project>
-    <Target Name="CopyAMD64Symbols" Condition="'$(OfficialBuild) == 'true'" BeforeTargets="Build">
+    <Target Name="CopyAMD64Symbols" Condition="'$(OfficialBuild)'' == 'true'" BeforeTargets="Build">
         <Copy 
             SourceFiles="$(ArtifactsBinDir)MSBuild\x64\Release\net472\MSBuild.pdb"
             DestinationFolder="$(ArtifactsSymStoreDirectory)\MSBuild\net472\amd64"

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,5 +1,5 @@
 <Project>
-    <Target Name="CopyAMD64Symbols" BeforeTargets="Build">
+    <Target Name="CopyAMD64Symbols" Condition="'$(OfficialBuild) == 'true'" BeforeTargets="Build">
         <Copy 
             SourceFiles="$(ArtifactsBinDir)MSBuild\x64\Release\net472\MSBuild.pdb"
             DestinationFolder="$(ArtifactsSymStoreDirectory)\MSBuild\net472\amd64"

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,5 +1,5 @@
 <Project>
-    <Target Name="CopyAMD64Symbols" Condition="'$(OfficialBuild)'' == 'true'" BeforeTargets="Build">
+    <Target Name="CopyAMD64Symbols" Condition="'$(OfficialBuild)' == 'true'" BeforeTargets="Build">
         <Copy 
             SourceFiles="$(ArtifactsBinDir)MSBuild\x64\Release\net472\MSBuild.pdb"
             DestinationFolder="$(ArtifactsSymStoreDirectory)\MSBuild\net472\amd64"

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -36,7 +36,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <AddAppConfigToBuildOutputs>false</AddAppConfigToBuildOutputs>
 
-    <DebugType Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
+    <DebugType Condition="'$(Platform)' == 'x64'">full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -36,7 +36,7 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <AddAppConfigToBuildOutputs>false</AddAppConfigToBuildOutputs>
 
-    <DebugType Condition="'$(Platform)' == 'x64'">full</DebugType><!-- Work around arcade stomping on symbols for same-program-different-arches. -->
+    <DebugType Condition="'$(Platform)' == 'x64'">full</DebugType><!-- Setting DebugType here goes hand in hand with eng\AfterSigning.targets. This is to prompt the x64 build to produce a 'full' .pdb that's `more compatible` then 'portable' and 'embedded' .pdbs. This doesn't get set on 32 bit architecture, which will default to 'embedded' and 'pdb2pdb' will convert those as needed. See https://github.com/microsoft/msbuild/pull/5070 for context. -->
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
fixes #5060 

This fixes our symbol check failures on our VS PRs by copying over the relevant `.pdb`s to where they need to be to get published during a pipeline build.