### PR TITLE
Don't swallow AfterTargets failures in multi-proc builds

### DIFF
--- a/documentation/wiki/Contributing-Code.md
+++ b/documentation/wiki/Contributing-Code.md
@@ -7,7 +7,7 @@ Because our focus right now is on maintaining backwards compatibility, the team 
 - Only contributions referencing an approved Issue will be accepted.
 - Pull requests that do not merge easily with the tip of the master branch will be declined. The author will be asked to merge with tip and submit a new pull request.
 - Submissions must meet functional and performance expectations, including scenarios for which the team doesn't yet have open source tests. This means you may be asked to fix and resubmit your pull request against a new open test case if it fails one of these tests.
-- Submissions must follow the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
+- Submissions must follow the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md)
 
 When you are ready to proceed with making a change, get set up to [build](Home.md "See 'Building Testing and Debugging'") the code and familiarize yourself with our workflow and our coding conventions. These two blogs posts on contributing code to open source projects are good too: [Open Source Contribution Etiquette by Miguel de Icaza](https://tirania.org/blog/archive/2010/Dec-31.html) and [Don’t “Push” Your Pull Requests by Ilya Grigorik](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/).
 
@@ -33,4 +33,4 @@ Please follow these guidelines when creating new issues in the issue tracker:
 - Subscribe to notifications for the created issue in case there are any follow up questions.
 
 ### Coding Conventions
-- Use the coding style outlined in the [.Net Foundation Coding Guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md)
+- Use the coding style outlined in the [.NET Runtime Coding Guidelines](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md)

--- a/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildManager_Tests.cs
@@ -2297,8 +2297,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// overall build result -- and thus the return value of the MSBuild task -- should reflect
         /// that failure. 
         /// </summary>
-        [Fact]
-        public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure(bool disableInProcNode)
         {
             var projA = _env.CreateFile(".proj").Path;
             var projB = _env.CreateFile(".proj").Path;
@@ -2328,6 +2330,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             File.WriteAllText(projA, CleanupFileContents(contentsA));
             File.WriteAllText(projB, CleanupFileContents(contentsB));
 
+            _parameters.DisableInProcNode = disableInProcNode;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null, new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
@@ -2343,8 +2346,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// that failure.  Specifically tests where there are multiple entrypoint targets with 
         /// AfterTargets, only one of which fails. 
         /// </summary>
-        [Fact]
-        public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure_MultipleEntrypoints()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FailedAfterTargetInP2PShouldCauseOverallBuildFailure_MultipleEntrypoints(bool disableInProcNode)
         {
             var projA = _env.CreateFile(".proj").Path;
             var projB = _env.CreateFile(".proj").Path;
@@ -2386,6 +2391,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             File.WriteAllText(projA, CleanupFileContents(contentsA));
             File.WriteAllText(projB, CleanupFileContents(contentsB));
 
+            _parameters.DisableInProcNode = disableInProcNode;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null, new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();
@@ -2406,8 +2412,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// that failure. This should also be true if the AfterTarget is an AfterTarget of the 
         /// entrypoint target.
         /// </summary>
-        [Fact]
-        public void FailedNestedAfterTargetInP2PShouldCauseOverallBuildFailure()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FailedNestedAfterTargetInP2PShouldCauseOverallBuildFailure(bool disableInProcNode)
         {
             var projA = _env.CreateFile(".proj").Path;
             var projB = _env.CreateFile(".proj").Path;
@@ -2441,6 +2449,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
             File.WriteAllText(projA, CleanupFileContents(contentsA));
             File.WriteAllText(projB, CleanupFileContents(contentsB));
 
+            _parameters.DisableInProcNode = disableInProcNode;
             _buildManager.BeginBuild(_parameters);
             var data = new BuildRequestData(projA, new Dictionary<string, string>(), null, new[] { "Build" }, new HostServices());
             BuildResult result = _buildManager.PendBuildRequest(data).Execute();

--- a/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/ResultsCache_Tests.cs
@@ -168,8 +168,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
         /// <summary>
         /// If a result had multiple targets associated with it and we only requested some of their 
-        /// results, the returned result should only contain the targets we asked for, BUT the overall 
-        /// status of the result should remain the same.  
+        /// results, the returned result should only contain the targets we asked for, and the overall
+        /// status of the result should reflect the targets we asked for as well.
         /// </summary>
         [Fact]
         public void TestRetrieveSubsetTargetsFromResult()
@@ -182,13 +182,13 @@ namespace Microsoft.Build.UnitTests.BackEnd
             result.AddResultsForTarget("testTarget2", BuildResultUtilities.GetEmptySucceedingTargetResult());
             cache.AddResult(result);
 
-            ResultsCacheResponse response = cache.SatisfyRequest(request, new List<string>(), new List<string>(new string[] { "testTarget2" }), new List<string>(new string[] { "testTarget" }), skippedResultsDoNotCauseCacheMiss: false);
+            ResultsCacheResponse response = cache.SatisfyRequest(request, new List<string>(), new List<string>(new string[] { "testTarget2" }), skippedResultsDoNotCauseCacheMiss: false);
 
             Assert.Equal(ResultsCacheResponseType.Satisfied, response.Type);
 
             Assert.True(AreResultsIdenticalForTarget(result, response.Results, "testTarget2"));
             Assert.False(response.Results.HasResultsForTarget("testTarget"));
-            Assert.Equal(BuildResultCode.Failure, response.Results.OverallResult);
+            Assert.Equal(BuildResultCode.Success, response.Results.OverallResult);
         }
 
         [Fact]

--- a/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
+++ b/src/Build/BackEnd/Components/BuildRequestEngine/BuildRequestEngine.cs
@@ -511,7 +511,6 @@ namespace Microsoft.Build.BackEnd
                                         request: request,
                                         configInitialTargets: config.ProjectInitialTargets,
                                         configDefaultTargets: config.ProjectDefaultTargets,
-                                        additionalTargetsToCheckForOverallResult: config.GetAfterTargetsForDefaultTargets(request),
                                         skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
 
                                     if (cacheResponse.Type == ResultsCacheResponseType.Satisfied)
@@ -1173,7 +1172,6 @@ namespace Microsoft.Build.BackEnd
                             request: newRequest,
                             configInitialTargets: matchingConfig.ProjectInitialTargets,
                             configDefaultTargets: matchingConfig.ProjectDefaultTargets,
-                            additionalTargetsToCheckForOverallResult: matchingConfig.GetAfterTargetsForDefaultTargets(newRequest),
                             skippedResultsDoNotCauseCacheMiss: _componentHost.BuildParameters.SkippedResultsDoNotCauseCacheMiss());
 
                         if (response.Type == ResultsCacheResponseType.Satisfied)

--- a/src/Build/BackEnd/Components/Caching/IResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/IResultsCache.cs
@@ -49,14 +49,12 @@ namespace Microsoft.Build.BackEnd
         /// <param name="request">The request whose results we should return</param>
         /// <param name="configInitialTargets">The initial targets for the request's configuration.</param>
         /// <param name="configDefaultTargets">The default targets for the request's configuration.</param>
-        /// <param name="additionalTargetsToCheckForOverallResult">Any additional targets that need to be checked to determine overall 
-        /// pass or failure, but that are not included as actual results. (E.g. AfterTargets of an entrypoint target)</param>
         /// <param name="skippedResultsDoNotCauseCacheMiss">If false, a cached skipped target will cause this method to return "NotSatisfied".  
         /// If true, then as long as there is a result in the cache (regardless of whether it was skipped or not), this method 
         /// will return "Satisfied". In most cases this should be false, but it may be set to true in a situation where there is no 
         /// chance of re-execution (which is the usual response to missing / skipped targets), and the caller just needs the data.</param>
         /// <returns>A response indicating the results, if any, and the targets needing to be built, if any.</returns>
-        ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, List<string> additionalTargetsToCheckForOverallResult, bool skippedResultsDoNotCauseCacheMiss);
+        ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, bool skippedResultsDoNotCauseCacheMiss);
 
         /// <summary>
         /// Clears the results for a specific configuration.

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -149,14 +149,12 @@ namespace Microsoft.Build.BackEnd
         /// <param name="request">The request whose results we should return</param>
         /// <param name="configInitialTargets">The initial targets for the request's configuration.</param>
         /// <param name="configDefaultTargets">The default targets for the request's configuration.</param>
-        /// <param name="additionalTargetsToCheckForOverallResult">Any additional targets that need to be checked to determine overall 
-        /// pass or failure, but that are not included as actual results. (E.g. AfterTargets of an entrypoint target)</param>
         /// <param name="skippedResultsDoNotCauseCacheMiss">If false, a cached skipped target will cause this method to return "NotSatisfied".  
         /// If true, then as long as there is a result in the cache (regardless of whether it was skipped or not), this method 
         /// will return "Satisfied". In most cases this should be false, but it may be set to true in a situation where there is no 
         /// chance of re-execution (which is the usual response to missing / skipped targets), and the caller just needs the data.</param>
         /// <returns>A response indicating the results, if any, and the targets needing to be built, if any.</returns>
-        public ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, List<string> additionalTargetsToCheckForOverallResult, bool skippedResultsDoNotCauseCacheMiss)
+        public ResultsCacheResponse SatisfyRequest(BuildRequest request, List<string> configInitialTargets, List<string> configDefaultTargets, bool skippedResultsDoNotCauseCacheMiss)
         {
             ErrorUtilities.VerifyThrowArgument(request.IsConfigurationResolved, "UnresolvedConfigurationInRequest");
             ResultsCacheResponse response = new ResultsCacheResponse(ResultsCacheResponseType.NotSatisfied);
@@ -207,7 +205,7 @@ namespace Microsoft.Build.BackEnd
                                 targetsToAddResultsFor.AddRange(configDefaultTargets);
                             }
 
-                            response.Results = new BuildResult(request, allResults, targetsToAddResultsFor.ToArray(), additionalTargetsToCheckForOverallResult, null);
+                            response.Results = new BuildResult(request, allResults, targetsToAddResultsFor.ToArray(), null);
                         }
                     }
                     else

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
@@ -77,14 +77,12 @@ namespace Microsoft.Build.Execution
             BuildRequest request,
             List<string> configInitialTargets,
             List<string> configDefaultTargets,
-            List<string> additionalTargetsToCheckForOverallResult,
             bool skippedResultsDoNotCauseCacheMiss)
         {
             var overrideRequest = _override.SatisfyRequest(
                 request,
                 configInitialTargets,
                 configDefaultTargets,
-                additionalTargetsToCheckForOverallResult,
                 skippedResultsDoNotCauseCacheMiss);
 
             if (overrideRequest.Type == ResultsCacheResponseType.Satisfied)
@@ -95,7 +93,6 @@ namespace Microsoft.Build.Execution
                         request,
                         configInitialTargets,
                         configDefaultTargets,
-                        additionalTargetsToCheckForOverallResult,
                         skippedResultsDoNotCauseCacheMiss)
                         .Type == ResultsCacheResponseType.NotSatisfied,
                     "caches should not overlap");
@@ -107,7 +104,6 @@ namespace Microsoft.Build.Execution
                 request,
                 configInitialTargets,
                 configDefaultTargets,
-                additionalTargetsToCheckForOverallResult,
                 skippedResultsDoNotCauseCacheMiss);
         }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1778,7 +1778,7 @@ namespace Microsoft.Build.BackEnd
         private ScheduleResponse TrySatisfyRequestFromCache(int nodeForResults, BuildRequest request, bool skippedResultsDoNotCauseCacheMiss)
         {
             BuildRequestConfiguration config = _configCache[request.ConfigurationId];
-            ResultsCacheResponse resultsResponse = _resultsCache.SatisfyRequest(request, config.ProjectInitialTargets, config.ProjectDefaultTargets, config.GetAfterTargetsForDefaultTargets(request), skippedResultsDoNotCauseCacheMiss);
+            ResultsCacheResponse resultsResponse = _resultsCache.SatisfyRequest(request, config.ProjectInitialTargets, config.ProjectDefaultTargets, skippedResultsDoNotCauseCacheMiss);
 
             if (resultsResponse.Type == ResultsCacheResponseType.Satisfied)
             {

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -677,43 +677,6 @@ namespace Microsoft.Build.BackEnd
             return allTargets;
         }
 
-        /// <summary>
-        /// Returns the list of targets that are AfterTargets (or AfterTargets of the AfterTargets) 
-        /// of the entrypoint targets.  
-        /// </summary>
-        public List<string> GetAfterTargetsForDefaultTargets(BuildRequest request)
-        {
-            // We may not have a project available.  In which case, return nothing -- we simply don't have 
-            // enough information to figure out what the correct answer is.
-            if (!IsCached && Project != null)
-            {
-                var afterTargetsFound = new HashSet<string>();
-
-                var targetsToCheckForAfterTargets = new Queue<string>((request.Targets.Count == 0) ? ProjectDefaultTargets : request.Targets);
-
-                while (targetsToCheckForAfterTargets.Count > 0)
-                {
-                    string targetToCheck = targetsToCheckForAfterTargets.Dequeue();
-
-                    IList<TargetSpecification> targetsWhichRunAfter = Project.GetTargetsWhichRunAfter(targetToCheck);
-
-                    foreach (TargetSpecification targetWhichRunsAfter in targetsWhichRunAfter)
-                    {
-                        if (afterTargetsFound.Add(targetWhichRunsAfter.TargetName))
-                        {
-                            // If it's already in there, we've already looked into it so no need to do so again.  Otherwise, add it 
-                            // to the list to check.
-                            targetsToCheckForAfterTargets.Enqueue(targetWhichRunsAfter.TargetName);
-                        }
-                    }
-                }
-
-                return new List<string>(afterTargetsFound);
-            }
-
-            return null;
-        }
-
         private Func<string, bool> shouldSkipStaticGraphIsolationOnReference;
 
         public bool ShouldSkipIsolationConstraintsForReference(string referenceFullPath)

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Build.Execution
         /// <param name="existingResults">The existing results, if any.</param>
         /// <param name="exception">The exception, if any</param>
         internal BuildResult(BuildRequest request, BuildResult existingResults, Exception exception)
-            : this(request, existingResults, null, null, exception)
+            : this(request, existingResults, null, exception)
         {
         }
 
@@ -189,9 +189,8 @@ namespace Microsoft.Build.Execution
         /// <param name="request">The build request with which these results should be associated.</param>
         /// <param name="existingResults">The existing results, if any.</param>
         /// <param name="targetNames">The list of target names that are the subset of results that should be returned.</param>
-        /// <param name="additionalTargetsToCheck">The additional targets that need to be taken into account when computing the overall result, if any.</param>
         /// <param name="exception">The exception, if any</param>
-        internal BuildResult(BuildRequest request, BuildResult existingResults, string[] targetNames, List<string> additionalTargetsToCheck, Exception exception)
+        internal BuildResult(BuildRequest request, BuildResult existingResults, string[] targetNames, Exception exception)
         {
             ErrorUtilities.VerifyThrow(request != null, "Must specify a request.");
             _submissionId = request.SubmissionId;
@@ -200,57 +199,17 @@ namespace Microsoft.Build.Execution
             _parentGlobalRequestId = request.ParentGlobalRequestId;
             _nodeRequestId = request.NodeRequestId;
             _circularDependency = false;
+            _baseOverallResult = true;
 
             if (existingResults == null)
             {
                 _requestException = exception;
                 _resultsByTarget = CreateTargetResultDictionary(0);
-                _baseOverallResult = true;
             }
             else
             {
                 _requestException = exception ?? existingResults._requestException;
-
                 _resultsByTarget = targetNames == null ? existingResults._resultsByTarget : CreateTargetResultDictionaryWithContents(existingResults, targetNames);
-
-                if (existingResults.OverallResult == BuildResultCode.Success || (additionalTargetsToCheck == null || additionalTargetsToCheck.Count == 0))
-                {
-                    // If we know for a fact that all of the existing results succeeded, then by definition we'll have 
-                    // succeeded too.  Alternately, if we don't have any additional targets to check, then we want the 
-                    // overall result to reflect only the targets included in this result, which the OverallResult 
-                    // property already does -- so just default to true in that case as well. 
-                    _baseOverallResult = true;
-                }
-                else
-                {
-                    // If the existing result is a failure, then we need to determine whether the targets we are 
-                    // specifically interested in contributed to that failure or not.  If they did not, then this 
-                    // result should be sucessful even though the result it is based on failed. 
-                    // 
-                    // For the most part, this is taken care of for us because any dependent targets that fail also 
-                    // mark their parent targets (up to and including the entrypoint target) as failed.  However, 
-                    // there is one case in which this is not true: if the entrypoint target has AfterTargets that 
-                    // fail, then as far as the entrypoint target knows when it is executing, it has succeeded.  The 
-                    // failure doesn't come until after.  On the other hand, we don't want to actually include the 
-                    // AfterTarget results in the build result itself if the user hasn't asked for them.  
-                    // 
-                    // So in the case where there are AfterTargets, we will check them for failure so that we can  
-                    // make sure the overall success/failure result is correct, but not actually add their contents 
-                    // to the new result. 
-                    _baseOverallResult = true;
-
-                    foreach (string additionalTarget in additionalTargetsToCheck)
-                    {
-                        if (existingResults.ResultsByTarget.TryGetValue(additionalTarget, out TargetResult targetResult))
-                        {
-                            if (targetResult.ResultCode == TargetResultCode.Failure && !targetResult.TargetFailureDoesntCauseBuildFailure)
-                            {
-                                _baseOverallResult = false;
-                                break;
-                            }
-                        }
-                    }
-                }
             }
         }
 
@@ -383,7 +342,8 @@ namespace Microsoft.Build.Execution
 
                 foreach (KeyValuePair<string, TargetResult> result in _resultsByTarget)
                 {
-                    if (result.Value.ResultCode == TargetResultCode.Failure && !result.Value.TargetFailureDoesntCauseBuildFailure)
+                    if ((result.Value.ResultCode == TargetResultCode.Failure && !result.Value.TargetFailureDoesntCauseBuildFailure)
+                        || result.Value.AfterTargetsHaveFailed)
                     {
                         return BuildResultCode.Failure;
                     }

--- a/src/Build/BackEnd/Shared/TargetResult.cs
+++ b/src/Build/BackEnd/Shared/TargetResult.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Build.Execution
         private bool _targetFailureDoesntCauseBuildFailure;
 
         /// <summary>
+        /// Flag indicating whether at least one target which has run after us (transitively via AfterTargets) failed.
+        /// </summary>
+        private bool _afterTargetsHaveFailed;
+
+        /// <summary>
         /// The store of items in this result.
         /// </summary>
         private ItemsStore _itemsStore;
@@ -141,6 +146,18 @@ namespace Microsoft.Build.Execution
             set => _targetFailureDoesntCauseBuildFailure = value;
         }
 
+        /// <summary>
+        /// Sets or gets a flag indicating whether at least one target which has run after us (transitively via AfterTargets) failed.
+        /// </summary>
+        internal bool AfterTargetsHaveFailed
+        {
+            [DebuggerStepThrough]
+            get => _afterTargetsHaveFailed;
+
+            [DebuggerStepThrough]
+            set => _afterTargetsHaveFailed = value;
+        }
+
         #region INodePacketTranslatable Members
 
         /// <summary>
@@ -239,6 +256,7 @@ namespace Microsoft.Build.Execution
         {
             translator.Translate(ref _result, WorkUnitResult.FactoryForDeserialization);
             translator.Translate(ref _targetFailureDoesntCauseBuildFailure);
+            translator.Translate(ref _afterTargetsHaveFailed);
             translator.Translate(ref _itemsStore, ItemsStore.FactoryForDeserialization);
         }
 


### PR DESCRIPTION
`BuildResult` had code in one of its constructors specifically to handle AfterTargets failures, making sure that they are propagated to the referenced target. This didn't work in multi-proc builds for multiple reasons:

1) The process orchestrating the build may have had no visibility into targets other than those requested to be executed by the worker process. This means that the `existingResults` argument typically didn't contain results for the targets with AfterTargets specified, meaning it had no way of knowing that they had failed.

2) The process orchestrating the build may not have loaded the project file handled by the worker process. This means that the `additionalTargetsToCheck` argument could have been `null`, again making it impossible for `BuildResult` to detect the dependency.

This change moves the logic of calculating target failures to the worker process, namely to `TargetBuilder`. A new flag `AfterTargetsHaveFailed` is introduced and calculated for each requested target after all targets have executed. This flag is then passed back as part of `TargetResult` and trivially used in `BuildResult`'s `OverallResult`. Note that targets with failed AfterTargets can still succeed in terms of their `ResultCode`, i.e. the failure is kept only in form of this bolt-on bit.

The now unused `GetAfterTargetsForDefaultTargets` is deleted.

Fixes #3345 