### PR TITLE
Add demand to try to force a different build machine

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -31,6 +31,7 @@ stages:
       name: VSEng-MicroBuildVS2019
       demands:
       - agent.os -equals Windows_NT
+      - VisualStudio_Version -equals 16.5
 
     timeoutInMinutes: 180
 

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -31,7 +31,7 @@ stages:
       name: VSEng-MicroBuildVS2019
       demands:
       - agent.os -equals Windows_NT
-      - VisualStudio_Version -equals 16.5
+      - VSTS_OS -equals Windows_Server_2019_Data_Center_with_Containers
 
     timeoutInMinutes: 180
 


### PR DESCRIPTION
Workaround for an apparent build-pool issue in the internal devdiv pool. Should be backed out ASAP.