### PR TITLE
Allow specifying task parameter logging options via UsingTask.

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -567,6 +567,8 @@ namespace Microsoft.Build.Framework
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+        public bool Log { get { throw null; } set { } }
+        public bool LogItemMetadata { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public bool Output { get { throw null; } }
         public System.Type PropertyType { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -566,6 +566,8 @@ namespace Microsoft.Build.Framework
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+        public bool Log { get { throw null; } set { } }
+        public bool LogItemMetadata { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public bool Output { get { throw null; } }
         public System.Type PropertyType { get { throw null; } }

--- a/ref/Microsoft.Build/net/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/net/Microsoft.Build.cs
@@ -425,6 +425,8 @@ namespace Microsoft.Build.Construction
         internal ProjectUsingTaskParameterElement() { }
         public override string Condition { get { throw null; } set { } }
         public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public bool Log { get { throw null; } }
+        public bool LogItemMetadata { get { throw null; } }
         public string Name { get { throw null; } set { } }
         public string Output { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation OutputLocation { get { throw null; } }

--- a/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
+++ b/ref/Microsoft.Build/netstandard/Microsoft.Build.cs
@@ -425,6 +425,8 @@ namespace Microsoft.Build.Construction
         internal ProjectUsingTaskParameterElement() { }
         public override string Condition { get { throw null; } set { } }
         public override Microsoft.Build.Construction.ElementLocation ConditionLocation { get { throw null; } }
+        public bool Log { get { throw null; } }
+        public bool LogItemMetadata { get { throw null; } }
         public string Name { get { throw null; } set { } }
         public string Output { get { throw null; } set { } }
         public Microsoft.Build.Construction.ElementLocation OutputLocation { get { throw null; } }

--- a/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
+++ b/src/Build.OM.UnitTests/Construction/ProjectUsingTaskElement_Tests.cs
@@ -445,30 +445,6 @@ namespace Microsoft.Build.UnitTests.OM.Construction
         /// Make sure there is an exception when a parameter group is added but no task factory attribute is on the using task
         /// </summary>
         [Fact]
-        public void ExceptionWhenNoTaskFactoryAndHavePG()
-        {
-            Assert.Throws<InvalidProjectFileException>(() =>
-            {
-                string content = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
-                        <UsingTask TaskName='t2' AssemblyName='an' Condition='c'>
-                            <ParameterGroup>
-                               <MyParameter/>
-                            </ParameterGroup>
-                        </UsingTask>
-                    </Project>
-                ";
-
-                ProjectRootElement project = ProjectRootElement.Create(XmlReader.Create(new StringReader(content)));
-                Helpers.GetFirst(project.Children);
-                Assert.True(false);
-            }
-           );
-        }
-        /// <summary>
-        /// Make sure there is an exception when a parameter group is added but no task factory attribute is on the using task
-        /// </summary>
-        [Fact]
         public void ExceptionWhenNoTaskFactoryAndHaveTask()
         {
             Assert.Throws<InvalidProjectFileException>(() =>

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -205,7 +205,8 @@ namespace Microsoft.Build.BackEnd
                 var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
                     ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix,
                     child.ItemType,
-                    itemsToAdd);
+                    itemsToAdd,
+                    logItemMetadata: true);
                 LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
@@ -237,7 +238,8 @@ namespace Microsoft.Build.BackEnd
                     var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
                         ItemGroupLoggingHelper.ItemGroupRemoveLogMessage,
                         child.ItemType,
-                        itemsToRemove);
+                        itemsToRemove,
+                        logItemMetadata: true);
                     LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -430,12 +430,12 @@ namespace Microsoft.Build.BackEnd
                 if (TaskParameterTypeVerifier.IsAssignableToITask(type))
                 {
                     ITaskItem[] outputs = GetItemOutputs(parameter);
-                    GatherTaskItemOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation);
+                    GatherTaskItemOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation, parameter);
                 }
                 else if (TaskParameterTypeVerifier.IsValueTypeOutputParameter(type))
                 {
                     string[] outputs = GetValueOutputs(parameter);
-                    GatherArrayStringAndValueOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation);
+                    GatherArrayStringAndValueOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation, parameter);
                 }
                 else
                 {
@@ -1283,12 +1283,16 @@ namespace Microsoft.Build.BackEnd
         /// </remarks>
         private bool InternalSetTaskParameter(TaskPropertyInfo parameter, IList parameterValue)
         {
-            if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameterValue.Count > 0)
+            if (LogTaskInputs &&
+                !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents &&
+                parameterValue.Count > 0 &&
+                parameter.Log)
             {
                 string parameterText = ItemGroupLoggingHelper.GetParameterText(
                     ItemGroupLoggingHelper.TaskParameterPrefix,
                     parameter.Name,
-                    parameterValue);
+                    parameterValue,
+                    parameter.LogItemMetadata);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
@@ -1370,7 +1374,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gets task item outputs
         /// </summary>
-        private void GatherTaskItemOutputs(bool outputTargetIsItem, string outputTargetName, ITaskItem[] outputs, ElementLocation parameterLocation)
+        private void GatherTaskItemOutputs(bool outputTargetIsItem, string outputTargetName, ITaskItem[] outputs, ElementLocation parameterLocation, TaskPropertyInfo parameter)
         {
             // if the task has generated outputs (if it didn't, don't do anything)
             if (outputs != null)
@@ -1425,12 +1429,13 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
 
-                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
+                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
                             ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
-                            outputs);
+                            outputs,
+                            parameter.LogItemMetadata);
 
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
@@ -1483,7 +1488,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gather task outputs in array form
         /// </summary>
-        private void GatherArrayStringAndValueOutputs(bool outputTargetIsItem, string outputTargetName, string[] outputs, ElementLocation parameterLocation)
+        private void GatherArrayStringAndValueOutputs(bool outputTargetIsItem, string outputTargetName, string[] outputs, ElementLocation parameterLocation, TaskPropertyInfo parameter)
         {
             // if the task has generated outputs (if it didn't, don't do anything)            
             if (outputs != null)
@@ -1501,12 +1506,13 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
 
-                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
+                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
                             ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
-                            outputs);
+                            outputs,
+                            parameter.LogItemMetadata);
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }

--- a/src/Build/Construction/ProjectUsingTaskParameterElement.cs
+++ b/src/Build/Construction/ProjectUsingTaskParameterElement.cs
@@ -132,6 +132,24 @@ namespace Microsoft.Build.Construction
             }
         }
 
+        public bool Log
+        {
+            get
+            {
+                string logAttribute = GetAttributeValue(XMakeAttributes.log);
+                return String.IsNullOrEmpty(logAttribute) ? true : bool.TryParse(logAttribute, out bool result) ? result : true;
+            }
+        }
+
+        public bool LogItemMetadata
+        {
+            get
+            {
+                string logItemMetadataAttribute = GetAttributeValue(XMakeAttributes.logItemMetadata);
+                return String.IsNullOrEmpty(logItemMetadataAttribute) ? true : bool.TryParse(logItemMetadataAttribute, out bool result) ? result : true;
+            }
+        }
+
         /// <summary>
         /// This does not allow conditions, so it should not be called.
         /// </summary>

--- a/src/Build/Construction/UsingTaskParameterGroupElement.cs
+++ b/src/Build/Construction/UsingTaskParameterGroupElement.cs
@@ -129,12 +129,11 @@ namespace Microsoft.Build.Construction
             ProjectUsingTaskElement parentUsingTask = parent as ProjectUsingTaskElement;
             ErrorUtilities.VerifyThrowInvalidOperation(parentUsingTask != null, "OM_CannotAcceptParent");
 
-            // Now since there is not goign to be a TaskElement on the using task we need to validate and make sure there is a TaskFactory attribute on the parent element and 
+            // Now since there is not going to be a TaskElement on the using task we need to validate and make sure there is a TaskFactory attribute on the parent element and 
             // that it is not empty
             if (parentUsingTask.TaskFactory.Length == 0)
             {
                 ErrorUtilities.VerifyThrow(parentUsingTask.Link == null, "TaskFactory");
-                ProjectXmlUtilities.VerifyThrowProjectRequiredAttribute(parent.XmlElement, "TaskFactory");
             }
 
             // UNDONE: Do check to make sure the parameter group is the first child

--- a/src/Build/Evaluation/ProjectParser.cs
+++ b/src/Build/Evaluation/ProjectParser.cs
@@ -66,7 +66,14 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Valid attributes on UsingTaskParameter element
         /// </summary>
-        private static readonly HashSet<string> ValidAttributesOnUsingTaskParameter = new HashSet<string> { XMakeAttributes.parameterType, XMakeAttributes.output, XMakeAttributes.required };
+        private static readonly HashSet<string> ValidAttributesOnUsingTaskParameter = new HashSet<string>
+        {
+            XMakeAttributes.parameterType,
+            XMakeAttributes.output,
+            XMakeAttributes.required,
+            XMakeAttributes.log,
+            XMakeAttributes.logItemMetadata
+        };
 
         /// <summary>
         /// Valid attributes on UsingTaskTask element

--- a/src/Build/Instance/TaskRegistry.cs
+++ b/src/Build/Instance/TaskRegistry.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Build.Execution
 
             if (String.IsNullOrEmpty(taskFactory) || taskFactory.Equals(RegisteredTaskRecord.AssemblyTaskFactory, StringComparison.OrdinalIgnoreCase) || taskFactory.Equals(RegisteredTaskRecord.TaskHostFactory, StringComparison.OrdinalIgnoreCase))
             {
-                ProjectXmlUtilities.VerifyThrowProjectNoChildElements(projectUsingTaskXml.XmlElement);
+                ProjectXmlUtilities.VerifyThrowProjectOnlyAllowedChildrenWithName(projectUsingTaskXml.XmlElement, XMakeElements.usingTaskParameterGroup);
             }
 
             if (projectUsingTaskXml.AssemblyFile.Length > 0)
@@ -1476,7 +1476,7 @@ namespace Microsoft.Build.Execution
                     }
 
 
-                    _taskFactoryWrapperInstance = new TaskFactoryWrapper(factory, loadedType, RegisteredName, TaskFactoryParameters);
+                    _taskFactoryWrapperInstance = new TaskFactoryWrapper(factory, loadedType, RegisteredName, TaskFactoryParameters, ParameterGroupAndTaskBody.UsingTaskParameters);
                 }
 
                 return true;
@@ -1694,7 +1694,13 @@ namespace Microsoft.Build.Execution
                             );
                         }
 
-                        UsingTaskParameters.Add(parameter.Name, new TaskPropertyInfo(parameter.Name, paramType, output, required));
+                        var taskPropertyInfo = new TaskPropertyInfo(parameter.Name, paramType, output, required)
+                        {
+                            Log = parameter.Log,
+                            LogItemMetadata = parameter.LogItemMetadata
+                        };
+
+                        UsingTaskParameters.Add(parameter.Name, taskPropertyInfo);
                     }
                 }
 

--- a/src/Build/Xml/ProjectXmlUtilities.cs
+++ b/src/Build/Xml/ProjectXmlUtilities.cs
@@ -42,6 +42,23 @@ namespace Microsoft.Build.Internal
             }
         }
 
+        /// <summary>
+        /// Throw an invalid project exception if there are any child elements with a different name than expected.
+        /// Used in the situation where we want to allow Parameters under UsingTask without the body (useful for setting
+        /// Log and LogItemMetadata)
+        /// </summary>
+        internal static void VerifyThrowProjectOnlyAllowedChildrenWithName(XmlElementWithLocation element, string allowedChildName)
+        {
+            foreach (var child in GetVerifyThrowProjectChildElements(element))
+            {
+                if (string.Equals(child.Name, allowedChildName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                ThrowProjectInvalidChildElement(child.Name, element.Name, element.Location);
+            }
+        }
 
         /// <summary>
         /// Throw an invalid project exception indicating that the child is not valid beneath the element because it is a duplicate

--- a/src/Framework/TaskPropertyInfo.cs
+++ b/src/Framework/TaskPropertyInfo.cs
@@ -46,5 +46,15 @@ namespace Microsoft.Build.Framework
         /// This task parameter is required (analogous to the [Required] attribute)
         /// </summary>
         public bool Required { get; private set; }
+
+        /// <summary>
+        /// This task parameter should be logged when LogTaskInputs is set. Defaults to true.
+        /// </summary>
+        public bool Log { get; set; } = true;
+
+        /// <summary>
+        /// When this task parameter is an item list, determines whether to log item metadata. Defaults to true.
+        /// </summary>
+        public bool LogItemMetadata { get; set; } = true;
     }
 }

--- a/src/Shared/XMakeAttributes.cs
+++ b/src/Shared/XMakeAttributes.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Build.Shared
         internal const string evaluate = "Evaluate";
         internal const string label = "Label";
         internal const string returns = "Returns";
+        internal const string log = "Log";
+        internal const string logItemMetadata = "LogItemMetadata";
 
         // Obsolete
         internal const string requiredRuntime = "RequiredRuntime";

--- a/src/Tasks/Microsoft.Common.tasks
+++ b/src/Tasks/Microsoft.Common.tasks
@@ -94,8 +94,19 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.AssignTargetPath"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.CallTarget"                            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.CombinePath"                           AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.ConvertToAbsolutePath"                 AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.Copy"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.ConvertToAbsolutePath"                 AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <AbsolutePaths LogItemMetadata="false" />
+        <Path Log="false" />
+      </ParameterGroup>
+    </UsingTask>
+    <UsingTask TaskName="Microsoft.Build.Tasks.Copy"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <CopiedFiles LogItemMetadata="false" />
+        <DestinationFiles LogItemMetadata="false" />
+        <SourceFiles LogItemMetadata="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.CreateCSharpManifestResourceName"      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.CreateItem"                            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.CreateProperty"                        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -109,7 +120,13 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.FindInList"                            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FindInvalidProjectReferences"          AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     
-    <UsingTask TaskName="Microsoft.Build.Tasks.FindUnderPath"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.FindUnderPath"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <Files LogItemMetadata="false" />
+        <InPath LogItemMetadata="false" />
+        <OutOfPath Log="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.FormatUrl"                             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.FormatVersion"                         AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateApplicationManifest"           AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -117,8 +134,16 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateBootstrapper"                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateDeploymentManifest"            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
 
-    <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR4" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' != ''">
+      <ParameterGroup>
+        <FilesWritten LogItemMetadata="false" />
+      </ParameterGroup>
+    </UsingTask>
+    <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR4" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''">
+      <ParameterGroup>
+        <FilesWritten LogItemMetadata="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateResource"                      AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR2" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''" />
 
     <UsingTask TaskName="Microsoft.Build.Tasks.GenerateTrustInfo"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -127,7 +152,11 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkPath"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetFrameworkSdkPath"                   AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.GetReferenceAssemblyPaths"             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.Hash"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.Hash"                                  AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <ItemsToHash LogItemMetadata="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.LC"                                    AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.MakeDir"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Message"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -140,7 +169,12 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.RegisterAssembly"                      AssemblyName="Microsoft.Build.Tasks.v3.5, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Runtime="CLR2" Condition="('$(MSBuildAssemblyVersion)' != '') and '$(DisableOutOfProcTaskHost)' == ''" />
 
     <UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir"                             AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.RemoveDuplicates"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.RemoveDuplicates"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <Filtered LogItemMetadata="false" />
+        <Inputs Log="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.RequiresFramework35SP1Assembly"        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.ResolveAssemblyReference"              AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.ResolveCodeAnalysisRuleSet"            AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
@@ -167,7 +201,11 @@
     <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash"                        AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.Warning"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.WriteCodeFragment"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
-    <UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
+    <UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile"                      AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''">
+      <ParameterGroup>
+        <Lines LogItemMetadata="false" />
+      </ParameterGroup>
+    </UsingTask>
     <UsingTask TaskName="Microsoft.Build.Tasks.XmlPeek"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.XmlPoke"                               AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />
     <UsingTask TaskName="Microsoft.Build.Tasks.XslTransformation"                     AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="'$(MSBuildAssemblyVersion)' != ''" />


### PR DESCRIPTION
This enables fine-grained control over whether:
 * to log log each parameter (whether input or output)
 * or whether to log item metadata for each ITaskItem[] parameter.

When LogTaskInputs is set the default behavior is still to log all parameters and all item metadata for ITaskItem[] parameters. Since this is very verbose and hurts performance without adding any useful informations it is valuable to be able to turn this logging off in certain situations.

This approach allows controlling logging via an extension to the UsingTask XML element. Even for the default AssemblyTaskFactory a ParameterGroup child element is now allowed, with subelements for parameters that can carry the new Log attribute or the new LogTask.

I've identified the specific tasks and parameters that we want to restrict logging for that would give us the most gains without losing any significant useful info:

https://github.com/KirillOsenkov/MSBuildStructuredLog/wiki/Task-Parameter-Logging