### PR TITLE
Allow disabling logging of task parameters and item metadata

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -567,6 +567,8 @@ namespace Microsoft.Build.Framework
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+        public bool Log { get { throw null; } set { } }
+        public bool LogItemMetadata { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public bool Output { get { throw null; } }
         public System.Type PropertyType { get { throw null; } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -566,6 +566,8 @@ namespace Microsoft.Build.Framework
     public partial class TaskPropertyInfo
     {
         public TaskPropertyInfo(string name, System.Type typeOfParameter, bool output, bool required) { }
+        public bool Log { get { throw null; } set { } }
+        public bool LogItemMetadata { get { throw null; } set { } }
         public string Name { get { throw null; } }
         public bool Output { get { throw null; } }
         public System.Type PropertyType { get { throw null; } }

--- a/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/IntrinsicTasks/ItemGroupIntrinsicTask.cs
@@ -205,7 +205,8 @@ namespace Microsoft.Build.BackEnd
                 var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
                     ItemGroupLoggingHelper.ItemGroupIncludeLogMessagePrefix,
                     child.ItemType,
-                    itemsToAdd);
+                    itemsToAdd,
+                    logItemMetadata: true);
                 LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
             }
 
@@ -237,7 +238,8 @@ namespace Microsoft.Build.BackEnd
                     var itemGroupText = ItemGroupLoggingHelper.GetParameterText(
                         ItemGroupLoggingHelper.ItemGroupRemoveLogMessage,
                         child.ItemType,
-                        itemsToRemove);
+                        itemsToRemove,
+                        logItemMetadata: true);
                     LoggingContext.LogCommentFromText(MessageImportance.Low, itemGroupText);
                 }
 

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -427,15 +427,17 @@ namespace Microsoft.Build.BackEnd
                 // grab the outputs from the task's designated output parameter (which is a .NET property)
                 Type type = parameter.PropertyType;
 
+                EnsureParameterInitialized(parameter, _batchBucket.Lookup);
+
                 if (TaskParameterTypeVerifier.IsAssignableToITask(type))
                 {
                     ITaskItem[] outputs = GetItemOutputs(parameter);
-                    GatherTaskItemOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation);
+                    GatherTaskItemOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation, parameter);
                 }
                 else if (TaskParameterTypeVerifier.IsValueTypeOutputParameter(type))
                 {
                     string[] outputs = GetValueOutputs(parameter);
-                    GatherArrayStringAndValueOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation);
+                    GatherArrayStringAndValueOutputs(outputTargetIsItem, outputTargetName, outputs, parameterLocation, parameter);
                 }
                 else
                 {
@@ -1042,6 +1044,8 @@ namespace Microsoft.Build.BackEnd
                 {
                     Type parameterType = parameter.PropertyType;
 
+                    EnsureParameterInitialized(parameter, _batchBucket.Lookup);
+
                     // try to set the parameter
                     if (TaskParameterTypeVerifier.IsValidScalarInputParameter(parameterType))
                     {
@@ -1222,6 +1226,29 @@ namespace Microsoft.Build.BackEnd
             return success;
         }
 
+        private void EnsureParameterInitialized(TaskPropertyInfo parameter, Lookup lookup)
+        {
+            if (parameter.Initialized)
+            {
+                return;
+            }
+
+            parameter.Initialized = true;
+
+            string taskAndParameterName = _taskName + "_" + parameter.Name;
+            string key = "DisableLogTaskParameter_" + taskAndParameterName;
+            string metadataKey = "DisableLogTaskParameterItemMetadata_" + taskAndParameterName;
+
+            if (lookup.GetProperty(key)?.EvaluatedValue == "true")
+            {
+                parameter.Log = false;
+            }
+            else if (lookup.GetProperty(metadataKey)?.EvaluatedValue == "true")
+            {
+                parameter.LogItemMetadata = false;
+            }
+        }
+
         /// <summary>
         /// Given an instantiated task, this helper method sets the specified vector parameter. Vector parameters can be composed
         /// of multiple item vectors. The semicolon is the only separator allowed, and white space around the semicolon is
@@ -1283,12 +1310,16 @@ namespace Microsoft.Build.BackEnd
         /// </remarks>
         private bool InternalSetTaskParameter(TaskPropertyInfo parameter, IList parameterValue)
         {
-            if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && parameterValue.Count > 0)
+            if (LogTaskInputs &&
+                !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents &&
+                parameterValue.Count > 0 &&
+                parameter.Log)
             {
                 string parameterText = ItemGroupLoggingHelper.GetParameterText(
                     ItemGroupLoggingHelper.TaskParameterPrefix,
                     parameter.Name,
-                    parameterValue);
+                    parameterValue,
+                    parameter.LogItemMetadata);
                 _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
             }
 
@@ -1370,7 +1401,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gets task item outputs
         /// </summary>
-        private void GatherTaskItemOutputs(bool outputTargetIsItem, string outputTargetName, ITaskItem[] outputs, ElementLocation parameterLocation)
+        private void GatherTaskItemOutputs(bool outputTargetIsItem, string outputTargetName, ITaskItem[] outputs, ElementLocation parameterLocation, TaskPropertyInfo parameter)
         {
             // if the task has generated outputs (if it didn't, don't do anything)
             if (outputs != null)
@@ -1425,12 +1456,13 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
 
-                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
+                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
                             ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
-                            outputs);
+                            outputs,
+                            parameter.LogItemMetadata);
 
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
@@ -1483,7 +1515,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Gather task outputs in array form
         /// </summary>
-        private void GatherArrayStringAndValueOutputs(bool outputTargetIsItem, string outputTargetName, string[] outputs, ElementLocation parameterLocation)
+        private void GatherArrayStringAndValueOutputs(bool outputTargetIsItem, string outputTargetName, string[] outputs, ElementLocation parameterLocation, TaskPropertyInfo parameter)
         {
             // if the task has generated outputs (if it didn't, don't do anything)            
             if (outputs != null)
@@ -1501,12 +1533,13 @@ namespace Microsoft.Build.BackEnd
                         }
                     }
 
-                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0)
+                    if (LogTaskInputs && !_taskLoggingContext.LoggingService.OnlyLogCriticalEvents && outputs.Length > 0 && parameter.Log)
                     {
                         string parameterText = ItemGroupLoggingHelper.GetParameterText(
                             ItemGroupLoggingHelper.OutputItemParameterMessagePrefix,
                             outputTargetName,
-                            outputs);
+                            outputs,
+                            parameter.LogItemMetadata);
                         _taskLoggingContext.LogCommentFromText(MessageImportance.Low, parameterText);
                     }
                 }

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -1239,11 +1239,11 @@ namespace Microsoft.Build.BackEnd
             string key = "DisableLogTaskParameter_" + taskAndParameterName;
             string metadataKey = "DisableLogTaskParameterItemMetadata_" + taskAndParameterName;
 
-            if (lookup.GetProperty(key)?.EvaluatedValue == "true")
+            if (string.Equals(lookup.GetProperty(key)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
             {
                 parameter.Log = false;
             }
-            else if (lookup.GetProperty(metadataKey)?.EvaluatedValue == "true")
+            else if (string.Equals(lookup.GetProperty(metadataKey)?.EvaluatedValue, "true", StringComparison.OrdinalIgnoreCase))
             {
                 parameter.LogItemMetadata = false;
             }

--- a/src/Framework/TaskPropertyInfo.cs
+++ b/src/Framework/TaskPropertyInfo.cs
@@ -46,5 +46,20 @@ namespace Microsoft.Build.Framework
         /// This task parameter is required (analogous to the [Required] attribute)
         /// </summary>
         public bool Required { get; private set; }
+
+        /// <summary>
+        /// This task parameter should be logged when LogTaskInputs is set. Defaults to true.
+        /// </summary>
+        public bool Log { get; set; } = true;
+
+        /// <summary>
+        /// When this task parameter is an item list, determines whether to log item metadata. Defaults to true.
+        /// </summary>
+        public bool LogItemMetadata { get; set; } = true;
+
+        /// <summary>
+        /// Whether the Log and LogItemMetadata properties have been assigned already.
+        /// </summary>
+        internal bool Initialized = false;
     }
 }

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -174,4 +174,20 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <NuGetPropsFile Condition="'$(NuGetPropsFile)'==''">$(MSBuildToolsPath)\NuGet.props</NuGetPropsFile>
   </PropertyGroup>
   <Import Condition="Exists('$(NuGetPropsFile)')" Project="$(NuGetPropsFile)" />
+
+  <PropertyGroup>
+    <DisableLogTaskParameter_ConvertToAbsolutePath_Path>true</DisableLogTaskParameter_ConvertToAbsolutePath_Path>
+    <DisableLogTaskParameter_FindUnderPath_OutOfPath>true</DisableLogTaskParameter_FindUnderPath_OutOfPath>
+    <DisableLogTaskParameter_RemoveDuplicates_Inputs>true</DisableLogTaskParameter_RemoveDuplicates_Inputs>
+    <DisableLogTaskParameterItemMetadata_ConvertToAbsolutePath_AbsolutePaths>true</DisableLogTaskParameterItemMetadata_ConvertToAbsolutePath_AbsolutePaths>
+    <DisableLogTaskParameterItemMetadata_Copy_CopiedFiles>true</DisableLogTaskParameterItemMetadata_Copy_CopiedFiles>
+    <DisableLogTaskParameterItemMetadata_Copy_DestinationFiles>true</DisableLogTaskParameterItemMetadata_Copy_DestinationFiles>
+    <DisableLogTaskParameterItemMetadata_Copy_SourceFiles>true</DisableLogTaskParameterItemMetadata_Copy_SourceFiles>
+    <DisableLogTaskParameterItemMetadata_FindUnderPath_Files>true</DisableLogTaskParameterItemMetadata_FindUnderPath_Files>
+    <DisableLogTaskParameterItemMetadata_FindUnderPath_InPath>true</DisableLogTaskParameterItemMetadata_FindUnderPath_InPath>
+    <DisableLogTaskParameterItemMetadata_GenerateResource_FilesWritten>true</DisableLogTaskParameterItemMetadata_GenerateResource_FilesWritten>
+    <DisableLogTaskParameterItemMetadata_Hash_ItemsToHash>true</DisableLogTaskParameterItemMetadata_Hash_ItemsToHash>
+    <DisableLogTaskParameterItemMetadata_RemoveDuplicates_Filtered>true</DisableLogTaskParameterItemMetadata_RemoveDuplicates_Filtered>
+    <DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>true</DisableLogTaskParameterItemMetadata_WriteLinesToFile_Lines>
+  </PropertyGroup>
 </Project>

--- a/src/Tasks/Microsoft.Common.props
+++ b/src/Tasks/Microsoft.Common.props
@@ -175,7 +175,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
   </PropertyGroup>
   <Import Condition="Exists('$(NuGetPropsFile)')" Project="$(NuGetPropsFile)" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(MSBuildLogVerboseTaskParameters)' != 'true' ">
     <DisableLogTaskParameter_ConvertToAbsolutePath_Path>true</DisableLogTaskParameter_ConvertToAbsolutePath_Path>
     <DisableLogTaskParameter_FindUnderPath_OutOfPath>true</DisableLogTaskParameter_FindUnderPath_OutOfPath>
     <DisableLogTaskParameter_RemoveDuplicates_Inputs>true</DisableLogTaskParameter_RemoveDuplicates_Inputs>


### PR DESCRIPTION
This enables fine-grained control over whether:

 * to log each parameter (whether input or output)
 * or whether to log item metadata for each ITaskItem[] parameter.

When LogTaskInputs is set the default behavior is still to log all parameters and all item metadata for ITaskItem[] parameters. Since this is very verbose and hurts performance without adding any useful information it is valuable to be able to turn this logging off in certain situations.

This approach allows controlling logging via setting simple properties or environment variables.

I've identified the specific tasks and parameters that we want to restrict logging for that would give us the most gains without losing any significant useful info:

https://github.com/KirillOsenkov/MSBuildStructuredLog/wiki/Task-Parameter-Logging