### PR TITLE
Remove FEATURE_VARIOUS_EXCEPTIONS

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -37,7 +37,8 @@
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Runtime.Loader" Version="4.0.0" />
     <PackageReference Update="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Update="System.Security.Principal.Windows" Version="4.3.0" />
+    <PackageReference Update="System.Security.Permissions" Version="4.7.0" />
+    <PackageReference Update="System.Security.Principal.Windows" Version="4.7.0" />
     <PackageReference Update="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Update="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Update="System.Threading.Thread" Version="4.0.0" />

--- a/src/Build.UnitTests/BackEnd/BuildResult_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildResult_Tests.cs
@@ -83,12 +83,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
             BuildRequest request = CreateNewBuildRequest(1, new string[0]);
             BuildResult result = new BuildResult(request);
             Assert.Null(result.Exception);
-#if FEATURE_VARIOUS_EXCEPTIONS
             AccessViolationException e = new AccessViolationException();
             result = new BuildResult(request, e);
 
             Assert.Equal(e, result.Exception);
-#endif
         }
 
         [Fact]

--- a/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/EventSourceSink_Tests.cs
@@ -91,9 +91,7 @@ namespace Microsoft.Build.UnitTests.Logging
             List<Exception> exceptionList = new List<Exception>();
             exceptionList.Add(new LoggerException());
             exceptionList.Add(new ArgumentException());
-#if FEATURE_VARIOUS_EXCEPTIONS
             exceptionList.Add(new StackOverflowException());
-#endif
 
             foreach (Exception exception in exceptionList)
             {

--- a/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingService_Tests.cs
@@ -152,13 +152,11 @@ namespace Microsoft.Build.UnitTests.Logging
             VerifyShutdownExceptions(null, className, exceptionType);
             Assert.Equal(LoggingServiceState.Shutdown, _initializedService.ServiceState);
 
-#if FEATURE_VARIOUS_EXCEPTIONS
             // Cause a StackOverflow exception in the shutdown of the logger
             // this kind of exception should not be caught
             className = "Microsoft.Build.UnitTests.Logging.LoggingService_Tests+ShutdownStackoverflowExceptionFL";
             exceptionType = typeof(StackOverflowException);
             VerifyShutdownExceptions(null, className, exceptionType);
-#endif
 
             Assert.Equal(LoggingServiceState.Shutdown, _initializedService.ServiceState);
         }
@@ -176,10 +174,8 @@ namespace Microsoft.Build.UnitTests.Logging
             logger = new LoggerThrowException(true, false, new Exception("boo"));
             VerifyShutdownExceptions(logger, null, typeof(InternalLoggerException));
 
-#if FEATURE_VARIOUS_EXCEPTIONS
             logger = new LoggerThrowException(true, false, new StackOverflowException());
             VerifyShutdownExceptions(logger, null, typeof(StackOverflowException));
-#endif
 
             Assert.Equal(LoggingServiceState.Shutdown, _initializedService.ServiceState);
         }
@@ -257,7 +253,6 @@ namespace Microsoft.Build.UnitTests.Logging
            );
         }
 
-#if FEATURE_VARIOUS_EXCEPTIONS
         /// <summary>
         /// Verify a critical exception is not wrapped
         /// </summary>
@@ -271,7 +266,6 @@ namespace Microsoft.Build.UnitTests.Logging
             }
            );
         }
-#endif
 
         /// <summary>
         /// Register an good Logger and verify it was registered.
@@ -1170,7 +1164,6 @@ namespace Microsoft.Build.UnitTests.Logging
             }
         }
 
-#if FEATURE_VARIOUS_EXCEPTIONS
         /// <summary>
         /// Forwarding logger which will throw a StackOverflowException
         /// in the shutdown method. This is to test the shutdown exception handling
@@ -1186,7 +1179,6 @@ namespace Microsoft.Build.UnitTests.Logging
             {
             }
         }
-#endif
 
         /// <summary>
         /// Logger which can throw a defined exception in the initialize or shutdown methods

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -690,14 +690,12 @@ namespace Microsoft.Build.BackEnd
                 await BuildAndReport();
                 MSBuildEventSource.Log.RequestThreadProcStop();
             }
-#if FEATURE_VARIOUS_EXCEPTIONS
             catch (ThreadAbortException)
             {
                 // Do nothing.  This will happen when the thread is forcibly terminated because we are shutting down, for example
                 // when the unit test framework terminates.
                 throw;
             }
-#endif
             catch (Exception e)
             {
                 // Dump all engine exceptions to a temp file

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -864,7 +864,6 @@ namespace Microsoft.Build.BackEnd
                         // Rethrow wrapped in order to avoid losing the callstack
                         throw new InternalLoggerException(taskException.Message, taskException, ex.BuildEventArgs, ex.ErrorCode, ex.HelpKeyword, ex.InitializationException);
                     }
-#if FEATURE_VARIOUS_EXCEPTIONS
                     else if (type == typeof(ThreadAbortException))
                     {
                         Thread.ResetAbort();
@@ -874,7 +873,6 @@ namespace Microsoft.Build.BackEnd
                         // Stack will be lost
                         throw taskException;
                     }
-#endif
                     else if (type == typeof(BuildAbortedException))
                     {
                         _continueOnError = ContinueOnError.ErrorAndStop;

--- a/src/Build/BackEnd/Node/InProcNode.cs
+++ b/src/Build/BackEnd/Node/InProcNode.cs
@@ -163,14 +163,12 @@ namespace Microsoft.Build.BackEnd
                     }
                 }
             }
-#if FEATURE_VARIOUS_EXCEPTIONS
             catch (ThreadAbortException)
             {
                 // Do nothing.  This will happen when the thread is forcibly terminated because we are shutting down, for example
                 // when the unit test framework terminates.
                 throw;
             }
-#endif
             catch (Exception e)
             {
                 // Dump all engine exceptions to a temp file

--- a/src/Directory.BeforeCommon.targets
+++ b/src/Directory.BeforeCommon.targets
@@ -91,7 +91,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETINTERFACE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_USERINTERACTIVE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_USERDOMAINNAME</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_VARIOUS_EXCEPTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAML_TYPES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_XAMLTASKFACTORY</DefineConstants>
     <FeatureXamlTypes>true</FeatureXamlTypes>

--- a/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/Framework/Microsoft.Build.Framework.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
+    <PackageReference Include="System.Security.Permissions" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <PackageReference Include="System.Threading.Thread" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <Reference Include="System.Xaml" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>

--- a/src/MSBuild/OutOfProcTaskHostNode.cs
+++ b/src/MSBuild/OutOfProcTaskHostNode.cs
@@ -837,14 +837,12 @@ namespace Microsoft.Build.CommandLine
             }
             catch (Exception e)
             {
-#if FEATURE_VARIOUS_EXCEPTIONS
                 if (e is ThreadAbortException)
                 {
                     // This thread was aborted as part of Cancellation, we will return a failure task result
                     taskResult = new OutOfProcTaskHostTaskResult(TaskCompleteType.Failure);
                 }
                 else
-#endif
                 if (ExceptionHandling.IsCriticalException(e))
                 {
                     throw;

--- a/src/Shared/ExceptionHandling.cs
+++ b/src/Shared/ExceptionHandling.cs
@@ -17,10 +17,8 @@ using System.Text;
 using System.Threading;
 using System.Xml;
 using Microsoft.Build.Shared.FileSystem;
-#if FEATURE_VARIOUS_EXCEPTIONS
 using System.Xml.Schema;
 using System.Runtime.Serialization;
-#endif
 
 namespace Microsoft.Build.Shared
 #endif
@@ -70,12 +68,10 @@ namespace Microsoft.Build.Shared
         internal static bool IsCriticalException(Exception e)
         {
             if (e is OutOfMemoryException
-#if FEATURE_VARIOUS_EXCEPTIONS
              || e is StackOverflowException
              || e is ThreadAbortException
              || e is ThreadInterruptedException
              || e is AccessViolationException
-#endif
 #if !BUILDINGAPPXTASKS
              || e is InternalErrorException
 #endif
@@ -144,10 +140,8 @@ namespace Microsoft.Build.Shared
         internal static bool IsXmlException(Exception e)
         {
             return e is XmlException
-#if FEATURE_VARIOUS_EXCEPTIONS
                 || e is XmlSyntaxException
                 || e is XmlSchemaException
-#endif
                 || e is UriFormatException; // XmlTextReader for example uses this under the covers
         }
 
@@ -168,14 +162,12 @@ namespace Microsoft.Build.Shared
             }
             else
             {
-#if FEATURE_VARIOUS_EXCEPTIONS
                 var schemaException = e as XmlSchemaException;
                 if (schemaException != null)
                 {
                     line = schemaException.LineNumber;
                     column = schemaException.LinePosition;
                 }
-#endif
             }
 
             return new LineAndColumn
@@ -227,12 +219,10 @@ namespace Microsoft.Build.Shared
                 || e is TargetParameterCountException   // thrown when the number of parameters for an invocation does not match the number expected
                 || e is InvalidCastException
                 || e is AmbiguousMatchException         // thrown when binding to a member results in more than one member matching the binding criteria
-#if FEATURE_VARIOUS_EXCEPTIONS
                 || e is CustomAttributeFormatException  // thrown if a custom attribute on a data type is formatted incorrectly
                 || e is InvalidFilterCriteriaException  // thrown in FindMembers when the filter criteria is not valid for the type of filter you are using
                 || e is TargetException                 // thrown when an attempt is made to invoke a non-static method on a null object.  This may occur because the caller does not
                                                         //     have access to the member, or because the target does not define the member, and so on.
-#endif
                 || e is MissingFieldException           // thrown when code in a dependent assembly attempts to access a missing field in an assembly that was modified.
                 || !NotExpectedException(e)             // Reflection can throw IO exceptions if the assembly cannot be opened
 
@@ -253,9 +243,7 @@ namespace Microsoft.Build.Shared
         {
             if
             (
-#if FEATURE_VARIOUS_EXCEPTIONS
                 e is SerializationException ||
-#endif
                 !NotExpectedReflectionException(e)
             )
             {

--- a/src/Tasks/AppConfig/AppConfigException.cs
+++ b/src/Tasks/AppConfig/AppConfigException.cs
@@ -11,11 +11,7 @@ namespace Microsoft.Build.Tasks
     /// </summary>
     [Serializable]
     internal class AppConfigException :
-#if FEATURE_VARIOUS_EXCEPTIONS
         System.ApplicationException
-#else
-        Exception
-#endif
     {
         /// <summary>
         /// The name of the app.config file.

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -992,6 +992,7 @@
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Resources.Writer" />
+    <PackageReference Include="System.Security.Permissions" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
 
     <!-- Need Win32 API on .NET Core to ping registry to determine long path support -->

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <PackageReference Include="System.Security.Permissions" />
     <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 


### PR DESCRIPTION
While working on something else I noticed this old (.NET Core 1) feature flag that we don't need any more since we have the guarded APIs everywhere now.