### PR TITLE
Prevent duplicate targets Fixes #5071

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -80,10 +80,7 @@ namespace Microsoft.Build.UnitTests.Construction
                       </Project>");
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(sln.Path), null, null, _buildEventContext, CreateMockLoggingService());
                 instances.ShouldHaveSingleItem();
-                if (!name.Equals("name.that.does.Not.Affect.The.Build.targets"))
-                {
-                    instances[0].Targets["Build"].AfterTargets.ShouldBe("NonsenseTarget");
-                }
+                instances[0].Targets["Build"].AfterTargets.ShouldBe(string.Empty);
                 MockLogger logger = new MockLogger(output);
                 instances[0].Build(targets: null, new List<ILogger> { logger }).ShouldBeTrue();
             }

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -61,6 +61,35 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
+        /// Test that if a before.<sln>.targets or after.<sln>.targets file has one of the default targets (Build, Clean, etc.) that it includes only the user-defined target.
+        /// </summary>
+        [Theory]
+        [InlineData("before.MySln.sln.targets")]
+        [InlineData("after.MySln.sln.targets")]
+        [InlineData("name.that.does.Not.Affect.The.Build.targets")]
+        public void SolutionProjectIgnoresDuplicateDefaultTargets(string name)
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
+                TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", @"Microsoft Visual Studio Solution File, Format Version 16.00");
+                TransientTestFile targetsFile = testEnvironment.CreateFile(folder, name,
+                    @"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                        <Target Name=""Build"" AfterTargets=""NonsenseTarget"">
+                        </Target>
+                      </Project>");
+                ProjectInstance[] instances = SolutionProjectGenerator.Generate(SolutionFile.Parse(sln.Path), null, null, _buildEventContext, CreateMockLoggingService());
+                instances.ShouldHaveSingleItem();
+                if (!name.Equals("name.that.does.Not.Affect.The.Build.targets"))
+                {
+                    instances[0].Targets["Build"].AfterTargets.ShouldBe("NonsenseTarget");
+                }
+                MockLogger logger = new MockLogger(output);
+                instances[0].Build(targets: null, new List<ILogger> { logger }).ShouldBeTrue();
+            }
+        }
+
+        /// <summary>
         /// Test that a solution filter file excludes projects not covered by its list of projects or their dependencies.
         /// </summary>
         [Fact]

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.UnitTests.Construction
         }
 
         /// <summary>
-        /// Test that if a before.<sln>.targets or after.<sln>.targets file has one of the default targets (Build, Clean, etc.) that it includes only the user-defined target.
+        /// Test that if a before.{sln}>.targets or after.{sln}.targets file has one of the default targets (Build, Clean, etc.) that it includes only the user-defined target.
         /// </summary>
         [Theory]
         [InlineData("before.MySln.sln.targets")]

--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.UnitTests.Construction
                 TransientTestFolder folder = testEnvironment.CreateFolder(createFolder: true);
                 TransientTestFile sln = testEnvironment.CreateFile(folder, "MySln.sln", @"Microsoft Visual Studio Solution File, Format Version 16.00");
                 TransientTestFile targetsFile = testEnvironment.CreateFile(folder, name,
-                    @"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                    @"<Project>
                         <Target Name=""Build"" AfterTargets=""NonsenseTarget"">
                         </Target>
                       </Project>");

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1971,10 +1971,7 @@ namespace Microsoft.Build.Construction
 
             string correctedTargetName = targetName ?? "Build";
 
-            if (traversalProject.Targets.Select(target => target.Key).Contains(correctedTargetName))
-            {
-                traversalProject.RemoveTarget(correctedTargetName);
-            }
+            traversalProject.RemoveTarget(correctedTargetName);
             ProjectTargetInstance target = traversalProject.AddTarget(correctedTargetName, string.Empty, string.Empty, outputItemAsItem, null, string.Empty, string.Empty, string.Empty, string.Empty, false /* legacy target returns behaviour */);
             AddReferencesBuildTask(target, targetName, outputItem);
         }

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1969,8 +1969,11 @@ namespace Microsoft.Build.Construction
                 outputItemAsItem = "@(" + outputItem + ")";
             }
 
-            ProjectTargetInstance target = traversalProject.AddTarget(targetName ?? "Build", String.Empty, String.Empty, outputItemAsItem, null, String.Empty, String.Empty, String.Empty, String.Empty, false /* legacy target returns behaviour */);
-            AddReferencesBuildTask(target, targetName, outputItem);
+            if (!traversalProject.Targets.Select(target => target.Key).Contains(targetName ?? "Build"))
+            {
+                ProjectTargetInstance target = traversalProject.AddTarget(targetName ?? "Build", string.Empty, string.Empty, outputItemAsItem, null, string.Empty, string.Empty, string.Empty, string.Empty, false /* legacy target returns behaviour */);
+                AddReferencesBuildTask(target, targetName, outputItem);
+            }
         }
 
         /// <summary>

--- a/src/Build/Construction/Solution/SolutionProjectGenerator.cs
+++ b/src/Build/Construction/Solution/SolutionProjectGenerator.cs
@@ -1969,11 +1969,14 @@ namespace Microsoft.Build.Construction
                 outputItemAsItem = "@(" + outputItem + ")";
             }
 
-            if (!traversalProject.Targets.Select(target => target.Key).Contains(targetName ?? "Build"))
+            string correctedTargetName = targetName ?? "Build";
+
+            if (traversalProject.Targets.Select(target => target.Key).Contains(correctedTargetName))
             {
-                ProjectTargetInstance target = traversalProject.AddTarget(targetName ?? "Build", string.Empty, string.Empty, outputItemAsItem, null, string.Empty, string.Empty, string.Empty, string.Empty, false /* legacy target returns behaviour */);
-                AddReferencesBuildTask(target, targetName, outputItem);
+                traversalProject.RemoveTarget(correctedTargetName);
             }
+            ProjectTargetInstance target = traversalProject.AddTarget(correctedTargetName, string.Empty, string.Empty, outputItemAsItem, null, string.Empty, string.Empty, string.Empty, string.Empty, false /* legacy target returns behaviour */);
+            AddReferencesBuildTask(target, targetName, outputItem);
         }
 
         /// <summary>


### PR DESCRIPTION
Duplicate targets break the build; this prevents MSBuild's default targets from being added if they already exist.

Fixes #5071 