### PR TITLE
Don't fail deserialization of item-spec project item metadata

### DIFF
--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1617,7 +1617,7 @@ namespace Microsoft.Build.Execution
                         {
                             int key = translator.Reader.ReadInt32();
                             int value = translator.Reader.ReadInt32();
-                            _directMetadata.Set(new ProjectMetadataInstance(interner.GetString(key), interner.GetString(value)));
+                            _directMetadata.Set(new ProjectMetadataInstance(interner.GetString(key), interner.GetString(value), true /* allow built-in metadata names */));
                         }
                     }
                 }

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1617,7 +1617,7 @@ namespace Microsoft.Build.Execution
                         {
                             int key = translator.Reader.ReadInt32();
                             int value = translator.Reader.ReadInt32();
-                            _directMetadata.Set(new ProjectMetadataInstance(interner.GetString(key), interner.GetString(value), true /* allow built-in metadata names */));
+                            _directMetadata.Set(new ProjectMetadataInstance(interner.GetString(key), interner.GetString(value), allowItemSpecModifiers: true));
                         }
                     }
                 }

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
+using System.Collections.Generic;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Tasks;
 using Microsoft.Build.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using Shouldly;
 
 namespace Microsoft.Build.UnitTests
 {
@@ -154,6 +158,45 @@ namespace Microsoft.Build.UnitTests
 
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(Path.Combine("Destination", "Foo.txt"));
             ObjectModelHelpers.AssertFileExistsInTempProjectDirectory(Path.Combine("Destination", "Subdir", "Bar.txt"));
+        }
+
+        /// <summary>
+        /// Using the CreateItem task to expand wildcards and verifying that the RecursiveDir metadatum is successfully
+        /// serialized/deserialized cross process.
+        /// </summary>
+        [Fact]
+        public void RecursiveDirOutOfProc()
+        {
+            ObjectModelHelpers.DeleteTempProjectDirectory();
+
+            string projectFileFullPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("Myapp.proj", @"
+                <Project ToolsVersion=`msbuilddefaulttoolsversion` xmlns=`msbuildnamespace`>
+                  <Target Name =`Repro` Returns=`@(Text)`>
+                    <CreateItem Include=`**\*.txt`>
+                      <Output TaskParameter=`Include` ItemName=`Text`/>
+                    </CreateItem>
+                  </Target>
+                </Project>
+                ");
+
+            ObjectModelHelpers.CreateFileInTempProjectDirectory(Path.Combine("Subdir", "Bar.txt"), "bar");
+
+            string originalCompressionThresholdVariable = Environment.GetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD");
+            Environment.SetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD", "0");
+            try
+            {
+                BuildRequestData data = new BuildRequestData(projectFileFullPath, new Dictionary<string, string>(), null, new string[] { "Repro" }, null);
+                BuildParameters parameters = new BuildParameters();
+                parameters.DisableInProcNode = true;
+                parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
+                BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
+                result.OverallResult.ShouldBe(BuildResultCode.Success);
+                result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir\\");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD", originalCompressionThresholdVariable);
+            }
         }
 
         /// <summary>

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -186,9 +186,12 @@ namespace Microsoft.Build.UnitTests
             env.SetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD", "0");
 
             BuildRequestData data = new BuildRequestData(projectFileFullPath, new Dictionary<string, string>(), null, new string[] { "Repro" }, null);
-            BuildParameters parameters = new BuildParameters();
-            parameters.DisableInProcNode = true;
-            parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
+            BuildParameters parameters = new BuildParameters
+            {
+                DisableInProcNode = true,
+                EnableNodeReuse = false,
+                Loggers = new ILogger[] { new MockLogger(_testOutput) },
+            };
             BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
             result.OverallResult.ShouldBe(BuildResultCode.Success);
             result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.DirectorySeparatorChar);

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Build.UnitTests
                 parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
                 BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
                 result.OverallResult.ShouldBe(BuildResultCode.Success);
-                result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir\\");
+                result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.PathSeparator);
             }
             finally
             {

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Build.UnitTests
                 parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
                 BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
                 result.OverallResult.ShouldBe(BuildResultCode.Success);
-                result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.PathSeparator);
+                result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.DirectorySeparatorChar);
             }
             finally
             {


### PR DESCRIPTION
The logic to decompress large target results was refusing to rehydrate project item metadata categorized as "item-specs". In particular, the `RecursiveDir` metadatum is explicitly set by the CreateItem task and falls into this category, causing the build to fail if certain conditions are met:
1. The build is out-of-proc.
2. The number of target results moved cross-proc meets the compression threshold.

It seems unnecessary to do elaborate validation on this codepath. We implicitly trust the serialized data. Fixing the issue by relaxing the checks so that compressed item-spec metadata can be deserialized.

Fixes #5225