### PR TITLE
Fix TaskParser probably has a bug in switch de-duplication logic.

### DIFF
--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -199,7 +199,11 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
 
             try
             {
-                string incorrectXmlContents = @"<ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
+                string incorrectXmlContents = @"<ProjectSchemaDefinitions
+                                       xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework`
+                                       xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml`
+                                       xmlns:sys=`clr-namespace:System;assembly=mscorlib`
+                                       xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
                                      <Rule Name=`CL`>
                                        <BoolProperty Name=`SameName` Switch=`Og` ReverseSwitch=`Og-` />
                                        <BoolProperty Name=`SameName` Switch=`Og` ReverseSwitch=`Og-` />

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -191,6 +191,29 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
             Assert.Equal(PropertyType.Boolean, properties.First.Value.Type);
         }
 
+        [Fact]
+        public void TestParseIncorrect_PropertyNamesMustBeUnique()
+        {
+            bool exceptionCaught = false;
+
+            try
+            {
+                string incorrectXmlContents = @"<ProjectSchemaDefinitions xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework` xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml` xmlns:sys=`clr-namespace:System;assembly=mscorlib` xmlns:impl=`clr-namespace:Microsoft.VisualStudio.Project.Contracts.Implementation;assembly=Microsoft.VisualStudio.Project.Contracts.Implementation`>
+                                     <Rule Name=`CL`>
+                                       <BoolProperty Name=`SameName` Switch=`Og` ReverseSwitch=`Og-` />
+                                       <BoolProperty Name=`SameName` Switch=`Og` ReverseSwitch=`Og-` />
+                                     </Rule>
+                                   </ProjectSchemaDefinitions>";
+                TaskParser tp = XamlTestHelpers.LoadAndParse(incorrectXmlContents, "CL");
+            }
+            catch (XamlParseException)
+            {
+                exceptionCaught = true;
+            }
+
+            Assert.True(exceptionCaught); // "Should have caught a XamlParseException"
+        }
+
         /// <summary>
         /// Tests a basic non-reversible booleans switch
         /// </summary>

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using Microsoft.Build.Tasks.Xaml;
 using System.Xaml;
 using Xunit;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
 {
@@ -209,10 +210,10 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
             catch (XamlParseException ex)
             {
                 exceptionCaught = true;
-                Assert.Equal("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.", ex.Message);
+                ex.Message.ShouldBe("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.");
             }
 
-            Assert.True(exceptionCaught); // "Should have caught a XamlParseException"
+            exceptionCaught.ShouldBeTrue(); // "Should have caught a XamlParseException"
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -206,9 +206,10 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
                                    </ProjectSchemaDefinitions>";
                 TaskParser tp = XamlTestHelpers.LoadAndParse(incorrectXmlContents, "CL");
             }
-            catch (XamlParseException)
+            catch (XamlParseException ex)
             {
                 exceptionCaught = true;
+                Assert.Equal("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.", ex.Message);
             }
 
             Assert.True(exceptionCaught); // "Should have caught a XamlParseException"

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
 
             Should
                 .Throw<XamlParseException>(() => XamlTestHelpers.LoadAndParse(incorrectXmlContents, "CL"))
-                .Message.ShouldBe("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.");
+                .Message.ShouldStartWith("MSB3724");
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
+++ b/src/Tasks.UnitTests/XamlTaskFactory_Tests.cs
@@ -195,11 +195,7 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
         [Fact]
         public void TestParseIncorrect_PropertyNamesMustBeUnique()
         {
-            bool exceptionCaught = false;
-
-            try
-            {
-                string incorrectXmlContents = @"<ProjectSchemaDefinitions
+            string incorrectXmlContents = @"<ProjectSchemaDefinitions
                                        xmlns=`clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework`
                                        xmlns:x=`http://schemas.microsoft.com/winfx/2006/xaml`
                                        xmlns:sys=`clr-namespace:System;assembly=mscorlib`
@@ -209,15 +205,10 @@ namespace Microsoft.Build.UnitTests.XamlTaskFactory_Tests
                                        <BoolProperty Name=`SameName` Switch=`Og` ReverseSwitch=`Og-` />
                                      </Rule>
                                    </ProjectSchemaDefinitions>";
-                TaskParser tp = XamlTestHelpers.LoadAndParse(incorrectXmlContents, "CL");
-            }
-            catch (XamlParseException ex)
-            {
-                exceptionCaught = true;
-                ex.Message.ShouldBe("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.");
-            }
 
-            exceptionCaught.ShouldBeTrue(); // "Should have caught a XamlParseException"
+            Should
+                .Throw<XamlParseException>(() => XamlTestHelpers.LoadAndParse(incorrectXmlContents, "CL"))
+                .Message.ShouldBe("MSB3724: Unable to create Xaml task.  Duplicate property name 'SameName'.");
         }
 
         /// <summary>

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -2221,6 +2221,10 @@
     <value>MSB3723: The parameter "{0}" requires missing parameter "{1}" to be set.</value>
     <comment>{StrBegin="MSB3723: "}</comment>
   </data>
+  <data name="Xaml.DuplicatePropertyName" xml:space="preserve">
+      <value>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</value>
+    <comment>{StrBegin="MSB3724: "}</comment>
+  </data>
 
   <!--
         The XslTransformation message bucket is: MSB3701-3710.

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Úloze nebyly předány žádné odkazy. Je vyžadován odkaz alespoň na knihovny mscorlib a Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Nelze vytvořit úlohu Xaml.  Kompilace se nezdařila. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Es wurden keine Verweise an die Aufgabe übergeben. Es sind mindestens Verweise auf mscorlib und Windows.Foundation erforderlich.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Die Xaml-Aufgabe kann nicht erstellt werden.  Fehler bei der Kompilierung.  {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2588,6 +2588,11 @@
         <target state="new">MSB3762: No references were passed to the task. References to at least mscorlib and Windows.Foundation are required.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="new">MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: No se pasó ninguna referencia a la tarea. Se requiere una referencia como mínimo a mscorlib y Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: No se puede crear la tarea XAML.  Error en la compilación.  {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Aucune référence n'a été passée à la tâche. Les références à mscorlib et Windows.Foundation, au minimum, sont obligatoires.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Impossible de créer la tâche Xaml.  Échec de la compilation. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: non sono stati passati riferimenti all'attività. Sono necessari almeno i riferimenti a mscorlib e Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: non è possibile creare l'attività XAML. La compilazione non è riuscita. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: 参照がタスクに渡されませんでした。少なくとも mscorlib と Windows.Foundation への参照が必要です。</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Xaml タスクを作成できません。コンパイルに失敗しました。{0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: 참조가 작업에 전달되지 않았습니다. 적어도 mscorlib 및 Windows.Foundation에 대한 참조가 필요합니다.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: XAML 작업을 만들 수 없습니다.  컴파일에 실패했습니다. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Do zadania nie zostały przekazane informacje o żadnych odwołaniach. Wymagane są odwołania co najmniej do biblioteki mscorlib i elementu Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Nie można utworzyć zadania Xaml.  Kompilacja nie powiodła się. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Nenhuma referência foi passada para a tarefa. São necessárias referências a pelo menos mscorlib e Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Não é possível criar a tarefa Xaml.  Falha na compilação. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: в задачу не переданы ссылки. Требуются ссылки как минимум на mscorlib и Windows.Foundation.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: не удается создать задачу XAML.  Ошибка компиляции. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: Göreve hiçbir başvuru geçirilmedi. En azından mscorlib ve Windows.Foundation başvuruları gereklidir.</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: Xaml görevi oluşturulamıyor.  Derleme başarısız. {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: 未向任务传递任何引用。至少需要对 mscorlib 和 Windows.Foundation 的引用。</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: 无法创建 Xaml 任务。编译失败。 {0}</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2528,6 +2528,11 @@
         <target state="translated">MSB3762: 沒有參考傳遞至工作。需要至少 mscorlib 和 Windows.Foundation 的參考。</target>
         <note>{StrBegin="MSB3762: "}</note>
       </trans-unit>
+      <trans-unit id="Xaml.DuplicatePropertyName">
+        <source>MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</source>
+        <target state="new">MSB3724: Unable to create Xaml task.  Duplicate property name '{0}'.</target>
+        <note>{StrBegin="MSB3724: "}</note>
+      </trans-unit>
       <trans-unit id="Xaml.TaskCreationFailed">
         <source>MSB3686: Unable to create Xaml task.  Compilation failed.  {0}</source>
         <target state="translated">MSB3686: 無法建立 XAML 工作。編譯失敗。{0}</target>

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Build.Tasks.Xaml
             }
             else
             {
-                throw new XamlParseException($"Duplicate property name '{propertyToAdd.Name}'");
+                throw new XamlParseException(ResourceUtilities.FormatResourceStringIgnoreCodeAndKeyword("Xaml.DuplicatePropertyName", propertyToAdd.Name));
             }
 
             // Inherit the Prefix from the Tool

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -307,7 +307,12 @@ namespace Microsoft.Build.Tasks.Xaml
             // generate the list of parameters in order
             if (!_switchesAdded.Contains(propertyToAdd.Name))
             {
+                _switchesAdded.Add(propertyToAdd.Name);
                 _switchOrderList.Add(propertyToAdd.Name);
+            }
+            else
+            {
+                throw new XamlParseException($"Duplicate property name '{propertyToAdd.Name}'");
             }
 
             // Inherit the Prefix from the Tool

--- a/src/Tasks/XamlTaskFactory/TaskParser.cs
+++ b/src/Tasks/XamlTaskFactory/TaskParser.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Build.Tasks.Xaml
     internal class TaskParser
     {
         /// <summary>
-        /// The set of switches added so far.
-        /// </summary>
-        private readonly HashSet<string> _switchesAdded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
         /// The ordered list of how the switches get emitted.
         /// </summary>
         private readonly List<string> _switchOrderList = new List<string>();
@@ -305,9 +300,8 @@ namespace Microsoft.Build.Tasks.Xaml
             }
 
             // generate the list of parameters in order
-            if (!_switchesAdded.Contains(propertyToAdd.Name))
+            if (!_switchOrderList.Contains(propertyToAdd.Name))
             {
-                _switchesAdded.Add(propertyToAdd.Name);
                 _switchOrderList.Add(propertyToAdd.Name);
             }
             else


### PR DESCRIPTION
Closes #75 

As far as I could observe, the only way to properly handle duplicate names is to die, because duplicate property names break code generation (code generator creates two fields with the same name), so I added the missing check and a new error message for this case.