### PR TITLE
Fix cache issues with graph exempt projects

### DIFF
--- a/scripts/Deploy-MSBuild.ps1
+++ b/scripts/Deploy-MSBuild.ps1
@@ -8,15 +8,30 @@ Param(
   [string] $runtime = "Desktop"
 )
 
+Set-StrictMode -Version "Latest"
+$ErrorActionPreference = "Stop"
+
 function Copy-WithBackup ($origin) {
-    $destinationPath = Join-Path -Path $destination -ChildPath (Split-Path $origin -leaf)
+    $directoryPart = Join-Path -Path $destination $origin.IntermediaryDirectories 
+    $destinationPath = Join-Path -Path $directoryPart (Split-Path $origin.SourceFile -leaf)
 
     if (Test-Path $destinationPath -PathType Leaf) {
         # Back up previous copy of the file
         Copy-Item $destinationPath $BackupFolder -ErrorAction Stop
     }
 
-    Copy-Item $origin $destinationPath -ErrorAction Stop
+    if (!(Test-Path $directoryPart)) {
+        [system.io.directory]::CreateDirectory($directoryPart)
+    }
+
+    Copy-Item $origin.SourceFile $destinationPath -ErrorAction Stop
+
+    echo "Copied $($origin.SourceFile) to $destinationPath"
+}
+
+function FileToCopy([string] $sourceFileRelativeToRepoRoot, [string] $intermediaryDirectories)
+{
+    return [PSCustomObject]@{"SourceFile"=$([IO.Path]::Combine($PSScriptRoot, "..", $sourceFileRelativeToRepoRoot)); "IntermediaryDirectories"=$intermediaryDirectories}
 }
 
 # TODO: find destination in PATH if not specified
@@ -36,58 +51,65 @@ if ($runtime -eq "Desktop") {
     $targetFramework = "netcoreapp2.1"
 }
 
-$filesToCopyToBin = @(
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Build.dll"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Build.Framework.dll"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Build.Tasks.Core.dll"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Build.Utilities.Core.dll"
+$bootstrapBinDirectory = "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework"
 
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Common.CrossTargeting.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Common.CurrentVersion.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Common.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.CSharp.CrossTargeting.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.CSharp.CurrentVersion.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.CSharp.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.Before.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Managed.After.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Net.props"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.CurrentVersion.props"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.CurrentVersion.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.props"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.NetFramework.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.VisualBasic.CrossTargeting.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.VisualBasic.CurrentVersion.targets"
-    "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.VisualBasic.targets"
+$filesToCopyToBin = @(
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Build.dll"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Build.Framework.dll"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Build.Tasks.Core.dll"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Build.Utilities.Core.dll"
+
+    FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.resources.dll" "en"
+    FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.Tasks.Core.resources.dll" "en"
+    FileToCopy "$bootstrapBinDirectory\en\Microsoft.Build.Utilities.Core.resources.dll" "en"
+    FileToCopy "$bootstrapBinDirectory\en\MSBuild.resources.dll" "en"
+
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Common.CrossTargeting.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Common.CurrentVersion.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Common.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.CSharp.CrossTargeting.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.CSharp.CurrentVersion.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.CSharp.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Managed.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Managed.Before.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Managed.After.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.Net.props"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.NetFramework.CurrentVersion.props"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.NetFramework.CurrentVersion.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.NetFramework.props"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.NetFramework.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.VisualBasic.CrossTargeting.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.VisualBasic.CurrentVersion.targets"
+    FileToCopy "$bootstrapBinDirectory\Microsoft.VisualBasic.targets"
 )
 
 if ($runtime -eq "Desktop") {
     $runtimeSpecificFiles = @(
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\MSBuild.exe"
-        "artifacts\bin\Microsoft.Build.Conversion\$configuration\$targetFramework\Microsoft.Build.Conversion.Core.dll"
-        "artifacts\bin\Microsoft.Build.Engine\$configuration\$targetFramework\Microsoft.Build.Engine.dll"
+        FileToCopy "$bootstrapBinDirectory\MSBuild.exe"
+        FileToCopy "artifacts\bin\Microsoft.Build.Conversion\$configuration\$targetFramework\Microsoft.Build.Conversion.Core.dll"
+        FileToCopy "artifacts\bin\Microsoft.Build.Engine\$configuration\$targetFramework\Microsoft.Build.Engine.dll"
 
-        "artifacts\bin\MSBuildTaskHost\$configuration\net35\MSBuildTaskHost.exe"
-        "artifacts\bin\MSBuildTaskHost\$configuration\net35\MSBuildTaskHost.pdb"
+        FileToCopy "artifacts\bin\MSBuildTaskHost\$configuration\net35\MSBuildTaskHost.exe"
+        FileToCopy "artifacts\bin\MSBuildTaskHost\$configuration\net35\MSBuildTaskHost.pdb"
 
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Data.Entity.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.ServiceModel.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.WinFx.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.WorkflowBuildExtensions.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Microsoft.Xaml.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Workflow.targets"
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\Workflow.VisualBasic.targets"
+        FileToCopy "$bootstrapBinDirectory\Microsoft.Data.Entity.targets"
+        FileToCopy "$bootstrapBinDirectory\Microsoft.ServiceModel.targets"
+        FileToCopy "$bootstrapBinDirectory\Microsoft.WinFx.targets"
+        FileToCopy "$bootstrapBinDirectory\Microsoft.WorkflowBuildExtensions.targets"
+        FileToCopy "$bootstrapBinDirectory\Microsoft.Xaml.targets"
+        FileToCopy "$bootstrapBinDirectory\Workflow.targets"
+        FileToCopy "$bootstrapBinDirectory\Workflow.VisualBasic.targets"
     )
 } else {
     $runtimeSpecificFiles = @(
-        "artifacts\bin\MSBuild.Bootstrap\$configuration\$targetFramework\MSBuild.dll"
+        FileToCopy "$bootstrapBinDirectory\MSBuild.dll"
     )
 }
 
 $filesToCopyToBin += $runtimeSpecificFiles
 
 foreach ($file in $filesToCopyToBin) {
-    Copy-WithBackup $([IO.Path]::Combine($PSScriptRoot, "..", $file))
+    Copy-WithBackup $file
 }
 
 Write-Host -ForegroundColor Green "Copy succeeded"

--- a/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestConfiguration_Tests.cs
@@ -502,7 +502,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             glob = $"$([MSBuild]::Escape('{glob}'))";
 
-            projectContents = projectContents ?? $@"
+            projectContents ??= $@"
 <Project>
     <ItemGroup>
         <{ItemTypeNames.GraphIsolationExemptReference} Include=`{glob};ShouldNotMatchAnything`/>

--- a/src/Build.UnitTests/BuildResultUtilities.cs
+++ b/src/Build.UnitTests/BuildResultUtilities.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Execution;
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
@@ -25,7 +22,12 @@ namespace Microsoft.Build.Unittest
 
         public static TargetResult GetNonEmptySucceedingTargetResult()
         {
-            return new TargetResult(new TaskItem[1] { new TaskItem("i", "v")}, BuildResultUtilities.GetSuccessResult());
+            return GetNonEmptySucceedingTargetResult("i", "v");
+        }
+
+        public static TargetResult GetNonEmptySucceedingTargetResult(string itemInclude, string definingFile = "")
+        {
+            return new TargetResult(new TaskItem[1] { new TaskItem(itemInclude, definingFile)}, BuildResultUtilities.GetSuccessResult());
         }
 
         public static WorkUnitResult GetSuccessResult()

--- a/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
+++ b/src/Build.UnitTests/Graph/GraphLoadedFromSolution_tests.cs
@@ -687,10 +687,10 @@ namespace Microsoft.Build.Graph.UnitTests
             if (projectConfigurations == null || graphFromSolution.ProjectNodes.All(n => n.ProjectReferences.Count == 0))
             {
                 graphFromSolution.GraphRoots.Select(GetProjectPath)
-                    .ShouldBeEquivalentTo(graph.GraphRoots.Select(GetProjectPath));
+                    .ShouldBeSameIgnoringOrder(graph.GraphRoots.Select(GetProjectPath));
 
                 graphFromSolution.ProjectNodes.Select(GetProjectPath)
-                    .ShouldBeEquivalentTo(graph.ProjectNodes.Select(GetProjectPath));
+                    .ShouldBeSameIgnoringOrder(graph.ProjectNodes.Select(GetProjectPath));
             }
 
             var expectedCurrentConfiguration = currentSolutionConfiguration ?? solutionConfigurations.First();

--- a/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
+++ b/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Graph.UnitTests
             additionalGlobalProperties = additionalGlobalProperties ?? new Dictionary<string, string>();
 
             IsNotMultitargeting(node).ShouldBeTrue();
-            node.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(EmptyGlobalProperties.AddRange(additionalGlobalProperties));
+            node.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(EmptyGlobalProperties.AddRange(additionalGlobalProperties));
             node.ProjectInstance.GetProperty(InnerBuildPropertyName).ShouldBeNull();
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.Build.Graph.UnitTests
             IsInnerBuild(outerBuild).ShouldBeFalse();
 
             outerBuild.ProjectInstance.GetProperty(InnerBuildPropertyName).ShouldBeNull();
-            outerBuild.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(EmptyGlobalProperties.AddRange(additionalGlobalProperties));
+            outerBuild.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(EmptyGlobalProperties.AddRange(additionalGlobalProperties));
         }
 
         public static void AssertInnerBuildEvaluation(
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
             if (InnerBuildPropertyIsSetViaGlobalProperty)
             {
-                innerBuild.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(
+                innerBuild.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(
                     EmptyGlobalProperties
                         .Add(InnerBuildPropertyName, innerBuildPropertyValue)
                         .AddRange(additionalGlobalProperties));

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -590,7 +590,7 @@ BuildEngine5.BuildProjectFilesInParallel(
             cache2.Value.ConfigCache.First().ProjectFullPath.ShouldBe(cache2.Key.ProjectInstance.FullPath);
 
             cache2.Value.ResultsCache.ShouldHaveSingleItem();
-            cache2.Value.ResultsCache.First().ResultsByTarget.Keys.ShouldBeEquivalentTo(new[] { "Build2" });
+            cache2.Value.ResultsCache.First().ResultsByTarget.Keys.ShouldBeSameIgnoringOrder(new[] { "Build2" });
 
             var cache1 = caches.FirstOrDefault(c => ProjectNumber(c.Key) == 1);
 
@@ -602,10 +602,10 @@ BuildEngine5.BuildProjectFilesInParallel(
                 switch (ProjectNumber(config.ProjectFullPath))
                 {
                     case 1:
-                        cache1.Value.ResultsCache.GetResultsForConfiguration(config.ConfigurationId).ResultsByTarget.Keys.ShouldBeEquivalentTo(new []{ "Build", "ExtraBuild"});
+                        cache1.Value.ResultsCache.GetResultsForConfiguration(config.ConfigurationId).ResultsByTarget.Keys.ShouldBeSameIgnoringOrder(new []{ "Build", "ExtraBuild"});
                         break;
                     case 2:
-                        cache1.Value.ResultsCache.GetResultsForConfiguration(config.ConfigurationId).ResultsByTarget.Keys.ShouldBeEquivalentTo(new[] { "UncachedTarget"});
+                        cache1.Value.ResultsCache.GetResultsForConfiguration(config.ConfigurationId).ResultsByTarget.Keys.ShouldBeSameIgnoringOrder(new[] { "UncachedTarget"});
                         break;
                     default: throw new NotImplementedException();
                 }

--- a/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
+++ b/src/Build.UnitTests/Graph/ParallelWorkSet_Tests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
             _workSet.WaitForAllWorkAndComplete();
             _workSet.IsCompleted.ShouldBeTrue();
-            _workSet.CompletedWork.ShouldBeEquivalentTo((IReadOnlyCollection<KeyValuePair<string, string>>) tt.ExpectedCompletedWork);
+            _workSet.CompletedWork.ShouldBeSameIgnoringOrder((IReadOnlyCollection<KeyValuePair<string, string>>) tt.ExpectedCompletedWork);
         }
     }
 }

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -114,13 +114,13 @@ namespace Microsoft.Build.Graph.UnitTests
                 node.AddProjectReference(reference1, referenceItem1, edges);
                 node.AddProjectReference(reference2, referenceItem2, edges);
 
-                node.ProjectReferences.ShouldBeEquivalentTo(new []{reference1, reference2});
+                node.ProjectReferences.ShouldBeSameIgnoringOrder(new []{reference1, reference2});
                 node.ReferencingProjects.ShouldBeEmpty();
 
-                reference1.ReferencingProjects.ShouldBeEquivalentTo(new[] {node});
+                reference1.ReferencingProjects.ShouldBeSameIgnoringOrder(new[] {node});
                 reference1.ProjectReferences.ShouldBeEmpty();
 
-                reference2.ReferencingProjects.ShouldBeEquivalentTo(new[] {node});
+                reference2.ReferencingProjects.ShouldBeSameIgnoringOrder(new[] {node});
                 reference2.ProjectReferences.ShouldBeEmpty();
 
                 edges[(node, reference1)].ShouldBe(referenceItem1);
@@ -336,16 +336,16 @@ namespace Microsoft.Build.Graph.UnitTests
             var root1 = GetFirstNodeWithProjectNumber(graph, 1);
             var globalPropertiesFor1 = new Dictionary<string, string> { ["B"] = "EntryPointB", ["C"] = "EntryPointC", ["IsGraphBuild"] = "true" };
 
-            root1.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor1);
-            root1.ProjectReferences.First(r => GetProjectNumber(r) == 3).ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor1);
-            root1.ProjectReferences.First(r => GetProjectNumber(r) == 4).ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor1);
+            root1.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor1);
+            root1.ProjectReferences.First(r => GetProjectNumber(r) == 3).ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor1);
+            root1.ProjectReferences.First(r => GetProjectNumber(r) == 4).ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor1);
 
             var root2 = GetFirstNodeWithProjectNumber(graph, 2);
             var globalPropertiesFor2 = new Dictionary<string, string> { ["IsGraphBuild"] = "true" };
 
-            root2.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor2);
-            root2.ProjectReferences.First(r => GetProjectNumber(r) == 4).ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor2);
-            root2.ProjectReferences.First(r => GetProjectNumber(r) == 5).ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(globalPropertiesFor2);
+            root2.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor2);
+            root2.ProjectReferences.First(r => GetProjectNumber(r) == 4).ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor2);
+            root2.ProjectReferences.First(r => GetProjectNumber(r) == 5).ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(globalPropertiesFor2);
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace Microsoft.Build.Graph.UnitTests
                 // Projects 2 and 3 both reference project 4, but with different properties, so they should not point to the same node.
                 GetFirstNodeWithProjectNumber(graph, 2).ProjectReferences.First().ShouldNotBe(GetFirstNodeWithProjectNumber(graph, 3).ProjectReferences.First());
                 GetFirstNodeWithProjectNumber(graph, 2).ProjectReferences.First().ProjectInstance.FullPath.ShouldEndWith("4.proj");
-                GetFirstNodeWithProjectNumber(graph, 2).ProjectReferences.First().ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(EmptyGlobalProperties);
+                GetFirstNodeWithProjectNumber(graph, 2).ProjectReferences.First().ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(EmptyGlobalProperties);
                 GetFirstNodeWithProjectNumber(graph, 3).ProjectReferences.First().ProjectInstance.FullPath.ShouldEndWith("4.proj");
                 GetFirstNodeWithProjectNumber(graph, 3).ProjectReferences.First().ProjectInstance.GlobalProperties.Count.ShouldBeGreaterThan(1);
             }
@@ -1726,13 +1726,13 @@ $@"
 
             innerBuildWithCommonReferences.ProjectReferences.Count.ShouldBe(4);
             var referenceNumbersSet = innerBuildWithCommonReferences.ProjectReferences.Select(r => Path.GetFileNameWithoutExtension(r.ProjectInstance.FullPath)).ToHashSet();
-            referenceNumbersSet.ShouldBeEquivalentTo(new HashSet<string>{"2", "3"});
+            referenceNumbersSet.ShouldBeSameIgnoringOrder(new HashSet<string>{"2", "3"});
 
             var innerBuildWithAdditionalReferences = GetNodesWithProjectNumber(graph, 1).First(n => n.ProjectInstance.GlobalProperties.TryGetValue(InnerBuildPropertyName, out string p) && p == "b");
 
             innerBuildWithAdditionalReferences.ProjectReferences.Count.ShouldBe(8);
             referenceNumbersSet = innerBuildWithAdditionalReferences.ProjectReferences.Select(r => Path.GetFileNameWithoutExtension(r.ProjectInstance.FullPath)).ToHashSet();
-            referenceNumbersSet.ShouldBeEquivalentTo(new HashSet<string>{"2", "3", "4", "5"});
+            referenceNumbersSet.ShouldBeSameIgnoringOrder(new HashSet<string>{"2", "3", "4", "5"});
         }
 
         [Fact]
@@ -1767,7 +1767,7 @@ $@"
             two.ProjectReferences.ShouldHaveSingleItem();
             two.ProjectReferences.First().ShouldBe(referencedInnerBuild);
 
-            referencedInnerBuild.ReferencingProjects.ShouldBeEquivalentTo(new []{two, outerBuild});
+            referencedInnerBuild.ReferencingProjects.ShouldBeSameIgnoringOrder(new []{two, outerBuild});
         }
 
         [Fact]
@@ -1852,7 +1852,7 @@ $@"
             // the outer build is necessary as the referencing inner build can still call targets on it
             GetNodesWithProjectNumber(graph, 2).Count().ShouldBe(2);
 
-            innerBuild1WithReferenceToInnerBuild2.ProjectReferences.ShouldBeEquivalentTo(new []{outerBuild2, innerBuild2});
+            innerBuild1WithReferenceToInnerBuild2.ProjectReferences.ShouldBeSameIgnoringOrder(new []{outerBuild2, innerBuild2});
         }
 
         public static IEnumerable<object[]> AllNodesShouldHaveGraphBuildGlobalPropertyData
@@ -1953,7 +1953,7 @@ $@"
 
                 foreach (var node in projectGraph.ProjectNodes)
                 {
-                    node.ProjectInstance.GlobalProperties.ShouldBeEquivalentTo(expectedGlobalProperties);
+                    node.ProjectInstance.GlobalProperties.ShouldBeSameIgnoringOrder(expectedGlobalProperties);
                 }
             }
         }

--- a/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
+++ b/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     buildParameters.OutputResultsCacheFile = outputCaches[node];
                 }
 
-                var logger = new MockLogger();
+                var logger = new MockLogger(env.Output);
 
                 buildParameters.Loggers = new[] {logger};
 

--- a/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
+++ b/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
@@ -17,9 +17,6 @@ using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.Build.UnitTests.Helpers;
 
-using ExpectedNodeBuildOutput = System.Collections.Generic.Dictionary<Microsoft.Build.Graph.ProjectGraphNode, string[]>;
-using OutputCacheDictionary = System.Collections.Generic.Dictionary<Microsoft.Build.Graph.ProjectGraphNode, string>;
-
 namespace Microsoft.Build.Graph.UnitTests
 {
     public class ResultCacheBasedBuilds_Tests : IDisposable
@@ -283,25 +280,24 @@ namespace Microsoft.Build.Graph.UnitTests
         [MemberData(nameof(BuildGraphData))]
         public void BuildProjectGraphUsingCaches(Dictionary<int, int[]> edges)
         {
-            var topoSortedNodes =
+            var graph =
                 CreateProjectGraph(
                     env: _env,
                     dependencyEdges: edges,
                     globalProperties: null,
-                    createProjectFile: CreateProjectFileWrapper)
-                    .ProjectNodesTopologicallySorted.ToArray();
+                    createProjectFile: CreateProjectFileWrapper);
 
-            var expectedOutput = new ExpectedNodeBuildOutput();
+            var expectedOutput = new Dictionary<ProjectGraphNode, string[]>();
 
-            var outputCaches = new OutputCacheDictionary();
+            var outputCaches = new Dictionary<ProjectGraphNode, string>();
 
             // Build unchanged project files using caches.
-            BuildUsingCaches(topoSortedNodes, expectedOutput, outputCaches, generateCacheFiles: true);
+            BuildGraphUsingCacheFiles(_env, graph, expectedOutput, outputCaches, generateCacheFiles: true);
 
             // Change the project files to remove all items.
             var collection = _env.CreateProjectCollection().Collection;
 
-            foreach (var node in topoSortedNodes)
+            foreach (var node in graph.ProjectNodesTopologicallySorted)
             {
                 var project = Project.FromFile(
                     node.ProjectInstance.FullPath,
@@ -315,35 +311,33 @@ namespace Microsoft.Build.Graph.UnitTests
             }
 
             // Build again using the first caches. Project file changes from references should not be visible.
-            BuildUsingCaches(
-                topoSortedNodes,
+            BuildGraphUsingCacheFiles(_env, graph,
                 expectedOutput,
                 outputCaches,
                 generateCacheFiles: false,
                 assertBuildResults: true,
                 // there are no items in the second build. The references are loaded from cache and have items,
                 // but the current project is loaded from file and has no items
-                (node, localExpectedOutput) => localExpectedOutput[node].Skip(1).ToArray());
+                expectedOutputProducer: (node, localExpectedOutput) => localExpectedOutput[node].Skip(1).ToArray());
         }
 
         [Fact]
         public void OutputCacheShouldNotContainInformationFromInputCaches()
         {
-            var topoSortedNodes =
+            var graph =
                 CreateProjectGraph(
                     env: _env,
-                    dependencyEdges: new Dictionary<int, int[]> { { 1, new[] { 2, 3 } } },
+                    dependencyEdges: new Dictionary<int, int[]> {{1, new[] {2, 3}}},
                     globalProperties: null,
-                    createProjectFile: CreateProjectFileWrapper)
-                    .ProjectNodesTopologicallySorted.ToArray();
+                    createProjectFile: CreateProjectFileWrapper);
 
-            var expectedOutput = new ExpectedNodeBuildOutput();
+            var expectedOutput = new Dictionary<ProjectGraphNode, string[]>();
 
-            var outputCaches = new OutputCacheDictionary();
+            var outputCaches = new Dictionary<ProjectGraphNode, string>();
 
-            BuildUsingCaches(topoSortedNodes, expectedOutput, outputCaches, generateCacheFiles: true);
+            BuildGraphUsingCacheFiles(_env, graph, expectedOutput, outputCaches, generateCacheFiles: true);
 
-            var rootNode = topoSortedNodes.First(n => Path.GetFileNameWithoutExtension(n.ProjectInstance.FullPath) == "1");
+            var rootNode = graph.ProjectNodesTopologicallySorted.First(n => Path.GetFileNameWithoutExtension(n.ProjectInstance.FullPath) == "1");
             var outputCache = outputCaches[rootNode];
 
             outputCache.ShouldNotBeNull();
@@ -367,24 +361,23 @@ namespace Microsoft.Build.Graph.UnitTests
         [Fact]
         public void MissingResultFromCacheShouldErrorDueToIsolatedBuildCacheEnforcement()
         {
-            var topoSortedNodes =
+            var graph =
                 CreateProjectGraph(
                     env: _env,
                     dependencyEdges: new Dictionary<int, int[]> { { 1, new[] { 2, 3 } } },
                     globalProperties: null,
-                    createProjectFile: CreateProjectFileWrapper)
-                    .ProjectNodesTopologicallySorted.ToArray();
+                    createProjectFile: CreateProjectFileWrapper);
 
-            var expectedOutput = new ExpectedNodeBuildOutput();
+            var expectedOutput = new Dictionary<ProjectGraphNode, string[]>();
 
-            var outputCaches = new OutputCacheDictionary();
+            var outputCaches = new Dictionary<ProjectGraphNode, string>();
 
-            BuildUsingCaches(topoSortedNodes, expectedOutput, outputCaches, generateCacheFiles: true);
+            BuildGraphUsingCacheFiles(_env, graph, expectedOutput, outputCaches, generateCacheFiles: true);
 
             // remove cache for project 3 to cause a cache miss
             outputCaches.Remove(expectedOutput.Keys.First(n => ProjectNumber(n) == "3"));
 
-            var results = BuildUsingCaches(topoSortedNodes, expectedOutput, outputCaches, generateCacheFiles: false, assertBuildResults: false);
+            var results = BuildGraphUsingCacheFiles(_env, graph, expectedOutput, outputCaches, generateCacheFiles: false, assertBuildResults: false);
 
             results["3"].Result.OverallResult.ShouldBe(BuildResultCode.Success);
             results["2"].Result.OverallResult.ShouldBe(BuildResultCode.Success);
@@ -400,46 +393,147 @@ namespace Microsoft.Build.Graph.UnitTests
             results["1"].Logger.Errors.First().BuildEventContext.TaskId.ShouldNotBe(BuildEventContext.InvalidTaskId);
         }
 
+        [Fact]
+        public void CacheFilesShouldNotContainTransitiveContent()
+        {
+            var graph = CreateProjectGraph(
+                _env,
+                dependencyEdges: new Dictionary<int, int[]>
+                {
+                    {1, new[] {2}},
+                    {2, new[] {3}}
+                },
+                extraContentPerProjectNumber: new Dictionary<int, string>
+                {
+                    {
+                        1,
+                        @"
+                          <Target Name=`Build` DependsOnTargets=`BeforeBuild`>
+                            <MSBuild Projects=`@(ProjectReference)` Targets='Build2'/>
+                          </Target>
+                          <Target Name=`BeforeBuild`>
+                            <Message Text=`BeforeBuild` />
+                          </Target>
+                          <Target Name=`AfterBuild` AfterTargets=`Build`>
+                            <Message Text=`AfterBuild` />
+                          </Target>"
+                    },
+                    {
+                        2,
+                        @"
+                          <Target Name=`Build2` DependsOnTargets=`BeforeBuild2`>
+                            <MSBuild Projects=`@(ProjectReference)` Targets='Build3'/>
+                            <Message Text=`Build2` />
+                          </Target>
+                          <Target Name=`BeforeBuild2`>
+                            <Message Text=`BeforeBuild2` />
+                          </Target>
+                          <Target Name=`AfterBuild2` AfterTargets=`Build2`>
+                            <Message Text=`AfterBuild2` />
+                          </Target>"
+                    },
+                    {
+                        3,
+                        @"
+                          <Target Name=`Build3` DependsOnTargets=`BeforeBuild3`>
+                            <Message Text=`Build-3` />
+                          </Target>
+                          <Target Name=`BeforeBuild3`>
+                            <Message Text=`BeforeBuild3` />
+                          </Target>
+                          <Target Name=`AfterBuild3` AfterTargets=`Build3`>
+                            <Message Text=`AfterBuild3` />
+                          </Target>"
+                    }
+                }
+                );
+
+            var caches = new Dictionary<ProjectGraphNode, string>();
+
+            var buildResults = BuildGraphUsingCacheFiles(_env, graph: graph,
+                expectedLogOutputPerNode: new Dictionary<ProjectGraphNode, string[]>(),
+                outputCaches: caches,
+                generateCacheFiles: true,
+                assertBuildResults: false);
+
+            foreach (var result in buildResults)
+            {
+                result.Value.Result.OverallResult.ShouldBe(BuildResultCode.Success);
+            }
+
+            buildResults.Count.ShouldBe(3);
+
+            caches.Count.ShouldBe(3);
+
+            var rootCache = caches.FirstOrDefault(c => ProjectNumber(c.Key) == "1");
+
+            rootCache.ShouldNotBeNull();
+
+            var (configCache, resultsCache, exception) = CacheSerialization.DeserializeCaches(rootCache.Value);
+
+            exception.ShouldBeNull();
+
+            configCache.ShouldHaveSingleItem();
+            configCache.First().ProjectFullPath.ShouldEndWith("1.proj");
+
+            resultsCache.ShouldHaveSingleItem();
+
+            var targetResults = resultsCache.First().ResultsByTarget;
+            targetResults.Count.ShouldBe(3);
+
+            var expectedTargetsInResultsCache = new[] {"Build", "BeforeBuild", "AfterBuild"};
+
+            foreach (var targetResult in targetResults)
+            {
+                expectedTargetsInResultsCache.ShouldContain(targetResult.Key);
+            }
+        }
+
         /// <summary>
         /// This method runs in two modes.
-        /// When <param name="generateCacheFiles"></param> is true, the method will fill in the empty <param name="outputCaches"/> and <param name="expectedNodeBuildOutput"/>, simulating a build from scratch.
-        /// When it is false, it uses the filled in <param name="outputCaches"/> and <param name="expectedNodeBuildOutput"/> to simulate a fully cached build.
+        /// When <param name="generateCacheFiles"></param> is true, the method will fill in
+        /// the empty <param name="outputCaches"/> and <param name="expectedLogOutputPerNode"/>simulating a build from scratch.
+        /// When it is false, it uses the filled in <param name="outputCaches"/> and <param name="expectedLogOutputPerNode"/> to simulate a fully cached build.
         /// 
         /// </summary>
-        /// <param name="topoSortedNodes"></param>
-        /// <param name="expectedNodeBuildOutput"></param>
+        /// <param name="env"></param>
+        /// <param name="graph"></param>
+        /// <param name="expectedLogOutputPerNode"></param>
         /// <param name="outputCaches"></param>
         /// <param name="generateCacheFiles"></param>
         /// <param name="assertBuildResults"></param>
         /// <param name="expectedOutputProducer"></param>
+        /// <param name="topoSortedNodes"></param>
         /// <returns></returns>
-        private Dictionary<string, (BuildResult Result, MockLogger Logger)> BuildUsingCaches(
-            IReadOnlyCollection<ProjectGraphNode> topoSortedNodes,
-            ExpectedNodeBuildOutput expectedNodeBuildOutput,
-            OutputCacheDictionary outputCaches,
+        internal static Dictionary<string, (BuildResult Result, MockLogger Logger)> BuildGraphUsingCacheFiles(
+            TestEnvironment env,
+            ProjectGraph graph,
+            Dictionary<ProjectGraphNode, string[]> expectedLogOutputPerNode,
+            Dictionary<ProjectGraphNode, string> outputCaches,
             bool generateCacheFiles,
             bool assertBuildResults = true,
             // (current node, expected output dictionary) -> actual expected output for current node
-            Func<ProjectGraphNode, ExpectedNodeBuildOutput, string[]> expectedOutputProducer = null)
+            Func<ProjectGraphNode, Dictionary<ProjectGraphNode, string[]>, string[]> expectedOutputProducer = null)
         {
-            expectedOutputProducer = expectedOutputProducer ?? ((node, expectedOutputs) => expectedOutputs[node]);
+            expectedOutputProducer ??= ((node, expectedOutputs) => expectedOutputs[node]);
 
-            var results = new Dictionary<string, (BuildResult Result, MockLogger Logger)>(topoSortedNodes.Count);
+            var results = new Dictionary<string, (BuildResult Result, MockLogger Logger)>(graph.ProjectNodesTopologicallySorted.Count);
 
             if (generateCacheFiles)
             {
                 outputCaches.ShouldBeEmpty();
-                expectedNodeBuildOutput.ShouldBeEmpty();
+                expectedLogOutputPerNode.ShouldBeEmpty();
             }
 
-            foreach (var node in topoSortedNodes)
+            foreach (var node in graph.ProjectNodesTopologicallySorted)
             {
                 if (generateCacheFiles)
                 {
-                    expectedNodeBuildOutput[node] = ExpectedBuildOutputForNode(node);
+                    expectedLogOutputPerNode[node] = ExpectedBuildOutputForNode(node);
                 }
 
-                var cacheFilesForReferences = node.ProjectReferences.Where(r => outputCaches.ContainsKey(r)).Select(r => outputCaches[r]).ToArray();
+                var cacheFilesForReferences =
+                    node.ProjectReferences.Where(r => outputCaches.ContainsKey(r)).Select(r => outputCaches[r]).ToArray();
 
                 var buildParameters = new BuildParameters
                 {
@@ -448,7 +542,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
                 if (generateCacheFiles)
                 {
-                    outputCaches[node] = _env.DefaultTestDirectory.CreateFile($"OutputCache-{ProjectNumber(node)}").Path;
+                    outputCaches[node] = env.DefaultTestDirectory.CreateFile($"OutputCache-{ProjectNumber(node)}").Path;
                     buildParameters.OutputResultsCacheFile = outputCaches[node];
                 }
 
@@ -469,7 +563,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
                     var actualOutput = result.ResultsByTarget["Build"].Items.Select(i => i.ItemSpec).ToArray();
 
-                    var expectedOutputForNode = expectedOutputProducer(node, expectedNodeBuildOutput);
+                    var expectedOutputForNode = expectedOutputProducer(node, expectedLogOutputPerNode);
 
                     actualOutput.ShouldBe(expectedOutputForNode);
                 }
@@ -483,7 +577,7 @@ namespace Microsoft.Build.Graph.UnitTests
 
                 expectedOutputForNode.Add(ProjectNumber(node));
 
-                foreach (var referenceOutput in node.ProjectReferences.SelectMany(n => expectedNodeBuildOutput[n]))
+                foreach (var referenceOutput in node.ProjectReferences.SelectMany(n => expectedLogOutputPerNode[n]))
                 {
                     if (!expectedOutputForNode.Contains(referenceOutput))
                     {

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -417,6 +417,8 @@ namespace Microsoft.Build.Execution
                 // Initialize additional build parameters.
                 _buildParameters.BuildId = GetNextBuildId();
 
+                // Loading caches from files turns on project isolation constraints.
+                // Undefined behavior for what would happen if file based caches are used without isolation.
                 if (_buildParameters.UsesCachedResults())
                 {
                     _buildParameters.IsolateProjects = true;
@@ -2491,8 +2493,8 @@ namespace Microsoft.Build.Execution
                 // should contain only the results from new builds, and should not contain old results inherited from the cache files.
                 // The override cache will contain the old build results, and the current cache will contain new results.
                 // Upon reads, both caches are interrogated (override before current), but writes should only happen in the current cache.
-                _componentFactories.ReplaceFactory(BuildComponentType.ConfigCache, new ConfigCacheWithOverride(cacheAggregation.ConfigCache));
-                _componentFactories.ReplaceFactory(BuildComponentType.ResultsCache, new ResultsCacheWithOverride(cacheAggregation.ResultsCache));
+                _componentFactories.ReplaceFactory(BuildComponentType.ConfigCache, new ConfigCacheWithOverride(cacheAggregation.ConfigCache, _buildParameters.IsolateProjects));
+                _componentFactories.ReplaceFactory(BuildComponentType.ResultsCache, new ResultsCacheWithOverride(cacheAggregation.ResultsCache, _buildParameters.IsolateProjects));
 
                 return true;
             }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2493,8 +2493,10 @@ namespace Microsoft.Build.Execution
                 // should contain only the results from new builds, and should not contain old results inherited from the cache files.
                 // The override cache will contain the old build results, and the current cache will contain new results.
                 // Upon reads, both caches are interrogated (override before current), but writes should only happen in the current cache.
-                _componentFactories.ReplaceFactory(BuildComponentType.ConfigCache, new ConfigCacheWithOverride(cacheAggregation.ConfigCache, _buildParameters.IsolateProjects));
-                _componentFactories.ReplaceFactory(BuildComponentType.ResultsCache, new ResultsCacheWithOverride(cacheAggregation.ResultsCache, _buildParameters.IsolateProjects));
+                var configCacheWithOverride = new ConfigCacheWithOverride(cacheAggregation.ConfigCache, _buildParameters.IsolateProjects);
+                _componentFactories.ReplaceFactory(BuildComponentType.ConfigCache, configCacheWithOverride);
+                _componentFactories.ReplaceFactory(BuildComponentType.ResultsCache,
+                    new ResultsCacheWithOverride(cacheAggregation.ResultsCache, _buildParameters.IsolateProjects, configCacheWithOverride));
 
                 return true;
             }

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -511,22 +511,24 @@ namespace Microsoft.Build.Execution
                 _configCache = ((IBuildComponentHost)this).GetComponent(BuildComponentType.ConfigCache) as IConfigCache;
                 _resultsCache = ((IBuildComponentHost)this).GetComponent(BuildComponentType.ResultsCache) as IResultsCache;
 
-                if (!usesInputCaches && (_buildParameters.ResetCaches || _configCache.IsConfigCacheSizeLargerThanThreshold()))
+                if (usesInputCaches)
+                {
+                    return;
+                }
+
+                if ((_buildParameters.ResetCaches || _configCache.IsConfigCacheSizeLargerThanThreshold()))
                 {
                     ResetCaches();
                 }
                 else
                 {
-                    if (!usesInputCaches)
-                    {
-                        List<int> configurationsCleared = _configCache.ClearNonExplicitlyLoadedConfigurations();
+                    List<int> configurationsCleared = _configCache.ClearNonExplicitlyLoadedConfigurations();
 
-                        if (configurationsCleared != null)
+                    if (configurationsCleared != null)
+                    {
+                        foreach (int configurationId in configurationsCleared)
                         {
-                            foreach (int configurationId in configurationsCleared)
-                            {
-                                _resultsCache.ClearResultsForConfiguration(configurationId);
-                            }
+                            _resultsCache.ClearResultsForConfiguration(configurationId);
                         }
                     }
 

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2486,9 +2486,11 @@ namespace Microsoft.Build.Execution
 
                 var cacheAggregation = cacheAggregator.Aggregate();
 
-                // using caches with override (override queried first before current cache) based on the assumption that during single project cached builds
-                // there's many old results, but just one single actively building project.
-
+                // In a build session with input caches, build results from cache files are separated from new build results executed in the current build session.
+                // This separation is done to differentiate between the two types, as the output caches that will be written by the current build session
+                // should contain only the results from new builds, and should not contain old results inherited from the cache files.
+                // The override cache will contain the old build results, and the current cache will contain new results.
+                // Upon reads, both caches are interrogated (override before current), but writes should only happen in the current cache.
                 _componentFactories.ReplaceFactory(BuildComponentType.ConfigCache, new ConfigCacheWithOverride(cacheAggregation.ConfigCache));
                 _componentFactories.ReplaceFactory(BuildComponentType.ResultsCache, new ResultsCacheWithOverride(cacheAggregation.ResultsCache));
 

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -66,6 +66,24 @@ namespace Microsoft.Build.BackEnd
 
         #region IConfigCache Members
 
+        /// <inheritdoc />
+        public bool TryGetConfiguration(int configId, out BuildRequestConfiguration existingConfig)
+        {
+            lock (_lockObject)
+            {
+                if (HasConfiguration(configId))
+                {
+                    existingConfig = this[configId];
+                    return true;
+                }
+                else
+                {
+                    existingConfig = null;
+                    return false;
+                }
+            }
+        }
+
         /// <summary>
         /// Adds the specified configuration to the cache.
         /// </summary>

--- a/src/Build/BackEnd/Components/Caching/IConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/IConfigCache.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Build.BackEnd
         BuildRequestConfiguration GetMatchingConfiguration(ConfigurationMetadata configMetadata);
 
         /// <summary>
-        /// Gets a matching configuration.  If no such configration exists, one is created and optionally loaded.
+        /// Gets a matching configuration.  If no such configuration exists, one is created and optionally loaded.
         /// </summary>
         /// <param name="configMetadata">The configuration metadata to match.</param>
         /// <param name="callback">Callback to be invoked if the configuration does not exist.</param>

--- a/src/Build/BackEnd/Components/Caching/IConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/IConfigCache.cs
@@ -28,6 +28,14 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
+        /// Check existence of entry and return value if present.
+        /// </summary>
+        /// <param name="configId">The configuration id.</param>
+        /// <param name="existingConfig">Corresponding configuration if configId is present. Null otherwise</param>
+        /// <returns>True if the cache contains the configuration. False otherwise. </returns>
+        bool TryGetConfiguration(int configId, out BuildRequestConfiguration existingConfig);
+
+        /// <summary>
         /// Adds the configuration to the cache.
         /// </summary>
         /// <param name="config">The configuration to add.</param>

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Build.Execution
 
             if (overrideResult != null)
             {
+                AssertCurrentCacheDoesNotContainResult(overrideResult);
                 return overrideResult;
             }
 
@@ -73,6 +74,7 @@ namespace Microsoft.Build.Execution
             var overrideResult = _override.GetResultsForConfiguration(configurationId);
             if (overrideResult != null)
             {
+                AssertCurrentCacheDoesNotContainResult(overrideResult);
                 return overrideResult;
             }
 
@@ -93,7 +95,7 @@ namespace Microsoft.Build.Execution
 
             if (overrideRequest.Type == ResultsCacheResponseType.Satisfied)
             {
-                AssertOverrideResultIsSupersetOfCurrentResult(_override.GetResultsForConfiguration(request.ConfigurationId), additionalTargetsToCheckForOverallResult);
+                AssertCurrentCacheDoesNotContainResult(_override.GetResultsForConfiguration(request.ConfigurationId));
 
                 return overrideRequest;
             }
@@ -127,7 +129,7 @@ namespace Microsoft.Build.Execution
             return GetEnumerator();
         }
 
-        private void AssertOverrideResultIsSupersetOfCurrentResult(BuildResult overrideResult, List<string> additionalTargetsToCheckForOverallResult)
+        private void AssertCurrentCacheDoesNotContainResult(BuildResult overrideResult)
         {
             // There could be an exempt project being built for which there is already an entry in the override cache (if the exempt project is also present
             // in an input cache, for example if a project both exempts a reference, and also has a ProjectReference on it).

--- a/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCacheWithOverride.cs
@@ -8,6 +8,9 @@ using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Execution
 {
+    // This class composes two caches, an override cache and a current cache.
+    // Reads are served from both caches (override first)
+    // Writes should only happen in the current cache.
     internal class ResultsCacheWithOverride : IResultsCache
     {
         private readonly IResultsCache _override;
@@ -119,6 +122,8 @@ namespace Microsoft.Build.Execution
 
         public IEnumerator<BuildResult> GetEnumerator()
         {
+            // Enumerators do not compose both caches to limit the influence of the override cache (reduce the number of possible states out there).
+            // So far all runtime examples do not need the two composed.
             return CurrentCache.GetEnumerator();
         }
 

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1586,6 +1586,11 @@ namespace Microsoft.Build.BackEnd
                 {
                     emitNonErrorLogs(_componentHost.LoggingService);
 
+                    if (request.SkipStaticGraphIsolationConstraints)
+                    {
+                        _configCache[request.ConfigurationId].SkippedFromStaticGraphIsolationConstraints = true;
+                    }
+
                     // Ensure there is no affinity mismatch between this request and a previous request of the same configuration.
                     NodeAffinity requestAffinity = GetNodeAffinityForRequest(request);
                     NodeAffinity existingRequestAffinity = NodeAffinity.Any;

--- a/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
+++ b/src/Build/BackEnd/Shared/BuildRequestConfiguration.cs
@@ -241,6 +241,7 @@ namespace Microsoft.Build.BackEnd
             IsCacheable = other.IsCacheable;
             _configId = configId;
             TargetNames = other.TargetNames;
+            _skippedFromStaticGraphIsolationConstraints = other._skippedFromStaticGraphIsolationConstraints;
         }
 
         /// <summary>
@@ -547,6 +548,12 @@ namespace Microsoft.Build.BackEnd
             set => _resultsNodeId = value;
         }
 
+        public bool SkippedFromStaticGraphIsolationConstraints
+        {
+            get => _skippedFromStaticGraphIsolationConstraints;
+            set => _skippedFromStaticGraphIsolationConstraints = value;
+        }
+
         /// <summary>
         /// Implementation of the equality operator.
         /// </summary>
@@ -678,6 +685,7 @@ namespace Microsoft.Build.BackEnd
         }
 
         private Func<string, bool> shouldSkipStaticGraphIsolationOnReference;
+        private bool _skippedFromStaticGraphIsolationConstraints;
 
         public bool ShouldSkipIsolationConstraintsForReference(string referenceFullPath)
         {
@@ -804,6 +812,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _resultsNodeId);
             translator.Translate(ref _savedCurrentDirectory);
             translator.TranslateDictionary(ref _savedEnvironmentVariables, StringComparer.OrdinalIgnoreCase);
+            translator.Translate(ref _skippedFromStaticGraphIsolationConstraints);
 
             // if the entire state is translated, then the transferred state, if exists, represents the full evaluation data
             if (_translateEntireProjectInstanceState &&
@@ -823,6 +832,7 @@ namespace Microsoft.Build.BackEnd
             translator.Translate(ref _projectDefaultTargets);
             translator.Translate(ref _projectInitialTargets);
             translator.TranslateDictionary(ref _globalProperties, ProjectPropertyInstance.FactoryForDeserialization);
+            translator.Translate(ref _skippedFromStaticGraphIsolationConstraints);
         }
 
         /// <summary>

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1248,14 +1248,14 @@ namespace Microsoft.Build.UnitTests
                 });
         }
 
-        internal static void ShouldBeEquivalentTo<K, V>(this IDictionary<K, V> a, IReadOnlyDictionary<K, V> b)
+        internal static void ShouldBeSameIgnoringOrder<K, V>(this IDictionary<K, V> a, IReadOnlyDictionary<K, V> b)
         {
             a.ShouldBeSubsetOf(b);
             b.ShouldBeSubsetOf(a);
             a.Count.ShouldBe(b.Count);
         }
 
-        internal static void ShouldBeEquivalentTo<K>(this IEnumerable<K> a, IEnumerable<K> b)
+        internal static void ShouldBeSameIgnoringOrder<K>(this IEnumerable<K> a, IEnumerable<K> b)
         {
             a.ShouldBeSubsetOf(b);
             b.ShouldBeSubsetOf(a);

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1569,6 +1569,28 @@ namespace Microsoft.Build.UnitTests
 
         internal static ProjectGraph CreateProjectGraph(
             TestEnvironment env,
+            IDictionary<int, int[]> dependencyEdges,
+            IDictionary<int, string> extraContentPerProjectNumber)
+        {
+            return CreateProjectGraph(
+                env: env,
+                dependencyEdges: dependencyEdges,
+                globalProperties: null,
+                createProjectFile: (environment, projectNumber, references, projectReferenceTargets, defaultTargets, extraContent) =>
+                {
+                    extraContentPerProjectNumber.ShouldContainKey(projectNumber);
+                    return CreateProjectFile(
+                        environment,
+                        projectNumber,
+                        references,
+                        projectReferenceTargets,
+                        defaultTargets,
+                        extraContentPerProjectNumber[projectNumber].Cleanup());
+                });
+        }
+
+        internal static ProjectGraph CreateProjectGraph(
+            TestEnvironment env,
             // direct dependencies that the kvp.key node has on the nodes represented by kvp.value
             IDictionary<int, int[]> dependencyEdges,
             IDictionary<string, string> globalProperties = null,
@@ -1576,7 +1598,7 @@ namespace Microsoft.Build.UnitTests
             IEnumerable<int> entryPoints = null,
             ProjectCollection projectCollection = null)
         {
-            createProjectFile = createProjectFile ?? CreateProjectFile;
+            createProjectFile ??= CreateProjectFile;
 
             var nodes = new Dictionary<int, (bool IsRoot, string ProjectPath)>();
 

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -1915,11 +1915,11 @@ namespace Microsoft.Build.UnitTests
                 _buildManager.BeginBuild(actualBuildParameters, deferredMessages);
             }
 
-            public BuildResult BuildProjectFile(string projectFile, string[] entryTargets = null)
+            public BuildResult BuildProjectFile(string projectFile, string[] entryTargets = null, Dictionary<string, string> globalProperties = null)
             {
                 var buildResult = _buildManager.BuildRequest(
                     new BuildRequestData(projectFile,
-                        new Dictionary<string, string>(),
+                        globalProperties ?? new Dictionary<string, string>(),
                         MSBuildConstants.CurrentToolsVersion,
                         entryTargets ?? new string[0],
                         null));


### PR DESCRIPTION
Fixes #4386

This PR fixes the bug cascade that results when exempting projects from graph isolation that also exist in the graph. It implements this region of the docs: https://github.com/microsoft/msbuild/compare/master...cdmihai:cacheAndIsolationDocumentation?expand=1#diff-5de82af4d8f52787d69b38fd58c509caR44

When a reference is exempt from isolation constraints, there can be multiple situations:
- the reference does not exist in the graph, or in the input caches files. This is what the original exemption feature was designed for, and it worked great for enabling WPF's on the fly generated projects work with isolation. All the following scenarios were not supported, and fixed in this PR.
- the reference exists in one or more input cache files. This causes part of the failures in #4386.  There are multiple sub cases here:
  - the reference is in the input cache, but its build results are not a superset of the current project's requests. This happens when the exempt project is in the input cache with results for other targets than the ones requested by the current project. 
  - the reference is in the  input cache and is a superset of the current project's requests.

Things this PR changes:
1. If the CacheAggregator detects conflicting incoming cache entries (conflicting instances of BuldRequestConfiguration and BuildResult), instead of erroring it will now merge them using the "first entry wins" strategy. BuildResults are merged at the level of individual target results. This allows multiple projects to exempt the same reference.
3. A BuildRequestConfiguration is marked as exempt (new bool field) whenever a building project marks it as exempt.
4. The override caches (ConfigCacheWithOverride, BuildResultsWithOverride) always ensure an entry is either in the override cache, or the current cache, but not in both.
  a. An exception here is the BuildResultsWithOverride cache, where an exempt configuration can appear in both caches, This happens when the exempt project is present in the input caches, but does not have target results that the current project wants to build. In this case, two things happen. In the ConfigWithOverride cache, the entry is migrated from the override cache to the current cache. In the BuildResultsWithOverride cache, The override entry gets the new, additional targets (not ideal, but it would be super hard to change), and the current cache gets only the newly built targets, to ensure the invariant that the current cache should only contain newly built things, and should never contain results from deserialized caches..

