### PR TITLE
Refactor translator APIs

### DIFF
--- a/src/Build.UnitTests/Collections/OMcollections_tests.cs
+++ b/src/Build.UnitTests/Collections/OMcollections_tests.cs
@@ -16,6 +16,7 @@ using Microsoft.Build.UnitTests.BackEnd;
 using Shouldly;
 using ObjectModel = System.Collections.ObjectModel;
 using Xunit;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.UnitTests.OM.Collections
 {

--- a/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
+++ b/src/Build.UnitTests/Construction/ElementLocation_Tests.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Reflection;
 using Xunit;
 using System.Text;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.UnitTests.Construction
 {

--- a/src/Build.UnitTests/Instance/ProjectMetadataInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectMetadataInstance_Internal_Tests.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Construction;
 using Microsoft.Build.UnitTests.BackEnd;
 using Xunit;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.UnitTests.OM.Instance
 {

--- a/src/Build.UnitTests/Instance/ProjectPropertyInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectPropertyInstance_Internal_Tests.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Evaluation;
 using Microsoft.Build.Construction;
 using Microsoft.Build.UnitTests.BackEnd;
 using Xunit;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.UnitTests.OM.Instance
 {

--- a/src/Build.UnitTests/Instance/TaskItem_Tests.cs
+++ b/src/Build.UnitTests/Instance/TaskItem_Tests.cs
@@ -13,6 +13,7 @@ using System.Xml;
 using Microsoft.Build.Framework;
 using System.IO;
 using Xunit;
+using Microsoft.Build.BackEnd;
 
 namespace Microsoft.Build.UnitTests.OM.Instance
 {

--- a/src/Build/BackEnd/BuildManager/RequestedProjectState.cs
+++ b/src/Build/BackEnd/BuildManager/RequestedProjectState.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Build.Execution
             return new Dictionary<string, List<string>>(capacity, StringComparer.OrdinalIgnoreCase);
         }
 
-        private static void TranslateMetadataForItem(ref List<string> list, ITranslator translator)
+        private static void TranslateMetadataForItem(ITranslator translator, ref List<string> list)
         {
             translator.Translate(ref list);
         }
 
-        private static void TranslateString(ref string s, ITranslator translator)
+        private static void TranslateString(ITranslator translator, ref string s)
         {
             translator.Translate(ref s);
         }

--- a/src/Build/BackEnd/Components/Caching/ConfigCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ConfigCache.cs
@@ -348,8 +348,8 @@ namespace Microsoft.Build.BackEnd
         {
             translator.TranslateDictionary(
                 ref _configurations,
-                (ref int configId, ITranslator aTranslator) => aTranslator.Translate(ref configId),
-                (ref BuildRequestConfiguration configuration, ITranslator aTranslator) =>
+                (ITranslator aTranslator, ref int configId) => aTranslator.Translate(ref configId),
+                (ITranslator aTranslator, ref BuildRequestConfiguration configuration) =>
                 {
                     if (translator.Mode == TranslationDirection.WriteToStream)
                     {
@@ -365,8 +365,8 @@ namespace Microsoft.Build.BackEnd
 
             translator.TranslateDictionary(
                 ref _configurationIdsByMetadata,
-                (ref ConfigurationMetadata configMetadata, ITranslator aTranslator) => aTranslator.Translate(ref configMetadata, ConfigurationMetadata.FactoryForDeserialization),
-                (ref int configId, ITranslator aTranslator) => aTranslator.Translate(ref configId),
+                (ITranslator aTranslator, ref ConfigurationMetadata configMetadata) => aTranslator.Translate(ref configMetadata, ConfigurationMetadata.FactoryForDeserialization),
+                (ITranslator aTranslator, ref int configId) => aTranslator.Translate(ref configId),
                 capacity => new Dictionary<ConfigurationMetadata, int>(capacity));
         }
 

--- a/src/Build/BackEnd/Components/Caching/ResultsCache.cs
+++ b/src/Build/BackEnd/Components/Caching/ResultsCache.cs
@@ -243,8 +243,8 @@ namespace Microsoft.Build.BackEnd
 
             translator.TranslateDictionary(
                 ref localReference,
-                (ref int i, ITranslator aTranslator) => aTranslator.Translate(ref i),
-                (ref BuildResult result, ITranslator aTranslator) => aTranslator.Translate(ref result),
+                (ITranslator aTranslator, ref int i) => aTranslator.Translate(ref i),
+                (ITranslator aTranslator, ref BuildResult result) => aTranslator.Translate(ref result),
                 capacity => new ConcurrentDictionary<int, BuildResult>(Environment.ProcessorCount, capacity));
 
             if (translator.Mode == TranslationDirection.ReadFromStream)

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2045,13 +2045,13 @@ namespace Microsoft.Build.Execution
         }
 
         // todo move to nested function after c#7
-        private static void TranslatorForTargetSpecificDictionaryKey(ref string key, ITranslator translator)
+        private static void TranslatorForTargetSpecificDictionaryKey(ITranslator translator, ref string key)
         {
             translator.Translate(ref key);
         }
 
         // todo move to nested function after c#7
-        private static void TranslatorForTargetSpecificDictionaryValue(ref List<TargetSpecification> value, ITranslator translator)
+        private static void TranslatorForTargetSpecificDictionaryValue(ITranslator translator, ref List<TargetSpecification> value)
         {
             translator.Translate(ref value, TargetSpecification.FactoryForDeserialization);
         }

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -391,12 +391,12 @@ namespace Microsoft.Build.Execution
             }
         }
 
-        private static void ParametersKeyTranslator(ref string key, ITranslator translator)
+        private static void ParametersKeyTranslator(ITranslator translator, ref string key)
         {
             translator.Translate(ref key);
         }
 
-        private static void ParametersValueTranslator(ref Tuple<string, ElementLocation> value, ITranslator translator)
+        private static void ParametersValueTranslator(ITranslator translator, ref Tuple<string, ElementLocation> value)
         {
             if (translator.Mode == TranslationDirection.WriteToStream)
             {

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -1707,13 +1707,13 @@ namespace Microsoft.Build.Execution
                 }
 
                 // todo move to nested function after C# 7
-                private static void TranslatorForTaskParametersKey(ref string key, ITranslator translator)
+                private static void TranslatorForTaskParametersKey(ITranslator translator, ref string key)
                 {
                     translator.Translate(ref key);
                 }
 
                 // todo move to nested function after C# 7
-                private static void TranslatorForTaskParameterValue(ref TaskPropertyInfo taskPropertyInfo, ITranslator translator)
+                private static void TranslatorForTaskParameterValue(ITranslator translator, ref TaskPropertyInfo taskPropertyInfo)
                 {
                     string name = null;
                     string propertyTypeName = null;
@@ -1783,13 +1783,13 @@ namespace Microsoft.Build.Execution
         }
 
         //todo make nested after C# 7
-        void TranslateTaskRegistrationKey(ref RegisteredTaskIdentity taskIdentity, ITranslator translator)
+        void TranslateTaskRegistrationKey(ITranslator translator, ref RegisteredTaskIdentity taskIdentity)
         {
             translator.Translate(ref taskIdentity);
         }
 
         //todo make nested after C# 7
-        void TranslateTaskRegistrationValue(ref List<RegisteredTaskRecord> taskRecords, ITranslator translator)
+        void TranslateTaskRegistrationValue(ITranslator translator, ref List<RegisteredTaskRecord> taskRecords)
         {
             translator.Translate(ref taskRecords, RegisteredTaskRecord.FactoryForDeserialization);
         }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -140,6 +140,7 @@
     </Compile>
     <Compile Include="..\Shared\TaskParameter.cs" />
     <Compile Include="..\Shared\TaskParameterTypeVerifier.cs" />
+    <Compile Include="..\Shared\TranslatorHelpers.cs" />
     <Compile Include="..\Shared\CommunicationsUtilities.cs" />
     <Compile Include="..\Shared\InterningBinaryReader.cs" />
     <Compile Include="..\Shared\TaskEngineAssemblyResolver.cs">

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -126,6 +126,7 @@
     <Compile Include="..\Shared\INodePacketHandler.cs" />
     <Compile Include="..\Shared\ITranslatable.cs" />
     <Compile Include="..\Shared\ITranslator.cs" />
+    <Compile Include="..\Shared\TranslatorHelpers.cs" />
     <Compile Include="..\Shared\BinaryTranslator.cs" />
     <Compile Include="..\Shared\CommunicationsUtilities.cs" />
     <Compile Include="..\Shared\InterningBinaryReader.cs" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -92,6 +92,7 @@
     <Compile Include="..\Shared\ITranslator.cs">
       <Link>ITranslator.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\TranslatorHelpers.cs" />
     <Compile Include="..\Shared\InternalErrorException.cs">
       <Link>InternalErrorException.cs</Link>
     </Compile>

--- a/src/Shared/ITranslatable.cs
+++ b/src/Shared/ITranslatable.cs
@@ -4,13 +4,6 @@
 namespace Microsoft.Build.BackEnd
 {
     /// <summary>
-    /// Delegate for users that want to translate an arbitrary structure that cannot implement <see cref="ITranslatable"/> (e.g. translating a complex collection)
-    /// </summary>
-    /// <param name="translator">the translator</param>
-    /// <param name="obj">the object to translate</param>
-    internal delegate void Translator<T>(ref T obj, ITranslator translator);
-
-    /// <summary>
     /// An interface representing an object which may be serialized by the node packet serializer.
     /// </summary>
     internal interface ITranslatable

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -17,6 +17,13 @@ namespace Microsoft.Build.BackEnd
     internal delegate T NodePacketValueFactory<T>(ITranslator translator);
 
     /// <summary>
+    /// Delegate for users that want to translate an arbitrary structure that doesn't implement <see cref="ITranslatable"/> (e.g. translating a complex collection)
+    /// </summary>
+    /// <param name="translator">the translator</param>
+    /// <param name="objectToTranslate">the object to translate</param>
+    internal delegate void ObjectTranslator<T>(ITranslator translator, ref T objectToTranslate);
+
+    /// <summary>
     /// This delegate is used to create arbitrary collection types for serialization.
     /// </summary>
     /// <typeparam name="T">The type of dictionary to be created.</typeparam>
@@ -161,7 +168,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="list">The list to be translated.</param>
         /// <param name="factory">factory to create type T</param>
         /// <typeparam name="T">A TaskItemType</typeparam>
-        void Translate<T>(ref List<T> list, NodePacketValueFactory<T> factory) where T : ITranslatable;
+        void Translate<T>(ref List<T> list, ObjectTranslator<T> objectTranslator);
 
         /// <summary>
         /// Translates a list of T where T implements INodePacketTranslateable using a collection factory
@@ -171,7 +178,7 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">An ITranslatable subtype</typeparam>
         /// <typeparam name="L">An IList subtype</typeparam>
         /// <param name="collectionFactory">factory to create a collection</param>
-        void Translate<T, L>(ref IList<T> list, NodePacketValueFactory<T> factory, NodePacketCollectionCreator<L> collectionFactory) where T : ITranslatable where L : IList<T>;
+        void Translate<T, L>(ref IList<T> list, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<L> collectionFactory) where L : IList<T>;
 
         /// <summary>
         /// Translates a DateTime.
@@ -241,16 +248,6 @@ namespace Microsoft.Build.BackEnd
             where T : ITranslatable, new();
 
         /// <summary>
-        /// Translates an object implementing INodePacketTranslatable which does not expose a
-        /// public parameterless constructor.
-        /// </summary>
-        /// <typeparam name="T">The reference type.</typeparam>
-        /// <param name="value">The value to be translated.</param>
-        /// <param name="factory">The factory method used to instantiate values of type T.</param>
-        void Translate<T>(ref T value, NodePacketValueFactory<T> factory)
-            where T : ITranslatable;
-
-        /// <summary>
         /// Translates a culture
         /// </summary>
         /// <param name="culture">The culture</param>
@@ -271,13 +268,12 @@ namespace Microsoft.Build.BackEnd
             where T : ITranslatable, new();
 
         /// <summary>
-        /// Translates an array of objects implementing INodePacketTranslatable requiring a factory to create.
+        /// Translates an array of objects.
         /// </summary>
         /// <typeparam name="T">The reference type.</typeparam>
         /// <param name="array">The array to be translated.</param>
-        /// <param name="factory">The factory method used to instantiate values of type T.</param>
-        void TranslateArray<T>(ref T[] array, NodePacketValueFactory<T> factory)
-            where T : ITranslatable;
+        /// <param name="objectTranslator">The delegate method used to translate values of type T.</param>
+        void TranslateArray<T>(ref T[] array, ObjectTranslator<T> objectTranslator);
 
         /// <summary>
         /// Translates a dictionary of { string, string }.
@@ -288,7 +284,7 @@ namespace Microsoft.Build.BackEnd
 
         void TranslateDictionary(ref IDictionary<string, string> dictionary, NodePacketCollectionCreator<IDictionary<string, string>> collectionCreator);
 
-        void TranslateDictionary<K, V>(ref IDictionary<K, V> dictionary, Translator<K> keyTranslator, Translator<V> valueTranslator, NodePacketCollectionCreator<IDictionary<K, V>> dictionaryCreator);
+        void TranslateDictionary<K, V>(ref IDictionary<K, V> dictionary, ObjectTranslator<K> keyTranslator, ObjectTranslator<V> valueTranslator, NodePacketCollectionCreator<IDictionary<K, V>> dictionaryCreator);
 
         /// <summary>
         /// Translates a dictionary of { string, T }.  
@@ -297,8 +293,8 @@ namespace Microsoft.Build.BackEnd
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="comparer">The comparer used to instantiate the dictionary.</param>
         /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
-        void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, NodePacketValueFactory<T> valueFactory)
-            where T : class, ITranslatable;
+        void TranslateDictionary<T>(ref Dictionary<string, T> dictionary, IEqualityComparer<string> comparer, ObjectTranslator<T> objectTranslator)
+            where T : class;
 
         /// <summary>
         /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
@@ -307,9 +303,9 @@ namespace Microsoft.Build.BackEnd
         /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
-        void TranslateDictionary<D, T>(ref D dictionary, NodePacketValueFactory<T> valueFactory)
+        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator)
             where D : IDictionary<string, T>, new()
-            where T : class, ITranslatable;
+            where T : class;
 
         /// <summary>
         /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
@@ -319,9 +315,9 @@ namespace Microsoft.Build.BackEnd
         /// <param name="dictionary">The dictionary to be translated.</param>
         /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
         /// <param name="collectionCreator">A factory used to create the dictionary.</param>
-        void TranslateDictionary<D, T>(ref D dictionary, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<D> collectionCreator)
+        void TranslateDictionary<D, T>(ref D dictionary, ObjectTranslator<T> objectTranslator, NodePacketCollectionCreator<D> collectionCreator)
             where D : IDictionary<string, T>
-            where T : class, ITranslatable;
+            where T : class;
 
         /// <summary>
         /// Translates the boolean that says whether this value is null or not

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Build.BackEnd
+{
+    internal static class TranslatorHelpers
+    {
+        /// <summary>
+        /// Translates an object implementing <see cref="ITranslatable"/> which does not expose a
+        /// public parameterless constructor.
+        /// </summary>
+        /// <typeparam name="T">The reference type.</typeparam>
+        /// <param name="translator">The translator</param>
+        /// <param name="instance">The value to be translated.</param>
+        /// <param name="factory">The factory method used to instantiate values of type T.</param>
+        public static void Translate<T>(
+            this ITranslator translator,
+            ref T instance,
+            NodePacketValueFactory<T> valueFactory) where T : ITranslatable
+        {
+            if (translator.Mode == TranslationDirection.ReadFromStream)
+            {
+                instance = valueFactory(translator);
+            }
+            else
+            {
+                instance.Translate(translator);
+            }
+        }
+
+        public static void Translate<T>(
+            this ITranslator translator,
+            ref List<T> list,
+            NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.Translate(ref list, objectTranslator);
+        }
+
+        public static void Translate<T, L>(
+            this ITranslator translator,
+            ref IList<T> list,
+            NodePacketValueFactory<T> valueFactory,
+            NodePacketCollectionCreator<L> collectionFactory) where L : IList<T> where T : ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.Translate(ref list, objectTranslator, collectionFactory);
+        }
+
+        public static void TranslateArray<T>(
+            this ITranslator translator,
+            ref T[] array,
+            NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.TranslateArray(ref array, objectTranslator);
+        }
+
+        public static void TranslateDictionary<T>(
+            this ITranslator translator,
+            ref Dictionary<string, T> dictionary,
+            IEqualityComparer<string> comparer,
+            NodePacketValueFactory<T> valueFactory) where T : class, ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.TranslateDictionary(ref dictionary, comparer, objectTranslator);
+        }
+
+        public static void TranslateDictionary<D, T>(
+            this ITranslator translator,
+            ref D dictionary,
+            NodePacketValueFactory<T> valueFactory)
+            where D : IDictionary<string, T>, new()
+            where T : class, ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.TranslateDictionary(ref dictionary, (ObjectTranslator<T>) objectTranslator);
+        }
+
+        public static void TranslateDictionary<D, T>(
+            this ITranslator translator,
+            ref D dictionary,
+            NodePacketValueFactory<T> valueFactory,
+            NodePacketCollectionCreator<D> collectionCreator)
+            where D : IDictionary<string, T>
+            where T : class, ITranslatable
+        {
+            void objectTranslator(ITranslator t2, ref T objectToTranslate)
+            {
+                if (t2.Mode == TranslationDirection.ReadFromStream)
+                {
+                    objectToTranslate = valueFactory(t2);
+                }
+                else
+                {
+                    objectToTranslate.Translate(t2);
+                }
+            }
+
+            translator.TranslateDictionary(ref dictionary, (ObjectTranslator<T>) objectTranslator, collectionCreator);
+        }
+
+
+        public static void TranslatableTranslator<T>(ITranslator t, ref T objectToTranslate) where T : class, ITranslatable, new()
+        {
+            objectToTranslate = null;
+            if (t.Mode == TranslationDirection.ReadFromStream)
+            {
+                objectToTranslate = new T();
+            }
+            objectToTranslate.Translate(t);
+        }
+
+        public static void FactoryAdapter<T>(ITranslator t, ref T objectToTranslate, Func<ITranslator, T> factoryForDeserialization)
+            where T : ITranslatable
+        {
+            if (t.Mode == TranslationDirection.ReadFromStream)
+            {
+                objectToTranslate = factoryForDeserialization(t);
+            }
+            else
+            {
+                objectToTranslate.Translate(t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
ITranslator methods now take an ObjectTranslator delegate which can translate an object in both directions, as opposed to requiring that objects implement ITranslatable and that a factory be passed in.

The TranslatorHelpers class includes extension methods which support the old APIs, so call sites that use ITranslatable objects and NodePacketValueFactory still work.