### PR TITLE
Enable WinMDExp task on .NET Core MSBuild

### DIFF
--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -481,6 +481,7 @@
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCodeType.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCompilers.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryTaskInfo.cs" />
+    <Compile Include="SdkToolsPathUtility.cs" />
     <Compile Include="System.Design.cs" />
     <Compile Include="system.design\stronglytypedresourcebuilder.cs" />
     <Compile Include="TaskExtension.cs">
@@ -500,6 +501,7 @@
     <Compile Include="Warning.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="WinMDExp.cs" />
     <Compile Include="XslTransformation.cs" />
     <Compile Include="AssignCulture.cs" />
     <Compile Include="Culture.cs" />
@@ -623,7 +625,6 @@
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="ResolveSDKReference.cs" />
-    <Compile Include="SdkToolsPathUtility.cs" />
     <Compile Include="RequiresFramework35SP1Assembly.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
@@ -649,7 +650,6 @@
     <Compile Include="UpdateManifest.cs" Condition="'$(MonoBuild)' != 'true'">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <Compile Include="WinMDExp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Compile Include="XamlTaskFactory\CommandLineGenerator.cs" />


### PR DESCRIPTION
This task will fail at runtime unless the .NET Framework SDK is installed, since winmdexp.exe is only present in that SDK. However, nothing about the task itself is incompatible with .NET Core. Furthermore, the error message that occurs if this happens is already very explanatory as to what needs to be done, so no changes are required there.

See also https://github.com/microsoft/microsoft-ui-xaml/issues/1891.  
Contributes to https://github.com/dotnet/sdk/issues/3042.