### PR TITLE
Find amd64/MSBuild.exe when run from a 64-bit process

### DIFF
--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -334,13 +334,7 @@ namespace Microsoft.Build.Shared
                 "MSBuild",
                 CurrentToolsVersion,
                 "Bin",
-#if NET35
-                IntPtr.Size == 8
-#else
-                System.Runtime.InteropServices.Marshal.SizeOf<IntPtr>() == 8
-#endif
-                  ? "amd64"
-                  : string.Empty,
+                IntPtr.Size == 8 ? "amd64" : string.Empty,
                 "MSBuild.exe");
         }
 

--- a/src/Shared/BuildEnvironmentHelper.cs
+++ b/src/Shared/BuildEnvironmentHelper.cs
@@ -329,7 +329,19 @@ namespace Microsoft.Build.Shared
 
         private static string GetMSBuildExeFromVsRoot(string visualStudioRoot)
         {
-            return FileUtilities.CombinePaths(visualStudioRoot, "MSBuild", CurrentToolsVersion, "Bin", "MSBuild.exe");
+            return FileUtilities.CombinePaths(
+                visualStudioRoot,
+                "MSBuild",
+                CurrentToolsVersion,
+                "Bin",
+#if NET35
+                IntPtr.Size == 8
+#else
+                System.Runtime.InteropServices.Marshal.SizeOf<IntPtr>() == 8
+#endif
+                  ? "amd64"
+                  : string.Empty,
+                "MSBuild.exe");
         }
 
         private static bool? _runningTests;


### PR DESCRIPTION
Fixes #5151 by inserting amd64 into the path if run from a 64-bit process
and discovering MSBuild in a Visual Studio installation.