### PR TITLE
Fix msbuild regression in version string, on mono

### DIFF
--- a/src/Build/Definition/ProjectCollection.cs
+++ b/src/Build/Definition/ProjectCollection.cs
@@ -479,7 +479,11 @@ namespace Microsoft.Build.Evaluation
                     var fullInformationalVersion = typeof(Constants).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
                     // use a truncated version with only 9 digits of SHA
-                    s_assemblyDisplayVersion = fullInformationalVersion.Substring(startIndex: 0, length: fullInformationalVersion.IndexOf('+') + 10);
+                    var plusIndex = fullInformationalVersion.IndexOf('+');
+                    s_assemblyDisplayVersion = plusIndex < 0
+                                                    ? fullInformationalVersion
+                                                    : fullInformationalVersion.Substring(startIndex: 0, length: plusIndex + 10);
+
                 }
 
                 return s_assemblyDisplayVersion;


### PR DESCRIPTION
We had worked around this issue last time in
https://github.com/mono/msbuild/commit/566653691020920c4dc9ddab218e699c8c68526c .
But fixing it this time, so that we don't hit it again.

Trace from the orignal commit:
```
MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
System.ArgumentOutOfRangeException: Index and length must refer to a location within the string.
Parameter name: length
  at System.String.Substring (System.Int32 startIndex, System.Int32 length) [0x00073] in /Users/radical/dev/mono/external/corefx/src/Common/src/CoreLib/System/String.Manipulation.cs:1626
  at Microsoft.Build.Evaluation.ProjectCollection.get_DisplayVersion () [0x00026] in /Users/radical/dev/msbuild/src/Build/Definition/ProjectCollection.cs:474
  at Microsoft.Build.CommandLine.MSBuildApp.DisplayCopyrightMessage () [0x0002d] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:3647
  at Microsoft.Build.CommandLine.MSBuildApp.ProcessCommandLineSwitches (Microsoft.Build.CommandLine.CommandLineSwitches switchesFromAutoResponseFile, Microsoft.Build.CommandLine.CommandLineSwitches switchesNotFromAutoResponseFile, System.String& projectFile, System.String[]& targets, System.String& toolsVersion, System.Collections.Generic.Dictionary`2[System.String,System.String]& globalProperties, Microsoft.Build.Framework.ILogger[]& loggers, Microsoft.Build.Framework.LoggerVerbosity& verbosity, System.Collections.Generic.List`1[Microsoft.Build.CommandLine.DistributedLoggerRecord]& distributedLoggerRecords, System.Int32& cpuCount, System.Boolean& enableNodeReuse, System.IO.TextWriter& preprocessWriter, System.Boolean& detailedSummary, System.Collections.Generic.ISet`1[System.String]& warningsAsErrors, System.Collections.Generic.ISet`1[System.String]& warningsAsMessages, System.Boolean& enableRestore, System.Boolean& interactive, Microsoft.Build.Logging.ProfilerLogger& profilerLogger, System.Boolean& enableProfiler, System.Collections.Generic.Dictionary`2[System.String,System.String]& restoreProperties, System.Boolean& isolateProjects, System.Boolean& graphBuild, System.String[]& inputResultsCaches, System.String& outputResultsCache, System.Boolean recursing) [0x0002d] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:2064
  at Microsoft.Build.CommandLine.MSBuildApp.Execute (System.String commandLine) [0x00418] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:791
  at Microsoft.Build.CommandLine.MSBuildApp.Main () [0x0001c] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:219 o]
```

Fixes https://github.com/mono/mono/issues/19177 .