### PR TITLE
Removing nuget image on msbuild side

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <None Include="$(ThirdPartyNotice)" Pack="true" PackagePath="notices" Visible="false" Condition=" '$(IsPackable)' == 'true' " />
-    <None Include="$(RepoRoot)branding\MSBuild-NuGet-Icon.png" Pack="true" PackagePath="\" Visible="false" Condition=" '$(IsPackable)' == 'true' " />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #4988 

From what I can tell, this issue was caused due to arcade and msbuild both adding the same image.