### PR TITLE
Don't import Microsoft.WinFX.targets for sdk style projects

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -109,6 +109,8 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
+        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTSVERBOSE") == "1";
+
         /// <summary>
         /// Emit events for project imports.
         /// </summary>

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -109,8 +109,6 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
-        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTSVERBOSE") == "1";
-
         /// <summary>
         /// Emit events for project imports.
         /// </summary>

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -9,6 +9,6 @@
         the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
    -->
 
-   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
+   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportFrameworkWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
 
 </Project>

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -9,6 +9,6 @@
         the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
    -->
 
-   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets') and '$(ImportWinFXTargets)' != 'false'" />
+   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="'$(ImportWinFXTargets)' != 'false' and Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
 
 </Project>

--- a/src/Tasks/Microsoft.WinFx.targets
+++ b/src/Tasks/Microsoft.WinFx.targets
@@ -9,6 +9,6 @@
         the shim will internally simply redirect to the real copy of the targets file in the .NET Framework. 
    -->
 
-   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets')" />
+   <Import Project="$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets" Condition="Exists('$(MSBuildFrameworkToolsPath)\Microsoft.WinFx.targets') and '$(ImportWinFXTargets)' != 'false'" />
 
 </Project>


### PR DESCRIPTION
Part 1 to fix https://github.com/microsoft/msbuild/issues/4948

Part 2 (sets the ImportWinFXTargets property to false): https://github.com/dotnet/sdk/pull/10998

This conditionally imports winfx.targets for all non-sdk style builds. Pairs with another PR for the sdk 
that ensures the condition will fall through.