### PR TITLE
Don't propagate TargetPath to RAR related files

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -197,6 +197,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool DisableNuGetSdkResolver = Environment.GetEnvironmentVariable("MSBUILDDISABLENUGETSDKRESOLVER") == "1";
 
         /// <summary>
+        /// Don't delete TargetPath metadata from associated files found by RAR.
+        /// </summary>
+        public readonly bool TargetPathForRelatedFiles = Environment.GetEnvironmentVariable("MSBUILDTARGETPATHFORRELATEDFILES") == "1";
+
+        /// <summary>
         /// Disable AssemblyLoadContext isolation for plugins.
         /// </summary>
         public readonly bool UseSingleLoadContext = Environment.GetEnvironmentVariable("MSBUILDSINGLELOADCONTEXT") == "1";

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -2918,6 +2918,10 @@ namespace Microsoft.Build.Tasks
             item.RemoveMetadata(ItemMetadataNames.winmdImplmentationFile);
             item.RemoveMetadata(ItemMetadataNames.imageRuntime);
             item.RemoveMetadata(ItemMetadataNames.winMDFile);
+            if (!Traits.Instance.EscapeHatches.TargetPathForRelatedFiles)
+            {
+                item.RemoveMetadata(ItemMetadataNames.targetPath);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #4756 by adding TargetPath to the list of metadata that shouldn't
be forwarded to "child"/related files discovered in RAR.

Adds an escape hatch for the behavior since we're not completely sure
there isn't user code that depends on the (surprising) behavior.