### PR TITLE
ActiveIssueDiscoverer: Always set category for ActiveIssue attribute

### DIFF
--- a/src/Xunit.NetCore.Extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/Xunit.NetCore.Extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -63,9 +63,9 @@ namespace Xunit.NetCore.Extensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
                 if (frameworks == (TargetFrameworkMonikers)0)
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
-
-                yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }
+
+            yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
         }
     }
 }


### PR DESCRIPTION
My expectation is that the "activeissue" category should be set given an [ActiveIssue] attribute, regardless if any OS conditions are being met.