### PR TITLE
Implement an empty SGen .NET Core task

### DIFF
--- a/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
+++ b/ref/Microsoft.Build.Tasks.Core/netstandard/Microsoft.Build.Tasks.Core.cs
@@ -682,6 +682,32 @@ namespace Microsoft.Build.Tasks
         public Microsoft.Build.Framework.TaskPropertyInfo[] GetTaskParameters() { throw null; }
         public bool Initialize(string taskName, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.TaskPropertyInfo> parameterGroup, string taskBody, Microsoft.Build.Framework.IBuildEngine taskFactoryLoggingHost) { throw null; }
     }
+    public partial class SGen : Microsoft.Build.Tasks.ToolTaskExtension
+    {
+        public SGen() { }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string BuildAssemblyName { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public string BuildAssemblyPath { get { throw null; } set { } }
+        public bool DelaySign { get { throw null; } set { } }
+        public string KeyContainer { get { throw null; } set { } }
+        public string KeyFile { get { throw null; } set { } }
+        public string Platform { get { throw null; } set { } }
+        public string[] References { get { throw null; } set { } }
+        public string SdkToolsPath { get { throw null; } set { } }
+        [Microsoft.Build.Framework.OutputAttribute]
+        public Microsoft.Build.Framework.ITaskItem[] SerializationAssembly { get { throw null; } set { } }
+        public string SerializationAssemblyName { get { throw null; } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public bool ShouldGenerateSerializer { get { throw null; } set { } }
+        protected override string ToolName { get { throw null; } }
+        public string[] Types { get { throw null; } set { } }
+        public bool UseKeep { get { throw null; } set { } }
+        [Microsoft.Build.Framework.RequiredAttribute]
+        public bool UseProxyTypes { get { throw null; } set { } }
+        public override bool Execute() { throw null; }
+        protected override string GenerateFullPathToTool() { throw null; }
+    }
     public abstract partial class TaskExtension : Microsoft.Build.Utilities.Task
     {
         internal TaskExtension() { }

--- a/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
+++ b/src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj
@@ -80,6 +80,7 @@
 
   <ItemGroup Condition="'$(MonoBuild)' == 'true'">
     <Compile Remove="LC_Tests.cs" />
+    <Compile Remove="SGen_Tests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFrameworkIdentifier) != '.NETFramework'">
@@ -126,7 +127,6 @@
     <Compile Remove="ResolveComReference_Tests.cs" />
     <Compile Remove="ResolveSDKReference_Tests.cs" />
     <Compile Remove="SdkToolsPathUtility_Tests.cs" />
-    <Compile Remove="SGen_Tests.cs" />
     <Compile Remove="TlbImp_Tests.cs" />
     <Compile Remove="VisualBasicParserUtilitites_Tests.cs" />
     <Compile Remove="VisualBasicTokenizer_Tests.cs" />

--- a/src/Tasks.UnitTests/SGen_Tests.cs
+++ b/src/Tasks.UnitTests/SGen_Tests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Build.UnitTests
     </Target>
 </Project>");
                 logger.ErrorCount.ShouldBe(1);
-                logger.Errors.First().Message.ShouldBe("SGen.TaskNotSupported");
+                logger.Errors.First().Code.ShouldBe("MSB3474");
             }
         }
 #else

--- a/src/Tasks.UnitTests/SGen_Tests.cs
+++ b/src/Tasks.UnitTests/SGen_Tests.cs
@@ -7,12 +7,46 @@ using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
 using System.IO;
+using System.Linq;
 using Xunit;
+using Xunit.Abstractions;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests
 {
     public class SGen_Tests
     {
+#if RUNTIME_TYPE_NETCORE
+        [Fact]
+        public void TaskFailsOnCore()
+        {
+            using (TestEnvironment testenv = TestEnvironment.Create())
+            {
+                MockLogger logger = ObjectModelHelpers.BuildProjectExpectFailure(@$"
+<Project>
+    <Target Name=""MyTarget"">
+        <SGen
+            BuildAssemblyName=""Foo""
+            BuildAssemblyPath=""Foo""
+            ShouldGenerateSerializer=""true""
+            UseProxyTypes=""true""
+            UseKeep=""true""
+            References=""Foo""
+            KeyContainer=""Foo""
+            KeyFile=""Foo""
+            DelaySign=""true""
+            SerializationAssembly=""Foo""
+            SdkToolsPath=""Foo""
+            Platform=""Foo""
+            Types=""Foo""
+        />
+    </Target>
+</Project>");
+                logger.ErrorCount.ShouldBe(1);
+                logger.Errors.First().Message.ShouldBe("SGen.TaskNotSupported");
+            }
+        }
+#else
         internal class SGenExtension : SGen
         {
             internal string CommandLine()
@@ -56,6 +90,7 @@ namespace Microsoft.Build.UnitTests
 
             Assert.True(commandLine.IndexOf("/keep", StringComparison.OrdinalIgnoreCase) >= 0);
         }
+
         [Fact]
         public void TestKeepFlagFalse()
         {
@@ -242,5 +277,6 @@ namespace Microsoft.Build.UnitTests
             
             Assert.Equal(targetCommandLine, commandLine);
         }
+#endif
     }
 }

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -484,6 +484,9 @@
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCodeType.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryCompilers.cs" />
     <Compile Include="RoslynCodeTaskFactory\RoslynCodeTaskFactoryTaskInfo.cs" />
+    <Compile Include="SGen.cs" Condition="'$(MonoBuild)' != 'true'">
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+    </Compile>
     <Compile Include="System.Design.cs" />
     <Compile Include="system.design\stronglytypedresourcebuilder.cs" />
     <Compile Include="TaskExtension.cs">
@@ -625,9 +628,6 @@
     <Compile Include="ResolveSDKReference.cs" />
     <Compile Include="SdkToolsPathUtility.cs" />
     <Compile Include="RequiresFramework35SP1Assembly.cs" Condition="'$(MonoBuild)' != 'true'">
-      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
-    </Compile>
-    <Compile Include="SGen.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="SignFile.cs" Condition="'$(MonoBuild)' != 'true'">

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1968,7 +1968,7 @@
     <comment>{StrBegin="MSB3473: "}</comment>
   </data>
   <data name="SGen.TaskNotSupported">
-    <value>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</value>
+    <value>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</value>
     <comment>{StrBegin="MSB3474: "}</comment>
   </data>
   <!--

--- a/src/Tasks/Resources/Strings.resx
+++ b/src/Tasks/Resources/Strings.resx
@@ -1967,6 +1967,10 @@
     <value>MSB3473: Path for "{0}" is invalid. {1}</value>
     <comment>{StrBegin="MSB3473: "}</comment>
   </data>
+  <data name="SGen.TaskNotSupported">
+    <value>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</value>
+    <comment>{StrBegin="MSB3474: "}</comment>
+  </data>
   <!--
         The SignFile message bucket is: MSB3481 - MSB3490
 

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: Cesta k objektu {0} je neplatná. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: Nebyl nalezen podpisový certifikát. Zkontrolujte, zda je uložen v osobním úložišti aktuálního uživatele.</target>

--- a/src/Tasks/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Resources/xlf/Strings.cs.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: Der Pfad für "{0}" ist ungültig. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: Das Signaturzertifikat wurde nicht gefunden. Stellen Sie sicher, dass es sich im persönlichen Speicher des aktuellen Benutzers befindet.</target>

--- a/src/Tasks/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Resources/xlf/Strings.de.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2343,6 +2343,11 @@
         <target state="new">MSB3473: Path for "{0}" is invalid. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="new">MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</target>

--- a/src/Tasks/Resources/xlf/Strings.en.xlf
+++ b/src/Tasks/Resources/xlf/Strings.en.xlf
@@ -2344,8 +2344,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Resources/xlf/Strings.es.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: La ruta de acceso de "{0}" no es válida. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: No se encuentra el certificado de firma. Asegúrese de que se encuentra en el almacén personal del usuario actual.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: Le chemin d'accès de "{0}" n'est pas valide. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: Impossible de trouver le certificat de signature. Vérifiez qu'il se trouve dans le magasin personnel de l'utilisateur actuel.</target>

--- a/src/Tasks/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.fr.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: il percorso di "{0}" non è valido. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: non è stato possibile trovare il certificato di firma. Verificare che si trovi nell'archivio personale dell'utente corrente.</target>

--- a/src/Tasks/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Resources/xlf/Strings.it.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: "{0}" のパスが無効です。{1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: 署名する証明書が見つかりませんでした。現在のユーザーの個人用ストアであることを確認してください。</target>

--- a/src/Tasks/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ja.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: "{0}"의 경로가 잘못되었습니다. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: 서명 인증서를 찾을 수 없습니다. 인증서가 현재 사용자의 개인 저장소에 있는지 확인하세요.</target>

--- a/src/Tasks/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ko.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: Ścieżka elementu „{0}” jest nieprawidłowa. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: Nie można zlokalizować certyfikatu podpisującego. Upewnij się, że znajduje się on w magazynie osobistym bieżącego użytkownika.</target>

--- a/src/Tasks/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pl.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Resources/xlf/Strings.pt-BR.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: O caminho para "{0}" não é válido. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: O certificado de autenticação não foi localizado. Verifique se ele está no repositório pessoal do usuário atual.</target>

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Resources/xlf/Strings.ru.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: Путь для "{0}" является недопустимым. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: не удалось обнаружить сертификат для подписи. Убедитесь, что объект находится в личном хранилище текущего пользователя.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: "{0}" yolu geçersiz. {1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: İmza sertifikası bulunamadı. Sertifikanın geçerli kullanıcının kişisel deposunda olduğunu doğrulayın.</target>

--- a/src/Tasks/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Resources/xlf/Strings.tr.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: “{0}”的路径无效。{1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: 未能找到签名证书。请确保它在当前用户的个人存储中。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hans.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2293,6 +2293,11 @@
         <target state="translated">MSB3473: "{0}" 的路徑無效。{1}</target>
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
+      <trans-unit id="SGen.TaskNotSupported">
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <note>{StrBegin="MSB3474: "}</note>
+      </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">
         <source>MSB3481: The signing certificate could not be located. Ensure that it is in the current user's personal store.</source>
         <target state="translated">MSB3481: 找不到簽署憑證。請確認該憑證位於目前使用者的個人存放區中。</target>

--- a/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Resources/xlf/Strings.zh-Hant.xlf
@@ -2294,8 +2294,8 @@
         <note>{StrBegin="MSB3473: "}</note>
       </trans-unit>
       <trans-unit id="SGen.TaskNotSupported">
-        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</source>
-        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Please instead use the Microsoft XML Serializer Generator. See https://go.microsoft.com/fwlink/?linkid=858594 for further details.</target>
+        <source>MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</source>
+        <target state="new">MSB3474: The task "{0}" is not supported on the .NET Core version of MSBuild. Use the Microsoft XML Serializer Generator package instead. See https://go.microsoft.com/fwlink/?linkid=858594 for more information.</target>
         <note>{StrBegin="MSB3474: "}</note>
       </trans-unit>
       <trans-unit id="SignFile.CertNotInStore">

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -11,6 +11,9 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+    /// <summary>
+    /// An interface containing public SGen task properties to make sure that all versions of the task have the same public surface.
+    /// </summary>
     internal interface ISGenTaskContract
     {
     #region Properties

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Build.Tasks
 #if RUNTIME_TYPE_NETCORE
     public class SGen : ToolTaskExtension, ISGenTaskContract
     {
-        #region Properties
+    #region Properties
 
         [Required]
         public string BuildAssemblyName { get; set; }
@@ -96,9 +96,9 @@ namespace Microsoft.Build.Tasks
 
         public string[] Types { get; set; }
 
-        #endregion
+    #endregion
 
-        #region Tool Members
+    #region Tool Members
 
         protected override string ToolName
         {
@@ -117,11 +117,11 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
-            Log.LogError("SGen.TaskNotSupported", nameof(SGen));
+            Log.LogErrorWithCodeFromResources("SGen.TaskNotSupported", nameof(SGen));
             return false;
         }
 
-        #endregion
+    #endregion
     }
 #else
     /// <summary>

--- a/src/Tasks/SGen.cs
+++ b/src/Tasks/SGen.cs
@@ -11,10 +11,123 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Tasks
 {
+    internal interface ISGenTaskContract
+    {
+    #region Properties
+
+        // Input files
+        [Required]
+        string BuildAssemblyName { get; set; }
+
+        [Required]
+        string BuildAssemblyPath { get; set; }
+
+        [Required]
+        bool ShouldGenerateSerializer { get; set; }
+
+        [Required]
+        bool UseProxyTypes { get; set; }
+
+        bool UseKeep { get; set; }
+
+        string[] References { get; set; }
+
+        string KeyContainer { get; set; }
+
+        string KeyFile { get; set; }
+
+        bool DelaySign { get; set; }
+
+        [Output]
+        ITaskItem[] SerializationAssembly { get; set; }
+
+        string SerializationAssemblyName { get; }
+
+        string SdkToolsPath { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the Compiler Platform used by SGen to generate the output assembly.
+        /// </summary>
+        string Platform { get; set; }
+
+        /// <summary>
+        /// Gets or Sets a list of specific Types to generate serialization code for, SGen will generate serialization code only for those types.
+        /// </summary>
+        string[] Types { get; set; }
+
+    #endregion
+    }
+
+#if RUNTIME_TYPE_NETCORE
+    public class SGen : ToolTaskExtension, ISGenTaskContract
+    {
+        #region Properties
+
+        [Required]
+        public string BuildAssemblyName { get; set; }
+
+        [Required]
+        public string BuildAssemblyPath { get; set; }
+
+        [Required]
+        public bool ShouldGenerateSerializer { get; set; }
+
+        [Required]
+        public bool UseProxyTypes { get; set; }
+
+        public bool UseKeep { get; set; }
+
+        public string[] References { get; set; }
+
+        public string KeyContainer { get; set; }
+
+        public string KeyFile { get; set; }
+
+        public bool DelaySign { get; set; }
+
+        [Output]
+        public ITaskItem[] SerializationAssembly { get; set; }
+
+        public string SerializationAssemblyName { get; }
+
+        public string SdkToolsPath { get; set; }
+
+        public string Platform { get; set; }
+
+        public string[] Types { get; set; }
+
+        #endregion
+
+        #region Tool Members
+
+        protected override string ToolName
+        {
+            get
+            {
+                ErrorUtilities.ThrowInternalErrorUnreachable();
+                return null;
+            }
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            ErrorUtilities.ThrowInternalErrorUnreachable();
+            return null;
+        }
+
+        public override bool Execute()
+        {
+            Log.LogError("SGen.TaskNotSupported", nameof(SGen));
+            return false;
+        }
+
+        #endregion
+    }
+#else
     /// <summary>
     /// Genererates a serialization assembly containing XML serializers for the input assembly.
     /// </summary>
-    public class SGen : ToolTaskExtension
+    public class SGen : ToolTaskExtension, ISGenTaskContract
     {
         private string _buildAssemblyPath;
         #region Properties
@@ -332,4 +445,5 @@ namespace Microsoft.Build.Tasks
 
         #endregion
     }
+#endif
 }


### PR DESCRIPTION
The SGen task has not been implemented on .NET Core and building a project with `<GenerateSerializationAssemblies>` is failing with what looks like an infrastructure error.

This PR is adding an empty implementation of the task which throws a nicer error pointing the user to the build-time serialization mechanism supported on .NET Core - Microsoft.XmlSerializer.Generator. The changes here are analogous to how the ResolveComReference task has been implemented to allow erroring out on Core.

Fixes #3583