### PR TITLE
Write generated AssemblyAttributes file to intermediate output path

### DIFF
--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
 using Xunit;
 using Xunit.Abstractions;
@@ -48,7 +49,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         /// <summary>
         /// Tests fix for https://github.com/microsoft/msbuild/issues/1479.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(NativeMethodsShared), nameof(NativeMethodsShared.IsWindows))]
         public void AssemblyAttributesLocation()
         {
             var expectedCompileItems = "a.cs;" + Path.Combine("obj", "Debug", ".NETFramework,Version=v4.0.AssemblyAttributes.cs");

--- a/src/Tasks.UnitTests/RegressionTests.cs
+++ b/src/Tasks.UnitTests/RegressionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.UnitTests;
@@ -45,7 +46,7 @@ namespace Microsoft.Build.Tasks.UnitTests
         }
 
         /// <summary>
-        /// Fix for https://github.com/microsoft/msbuild/issues/1479.
+        /// Tests fix for https://github.com/microsoft/msbuild/issues/1479.
         /// </summary>
         [Fact]
         public void AssemblyAttributesLocation()
@@ -68,7 +69,9 @@ namespace Microsoft.Build.Tasks.UnitTests
   </Target>
 </Project>
 ");
-            Assert.True(project.Build(new MockLogger(_output)));
+            var logger = new MockLogger(_output);
+            bool result = project.Build(logger);
+            Assert.True(result, "Output:" + Environment.NewLine + logger.FullLog);
         }
     }
 }

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -3286,7 +3286,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   <PropertyGroup Condition="'$(TargetFrameworkMoniker)' != ''">
     <!-- Do not clean if we are going to default the path to the temp directory -->
     <TargetFrameworkMonikerAssemblyAttributesFileClean Condition="'$(TargetFrameworkMonikerAssemblyAttributesFileClean)' == '' and '$(TargetFrameworkMonikerAssemblyAttributesPath)' != ''">true</TargetFrameworkMonikerAssemblyAttributesFileClean>
-    <TargetFrameworkMonikerAssemblyAttributesPath Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' == ''">$([System.IO.Path]::Combine('$([System.IO.Path]::GetTempPath())','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+    <TargetFrameworkMonikerAssemblyAttributesPath Condition="'$(TargetFrameworkMonikerAssemblyAttributesPath)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/microsoft/msbuild/issues/1479 as suggested in the issue description.