### PR TITLE
vs.relatedProcessFiles for MSBuild assemblies

### DIFF
--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -9,6 +9,16 @@ vs.dependencies
   vs.dependency id=Microsoft.VisualStudio.PackageGroup.NuGet
                 version=[15.0,17.0)
 
+vs.relatedProcessFiles
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.Framework.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.Tasks.Core.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\amd64\Microsoft.Build.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\amd64\Microsoft.Build.Framework.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\amd64\Microsoft.Build.Tasks.Core.dll"
+  vs.relatedProcessFile Path="[InstallDir]\MSBuild\Current\Bin\amd64\Microsoft.Build.Utilities.Core.dll"
+
 folder InstallDir:\MSBuild\Current
   file source=$(X86BinPath)Microsoft.Common.props
   file source=$(X86BinPath)Microsoft.VisualStudioVersion.v16.Common.props


### PR DESCRIPTION
Add an explicit list of MSBuild assemblies that might be loaded by an
application outside of the Visual Studio installation directory, so that
VS Setup can find any applications using these files and shut them down
before updating VS.

Closes #5025.