### PR TITLE
Special-case CallTarget which doesn't return errors itself even when it

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -745,7 +745,7 @@ namespace Microsoft.Build.BackEnd
             UpdateContinueOnError(bucket, taskHost);
 
             bool taskResult = false;
-            bool isMSBuildTask = false;
+            bool isMSBuildTaskOrCallTargetTask = false;
 
             WorkUnitResultCode resultCode = WorkUnitResultCode.Success;
             WorkUnitActionCode actionCode = WorkUnitActionCode.Continue;
@@ -773,7 +773,7 @@ namespace Microsoft.Build.BackEnd
                         ErrorUtilities.VerifyThrow(msbuildTask != null, "Unexpected MSBuild internal task.");
 
                         var undeclaredProjects = GetUndeclaredProjects(msbuildTask);
-                        isMSBuildTask = true;
+                        isMSBuildTaskOrCallTargetTask = true;
 
                         if (undeclaredProjects != null && undeclaredProjects.Count != 0)
                         {
@@ -810,6 +810,7 @@ namespace Microsoft.Build.BackEnd
                     else if (taskType == typeof(CallTarget))
                     {
                         CallTarget callTargetTask = host.TaskInstance as CallTarget;
+                        isMSBuildTaskOrCallTargetTask = true;
                         taskResult = await callTargetTask.ExecuteInternal();
                     }
                     else
@@ -949,7 +950,7 @@ namespace Microsoft.Build.BackEnd
                 // When a task fails it must log an error. If a task fails to do so,
                 // that is logged as an error. MSBuild tasks are an exception because
                 // errors are not logged directly from them, but the tasks spawned by them.
-                if (!isMSBuildTask && taskReturned && !taskResult && !taskLoggingContext.HasLoggedErrors)
+                if (!isMSBuildTaskOrCallTargetTask && taskReturned && !taskResult && !taskLoggingContext.HasLoggedErrors)
                 {
                     if (_continueOnError == ContinueOnError.WarnAndContinue)
                     {

--- a/src/Tasks.UnitTests/CallTarget_Tests.cs
+++ b/src/Tasks.UnitTests/CallTarget_Tests.cs
@@ -12,6 +12,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using System.Text.RegularExpressions;
+using Shouldly;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests
@@ -109,6 +110,22 @@ namespace Microsoft.Build.UnitTests
             logger.AssertLogContains("Inside A");
             logger.AssertLogContains("Inside B");
             logger.AssertLogContains("Inside C");
+        }
+
+        [Fact]
+        public void FailsWithOnlyTargetErrors()
+        {
+            MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(@"
+                <Project>
+                  <Target Name='Init'>
+                    <CallTarget Targets='Inside' />
+                  </Target>
+                  <Target Name='Inside'>
+                    <Error />
+                  </Target>
+                </Project>");
+
+            logger.ErrorCount.ShouldBe (1);
         }
 
         /// <summary>


### PR DESCRIPTION
.. fails. The errors are logged by the targets invoked by `CallTarget`.

Fixes https://github.com/microsoft/msbuild/issues/5155 .