### PR TITLE
Normalize plugin paths before loading

### DIFF
--- a/src/Build.UnitTests/BackEnd/AssemblyLoadContextTestTasks.cs
+++ b/src/Build.UnitTests/BackEnd/AssemblyLoadContextTestTasks.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace AssemblyLoadContextTest
+{
+    public class RegisterObject : Task
+    {
+        internal const string CacheKey = "RegressionForMSBuild#5080";
+
+        public override bool Execute()
+        {
+            BuildEngine4.RegisterTaskObject(
+                  CacheKey,
+                  new RegisterObject(),
+                  RegisteredTaskObjectLifetime.Build,
+                  allowEarlyCollection: false);
+
+            return true;
+        }
+    }
+
+    public class RetrieveObject : Task
+    {
+        public override bool Execute()
+        {
+            var entry = (RegisterObject)BuildEngine4.GetRegisteredTaskObject(RegisterObject.CacheKey, RegisteredTaskObjectLifetime.Build);
+
+            return true;
+        }
+    }
+}

--- a/src/Shared/CoreCLRAssemblyLoader.cs
+++ b/src/Shared/CoreCLRAssemblyLoader.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Build.Shared
 
             Debug.Assert(Path.IsPathRooted(fullPath));
 
+            // Normalize because the same assembly might get loaded via
+            // multiple paths (for instance, the `build` and `buildCrossTargeting`
+            // folders in a NuGet package).
+            fullPath = FileUtilities.NormalizePath(fullPath);
+
             lock (_guard)
             {
                 Assembly assembly;


### PR DESCRIPTION
Fixes #5080 by normalizing plugin assembly paths before deduplicating
loads based on those paths.

Does not fix the cross-assembly register/retrieve object problem #5084.