### PR TITLE
Option to Truncate Task Input-Logging

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using System.Reflection;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -75,7 +76,14 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("        ");
                     }
 
-                    sb.Append(GetStringFromParameterValue(parameterValue[i]));
+                    string data = GetStringFromParameterValue(parameterValue[i]);
+
+                    if(!Traits.Instance.EscapeHatches.LogTaskInputsVerbose && data.Length > )
+                    {
+
+                    }
+
+                    sb.Append(data);
 
                     if (!specialTreatmentForSingle && i < parameterValue.Count - 1)
                     {

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd
                     sb.Append("\n");
                 }
 
-                bool logVerbose = Traits.Instance.EscapeHatches.LogTaskInputsVerbose;
+                bool truncateLogging = Traits.Instance.EscapeHatches.TruncateTaskInputLogging;
 
                 for (int i = 0; i < parameterValue.Count; i++)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("\n");
                     }
 
-                    if (!logVerbose && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
+                    if (truncateLogging && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
                     {
                         sb.Append(ResourceUtilities.GetResourceString("LogTaskInputs.Truncated"));
                         break;

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// The default character limit for logging parameters. 10k is somewhat arbitrary, see https://github.com/microsoft/msbuild/issues/4907.
         /// </summary>
-        internal static int parameterCharacterLimit = 10_000;
+        internal static int parameterCharacterLimit = 40_000;
 
         /// <summary>
         /// The default parameter limit for logging. 200 is somewhat arbitrary, see https://github.com/microsoft/msbuild/pull/5210.

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd
                     sb.Append("\n");
                 }
 
-                bool truncateLogging = Traits.Instance.EscapeHatches.TruncateTaskInputLogging;
+                bool logAllTaskInputs = Traits.Instance.EscapeHatches.LogAllTaskInputs;
 
                 for (int i = 0; i < parameterValue.Count; i++)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("\n");
                     }
 
-                    if (truncateLogging && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
+                    if (!logAllTaskInputs && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
                     {
                         sb.Append(ResourceUtilities.GetResourceString("LogTaskInputs.Truncated"));
                         break;

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Build.BackEnd
 
                     if (!logVerbose && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
                     {
-                        sb.Append("...\nThe parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1");
+                        sb.Append(ResourceUtilities.GetResourceString("LogTaskInputs.Truncated"));
                         break;
                     }
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
-using System.Reflection;
 using Microsoft.Build.Utilities;
+using System.Reflection;
 
 namespace Microsoft.Build.BackEnd
 {
@@ -18,9 +18,14 @@ namespace Microsoft.Build.BackEnd
     internal static class ItemGroupLoggingHelper
     {
         /// <summary>
-        /// The default character limit for logging parameters.
+        /// The default character limit for logging parameters. 10k is somewhat arbitrary, see https://github.com/microsoft/msbuild/issues/4907.
         /// </summary>
-        internal static int parameterTextLimit = 10000;
+        internal static int parameterCharacterLimit = 10_000;
+
+        /// <summary>
+        /// The default parameter limit for logging. 200 is somewhat arbitrary, see https://github.com/microsoft/msbuild/pull/5210.
+        /// </summary>
+        internal static int parameterLimit = 200;
 
         /// <summary>
         /// Gets a text serialized value of a parameter for logging.
@@ -69,6 +74,8 @@ namespace Microsoft.Build.BackEnd
                     sb.Append("\n");
                 }
 
+                bool logVerbose = Traits.Instance.EscapeHatches.LogTaskInputsVerbose;
+
                 for (int i = 0; i < parameterValue.Count; i++)
                 {
                     if (parameterValue[i] == null)
@@ -88,9 +95,9 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("\n");
                     }
 
-                    if (!Traits.Instance.EscapeHatches.LogTaskInputsVerbose && sb.Length >= parameterTextLimit)
+                    if (!logVerbose && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
                     {
-                        sb.Append("...\nThe parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE=1");
+                        sb.Append("...\nThe parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1");
                         break;
                     }
                 }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Build.BackEnd
     internal static class ItemGroupLoggingHelper
     {
         /// <summary>
+        /// The default character limit for logging parameters.
+        /// </summary>
+        internal static int parameterTextLimit = 10000;
+
+        /// <summary>
         /// Gets a text serialized value of a parameter for logging.
         /// </summary>
         internal static string GetParameterText(string prefix, string parameterName, params object[] parameterValues)
@@ -76,18 +81,17 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("        ");
                     }
 
-                    string data = GetStringFromParameterValue(parameterValue[i]);
-
-                    if(!Traits.Instance.EscapeHatches.LogTaskInputsVerbose && data.Length > )
-                    {
-
-                    }
-
-                    sb.Append(data);
+                    sb.Append(GetStringFromParameterValue(parameterValue[i]));
 
                     if (!specialTreatmentForSingle && i < parameterValue.Count - 1)
                     {
                         sb.Append("\n");
+                    }
+
+                    if (!Traits.Instance.EscapeHatches.LogTaskInputsVerbose && sb.Length >= parameterTextLimit)
+                    {
+                        sb.Append("...\nThe parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE=1");
+                        break;
                     }
                 }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Build.BackEnd
                     sb.Append("\n");
                 }
 
-                bool logAllTaskInputs = Traits.Instance.EscapeHatches.LogAllTaskInputs;
+                bool truncateTaskInputs = Traits.Instance.EscapeHatches.TruncateTaskInputs;
 
                 for (int i = 0; i < parameterValue.Count; i++)
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("\n");
                     }
 
-                    if (!logAllTaskInputs && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
+                    if (truncateTaskInputs && (sb.Length >= parameterCharacterLimit || i > parameterLimit))
                     {
                         sb.Append(ResourceUtilities.GetResourceString("LogTaskInputs.Truncated"));
                         break;

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -617,7 +617,7 @@
     <value>Environment at start of build:</value>
   </data>
   <data name="LogTaskInputs.Truncated" UESanitized="false" Visibility="Public">
-    <value>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</value>
+    <value>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</value>
   </data>
   <data name="MetadataDefinitionCannotContainItemVectorExpression" UESanitized="false" Visibility="Public">
     <value>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</value>

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -616,6 +616,9 @@
   <data name="EnvironmentHeader" UESanitized="false" Visibility="Public">
     <value>Environment at start of build:</value>
   </data>
+  <data name="LogTaskInputs.Truncated" UESanitized="false" Visibility="Public">
+    <value>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</value>
+  </data>
   <data name="MetadataDefinitionCannotContainItemVectorExpression" UESanitized="false" Visibility="Public">
     <value>MSB4164: The value "{0}" of metadata "{1}" contains an item list expression. Item list expressions are not allowed on default metadata values.</value>
     <comment>{StrBegin="MSB4164: "}</comment>

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojekt {0} byl vygenerován.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Das Metaprojekt "{0}" wurde generiert.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="new">Metaproject "{0}" generated.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Se generó el metaproyecto "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Le métaprojet "{0}" a été généré.</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Il metaprogetto "{0}" è stato generato.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">メタプロジェクト "{0}" が生成されました。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">메타프로젝트 "{0}"이(가) 생성되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Wygenerowano metaprojekt „{0}”.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojeto "{0}" gerado.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Создан метапроект "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">"{0}" meta projesi oluşturuldu.</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已生成元项目“{0}”。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -107,6 +107,11 @@
       LOCALIZATION: {0} is an enum value of LoggerVerbosity.
     </note>
       </trans-unit>
+      <trans-unit id="LogTaskInputs.Truncated">
+        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已產生中繼專案 "{0}"。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -108,8 +108,8 @@
     </note>
       </trans-unit>
       <trans-unit id="LogTaskInputs.Truncated">
-        <source>The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</source>
-        <target state="new">The parameters have been truncated beyond this point. To view all parameters, set environment variable MSBUILDLOGTASKINPUTSVERBOSE to 1.</target>
+        <source>The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</source>
+        <target state="new">The parameters have been truncated beyond this point. To view all parameters, clear the MSBUILDTRUNCATETASKINPUTLOGGING environment variable.</target>
         <note />
       </trans-unit>
       <trans-unit id="MetaprojectGenerated">

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Stop truncating task inputs when logging them.
         /// </summary>
-        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGALLTASKINPUTS") == "1";
+        public readonly bool TruncateTaskInputLogging = Environment.GetEnvironmentVariable("MSBUILDTRUNCATETASKINPUTLOGGING") == "1";
 
         /// <summary>
         /// Emit events for project imports.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -116,7 +116,8 @@ namespace Microsoft.Build.Utilities
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
         /// <summary>
-        /// Stop truncating task inputs when logging them. Setting any value disables this.
+        /// Truncate task inputs when logging them. This can reduce memory pressure
+        /// at the expense of log usefulness.
         /// </summary>
         public readonly bool TruncateTaskInputs = Environment.GetEnvironmentVariable("MSBUILDTRUNCATETASKINPUTS") == "1";
 

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -116,6 +116,11 @@ namespace Microsoft.Build.Utilities
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
         /// <summary>
+        /// Stop truncating task inputs when logging them.
+        /// </summary>
+        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTSVERBOSE") == "1";
+
+        /// <summary>
         /// Emit events for project imports.
         /// </summary>
         private bool? _logProjectImports;

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Stop truncating task inputs when logging them.
         /// </summary>
-        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTSVERBOSE") == "1";
+        public readonly bool LogTaskInputsVerbose = Environment.GetEnvironmentVariable("MSBUILDLOGALLTASKINPUTS") == "1";
 
         /// <summary>
         /// Emit events for project imports.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Utilities
         /// <summary>
         /// Stop truncating task inputs when logging them. Setting any value disables this.
         /// </summary>
-        public readonly bool LogAllTaskInputs = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLTASKINPUTS"));
+        public readonly bool TruncateTaskInputs = Environment.GetEnvironmentVariable("MSBUILDTRUNCATETASKINPUTS") == "1";
 
         /// <summary>
         /// Emit events for project imports.

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -116,9 +116,9 @@ namespace Microsoft.Build.Utilities
         public readonly bool AlwaysUseContentTimestamp = Environment.GetEnvironmentVariable("MSBUILDALWAYSCHECKCONTENTTIMESTAMP") == "1";
 
         /// <summary>
-        /// Stop truncating task inputs when logging them.
+        /// Stop truncating task inputs when logging them. Setting any value disables this.
         /// </summary>
-        public readonly bool TruncateTaskInputLogging = Environment.GetEnvironmentVariable("MSBUILDTRUNCATETASKINPUTLOGGING") == "1";
+        public readonly bool LogAllTaskInputs = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDLOGALLTASKINPUTS"));
 
         /// <summary>
         /// Emit events for project imports.


### PR DESCRIPTION
After a limit of 10k characters, stop logging task inputs.

Fixes https://github.com/microsoft/msbuild/issues/4907

cc: @rainersigwald @cdmihai How would we go about using a localized string instead of the hard-coded english one I used?