### PR TITLE
Backport stuff mistargeted to 16.6

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3883,6 +3883,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionStringPadLeftComplex()
+        {
+            TestPropertyFunction("$(prop.PadLeft($([MSBuild]::Multiply(1, 2)), '0'))", "prop", "x", "0x");
+        }
+
+        [Fact]
         public void PropertyFunctionStringPadRight1()
         {
             TestPropertyFunction("$(prop.PadRight(2))", "prop", "x", "x ");
@@ -3947,6 +3953,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionMSBuildAddComplex()
+        {
+            TestPropertyFunction("$([MSBuild]::Add($(X), $([MSBuild]::Add(2, 3))))", "X", "7", "12");
+        }
+
+        [Fact]
         public void PropertyFunctionMSBuildSubtract()
         {
             TestPropertyFunction("$([MSBuild]::Subtract($(X), 20100000))", "X", "20100042", "42");
@@ -3956,6 +3968,12 @@ $(
         public void PropertyFunctionMSBuildMultiply()
         {
             TestPropertyFunction("$([MSBuild]::Multiply($(X), 8800))", "X", "2", "17600");
+        }
+
+        [Fact]
+        public void PropertyFunctionMSBuildMultiplyComplex()
+        {
+            TestPropertyFunction("$([MSBuild]::Multiply($(X), $([MSBuild]::Multiply(1, 8800))))", "X", "2", "17600");
         }
 
         [Fact]

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4170,6 +4170,9 @@ namespace Microsoft.Build.Evaluation
             {
                 switch (value)
                 {
+                    case double d:
+                        arg0 = Convert.ToInt32(d);
+                        return arg0 == d;
                     case int i:
                         arg0 = i;
                         return true;
@@ -4178,6 +4181,22 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 arg0 = 0;
+                return false;
+            }
+
+            private static bool TryConvertToDouble(object value, out double arg)
+            {
+                if (value is double unboxed)
+                {
+                    arg = unboxed;
+                    return true;
+                }
+                else if (value is string str && double.TryParse(str, out arg))
+                {
+                    return true;
+                }
+
+                arg = 0;
                 return false;
             }
 
@@ -4217,15 +4236,8 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                if (args[0] is string value0 &&
-                    args[1] is string value1 &&
-                    double.TryParse(value0, out arg0) &&
-                    double.TryParse(value1, out arg1))
-                {
-                    return true;
-                }
-
-                return false;
+                return TryConvertToDouble(args[0], out arg0) &&
+                       TryConvertToDouble(args[1], out arg1);
             }
 
             private static bool TryGetArgs(object[] args, out int arg0, out string arg1)
@@ -4238,11 +4250,9 @@ namespace Microsoft.Build.Evaluation
                     return false;
                 }
 
-                var value0 = args[0] as string;
                 arg1 = args[1] as string;
-                if (value0 != null &&
-                    arg1 != null &&
-                    int.TryParse(value0, out arg0))
+                if (TryConvertToInt(args[0], out arg0) &&
+                    arg1 != null)
                 {
                     return true;
                 }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -3519,13 +3519,14 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                if (distributedLoggerRecord.CentralLogger is INodeLogger nodeLogger)
+                ILogger centralLogger = distributedLoggerRecord.CentralLogger;
+                if (centralLogger is INodeLogger nodeLogger)
                 {
                     nodeLogger.Initialize(replayEventSource, cpuCount);
                 }
-                else
+                else if (centralLogger != null)
                 {
-                    distributedLoggerRecord.CentralLogger.Initialize(replayEventSource);
+                    centralLogger.Initialize(replayEventSource);
                 }
             }
 
@@ -3558,7 +3559,7 @@ namespace Microsoft.Build.CommandLine
 
             foreach (var distributedLoggerRecord in distributedLoggerRecords)
             {
-                distributedLoggerRecord.CentralLogger.Shutdown();
+                distributedLoggerRecord.CentralLogger?.Shutdown();
             }
         }
 

--- a/src/Tasks/AppConfig/AppConfig.cs
+++ b/src/Tasks/AppConfig/AppConfig.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Shared;
@@ -23,6 +24,11 @@ namespace Microsoft.Build.Tasks
             try
             {
                 var readerSettings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore };
+
+                // it's important to normalize the path as it may contain two slashes
+                // see https://github.com/microsoft/msbuild/issues/4335 for details.
+                appConfigFile = FileUtilities.NormalizePath(appConfigFile);
+
                 reader = XmlReader.Create(appConfigFile, readerSettings);
                 Read(reader);
             }


### PR DESCRIPTION
This is just cherry-picks of #5029, #5028, and #5023, which I merged without realizing that they were targeted to `master` rather than the intended `vs16.5`. Sorry @KirillOsenkov!