### PR TITLE
Reduce allocations in ItemGroupLoggingHelper.

### DIFF
--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Build.BackEnd
             bucket.Expander.Metadata = metadataTable;
 
             // Second, expand the item include and exclude, and filter existing metadata as appropriate.
-            IList<ProjectItemInstance> itemsToAdd = ExpandItemIntoItems(child, bucket.Expander, keepMetadata, removeMetadata);
+            List<ProjectItemInstance> itemsToAdd = ExpandItemIntoItems(child, bucket.Expander, keepMetadata, removeMetadata);
 
             // Third, expand the metadata.           
             foreach (ProjectItemGroupTaskMetadataInstance metadataInstance in child.Metadata)
@@ -202,7 +202,10 @@ namespace Microsoft.Build.BackEnd
 
             if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToAdd != null && itemsToAdd.Count > 0)
             {
-                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("ItemGroupIncludeLogMessagePrefix"), child.ItemType, itemsToAdd.ToArray());
+                var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
+                    ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix,
+                    child.ItemType,
+                    itemsToAdd);
                 LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
@@ -231,7 +234,10 @@ namespace Microsoft.Build.BackEnd
             {
                 if (LogTaskInputs && !LoggingContext.LoggingService.OnlyLogCriticalEvents && itemsToRemove.Count > 0)
                 {
-                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("ItemGroupRemoveLogMessage"), child.ItemType, itemsToRemove.ToArray());
+                    var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
+                        ItemGroupLoggingHelper.ItemGroupRemoveLogMessage,
+                        child.ItemType,
+                        itemsToRemove);
                     LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 
@@ -333,7 +339,7 @@ namespace Microsoft.Build.BackEnd
         /// been refactored.
         /// </remarks>
         /// <returns>A list of items.</returns>
-        private IList<ProjectItemInstance> ExpandItemIntoItems
+        private List<ProjectItemInstance> ExpandItemIntoItems
         (
             ProjectItemGroupTaskItemInstance originalItem,
             Expander<ProjectPropertyInstance, ProjectItemInstance> expander,
@@ -344,7 +350,7 @@ namespace Microsoft.Build.BackEnd
             //todo this is duplicated logic with the item computation logic from evaluation (in LazyIncludeOperation.SelectItems)
 
             ProjectErrorUtilities.VerifyThrowInvalidProject(!(keepMetadata != null && removeMetadata != null), originalItem.KeepMetadataLocation, "KeepAndRemoveMetadataMutuallyExclusive");
-            IList<ProjectItemInstance> items = new List<ProjectItemInstance>();
+            List<ProjectItemInstance> items = new List<ProjectItemInstance>();
 
             // Expand properties and metadata in Include
             string evaluatedInclude = expander.ExpandIntoStringLeaveEscaped(originalItem.Include, ExpanderOptions.ExpandPropertiesAndMetadata, originalItem.IncludeLocation);

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -16,13 +16,10 @@ namespace Microsoft.Build.BackEnd
     /// </summary>
     internal static class ItemGroupLoggingHelper
     {
-        /// <summary>
-        /// Gets a text serialized value of a parameter for logging.
-        /// </summary>
-        internal static string GetParameterText(string prefix, string parameterName, params object[] parameterValues)
-        {
-            return GetParameterText(prefix, parameterName, (IList)parameterValues);
-        }
+        internal static string ItemGroupIncludeLogMessagePrefix = ResourceUtilities.GetResourceString("ItemGroupIncludeLogMessagePrefix");
+        internal static string ItemGroupRemoveLogMessage = ResourceUtilities.GetResourceString("ItemGroupRemoveLogMessage");
+        internal static string OutputItemParameterMessagePrefix = ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix");
+        internal static string TaskParameterPrefix = ResourceUtilities.GetResourceString("TaskParameterPrefix");
 
         /// <summary>
         /// Gets a text serialized value of a parameter for logging.
@@ -56,7 +53,8 @@ namespace Microsoft.Build.BackEnd
                     sb.Append("\n    ");
                 }
 
-                sb.Append(parameterName + "=");
+                sb.Append(parameterName);
+                sb.Append('=');
 
                 if (!specialTreatmentForSingle)
                 {
@@ -75,7 +73,7 @@ namespace Microsoft.Build.BackEnd
                         sb.Append("        ");
                     }
 
-                    sb.Append(GetStringFromParameterValue(parameterValue[i]));
+                    AppendStringFromParameterValue(sb, parameterValue[i]);
 
                     if (!specialTreatmentForSingle && i < parameterValue.Count - 1)
                     {
@@ -95,53 +93,93 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         internal static string GetStringFromParameterValue(object parameterValue)
         {
-            var type = parameterValue.GetType();
-
-            ErrorUtilities.VerifyThrow(!type.IsArray, "scalars only");
-
-            if (type == typeof(string))
+            // fast path for the common case
+            if (parameterValue is string valueText)
             {
-                return (string)parameterValue;
+                return valueText;
             }
-            else if (type.GetTypeInfo().IsValueType)
+
+            using (var sb = new ReuseableStringBuilder())
             {
-                return (string)Convert.ChangeType(parameterValue, typeof(string), CultureInfo.CurrentCulture);
+                AppendStringFromParameterValue(sb, parameterValue);
+                return sb.ToString();
             }
-            else if (typeof(ITaskItem).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+        }
+
+        // Avoid allocating a temporary list to hold metadata for sorting every time.
+        // Each thread gets its own copy.
+        [ThreadStatic]
+        private static List<KeyValuePair<string, string>> keyValuePairList;
+
+        private static void AppendStringFromParameterValue(ReuseableStringBuilder sb, object parameterValue)
+        {
+            if (parameterValue is string text)
             {
-                var item = ((ITaskItem)parameterValue);
-                string result = item.ItemSpec;
+                sb.Append(text);
+            }
+            else if (parameterValue is ITaskItem item)
+            {
+                sb.Append(item.ItemSpec);
 
                 var customMetadata = item.CloneCustomMetadata();
+                int count = customMetadata.Count;
 
-                if (customMetadata.Count > 0)
+                if (count > 0)
                 {
-                    result += "\n";
-                    var names = new List<string>();
+                    sb.Append('\n');
 
-                    foreach (string name in customMetadata.Keys)
+                    // need to initialize the thread static on each new thread
+                    if (keyValuePairList == null)
                     {
-                        names.Add(name);
+                        keyValuePairList = new List<KeyValuePair<string, string>>(count);
                     }
 
-                    names.Sort();
-
-                    for (int i = 0; i < names.Count; i++)
+                    var customMetadataDictionary = customMetadata as IDictionary<string, string>;
+                    if (customMetadataDictionary != null)
                     {
-                        result += "                " + names[i] + "=" + customMetadata[names[i]];
-
-                        if (i < names.Count - 1)
+                        foreach (KeyValuePair<string, string> kvp in customMetadataDictionary)
                         {
-                            result += "\n";
+                            keyValuePairList.Add(kvp);
                         }
                     }
+                    else
+                    {
+                        foreach (DictionaryEntry kvp in customMetadata)
+                        {
+                            keyValuePairList.Add(new KeyValuePair<string, string>((string)kvp.Key, (string)kvp.Value));
+                        }
+                    }
+
+                    if (count > 1)
+                    {
+                        keyValuePairList.Sort((l, r) => StringComparer.OrdinalIgnoreCase.Compare(l.Key, r.Key));
+                    }
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var kvp = keyValuePairList[i];
+                        sb.Append("                ");
+                        sb.Append(kvp.Key);
+                        sb.Append('=');
+                        sb.Append(kvp.Value);
+
+                        if (i < count - 1)
+                        {
+                            sb.Append('\n');
+                        }
+                    }
+
+                    keyValuePairList.Clear();
                 }
-
-                return result;
             }
-
-            ErrorUtilities.ThrowInternalErrorUnreachable();
-            return null;
+            else if (parameterValue.GetType().GetTypeInfo().IsValueType)
+            {
+                sb.Append((string)Convert.ChangeType(parameterValue, typeof(string), CultureInfo.CurrentCulture));
+            }
+            else
+            {
+                ErrorUtilities.ThrowInternalErrorUnreachable();
+            }
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupLoggingHelper.cs
@@ -134,8 +134,7 @@ namespace Microsoft.Build.BackEnd
                         keyValuePairList = new List<KeyValuePair<string, string>>(count);
                     }
 
-                    var customMetadataDictionary = customMetadata as IDictionary<string, string>;
-                    if (customMetadataDictionary != null)
+                    if (customMetadata is IDictionary<string, string> customMetadataDictionary)
                     {
                         foreach (KeyValuePair<string, string> kvp in customMetadataDictionary)
                         {
@@ -172,7 +171,7 @@ namespace Microsoft.Build.BackEnd
                     keyValuePairList.Clear();
                 }
             }
-            else if (parameterValue.GetType().GetTypeInfo().IsValueType)
+            else if (parameterValue.GetType().IsValueType)
             {
                 sb.Append((string)Convert.ChangeType(parameterValue, typeof(string), CultureInfo.CurrentCulture));
             }

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1285,8 +1285,10 @@ namespace Microsoft.Build.BackEnd
         {
             if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameterValue.Count > 0)
             {
-                string parameterText = ResourceUtilities.GetResourceString("TaskParameterPrefix");
-                parameterText = ItemGroupLoggingHelper.GetParameterText(parameterText, parameter.Name, parameterValue);
+                string parameterText = ItemGroupLoggingHelper.GetParameterText(
+                    ItemGroupLoggingHelper.TaskParameterPrefix,
+                    parameter.Name,
+                    parameterValue);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
@@ -1312,7 +1314,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     _taskLoggingContext.LogCommentFromText(
                         MessageImportance.Low,
-                        ResourceUtilities.GetResourceString("TaskParameterPrefix") + parameter.Name + "=" + ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
+                        ItemGroupLoggingHelper.TaskParameterPrefix + parameter.Name + "=" + ItemGroupLoggingHelper.GetStringFromParameterValue(parameterValue));
                 }
             }
 
@@ -1426,7 +1428,7 @@ namespace Microsoft.Build.BackEnd
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
-                            ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix"),
+                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
                             outputs);
 
@@ -1501,7 +1503,10 @@ namespace Microsoft.Build.BackEnd
 
                     if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
                     {
-                        string parameterText = ItemGroupLoggingHelper.GetParameterText(ResourceUtilities.GetResourceString("OutputItemParameterMessagePrefix"), outputTargetName, outputs);
+                        string parameterText = ItemGroupLoggingHelper.GetParameterText(
+                            ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
+                            outputTargetName,
+                            outputs);
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }


### PR DESCRIPTION
This code is a very hot path (though only hit when LogTaskInputs is set).
There was an n^2 string concatenation problem alongside with other easily avoidable allocations.
Cache resource strings to avoid extracting them from resources every time.
Use a ThreadStatic field to avoid allocating an array every time.
Sorting key value pairs in place is 3x faster than LINQ OrderBy.

Remove an overload of GetParameterText that accepts params. Everyone calling it was calling an unnecessary ToArray().
Use List instead of IList to be able to call the overload that accepts IList.