### PR TITLE
Updating BootstrapUtil to look for packages in additional folders

### DIFF
--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -444,13 +444,20 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
             foreach (string file in files)
             {
-                string folder = System.IO.Path.GetDirectoryName(file);
-                if (folder.Substring(0, invariantPath.Length).ToLowerInvariant().CompareTo(invariantPath) == 0)
+                List<string> packagePaths = new List<string>() { invariantPath };
+                packagePaths.AddRange(Util.AdditionalPackagePaths.Select(p => Util.AddTrailingChar(p.ToLowerInvariant(), System.IO.Path.DirectorySeparatorChar)));
+                foreach (string packagePath in packagePaths)
                 {
-                    string relPath = folder.Substring(invariantPath.Length);
-                    if (!folders.Contains(relPath))
+                    string folder = System.IO.Path.GetDirectoryName(file);
+                    if (folder.Length >= packagePath.Length && folder.Substring(0, packagePath.Length).ToLowerInvariant().CompareTo(packagePath) == 0)
                     {
-                        folders.Add(relPath);
+                        string relPath = folder.Substring(packagePath.Length);
+                        if (!folders.Contains(relPath))
+                        {
+                            folders.Add(relPath);
+                        }
+
+                        break;
                     }
                 }
             }
@@ -576,18 +583,23 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             _xmlNamespaceManager.AddNamespace(BOOTSTRAPPER_PREFIX, BOOTSTRAPPER_NAMESPACE);
 
             XmlElement rootElement = _document.CreateElement("Products", BOOTSTRAPPER_NAMESPACE);
-            string packagePath = PackagePath;
 
-            if (FileSystems.Default.DirectoryExists(packagePath))
+            List<string> packagePaths = new List<string>() { PackagePath };
+            packagePaths.AddRange(Util.AdditionalPackagePaths);
+            foreach (string packagePath in packagePaths)
             {
-                foreach (string strSubDirectory in Directory.GetDirectories(packagePath))
+                if (FileSystems.Default.DirectoryExists(packagePath))
                 {
-                    int nStartIndex = packagePath.Length;
-                    if ((strSubDirectory.ToCharArray())[nStartIndex] == System.IO.Path.DirectorySeparatorChar)
+                    foreach (string strSubDirectory in Directory.GetDirectories(packagePath))
                     {
-                        nStartIndex = nStartIndex + 1;
+                        int nStartIndex = packagePath.Length;
+                        if ((strSubDirectory.ToCharArray())[nStartIndex] == System.IO.Path.DirectorySeparatorChar)
+                        {
+                            nStartIndex = nStartIndex + 1;
+                        }
+
+                        ExploreDirectory(strSubDirectory.Substring(nStartIndex), rootElement, packagePath);
                     }
-                    ExploreDirectory(strSubDirectory.Substring(nStartIndex), rootElement);
                 }
             }
 
@@ -887,11 +899,10 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             return xmlDocument;
         }
 
-        private void ExploreDirectory(string strSubDirectory, XmlElement rootElement)
+        private void ExploreDirectory(string strSubDirectory, XmlElement rootElement, string packagePath)
         {
             try
             {
-                string packagePath = PackagePath;
                 string strSubDirectoryFullPath = System.IO.Path.Combine(packagePath, strSubDirectory);
 
                 // figure out our product file paths based on the directory full path

--- a/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
+++ b/src/Tasks/BootstrapperUtil/BootstrapperBuilder.cs
@@ -442,13 +442,15 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             var files = new List<string>();
             BuildPackages(settings, null, null, files, null);
 
+            List<string> packagePaths = new List<string>() { invariantPath };
+            packagePaths.AddRange(Util.AdditionalPackagePaths.Select(p => Util.AddTrailingChar(p.ToLowerInvariant(), System.IO.Path.DirectorySeparatorChar)));
+
             foreach (string file in files)
             {
-                List<string> packagePaths = new List<string>() { invariantPath };
-                packagePaths.AddRange(Util.AdditionalPackagePaths.Select(p => Util.AddTrailingChar(p.ToLowerInvariant(), System.IO.Path.DirectorySeparatorChar)));
+                string folder = System.IO.Path.GetDirectoryName(file);
+
                 foreach (string packagePath in packagePaths)
                 {
-                    string folder = System.IO.Path.GetDirectoryName(file);
                     if (folder.Length >= packagePath.Length && folder.Substring(0, packagePath.Length).ToLowerInvariant().CompareTo(packagePath) == 0)
                     {
                         string relPath = folder.Substring(packagePath.Length);

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using Microsoft.Win32;
@@ -17,7 +18,10 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
 
         private const string REGISTRY_DEFAULTPATH = "Path";
 
+        private const string BOOTSTRAPPER_REGISTRY_ADDITIONAL_PACKAGE_PATHS_KEYNAME = "AdditionalPackagePaths";
+
         private static string s_defaultPath;
+        private static List<string> s_additionalPackagePaths;
 
         public static string AddTrailingChar(string str, char ch)
         {
@@ -143,6 +147,44 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             }
 
             return Directory.GetCurrentDirectory();
+        }
+
+        // Gets the list of additional paths to inspect for packages as defined in the registry
+        public static List<string> AdditionalPackagePaths
+        {
+            get
+            {
+                if (s_additionalPackagePaths == null)
+                {
+                    s_additionalPackagePaths = new List<string>();
+                    RegistryKey bootstrapperBaseRegKey = Registry.LocalMachine.OpenSubKey(BOOTSTRAPPER_REGISTRY_PATH_BASE);
+                    if (bootstrapperBaseRegKey == null)
+                    {
+                        bootstrapperBaseRegKey = Registry.LocalMachine.OpenSubKey(BOOTSTRAPPER_WOW64_REGISTRY_PATH_BASE);
+                    }
+
+                    if (bootstrapperBaseRegKey != null)
+                    {
+                        RegistryKey additionalPackagePathsRegKey = bootstrapperBaseRegKey.OpenSubKey(BOOTSTRAPPER_REGISTRY_ADDITIONAL_PACKAGE_PATHS_KEYNAME);
+                        if (additionalPackagePathsRegKey != null)
+                        {
+                            foreach (string key in additionalPackagePathsRegKey.GetValueNames())
+                            {
+                                if (additionalPackagePathsRegKey.GetValueKind(key) == RegistryValueKind.String)
+                                {
+                                    string path = (string)additionalPackagePathsRegKey.GetValue(key);
+                                    if (!string.IsNullOrEmpty(path))
+                                    {
+                                        s_additionalPackagePaths.Add(path);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return s_additionalPackagePaths;
+            }
         }
 
         private static string ReadRegistryString(RegistryKey key, string path, string registryValue)

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                         }
                     }
 
-                    s_additionalPackagePaths = new List<string>(additionalPackagePaths);
+                    s_additionalPackagePaths = additionalPackagePaths;
                 }
 
                 return s_additionalPackagePaths;

--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
             {
                 if (s_additionalPackagePaths == null)
                 {
-                    s_additionalPackagePaths = new List<string>();
+                    List<string> additionalPackagePaths = new List<string>();
                     RegistryKey bootstrapperBaseRegKey = Registry.LocalMachine.OpenSubKey(BOOTSTRAPPER_REGISTRY_PATH_BASE);
                     if (bootstrapperBaseRegKey == null)
                     {
@@ -175,12 +175,14 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                                     string path = (string)additionalPackagePathsRegKey.GetValue(key);
                                     if (!string.IsNullOrEmpty(path))
                                     {
-                                        s_additionalPackagePaths.Add(path);
+                                        additionalPackagePaths.Add(path);
                                     }
                                 }
                             }
                         }
                     }
+
+                    s_additionalPackagePaths = new List<string>(additionalPackagePaths);
                 }
 
                 return s_additionalPackagePaths;


### PR DESCRIPTION
We want teams to be able to install bootstrapper packages from outside the VS MSIs where they currently come from.  Right now we only enumerate packages from a single directory that's defined in the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\GenericBootstrapper reg key.  I'm making it so if there's any additional paths specified under the AdditionalPackagePaths sub key we'll look for bootstrapper packages in those paths as well.

One small issue with this change is that when a bootstrapper specified in a clickonce or setup project isn't found we give a warning like this:

_Item '.NETFramework,Version=v4.7.2' could not be located in 'C:\Program Files (x86)\Microsoft SDKs\ClickOnce Bootstrapper\'_

Ideally this would be updated to also mention any possible additional paths that have been specified using this new support.  But since that would require a string change and a new public interface to properly support I've decided to delay that part of the change until 16.6.