### PR TITLE
Reduce allocations in ItemGroupLoggingHelper.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Build.BackEnd
 
             if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToAdd != null && itemsToAdd.Count > 0)
             {
-                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("ItemGroupIncludeLogMessagePrefix"), child.ItemType, itemsToAdd.ToArray());
+                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix, child.ItemType, itemsToAdd.ToArray());
                 LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
@@ -231,7 +231,7 @@ namespace Microsoft.Build.BackEnd
             {
                 if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToRemove.Count > 0)
                 {
-                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("ItemGroupRemoveLogMessage"), child.ItemType, itemsToRemove.ToArray());
+                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.ItemGroupRemoveLogMessage, child.ItemType, itemsToRemove.ToArray());
                     LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.BackEnd
             bucket.Expander.Metadata = metadataTable;
 
             // Second, expand the item include and exclude, and filter existing metadata as appropriate.
-            IList<ProjectItemInstance> itemsToAdd = ExpandItemIntoItems(child, bucket.Expander, keepMetadata, removeMetadata);
+            List<ProjectItemInstance> itemsToAdd = ExpandItemIntoItems(child, bucket.Expander, keepMetadata, removeMetadata);
 
             // Third, expand the metadata.           
             foreach (ProjectItemGroupTaskMetadataInstance metadataInstance in child.Metadata)
@@ -202,7 +202,11 @@ namespace Microsoft.Build.BackEnd
 
             if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToAdd != null && itemsToAdd.Count > 0)
             {
-                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix, child.ItemType, itemsToAdd.ToArray());
+                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
+                    ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix,
+                    child.ItemType,
+                    itemsToAdd,
+                    includeMetadata: true);
                 LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
@@ -231,7 +235,11 @@ namespace Microsoft.Build.BackEnd
             {
                 if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToRemove.Count > 0)
                 {
-                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.ItemGroupRemoveLogMessage, child.ItemType, itemsToRemove.ToArray());
+                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
+                        ItemGroupLoggingHelper.ItemGroupRemoveLogMessage,
+                        child.ItemType,
+                        itemsToRemove,
+                        includeMetadata: true);
                     LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 
@@ -333,7 +341,7 @@ namespace Microsoft.Build.BackEnd
         /// been refactored.
         /// </remarks>
         /// <returns>A list of items.</returns>
-        private IList<ProjectItemInstance> ExpandItemIntoItems
+        private List<ProjectItemInstance> ExpandItemIntoItems
         (
             ProjectItemGroupTaskItemInstance originalItem,
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander,
@@ -344,7 +352,7 @@ namespace Microsoft.Build.BackEnd
             //todo this is duplicated logic with the item computation logic from evaluation (in LazyIncludeOperation.SelectItems)
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!(keepMetadata != null && removeMetadata != null), originalItem.KeepMetadataLocation, "KeepAndRemoveMetadataMutuallyExclusive");
-            IList<ProjectItemInstance> items = new List<ProjectItemInstance>();
+            List<ProjectItemInstance> items = new List<ProjectItemInstance>();
 
             // Expand properties and metadata in Include
             string evaluatedInclude = expander.ExpandIntoStringLeaveEscaped(originalItem.Include, ExpanderOptions.ExpandPropertiesAndMetadata, originalItem.IncludeLocation);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -93,6 +93,12 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static string GetStringFromParameterValue(object parameterValue, bool includeMetadata = false)
         {
+            // fast path for the common case
+            if (parameterValue is string valueText)
+            {
+                return valueText;
+            }
+
             using (var sb = new ReuseableStringBuilder())
             {
                 AppendStringFromParameterValue(sb, parameterValue, includeMetadata);

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1285,7 +1285,10 @@ namespace Microsoft.Build.BackEnd
         {
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameterValue.Count > 0)
             {
-                string parameterText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.TaskParameterPrefix, parameter.Name, parameterValue);
+                string parameterText = ItemGroupLoggingHelper.GetParameterText(
+                    ItemGroupLoggingHelper.TaskParameterPrefix,
+                    parameter.Name,
+                    parameterValue);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
@@ -1427,7 +1430,8 @@ namespace Microsoft.Build.BackEnd
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
                             ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
-                            outputs);
+                            outputs,
+                            includeMetadata: true);
 
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
@@ -1500,7 +1504,11 @@ namespace Microsoft.Build.BackEnd
 
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
                     {
-                        string parameterText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.OutputItemParameterMessagePrefix, outputTargetName, outputs);
+                        string parameterText = ItemGroupLoggingHelper.GetParameterText(
+                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
+                            outputTargetName,
+                            outputs,
+                            includeMetadata: true);
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1288,7 +1288,8 @@ namespace Microsoft.Build.BackEnd
                 string parameterText = ItemGroupLoggingHelper.GetParameterText(
                     ItemGroupLoggingHelper.TaskParameterPrefix,
                     parameter.Name,
-                    parameterValue);
+                    parameterValue,
+                    includeMetadata: Traits.Instance.EscapeHatches.LogTaskInputItemMetadata);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1285,8 +1285,7 @@ namespace Microsoft.Build.BackEnd
         {
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameterValue.Count > 0)
             {
-                string parameterText = ResourceUtilities.GetResourceString("TaskParameterPrefix");
-                parameterText = ItemGroupLoggingHelper.GetParameterText(parameterText, parameter.Name, parameterValue);
+                string parameterText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.TaskParameterPrefix, parameter.Name, parameterValue);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
@@ -1312,7 +1311,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     _taskLoggingContext.LogCommentFromText(
                         MessageImportance.Low,
-                        ResourceUtilities.GetResourceString("TaskParameterPrefix") + parameter.Name + "=" + ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
+                        ItemGroupLoggingHelper.TaskParameterPrefix + parameter.Name + "=" + ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
                 }
             }
 
@@ -1426,7 +1425,7 @@ namespace Microsoft.Build.BackEnd
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
-                            ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix"),
+                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
                             outputs);
 
@@ -1501,7 +1500,7 @@ namespace Microsoft.Build.BackEnd
 
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
                     {
-                        string parameterText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix"), outputTargetName, outputs);
+                        string parameterText = ItemGroupLoggingHelper.GetParameterText(ItemGroupLoggingHelper.OutputItemParameterMessagePrefix, outputTargetName, outputs);
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -158,6 +158,12 @@ namespace Microsoft.Build.Utilities
         }
 
         /// <summary>
+        /// Log metadata for items that are inputs to tasks.
+        /// This is only relevant when <see cref="LogTaskInputs" /> is already true.
+        /// </summary>
+        public readonly bool LogTaskInputItemMetadata = Environment.GetEnvironmentVariable("MSBUILDLOGTASKINPUTITEMMETADATA") == "1";
+
+        /// <summary>
         /// Read information only once per file per ResolveAssemblyReference invocation.
         /// </summary>
         public readonly bool CacheAssemblyInformation = Environment.GetEnvironmentVariable("MSBUILDDONOTCACHERARASSEMBLYINFORMATION") != "1";


### PR DESCRIPTION
This code is a very hot path (though only hit when LogTaskInputs is set).
There was an n^2 string concatenation problem alongside with other easily avoidable allocations.
Cache resource strings to avoid extracting them from resources every time.
Use a ThreadStatic field to avoid allocating an array every time.
Sorting key value pairs in place is 3x faster than LINQ OrderBy.