### PR TITLE
Fast path when evaluating string.PadLeft(int, char)

### DIFF
--- a/src/Build.UnitTests/Evaluation/Expander_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/Expander_Tests.cs
@@ -3889,6 +3889,12 @@ $(
         }
 
         [Fact]
+        public void PropertyFunctionStringPadLeftChar()
+        {
+            TestPropertyFunction("$(VersionSuffixBuildOfTheDay.PadLeft(3, $([System.Convert]::ToChar(`0`))))", "VersionSuffixBuildOfTheDay", "4", "004");
+        }
+
+        [Fact]
         public void PropertyFunctionStringPadRight1()
         {
             TestPropertyFunction("$(prop.PadRight(2))", "prop", "x", "x ");

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -4251,6 +4251,11 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 arg1 = args[1] as string;
+                if (arg1 == null && args[1] is char ch)
+                {
+                    arg1 = ch.ToString();
+                }
+
                 if (TryConvertToInt(args[0], out arg0) &&
                     arg1 != null)
                 {


### PR DESCRIPTION
The previous fast path was only expecting the args of int and string, but was actually given int and char. So the fast path was not taken for expressions such as:

$(VersionSuffixBuildOfTheDay.PadLeft(2, $([System.Convert]::ToChar(`0`))))

Try to interpret int and char as int and string, this ensures the fast path is taken.

This fixes a first-chance MissingMethodException.