### PR TITLE
Add back support for host objects in 64-bit MSBuild

### DIFF
--- a/src/Build/Instance/HostServices.cs
+++ b/src/Build/Instance/HostServices.cs
@@ -90,11 +90,6 @@ namespace Microsoft.Build.Execution
                 {
 #if FEATURE_COM_INTEROP
 
-                    if (Environment.Is64BitProcess)
-                    {
-                        throw new PlatformNotSupportedException("GetHostObject with monikerName is only supported in 32 bit");
-                    }
-
                     try
                     {
                         object objectFromRunningObjectTable =
@@ -160,11 +155,6 @@ namespace Microsoft.Build.Execution
             ErrorUtilities.VerifyThrowArgumentNull(targetName, "targetName");
             ErrorUtilities.VerifyThrowArgumentNull(taskName, "taskName");
             ErrorUtilities.VerifyThrowArgumentNull(monikerName, "monikerName");
-
-            if (Environment.Is64BitProcess)
-            {
-                throw new PlatformNotSupportedException("RegisterHostObject with monikerName is only supported in 32 bit");
-            }
 
             _hostObjectMap = _hostObjectMap ?? new Dictionary<string, HostObjects>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -128,6 +128,7 @@
            Text="TlbExp was not found. Ensure that you have installed everything from .vsconfig. If you have, please report a bug to MSBuild." />
 
     <Exec Command="&quot;$(TlbExpPath)&quot; $(TlbExpVerbosity) /NOLOGO @(TlbExpAssemblyPaths->'/asmpath:&quot;%(Identity)&quot;', ' ') &quot;$(TargetPath)&quot; /out:&quot;$(TargetDir)$(TargetName).tlb&quot;" />
+    <Exec Command="&quot;$(TlbExpPath)&quot; $(TlbExpVerbosity) /NOLOGO @(TlbExpAssemblyPaths->'/asmpath:&quot;%(Identity)&quot;', ' ') &quot;$(TargetPath)&quot; /out:&quot;$(TargetDir)x64\$(TargetName).tlb&quot; /win64" />
   </Target>
 
   <Import Project="$(BUILD_STAGINGDIRECTORY)\MicroBuild\Plugins\MicroBuild.Plugins.IBCMerge.*\**\build\MicroBuild.Plugins.*.targets" Condition="'$(BUILD_STAGINGDIRECTORY)' != '' and $(TargetFramework.StartsWith('net4')) and '$(MicroBuild_EnablePGO)' != 'false'" />

--- a/src/Package/GetBinPaths.targets
+++ b/src/Package/GetBinPaths.targets
@@ -9,6 +9,11 @@
                       OutputItemType="MSBuildResolvedProjectReferencePath"
                       SetTargetFramework="TargetFramework=$(TargetFramework)"/>
 
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Framework\Microsoft.Build.Framework.csproj"
+                      Private="false"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="FrameworkResolvedProjectReferencePath" />
+
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\MSBuildTaskHost\MSBuildTaskHost.csproj"
                       Private="false"
                       ReferenceOutputAssembly="false"
@@ -47,6 +52,7 @@
     <PropertyGroup>
       <X86BinPath>@(MSBuildResolvedProjectReferencePath->'%(RootDir)%(Directory)')</X86BinPath>
       <X64BinPath>@(MSBuildX64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</X64BinPath>
+      <FrameworkBinPath>@(FrameworkResolvedProjectReferencePath->'%(RootDir)%(Directory)')</FrameworkBinPath>
       <MSBuildTaskHostBinPath>@(MSBuildTaskHostResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostBinPath>
       <MSBuildTaskHostX64BinPath>@(MSBuildTaskHostX64ResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildTaskHostX64BinPath>
       <MSBuildConversionBinPath>@(MSBuildConversionResolvedProjectReferencePath->'%(RootDir)%(Directory)')</MSBuildConversionBinPath>

--- a/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
+++ b/src/Package/MSBuild.VSSetup/MSBuild.VSSetup.csproj
@@ -34,6 +34,7 @@
       <SwrProperty Include="Version=$(VsixVersion)" />
       <SwrProperty Include="X86BinPath=$(X86BinPath)" />
       <SwrProperty Include="X64BinPath=$(X64BinPath)" />
+      <SwrProperty Include="FrameworkBinPath=$(FrameworkBinPath)" />
       <SwrProperty Include="TaskHostBinPath=$(MSBuildTaskHostBinPath)" />
       <SwrProperty Include="TaskHostX64BinPath=$(MSBuildTaskHostX64BinPath)" />
       <SwrProperty Include="MSBuildConversionBinPath=$(MSBuildConversionBinPath)" />

--- a/src/Package/MSBuild.VSSetup/files.swr
+++ b/src/Package/MSBuild.VSSetup/files.swr
@@ -177,6 +177,7 @@ folder InstallDir:\MSBuild\Current\Bin\amd64
   file source=$(X86BinPath)Microsoft.Build.dll vs.file.ngenArchitecture=all
   file source=$(MSBuildConversionBinPath)Microsoft.Build.Engine.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Framework.dll vs.file.ngenArchitecture=all
+  file source=$(FrameworkBinPath)x64\Microsoft.Build.Framework.tlb
   file source=$(X86BinPath)Microsoft.Build.Tasks.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)Microsoft.Build.Utilities.Core.dll vs.file.ngenArchitecture=all
   file source=$(X86BinPath)System.Buffers.dll vs.file.ngenArchitecture=all


### PR DESCRIPTION
This reverts commit 28ce126ed4f2220d87317b7f95d03d116c72bb4b.

The original commit failed RPS twice, so it was reverted. It then passed RPS twice, so this reverts its revert.