### PR TITLE
Use environment variable for handshake Resolves #4961

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -14,6 +14,7 @@ using System.Security.Permissions;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Internal;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -71,8 +72,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="enableLowPriority">Is the build running at low priority?</param>
         internal static long GetHostHandshake(bool enableNodeReuse, bool enableLowPriority)
         {
-            CommunicationsUtilities.Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", enableNodeReuse={2}, enableLowPriority={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, enableNodeReuse, enableLowPriority);
-            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetNodeProviderContext(enableNodeReuse, enableLowPriority, EnvironmentUtilities.Is64BitProcess));
+            CommunicationsUtilities.Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", enableNodeReuse={2}, enableLowPriority={3}", Traits.MSBuildNodeHandshakeSalt, BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, enableNodeReuse, enableLowPriority);
+            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: false, nodeReuse: enableNodeReuse, lowPriority: enableLowPriority, is64Bit: EnvironmentUtilities.Is64BitProcess));
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -3,24 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
-using System.IO;
-using System.IO.Pipes;
 using System.Diagnostics;
-using System.Threading;
-using System.Runtime.InteropServices;
-using System.Security;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.AccessControl;
 #endif
-using System.Security.Principal;
 #if FEATURE_SECURITY_PERMISSIONS
 using System.Security.Permissions;
 #endif
 
 using Microsoft.Build.Shared;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Internal;
 
@@ -81,19 +72,7 @@ namespace Microsoft.Build.BackEnd
         internal static long GetHostHandshake(bool enableNodeReuse, bool enableLowPriority)
         {
             CommunicationsUtilities.Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", enableNodeReuse={2}, enableLowPriority={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, enableNodeReuse, enableLowPriority);
-
-            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
-            long baseHandshake = CommunicationsUtilities.GetHandshakeHashCode(salt);
-
-            baseHandshake = baseHandshake*17 + Constants.AssemblyTimestamp;
-
-            baseHandshake = baseHandshake*17 + EnvironmentUtilities.Is64BitProcess.GetHashCode();
-
-            baseHandshake = baseHandshake*17 + enableNodeReuse.GetHashCode();
-
-            baseHandshake = baseHandshake*17 + enableLowPriority.GetHashCode();
-
-            return CommunicationsUtilities.GenerateHostHandshakeFromBase(baseHandshake, GetClientHandshake());
+            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetNodeProviderContext(enableNodeReuse, enableLowPriority, EnvironmentUtilities.Is64BitProcess));
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -80,7 +80,12 @@ namespace Microsoft.Build.BackEnd
         /// <param name="enableLowPriority">Is the build running at low priority?</param>
         internal static long GetHostHandshake(bool enableNodeReuse, bool enableLowPriority)
         {
-            long baseHandshake = Constants.AssemblyTimestamp;
+            CommunicationsUtilities.Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", enableNodeReuse={2}, enableLowPriority={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, enableNodeReuse, enableLowPriority);
+
+            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+            long baseHandshake = CommunicationsUtilities.GetHandshakeHashCode(salt);
+
+            baseHandshake = baseHandshake*17 + Constants.AssemblyTimestamp;
 
             baseHandshake = baseHandshake*17 + EnvironmentUtilities.Is64BitProcess.GetHashCode();
 

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// A mapping of all the nodes managed by this provider.
         /// </summary>
-        private Dictionary<TaskHostContext, NodeContext> _nodeContexts;
+        private Dictionary<HandshakeOptions, NodeContext> _nodeContexts;
 
         /// <summary>
         /// A mapping of all of the INodePacketFactories wrapped by this provider.
@@ -186,7 +186,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="hostContext">The node to which data shall be sent.</param>
         /// <param name="packet">The packet to send.</param>
-        public void SendData(TaskHostContext hostContext, INodePacket packet)
+        public void SendData(HandshakeOptions hostContext, INodePacket packet)
         {
             ErrorUtilities.VerifyThrow(_nodeContexts.ContainsKey(hostContext), "Invalid host context specified: {0}.", hostContext.ToString());
 
@@ -243,7 +243,7 @@ namespace Microsoft.Build.BackEnd
         public void InitializeComponent(IBuildComponentHost host)
         {
             this.ComponentHost = host;
-            _nodeContexts = new Dictionary<TaskHostContext, NodeContext>();
+            _nodeContexts = new Dictionary<HandshakeOptions, NodeContext>();
             _nodeIdToPacketFactory = new Dictionary<int, INodePacketFactory>();
             _nodeIdToPacketHandler = new Dictionary<int, INodePacketHandler>();
             _activeNodes = new HashSet<int>();
@@ -388,9 +388,9 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Given a TaskHostContext, returns the name of the executable we should be searching for.
         /// </summary>
-        internal static string GetTaskHostNameFromHostContext(TaskHostContext hostContext)
+        internal static string GetTaskHostNameFromHostContext(HandshakeOptions hostContext)
         {
-            if (hostContext == TaskHostContext.X64CLR4 || hostContext == TaskHostContext.X32CLR4)
+            if (hostContext == HandshakeOptions.X64CLR4 || hostContext == HandshakeOptions.X32CLR4)
             {
                 if (s_msbuildName == null)
                 {
@@ -404,7 +404,7 @@ namespace Microsoft.Build.BackEnd
 
                 return s_msbuildName;
             }
-            else if (hostContext == TaskHostContext.X32CLR2 || hostContext == TaskHostContext.X64CLR2)
+            else if (hostContext == HandshakeOptions.X32CLR2 || hostContext == HandshakeOptions.X64CLR2)
             {
                 return TaskHostNameForClr2TaskHost;
             }
@@ -420,7 +420,7 @@ namespace Microsoft.Build.BackEnd
         /// executable (MSBuild or MSBuildTaskHost) that we wish to use, or null
         /// if that location cannot be resolved.
         /// </summary>
-        internal static string GetMSBuildLocationFromHostContext(TaskHostContext hostContext)
+        internal static string GetMSBuildLocationFromHostContext(HandshakeOptions hostContext)
         {
             string toolName = GetTaskHostNameFromHostContext(hostContext);
             string toolPath = null;
@@ -430,7 +430,7 @@ namespace Microsoft.Build.BackEnd
 
             switch (hostContext)
             {
-                case TaskHostContext.X32CLR2:
+                case HandshakeOptions.X32CLR2:
                     if (s_pathToX32Clr2 == null)
                     {
                         s_pathToX32Clr2 = Environment.GetEnvironmentVariable("MSBUILDTASKHOSTLOCATION");
@@ -442,7 +442,7 @@ namespace Microsoft.Build.BackEnd
 
                     toolPath = s_pathToX32Clr2;
                     break;
-                case TaskHostContext.X64CLR2:
+                case HandshakeOptions.X64CLR2:
                     if (s_pathToX64Clr2 == null)
                     {
                         s_pathToX64Clr2 = Environment.GetEnvironmentVariable("MSBUILDTASKHOSTLOCATION64");
@@ -455,7 +455,7 @@ namespace Microsoft.Build.BackEnd
 
                     toolPath = s_pathToX64Clr2;
                     break;
-                case TaskHostContext.X32CLR4:
+                case HandshakeOptions.X32CLR4:
                     if (s_pathToX32Clr4 == null)
                     {
                         s_pathToX32Clr4 = s_baseTaskHostPath;
@@ -463,7 +463,7 @@ namespace Microsoft.Build.BackEnd
 
                     toolPath = s_pathToX32Clr4;
                     break;
-                case TaskHostContext.X64CLR4:
+                case HandshakeOptions.X64CLR4:
                     if (s_pathToX64Clr4 == null)
                     {
                         s_pathToX64Clr4 = s_baseTaskHostPath64;
@@ -487,7 +487,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Make sure a node in the requested context exists.
         /// </summary>
-        internal bool AcquireAndSetUpHost(TaskHostContext hostContext, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration)
+        internal bool AcquireAndSetUpHost(HandshakeOptions hostContext, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration)
         {
             NodeContext context = null;
             bool nodeCreationSucceeded = false;
@@ -519,7 +519,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Expected to be called when TaskHostTask is done with host of the given context.
         /// </summary>
-        internal void DisconnectFromHost(TaskHostContext hostContext)
+        internal void DisconnectFromHost(HandshakeOptions hostContext)
         {
             ErrorUtilities.VerifyThrow(_nodeIdToPacketFactory.ContainsKey((int)hostContext) && _nodeIdToPacketHandler.ContainsKey((int)hostContext), "Why are we trying to disconnect from a context that we already disconnected from?  Did we call DisconnectFromHost twice?");
 
@@ -530,7 +530,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Instantiates a new MSBuild or MSBuildTaskHost process acting as a child node.
         /// </summary>
-        internal bool CreateNode(TaskHostContext hostContext, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration)
+        internal bool CreateNode(HandshakeOptions hostContext, INodePacketFactory factory, INodePacketHandler handler, TaskHostConfiguration configuration)
         {
             ErrorUtilities.VerifyThrowArgumentNull(factory, "factory");
             ErrorUtilities.VerifyThrow(!_nodeIdToPacketFactory.ContainsKey((int)hostContext), "We should not already have a factory for this context!  Did we forget to call DisconnectFromHost somewhere?");
@@ -590,7 +590,7 @@ namespace Microsoft.Build.BackEnd
         {
             lock (_nodeContexts)
             {
-                _nodeContexts.Remove((TaskHostContext)nodeId);
+                _nodeContexts.Remove((HandshakeOptions)nodeId);
             }
 
             // May also be removed by unnatural termination, so don't assume it's there

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static string GetTaskHostNameFromHostContext(HandshakeOptions hostContext)
         {
-            ErrorUtilities.ThrowInternalErrorUnreachable((hostContext & HandshakeOptions.TaskHost) == HandshakeOptions.TaskHost);
+            ErrorUtilities.VerifyThrowInternalErrorUnreachable((hostContext & HandshakeOptions.TaskHost) == HandshakeOptions.TaskHost);
             if ((hostContext & HandshakeOptions.CLR2) == HandshakeOptions.CLR2) {
                 return TaskHostNameForClr2TaskHost;
             }
@@ -422,7 +422,7 @@ namespace Microsoft.Build.BackEnd
 
             s_baseTaskHostPath = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
             s_baseTaskHostPath64 = BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64;
-            ErrorUtilities.ThrowInternalErrorUnreachable((hostContext & HandshakeOptions.TaskHost) == HandshakeOptions.TaskHost);
+            ErrorUtilities.VerifyThrowInternalErrorUnreachable((hostContext & HandshakeOptions.TaskHost) == HandshakeOptions.TaskHost);
 
             if ((hostContext & HandshakeOptions.X64) == HandshakeOptions.X64 && (hostContext & HandshakeOptions.CLR2) == HandshakeOptions.CLR2)
             {

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Build.Evaluation
             parameters.Add(XMakeAttributes.runtime, runtime);
             parameters.Add(XMakeAttributes.architecture, architecture);
 
-            TaskHostContext desiredContext = CommunicationsUtilities.GetTaskHostContext(parameters);
+            HandshakeOptions desiredContext = CommunicationsUtilities.GetTaskHostContext(parameters);
             string taskHostLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(desiredContext);
 
             if (taskHostLocation != null && FileUtilities.FileExistsNoThrow(taskHostLocation))

--- a/src/Build/Evaluation/IntrinsicFunctions.cs
+++ b/src/Build/Evaluation/IntrinsicFunctions.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Build.Evaluation
             parameters.Add(XMakeAttributes.runtime, runtime);
             parameters.Add(XMakeAttributes.architecture, architecture);
 
-            HandshakeOptions desiredContext = CommunicationsUtilities.GetTaskHostContext(parameters);
+            HandshakeOptions desiredContext = CommunicationsUtilities.GetHandshakeOptions(taskHost: true, taskHostParameters: parameters);
             string taskHostLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(desiredContext);
 
             if (taskHostLocation != null && FileUtilities.FileExistsNoThrow(taskHostLocation))

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Build.BackEnd
         /// The task host context of the task host we're launching -- used to 
         /// communicate with the task host. 
         /// </summary>
-        private HandshakeOptions _requiredContext = HandshakeOptions.Invalid;
+        private HandshakeOptions _requiredContext = HandshakeOptions.None;
 
         /// <summary>
         /// True if currently connected to the task host; false otherwise. 
@@ -551,28 +551,10 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void LogErrorUnableToCreateTaskHost(HandshakeOptions requiredContext, string runtime, string architecture, NodeFailedToLaunchException e)
         {
-            string msbuildLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(requiredContext);
-
-            if (msbuildLocation == null)
-            {
+            string msbuildLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(requiredContext) ??
                 // We don't know the path -- probably we're trying to get a 64-bit assembly on a 
                 // 32-bit machine.  At least give them the exe name to look for, though ...
-                switch (requiredContext)
-                {
-                    case HandshakeOptions.X32CLR2:
-                    case HandshakeOptions.X64CLR2:
-                        msbuildLocation = "MSBuildTaskHost.exe";
-                        break;
-                    case HandshakeOptions.X32CLR4:
-                    case HandshakeOptions.X64CLR4:
-                        msbuildLocation = "MSBuild.exe";
-                        break;
-                    case HandshakeOptions.Invalid:
-                    default:
-                        ErrorUtilities.ThrowInternalErrorUnreachable();
-                        break;
-                }
-            }
+                (requiredContext.HasFlag(HandshakeOptions.CLR2) ? "MSBuildTaskHost.exe" : "MSBuild.exe");
 
             if (e == null)
             {

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Build.BackEnd
         /// The task host context of the task host we're launching -- used to 
         /// communicate with the task host. 
         /// </summary>
-        private TaskHostContext _requiredContext = TaskHostContext.Invalid;
+        private HandshakeOptions _requiredContext = HandshakeOptions.Invalid;
 
         /// <summary>
         /// True if currently connected to the task host; false otherwise. 
@@ -549,7 +549,7 @@ namespace Microsoft.Build.BackEnd
         /// Since we log that we weren't able to connect to the task host in a couple of different places,
         /// extract it out into a separate method. 
         /// </summary>
-        private void LogErrorUnableToCreateTaskHost(TaskHostContext requiredContext, string runtime, string architecture, NodeFailedToLaunchException e)
+        private void LogErrorUnableToCreateTaskHost(HandshakeOptions requiredContext, string runtime, string architecture, NodeFailedToLaunchException e)
         {
             string msbuildLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(requiredContext);
 
@@ -559,15 +559,15 @@ namespace Microsoft.Build.BackEnd
                 // 32-bit machine.  At least give them the exe name to look for, though ...
                 switch (requiredContext)
                 {
-                    case TaskHostContext.X32CLR2:
-                    case TaskHostContext.X64CLR2:
+                    case HandshakeOptions.X32CLR2:
+                    case HandshakeOptions.X64CLR2:
                         msbuildLocation = "MSBuildTaskHost.exe";
                         break;
-                    case TaskHostContext.X32CLR4:
-                    case TaskHostContext.X64CLR4:
+                    case HandshakeOptions.X32CLR4:
+                    case HandshakeOptions.X64CLR4:
                         msbuildLocation = "MSBuild.exe";
                         break;
-                    case TaskHostContext.Invalid:
+                    case HandshakeOptions.Invalid:
                     default:
                         ErrorUtilities.ThrowInternalErrorUnreachable();
                         break;

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Build.BackEnd
             {
                 lock (_taskHostLock)
                 {
-                    _requiredContext = CommunicationsUtilities.GetTaskHostContext(_taskHostParameters);
+                    _requiredContext = CommunicationsUtilities.GetHandshakeOptions(taskHost: true, taskHostParameters: _taskHostParameters);
                     _connectedToTaskHost = _taskHostProvider.AcquireAndSetUpHost(_requiredContext, this, this, hostConfiguration);
                 }
 

--- a/src/Build/Instance/TaskFactories/TaskHostTask.cs
+++ b/src/Build/Instance/TaskFactories/TaskHostTask.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Build.BackEnd
             string msbuildLocation = NodeProviderOutOfProcTaskHost.GetMSBuildLocationFromHostContext(requiredContext) ??
                 // We don't know the path -- probably we're trying to get a 64-bit assembly on a 
                 // 32-bit machine.  At least give them the exe name to look for, though ...
-                (requiredContext.HasFlag(HandshakeOptions.CLR2) ? "MSBuildTaskHost.exe" : "MSBuild.exe");
+                ((requiredContext & HandshakeOptions.CLR2) == HandshakeOptions.CLR2 ? "MSBuildTaskHost.exe" : "MSBuild.exe");
 
             if (e == null)
             {

--- a/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
+++ b/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetHostHandshake()
         {
-            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
+            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: true));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetClientHandshake()
         {
-            return CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
+            return CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetHandshakeOptions(taskHost: true));
         }
     }
 }

--- a/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
+++ b/src/MSBuild/NodeEndpointOutOfProcTaskHost.cs
@@ -32,8 +32,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetHostHandshake()
         {
-            long hostHandshake = CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
-            return hostHandshake;
+            return CommunicationsUtilities.GetHostHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
         }
 
         /// <summary>
@@ -41,8 +40,7 @@ namespace Microsoft.Build.CommandLine
         /// </summary>
         protected override long GetClientHandshake()
         {
-            long clientHandshake = CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
-            return clientHandshake;
+            return CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetCurrentTaskHostContext());
         }
     }
 }

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -677,7 +677,7 @@ namespace Microsoft.Build.Internal
         /// but stripped out architecture specific defines
         /// that causes the hashcode to be different and this causes problem in cross-architecture handshaking
         /// </summary>
-        private static int GetHandshakeHashCode(string fileVersion)
+        internal static int GetHandshakeHashCode(string fileVersion)
         {
             unsafe
             {

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Build.Internal
         internal static long GetHostHandshake(HandshakeOptions nodeType)
         {
             string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
-            string toolsDirectory = nodeType.HasFlag(HandshakeOptions.X64) ? BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64 : BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+            string toolsDirectory = (nodeType & HandshakeOptions.X64) == HandshakeOptions.X64 ? BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64 : BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
             int nodeHandshakeSalt = GetHandshakeHashCode(salt + toolsDirectory);
 
             Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", nodeType={2}, FileVersionHash={3}", salt, toolsDirectory, nodeType, FileVersionHash);

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -154,6 +154,21 @@ namespace Microsoft.Build.Internal
             }
         }
 
+        private static bool Is64Bit(HandshakeOptions options)
+        {
+            switch (options) {
+                case HandshakeOptions.X64CLR2:
+                case HandshakeOptions.X64CLR4:
+                case HandshakeOptions.NodeProviderNodeReuseLowPriority64Bit:
+                case HandshakeOptions.NodeProviderNodeReuseNormalPriority64Bit:
+                case HandshakeOptions.NodeProviderNoNodeReuseLowPriority64Bit:
+                case HandshakeOptions.NodeProviderNoNodeReuseNormalPriority64Bit:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         /// <summary>
         /// Get environment block
         /// </summary>
@@ -334,10 +349,11 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static long GetHostHandshake(HandshakeOptions nodeType)
         {
-            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT") + BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
-            int nodeHandshakeSalt = GetHandshakeHashCode(salt);
+            string salt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
+            string toolsDirectory = Is64Bit(nodeType) ? BuildEnvironmentHelper.Instance.MSBuildToolsDirectory64 : BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32;
+            int nodeHandshakeSalt = GetHandshakeHashCode(salt + toolsDirectory);
 
-            Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", hostContext={2}, FileVersionHash={3}", Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT"), BuildEnvironmentHelper.Instance.MSBuildToolsDirectory32, nodeType, FileVersionHash);
+            Trace("MSBUILDNODEHANDSHAKESALT=\"{0}\", msbuildDirectory=\"{1}\", nodeType={2}, FileVersionHash={3}", salt, toolsDirectory, nodeType, FileVersionHash);
 
             //FileVersionHash (32 bits) is shifted 8 bits to avoid session ID collision
             //nodeType (4 bits) is shifted just after the FileVersionHash

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Build.Shared
         /// Indicates the code path followed should not have been possible.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
-        internal static void ThrowInternalErrorUnreachable(bool condition)
+        internal static void VerifyThrowInternalErrorUnreachable(bool condition)
         {
             if (s_throwExceptions && !condition)
             {

--- a/src/Shared/ErrorUtilities.cs
+++ b/src/Shared/ErrorUtilities.cs
@@ -89,6 +89,19 @@ namespace Microsoft.Build.Shared
         /// Indicates the code path followed should not have been possible.
         /// This is only for situations that would mean that there is a bug in MSBuild itself.
         /// </summary>
+        internal static void ThrowInternalErrorUnreachable(bool condition)
+        {
+            if (s_throwExceptions && !condition)
+            {
+                throw new InternalErrorException("Unreachable?");
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// Indicates the code path followed should not have been possible.
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
         internal static void ThrowIfTypeDoesNotImplementToString(object param)
         {
 #if DEBUG

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool EnableRestoreFirst = Environment.GetEnvironmentVariable("MSBUILDENABLERESTOREFIRST") == "1";
 
         /// <summary>
+        /// Allow the user to specify that two processes should not be communicating via an environment variable.
+        /// </summary>
+        public static readonly int MSBuildNodeHandshakeSalt = ParseIntFromEnvironmentVariableOrDefault("MSBUILDNODEHANDSHAKESALT", -1);
+
+        /// <summary>
         /// Setting the associated environment variable to 1 restores the pre-15.8 single
         /// threaded (slower) copy behavior. Zero implies Int32.MaxValue, less than zero
         /// (default) uses the empirical default in Copy.cs, greater than zero can allow

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Allow the user to specify that two processes should not be communicating via an environment variable.
         /// </summary>
-        public static readonly int MSBuildNodeHandshakeSalt = ParseIntFromEnvironmentVariableOrDefault("MSBUILDNODEHANDSHAKESALT", -1);
+        public static readonly string MSBuildNodeHandshakeSalt = Environment.GetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT");
 
         /// <summary>
         /// Setting the associated environment variable to 1 restores the pre-15.8 single


### PR DESCRIPTION
Adds use of an environment variable for non-task host nodes as well. Some duplicated logic should ideally be refactored pending acceptance of an altered handshake.

Fixes #4961.