### PR TITLE
Remove usages of Tuples

### DIFF
--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -21,8 +21,8 @@ using Microsoft.Build.Shared;
 
 using Task = System.Threading.Tasks.Task;
 // can't use an actual ProvenanceResult because it points to a ProjectItemElement which is hard to mock.
-using ProvenanceResultTupleList = System.Collections.Generic.List<System.Tuple<string, Microsoft.Build.Evaluation.Operation, Microsoft.Build.Evaluation.Provenance, int>>;
-using GlobResultList = System.Collections.Generic.List<System.Tuple<string, string[], System.Collections.Immutable.ImmutableHashSet<string>, System.Collections.Immutable.ImmutableHashSet<string>>>;
+using ProvenanceResultTupleList = System.Collections.Generic.List<(string, Microsoft.Build.Evaluation.Operation, Microsoft.Build.Evaluation.Provenance, int)>;
+using GlobResultList = System.Collections.Generic.List<(string, string[], System.Collections.Immutable.ImmutableHashSet<string>, System.Collections.Immutable.ImmutableHashSet<string>)>;
 using InvalidProjectFileException = Microsoft.Build.Exceptions.InvalidProjectFileException;
 using ToolLocationHelper = Microsoft.Build.Utilities.ToolLocationHelper;
 using TargetDotNetFrameworkVersion = Microsoft.Build.Utilities.TargetDotNetFrameworkVersion;
@@ -2756,8 +2756,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("B", Operation.Exclude, Provenance.StringLiteral, 1)
+                ("A", Operation.Include, Provenance.StringLiteral, 1),
+                ("B", Operation.Exclude, Provenance.StringLiteral, 1)
             };
 
             AssertProvenanceResult(expected, project, "1");
@@ -2792,7 +2792,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+                ("A", Operation.Include, Provenance.Glob, 1),
             };
 
             AssertProvenanceResult(expected, project, "a");
@@ -2815,8 +2815,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                Tuple.Create("B", Operation.Exclude, Provenance.Glob, 1)
+                ("A", Operation.Include, Provenance.Glob, 1),
+                ("B", Operation.Exclude, Provenance.Glob, 1)
             };
 
             AssertProvenanceResult(expected, project, "2.foo");
@@ -2836,14 +2836,14 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
+                ("A", Operation.Include, Provenance.Glob, 1),
             };
 
             AssertProvenanceResult(expected, project, "ab*cd");
 
             expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.Glob, 1),
+                ("B", Operation.Include, Provenance.Glob, 1),
             };
 
             AssertProvenanceResult(expected, project, "tx?yz");
@@ -2867,7 +2867,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             for (int i = 0; i < itemElements; i++)
             {
                 sb.AppendLine($"<i_{i} Include=\"a\"/>");
-                expected.Add(Tuple.Create($"i_{i}", Operation.Include, Provenance.StringLiteral, 1));
+                expected.Add(($"i_{i}", Operation.Include, Provenance.StringLiteral, 1));
             }
 
             project = string.Format(project, sb);
@@ -2890,8 +2890,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                Tuple.Create("B", Operation.Exclude, Provenance.Glob, 1)
+                ("A", Operation.Include, Provenance.Glob, 1),
+                ("B", Operation.Exclude, Provenance.Glob, 1)
             };
 
             // Create a project. The initial evaluation does not record the information needed for GetItemProvenance
@@ -2923,7 +2923,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Exclude, Provenance.Glob, 1)
+                ("A", Operation.Exclude, Provenance.Glob, 1)
             };
 
             AssertProvenanceResult(expected, project, @"bin\1.cs");
@@ -2960,8 +2960,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 3),
-                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 4)
+                ("A", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 3),
+                ("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 4)
             };
 
             AssertProvenanceResult(expected, project, "1.foo");
@@ -2983,8 +2983,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 2),
-                Tuple.Create("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 2)
+                ("B", Operation.Include, Provenance.Glob | Provenance.StringLiteral, 2),
+                ("B", Operation.Exclude, Provenance.Glob | Provenance.StringLiteral, 2)
             };
 
             AssertProvenanceResult(expected, project, "1.foo", "B");
@@ -3008,10 +3008,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     0, // first item 'a' from the include
                     new ProvenanceResultTupleList()
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 2),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
+                        ("A", Operation.Include, Provenance.StringLiteral, 2),
+                        ("A", Operation.Update, Provenance.StringLiteral, 1),
+                        ("A", Operation.Update, Provenance.Glob, 1),
+                        ("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
                     }
                 };
 
@@ -3028,7 +3028,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     2, // item 'a' from last include
                     new ProvenanceResultTupleList()
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+                        ("A", Operation.Include, Provenance.StringLiteral, 1)
                     }
                 };
 
@@ -3045,7 +3045,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     0, // item 'a' from first include
                     new ProvenanceResultTupleList()
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+                        ("A", Operation.Include, Provenance.StringLiteral, 1)
                     }
                 };
 
@@ -3076,9 +3076,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     2, // item 'a' from second include
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 2),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
+                        ("A", Operation.Include, Provenance.StringLiteral, 1),
+                        ("A", Operation.Update, Provenance.StringLiteral, 2),
+                        ("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2)
                     }
                 };
             }
@@ -3110,8 +3110,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("A", Operation.Exclude, Provenance.Inconclusive | Provenance.StringLiteral, 3)
+                ("B", Operation.Include, Provenance.StringLiteral, 1),
+                ("A", Operation.Exclude, Provenance.Inconclusive | Provenance.StringLiteral, 3)
             };
 
             AssertProvenanceResult(expected, project, "1");
@@ -3136,9 +3136,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("A", Operation.Include, Provenance.Inconclusive | Provenance.StringLiteral, 3),
-                Tuple.Create("C", Operation.Include, Provenance.Inconclusive, 3)
+                ("B", Operation.Include, Provenance.StringLiteral, 1),
+                ("A", Operation.Include, Provenance.Inconclusive | Provenance.StringLiteral, 3),
+                ("C", Operation.Include, Provenance.Inconclusive, 3)
             };
 
             AssertProvenanceResult(expected, project, "1");
@@ -3162,8 +3162,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("A", Operation.Include, Provenance.Inconclusive | Provenance.Glob, 3)
+                ("B", Operation.Include, Provenance.StringLiteral, 1),
+                ("A", Operation.Include, Provenance.Inconclusive | Provenance.Glob, 3)
             };
 
             AssertProvenanceResult(expected, project, "1");
@@ -3190,8 +3190,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("B", Operation.Include, Provenance.StringLiteral | Provenance.Inconclusive, 1),
-                Tuple.Create("C", Operation.Include, Provenance.StringLiteral, 1)
+                ("B", Operation.Include, Provenance.StringLiteral | Provenance.Inconclusive, 1),
+                ("C", Operation.Include, Provenance.StringLiteral, 1)
             };
 
             AssertProvenanceResult(expected, project, "a");
@@ -3261,7 +3261,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected1Foo = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 3)
+                ("A", Operation.Include, Provenance.StringLiteral, 3)
             };
 
             AssertProvenanceResult(expected1Foo, projectContents, "1.foo");
@@ -3275,7 +3275,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 var expected2Foo = new ProvenanceResultTupleList
                 {
-                    Tuple.Create("B", Operation.Include, Provenance.StringLiteral, 1)
+                    ("B", Operation.Include, Provenance.StringLiteral, 1)
                 };
 
                 AssertProvenanceResult(expected2Foo, project.GetItemProvenance(@"../x/d13/../../x/d12/d23/../2.foo"));
@@ -3305,8 +3305,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 var expectedProvenance = new ProvenanceResultTupleList
                 {
-                    Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                    Tuple.Create("B", Operation.Include, Provenance.StringLiteral | Provenance.Inconclusive, 1)
+                    ("A", Operation.Include, Provenance.StringLiteral, 1),
+                    ("B", Operation.Include, Provenance.StringLiteral | Provenance.Inconclusive, 1)
                 };
 
                 AssertProvenanceResult(expectedProvenance, project.GetItemProvenance(@"1.foo"));
@@ -3331,7 +3331,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             AssertProvenanceResult(expected, project, @"?:/*\|");
 
-            expected.Add(Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1));
+            expected.Add(("A", Operation.Include, Provenance.StringLiteral, 1));
 
             AssertProvenanceResult(expected, project, @"|:/\");
         }
@@ -3368,7 +3368,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1)
+                ("A", Operation.Include, Provenance.StringLiteral, 1)
             };
 
             AssertProvenanceResult(expected, project, "A");
@@ -3397,9 +3397,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     // the expected GetItemProvenance result
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral | Provenance.Glob, 3),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 3),
-                        Tuple.Create("A", Operation.Remove, Provenance.StringLiteral | Provenance.Glob, 3)
+                        ("A", Operation.Include, Provenance.StringLiteral | Provenance.Glob, 3),
+                        ("A", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 3),
+                        ("A", Operation.Remove, Provenance.StringLiteral | Provenance.Glob, 3)
                     }
                 };
 
@@ -3416,9 +3416,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     "abc",
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.StringLiteral, 1),
-                        Tuple.Create("A", Operation.Remove, Provenance.StringLiteral, 1)
+                        ("A", Operation.Include, Provenance.StringLiteral, 1),
+                        ("A", Operation.Update, Provenance.StringLiteral, 1),
+                        ("A", Operation.Remove, Provenance.StringLiteral, 1)
                     }
                 };
 
@@ -3449,9 +3449,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     "abc",
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Remove, Provenance.Glob, 1)
+                        ("A", Operation.Include, Provenance.Glob, 1),
+                        ("A", Operation.Update, Provenance.Glob, 1),
+                        ("A", Operation.Remove, Provenance.Glob, 1)
                     }
                 };
 
@@ -3475,9 +3475,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     "a%62c",
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Remove, Provenance.Glob, 1)
+                        ("A", Operation.Include, Provenance.Glob, 1),
+                        ("A", Operation.Update, Provenance.Glob, 1),
+                        ("A", Operation.Remove, Provenance.Glob, 1)
                     }
                 };
 
@@ -3487,9 +3487,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     "abcdefc",
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Remove, Provenance.Glob, 1)
+                        ("A", Operation.Include, Provenance.Glob, 1),
+                        ("A", Operation.Update, Provenance.Glob, 1),
+                        ("A", Operation.Remove, Provenance.Glob, 1)
                     }
                 };
 
@@ -3499,9 +3499,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                     "a%62%61c",
                     new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Update, Provenance.Glob, 1),
-                        Tuple.Create("A", Operation.Remove, Provenance.Glob, 1)
+                        ("A", Operation.Include, Provenance.Glob, 1),
+                        ("A", Operation.Update, Provenance.Glob, 1),
+                        ("A", Operation.Remove, Provenance.Glob, 1)
                     }
                 };
             }
@@ -3534,10 +3534,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("C", Operation.Update, Provenance.StringLiteral, 1),
-                Tuple.Create("D", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2),
-                Tuple.Create("E", Operation.Update, Provenance.Glob | Provenance.Inconclusive, 3)
+                ("A", Operation.Include, Provenance.StringLiteral, 1),
+                ("C", Operation.Update, Provenance.StringLiteral, 1),
+                ("D", Operation.Update, Provenance.StringLiteral | Provenance.Glob, 2),
+                ("E", Operation.Update, Provenance.Glob | Provenance.Inconclusive, 3)
             };
 
             AssertProvenanceResult(expected, project, "1.foo");
@@ -3564,10 +3564,10 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new ProvenanceResultTupleList
             {
-                Tuple.Create("A", Operation.Include, Provenance.StringLiteral, 1),
-                Tuple.Create("C", Operation.Remove, Provenance.StringLiteral, 1),
-                Tuple.Create("D", Operation.Remove, Provenance.StringLiteral | Provenance.Glob, 2),
-                Tuple.Create("E", Operation.Remove, Provenance.Glob | Provenance.Inconclusive, 3)
+                ("A", Operation.Include, Provenance.StringLiteral, 1),
+                ("C", Operation.Remove, Provenance.StringLiteral, 1),
+                ("D", Operation.Remove, Provenance.StringLiteral | Provenance.Glob, 2),
+                ("E", Operation.Remove, Provenance.Glob | Provenance.Inconclusive, 3)
             };
 
             AssertProvenanceResult(expected, project, "1.foo");
@@ -3601,7 +3601,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
                 expectedProvenance = provenanceShouldFindAMatch
                     ? new ProvenanceResultTupleList
                     {
-                        Tuple.Create("A", Operation.Include, provenanceKind, 1)
+                        ("A", Operation.Include, provenanceKind, 1)
                     }
                     : new ProvenanceResultTupleList();
 
@@ -3676,7 +3676,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             var expectedExcludes = new[] { "1", "*", "3" }.ToImmutableHashSet();
             var expected = new GlobResultList
             {
-                Tuple.Create("A", expectedIncludes, expectedExcludes, ImmutableHashSet.Create<string>())
+                ("A", expectedIncludes, expectedExcludes, ImmutableHashSet.Create<string>())
             };
 
             AssertGlobResult(expected, project);
@@ -3699,8 +3699,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new GlobResultList
             {
-                Tuple.Create("A", new []{"**"}, new [] {"e**"}.ToImmutableHashSet(), new [] {"c"}.ToImmutableHashSet()),
-                Tuple.Create("A", new []{"*"}, new [] {"e*"}.ToImmutableHashSet(), new [] {"c", "b", "a"}.ToImmutableHashSet()),
+                ("A", new []{"**"}, new [] {"e**"}.ToImmutableHashSet(), new [] {"c"}.ToImmutableHashSet()),
+                ("A", new []{"*"}, new [] {"e*"}.ToImmutableHashSet(), new [] {"c", "b", "a"}.ToImmutableHashSet()),
             };
 
             AssertGlobResult(expected, project);
@@ -3813,7 +3813,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             var expectedExcludes = new[] { "1", "*", "3" }.ToImmutableHashSet();
             var expected = new GlobResultList
             {
-                Tuple.Create("A", expectedIncludes, expectedExcludes, ImmutableHashSet<string>.Empty)
+                ("A", expectedIncludes, expectedExcludes, ImmutableHashSet<string>.Empty)
             };
 
             AssertGlobResult(expected, project, "A");
@@ -3836,7 +3836,7 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
             var expected = new GlobResultList
             {
-                Tuple.Create("A", new []{"*"}, new[] {"*"}.ToImmutableHashSet(), ImmutableHashSet<string>.Empty),
+                ("A", new []{"*"}, new[] {"*"}.ToImmutableHashSet(), ImmutableHashSet<string>.Empty),
             };
 
             AssertGlobResult(expected, project);
@@ -3864,8 +3864,8 @@ namespace Microsoft.Build.UnitTests.OM.Definition
 
                 var expected = new GlobResultList
                 {
-                    Tuple.Create("C", new []{"**"}, new [] {"build.proj", "a", "b"}.ToImmutableHashSet(), new [] {"build.proj", "a", "b"}.ToImmutableHashSet()),
-                    Tuple.Create("A", new []{"*"}, ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty)
+                    ("C", new []{"**"}, new [] {"build.proj", "a", "b"}.ToImmutableHashSet(), new [] {"build.proj", "a", "b"}.ToImmutableHashSet()),
+                    ("A", new []{"*"}, ImmutableHashSet<string>.Empty, ImmutableHashSet<string>.Empty)
                 };
 
                 AssertGlobResultsEqual(expected, globResult);

--- a/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskExecutionHost_Tests.cs
@@ -135,8 +135,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void ValidateNoParameters()
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-            parameters["ExecuteReturnParam"] = new Tuple<string, ElementLocation>("true", ElementLocation.Create("foo.proj"));
+            var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+            parameters["ExecuteReturnParam"] = ("true", ElementLocation.Create("foo.proj"));
 
             Assert.True(_host.SetTaskParameters(parameters));
             Assert.Single(_parametersSetOnTask);
@@ -151,7 +151,7 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Assert.Throws<InvalidProjectFileException>(() =>
             {
-                Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
+                var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
                 _host.SetTaskParameters(parameters);
             }
            );
@@ -162,8 +162,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void ValidateNonExistantParameter()
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-            parameters["NonExistantParam"] = new Tuple<string, ElementLocation>("foo", ElementLocation.Create("foo.proj"));
+            var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+            parameters["NonExistantParam"] = ("foo", ElementLocation.Create("foo.proj"));
             Assert.False(_host.SetTaskParameters(parameters));
         }
 
@@ -602,8 +602,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TestExecuteTrue()
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-            parameters["ExecuteReturnParam"] = new Tuple<string, ElementLocation>("true", ElementLocation.Create("foo.proj"));
+            var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+            parameters["ExecuteReturnParam"] = ("true", ElementLocation.Create("foo.proj"));
 
             Assert.True(_host.SetTaskParameters(parameters));
 
@@ -618,8 +618,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TestExecuteFalse()
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-            parameters["ExecuteReturnParam"] = new Tuple<string, ElementLocation>("false", ElementLocation.Create("foo.proj"));
+            var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+            parameters["ExecuteReturnParam"] = ("false", ElementLocation.Create("foo.proj"));
 
             Assert.True(_host.SetTaskParameters(parameters));
 
@@ -636,8 +636,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Assert.Throws<IndexOutOfRangeException>(() =>
             {
-                Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-                parameters["ExecuteReturnParam"] = new Tuple<string, ElementLocation>("false", ElementLocation.Create("foo.proj"));
+                var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+                parameters["ExecuteReturnParam"] = ("false", ElementLocation.Create("foo.proj"));
 
                 Dispose();
                 InitializeHost(true);
@@ -1398,8 +1398,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// </summary>
         private void SetTaskParameter(string parameterName, string value)
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = GetStandardParametersDictionary(true);
-            parameters[parameterName] = new Tuple<string, ElementLocation>(value, ElementLocation.Create("foo.proj"));
+            var parameters = GetStandardParametersDictionary(true);
+            parameters[parameterName] = (value, ElementLocation.Create("foo.proj"));
             bool success = _host.SetTaskParameters(parameters);
             Assert.True(success);
         }
@@ -1407,10 +1407,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         /// <summary>
         /// Helper method for tests
         /// </summary>
-        private Dictionary<string, Tuple<string, ElementLocation>> GetStandardParametersDictionary(bool returnParam)
+        private Dictionary<string, (string, ElementLocation)> GetStandardParametersDictionary(bool returnParam)
         {
-            Dictionary<string, Tuple<string, ElementLocation>> parameters = new Dictionary<string, Tuple<string, ElementLocation>>(StringComparer.OrdinalIgnoreCase);
-            parameters["ExecuteReturnParam"] = new Tuple<string, ElementLocation>(returnParam ? "true" : "false", ElementLocation.Create("foo.proj"));
+            var parameters = new Dictionary<string, (string, ElementLocation)>(StringComparer.OrdinalIgnoreCase);
+            parameters["ExecuteReturnParam"] = (returnParam ? "true" : "false", ElementLocation.Create("foo.proj"));
             return parameters;
         }
 

--- a/src/Build.UnitTests/Instance/ProjectTaskInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectTaskInstance_Internal_Tests.cs
@@ -28,15 +28,15 @@ namespace Microsoft.Build.Engine.UnitTests.Instance
 
                 yield return new object[]
                 {
-                    new Dictionary<string, Tuple<string, MockElementLocation>>(),
+                    new Dictionary<string, (string, MockElementLocation)>(),
                     new List<ProjectTaskInstanceChild>()
                 };
 
                 yield return new object[]
                 {
-                    new Dictionary<string, Tuple<string, MockElementLocation>>
+                    new Dictionary<string, (string, MockElementLocation)>
                     {
-                        {"p1", Tuple.Create("v1", new MockElementLocation("p1"))}
+                        {"p1", ("v1", new MockElementLocation("p1"))}
                     },
                     new List<ProjectTaskInstanceChild>
                     {
@@ -46,10 +46,10 @@ namespace Microsoft.Build.Engine.UnitTests.Instance
 
                 yield return new object[]
                 {
-                    new Dictionary<string, Tuple<string, MockElementLocation>>
+                    new Dictionary<string, (string, MockElementLocation)>
                     {
-                        {"p1", Tuple.Create("v1", new MockElementLocation("p1"))},
-                        {"p2", Tuple.Create("v2", new MockElementLocation("p2"))}
+                        {"p1", ("v1", new MockElementLocation("p1"))},
+                        {"p2", ("v2", new MockElementLocation("p2"))}
                     },
                     new List<ProjectTaskInstanceChild>
                     {

--- a/src/Build.UnitTests/Instance/ProjectTaskInstance_Internal_Tests.cs
+++ b/src/Build.UnitTests/Instance/ProjectTaskInstance_Internal_Tests.cs
@@ -63,15 +63,15 @@ namespace Microsoft.Build.Engine.UnitTests.Instance
         [Theory]
         [MemberData(nameof(TestData))]
         public void ProjectTaskInstanceCanSerializeViaTranslator(
-            IDictionary<string, Tuple<string, MockElementLocation>> parameters,
+            IDictionary<string, (string, MockElementLocation)> parameters,
             List<ProjectTaskInstanceChild> outputs)
         {
-            parameters = parameters ?? new Dictionary<string, Tuple<string, MockElementLocation>>();
+            parameters = parameters ?? new Dictionary<string, (string, MockElementLocation)>();
 
-            var parametersCopy = new Dictionary<string, Tuple<string, ElementLocation>>(parameters.Count);
+            var parametersCopy = new Dictionary<string, (string, ElementLocation)>(parameters.Count);
             foreach (var param in parameters)
             {
-                parametersCopy[param.Key] = Tuple.Create(param.Value.Item1, (ElementLocation) param.Value.Item2);
+                parametersCopy[param.Key] = (param.Value.Item1, param.Value.Item2);
             }
 
             var original = CreateTargetTask(null, parametersCopy, outputs);

--- a/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
+++ b/src/Build.UnitTests/TestComparers/ProjectInstanceModelTestComparers.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Build.Engine.UnitTests.TestComparers
             throw new NotImplementedException();
         }
 
-        private void AssertParametersEqual(IDictionary<string, Tuple<string, ElementLocation>> x, IDictionary<string, Tuple<string, ElementLocation>> y)
+        private void AssertParametersEqual(IDictionary<string, (string, ElementLocation)> x, IDictionary<string, (string, ElementLocation)> y)
         {
             Assert.Equal(x.Count, y.Count);
 

--- a/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
+++ b/src/Build.UnitTests/TestData/ProjectInstanceTestObjects.cs
@@ -105,14 +105,14 @@ namespace Microsoft.Build.Engine.UnitTests.TestData
 
         public static ProjectTaskInstance CreateTargetTask(
             int? counter = null,
-            IDictionary<string, Tuple<string, ElementLocation>> parameters = null,
+            IDictionary<string, (string, ElementLocation)> parameters = null,
             List<ProjectTaskInstanceChild> outputs = null)
         {
             var stringCounter = CounterToString(counter);
 
             var readonlyParameters = parameters != null
-                ? new CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>(parameters)
-                : new CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>();
+                ? new CopyOnWriteDictionary<string, (string, ElementLocation)>(parameters)
+                : new CopyOnWriteDictionary<string, (string, ElementLocation)>();
 
             outputs = outputs ?? new List<ProjectTaskInstanceChild>();
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Build.BackEnd
 
             List<string> taskParameters = new List<string>(_taskNode.ParametersForBuild.Count + _taskNode.Outputs.Count);
 
-            foreach (KeyValuePair<string, Tuple<string, ElementLocation>> taskParameter in _taskNode.ParametersForBuild)
+            foreach (KeyValuePair<string, (string, ElementLocation)> taskParameter in _taskNode.ParametersForBuild)
             {
                 taskParameters.Add(taskParameter.Value.Item1);
             }

--- a/src/Build/BackEnd/TaskExecutionHost/AddInParts/ITaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/AddInParts/ITaskExecutionHost.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Build.BackEnd
         /// <summary>
         /// Sets a task parameter using an unevaluated value, which will be expanded by the batch bucket.
         /// </summary>
-        bool SetTaskParameters(IDictionary<string, Tuple<string, ElementLocation>> parameters);
+        bool SetTaskParameters(IDictionary<string, (string, ElementLocation)> parameters);
 
         /// <summary>
         /// Gets all of the outputs and stores them in the batch bucket.

--- a/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
+++ b/src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs
@@ -321,7 +321,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         /// <param name="parameters">The name/value pairs for the parameters.</param>
         /// <returns>True if the parameters were set correctly, false otherwise.</returns>
-        bool ITaskExecutionHost.SetTaskParameters(IDictionary<string, Tuple<string, ElementLocation>> parameters)
+        bool ITaskExecutionHost.SetTaskParameters(IDictionary<string, (string, ElementLocation)> parameters)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parameters, nameof(parameters));
 
@@ -333,7 +333,7 @@ namespace Microsoft.Build.BackEnd
             IDictionary<string, string> requiredParameters = GetNamesOfPropertiesWithRequiredAttribute();
 
             // look through all the attributes of the task element
-            foreach (KeyValuePair<string, Tuple<string, ElementLocation>> parameter in parameters)
+            foreach (KeyValuePair<string, (string, ElementLocation)> parameter in parameters)
             {
                 bool taskParameterSet = false;  // Did we actually call the setter on this task parameter?
                 bool success;

--- a/src/Build/Construction/ProjectTaskElement.cs
+++ b/src/Build/Construction/ProjectTaskElement.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// The parameters (excepting condition and continue-on-error)
         /// </summary>
-        private CopyOnWriteDictionary<string, Tuple<string, ElementLocation>> _parameters;
+        private CopyOnWriteDictionary<string, (string, ElementLocation)> _parameters;
 
         /// <summary>
         /// Protection for the parameters cache
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Construction
 
                     var parametersClone = new Dictionary<string, string>(_parameters.Count, StringComparer.OrdinalIgnoreCase);
 
-                    foreach (KeyValuePair<string, Tuple<string, ElementLocation>> entry in _parameters)
+                    foreach (KeyValuePair<string, (string, ElementLocation)> entry in _parameters)
                     {
                         parametersClone[entry.Key] = entry.Value.Item1;
                     }
@@ -179,7 +179,7 @@ namespace Microsoft.Build.Construction
                     EnsureParametersInitialized();
                     var parameterLocations = new List<KeyValuePair<string, ElementLocation>>();
 
-                    foreach (KeyValuePair<string, Tuple<string, ElementLocation>> entry in _parameters)
+                    foreach (KeyValuePair<string, (string, ElementLocation)> entry in _parameters)
                     {
                         parameterLocations.Add(new KeyValuePair<string, ElementLocation>(entry.Key, entry.Value.Item2));
                     }
@@ -210,7 +210,7 @@ namespace Microsoft.Build.Construction
         /// <summary>
         /// Retrieves a copy of the parameters as used during evaluation.
         /// </summary>
-        internal CopyOnWriteDictionary<string, Tuple<string, ElementLocation>> ParametersForEvaluation
+        internal CopyOnWriteDictionary<string, (string, ElementLocation)> ParametersForEvaluation
         {
             get
             {
@@ -302,7 +302,7 @@ namespace Microsoft.Build.Construction
 
                 EnsureParametersInitialized();
 
-                if (_parameters.TryGetValue(name, out Tuple<string, ElementLocation> parameter))
+                if (_parameters.TryGetValue(name, out (string, ElementLocation) parameter))
                 {
                     return parameter.Item1;
                 }
@@ -443,7 +443,7 @@ namespace Microsoft.Build.Construction
         {
             if (_parameters == null)
             {
-                _parameters = new CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>(XmlElement.Attributes.Count, StringComparer.OrdinalIgnoreCase);
+                _parameters = new CopyOnWriteDictionary<string, (string, ElementLocation)>(XmlElement.Attributes.Count, StringComparer.OrdinalIgnoreCase);
 
                 foreach (XmlAttributeWithLocation attribute in XmlElement.Attributes)
                 {
@@ -453,7 +453,7 @@ namespace Microsoft.Build.Construction
                         // That means that if the name of the file is changed after first load (possibly from null) it will
                         // remain the old value here. Correctly, this should cache the attribute not the location. Fixing 
                         // that will need profiling, though, as this cache was added for performance.
-                        _parameters[attribute.Name] = new Tuple<string, ElementLocation>(attribute.Value, attribute.Location);
+                        _parameters[attribute.Name] = (attribute.Value, attribute.Location);
                     }
                 }
             }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2686,37 +2686,37 @@ namespace Microsoft.Build.Evaluation
                     }
 
                     var matchOccurrences = ItemMatchesInItemSpecString(itemToMatch, itemSpec, elementLocation, itemElement.ContainingProject.DirectoryPath, _data.Expander, out Provenance provenance);
-                    Tuple<Provenance, int> result = matchOccurrences > 0 ? Tuple.Create(provenance, matchOccurrences) : null;
-
-                    return result?.Item2 > 0
-                        ? new ProvenanceResult(itemElement, operation, result.Item1, result.Item2)
-                        : null;
-                }
-
-                Func<ProvenanceResult>[] provenanceProviders =
-                {
-                // provenance provider for include item elements
-                () =>
-                {
-                    var includeResult = SingleItemSpecProvenance(itemElement.Include, itemElement.IncludeLocation, Operation.Include);
-                    if (includeResult == null)
+                    if (matchOccurrences > 0)
                     {
-                        return null;
+                        return new ProvenanceResult(itemElement, operation, provenance, matchOccurrences);
                     }
 
+                    return null;
+                }
+
+                var includeResult = SingleItemSpecProvenance(itemElement.Include, itemElement.IncludeLocation, Operation.Include);
+                if (includeResult != null)
+                {
                     var excludeResult = SingleItemSpecProvenance(itemElement.Exclude, itemElement.ExcludeLocation, Operation.Exclude);
+                    if (excludeResult != null)
+                    {
+                        return excludeResult;
+                    }
 
-                    return excludeResult ?? includeResult;
-                },
+                    if (includeResult != null)
+                    {
+                        return includeResult;
+                    }
+                }
 
-                // provenance provider for update item elements
-                () => SingleItemSpecProvenance(itemElement.Update, itemElement.UpdateLocation, Operation.Update),
-                
-                // provenance provider for remove item elements
-                () => SingleItemSpecProvenance(itemElement.Remove, itemElement.RemoveLocation, Operation.Remove)
-            };
+                var result = SingleItemSpecProvenance(itemElement.Update, itemElement.UpdateLocation, Operation.Update);
+                if (result != null)
+                {
+                    return result;
+                }
 
-                return provenanceProviders.Select(provider => provider()).FirstOrDefault(provenanceResult => provenanceResult != null);
+                result = SingleItemSpecProvenance(itemElement.Remove, itemElement.RemoveLocation, Operation.Remove);
+                return result;
             }
 
             /// <summary>

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Build.Globbing
                     {
                         var normalizedFixedPart = NormalizeTheFixedDirectoryPartAgainstTheGlobRoot(fixedDirPart, globRoot);
 
-                        return Tuple.Create(normalizedFixedPart, wildcardDirPart, filePart);
+                        return (normalizedFixedPart, wildcardDirPart, filePart);
                     });
 
                 // compile the regex since it's expected to be used multiple times

--- a/src/Build/Instance/ProjectTaskInstance.cs
+++ b/src/Build/Instance/ProjectTaskInstance.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Build.Execution
         /// Unordered set of task parameter names and unevaluated values.
         /// This is a dead, read-only collection.
         /// </summary>
-        private CopyOnWriteDictionary<string, Tuple<string, ElementLocation>> _parameters;
+        private CopyOnWriteDictionary<string, (string, ElementLocation)> _parameters;
 
         /// <summary>
         /// Output properties and items below this task. This is an ordered collection
@@ -138,7 +138,7 @@ namespace Microsoft.Build.Execution
             continueOnError,
             msbuildRuntime,
             msbuildArchitecture,
-            new CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>(8, StringComparer.OrdinalIgnoreCase),
+            new CopyOnWriteDictionary<string, (string, ElementLocation)>(8, StringComparer.OrdinalIgnoreCase),
             new List<ProjectTaskInstanceChild>(),
             location,
             condition == string.Empty ? null : ElementLocation.EmptyLocation,
@@ -155,7 +155,7 @@ namespace Microsoft.Build.Execution
             string continueOnError,
             string msbuildRuntime,
             string msbuildArchitecture,
-            CopyOnWriteDictionary<string, Tuple<string, ElementLocation>> parameters,
+            CopyOnWriteDictionary<string, (string, ElementLocation)> parameters,
             List<ProjectTaskInstanceChild> outputs,
             ElementLocation location,
             ElementLocation conditionLocation,
@@ -238,7 +238,7 @@ namespace Microsoft.Build.Execution
             get
             {
                 Dictionary<string, string> filteredParameters = new Dictionary<string, string>(_parameters.Count, StringComparer.OrdinalIgnoreCase);
-                foreach (KeyValuePair<string, Tuple<string, ElementLocation>> parameter in _parameters)
+                foreach (KeyValuePair<string, (string, ElementLocation)> parameter in _parameters)
                 {
                     filteredParameters[parameter.Key] = parameter.Value.Item1;
                 }
@@ -247,7 +247,7 @@ namespace Microsoft.Build.Execution
             }
         }
 
-        internal IDictionary<string, Tuple<string, ElementLocation>> TestGetParameters => _parameters;
+        internal IDictionary<string, (string, ElementLocation)> TestGetParameters => _parameters;
 
         /// <summary>
         /// Ordered set of output property and item objects.
@@ -301,7 +301,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Retrieves the parameters dictionary as used during the build.
         /// </summary>
-        internal IDictionary<string, Tuple<string, ElementLocation>> ParametersForBuild
+        internal IDictionary<string, (string, ElementLocation)> ParametersForBuild
         {
             get { return _parameters; }
         }
@@ -313,8 +313,7 @@ namespace Microsoft.Build.Execution
         /// <returns>The parameter value, or null if it does not exist.</returns>
         internal string GetParameter(string parameterName)
         {
-            Tuple<string, ElementLocation> parameterValue = null;
-            if (_parameters.TryGetValue(parameterName, out parameterValue))
+            if (_parameters.TryGetValue(parameterName, out var parameterValue))
             {
                 return parameterValue.Item1;
             }
@@ -329,7 +328,7 @@ namespace Microsoft.Build.Execution
         /// <param name="unevaluatedValue">The unevaluated value for the parameter.</param>
         internal void SetParameter(string parameterName, string unevaluatedValue)
         {
-            _parameters[parameterName] = new Tuple<string, ElementLocation>(unevaluatedValue, ElementLocation.EmptyLocation);
+            _parameters[parameterName] = (unevaluatedValue, ElementLocation.EmptyLocation);
         }
 
         /// <summary>
@@ -378,16 +377,16 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _msbuildRuntimeLocation, ElementLocation.FactoryForDeserialization);
             translator.Translate(ref _msbuildArchitectureLocation, ElementLocation.FactoryForDeserialization);
 
-            IDictionary<string, Tuple<string, ElementLocation>> localParameters = _parameters;
+            IDictionary<string, (string, ElementLocation)> localParameters = _parameters;
             translator.TranslateDictionary(
                 ref localParameters,
                 ParametersKeyTranslator,
                 ParametersValueTranslator,
-                count => new CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>(count));
+                count => new CopyOnWriteDictionary<string, (string, ElementLocation)>(count));
 
             if (translator.Mode == TranslationDirection.ReadFromStream && localParameters != null)
             {
-                _parameters = (CopyOnWriteDictionary<string, Tuple<string, ElementLocation>>) localParameters;
+                _parameters = (CopyOnWriteDictionary<string, (string, ElementLocation)>) localParameters;
             }
         }
 
@@ -396,7 +395,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref key);
         }
 
-        private static void ParametersValueTranslator(ref Tuple<string, ElementLocation> value, ITranslator translator)
+        private static void ParametersValueTranslator(ref (string, ElementLocation) value, ITranslator translator)
         {
             if (translator.Mode == TranslationDirection.WriteToStream)
             {
@@ -414,7 +413,7 @@ namespace Microsoft.Build.Execution
                 translator.Translate(ref item1);
                 translator.Translate(ref item2, ElementLocation.FactoryForDeserialization);
 
-                value = Tuple.Create(item1, item2);
+                value = (item1, item2);
             }
         }
 

--- a/src/Shared/CopyOnWriteDictionary.cs
+++ b/src/Shared/CopyOnWriteDictionary.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Collections
     /// be run in a separate appdomain.
     /// </comment>
     [Serializable]
-    internal class CopyOnWriteDictionary<K, V> : IDictionary<K, V>, IDictionary where V : class
+    internal class CopyOnWriteDictionary<K, V> : IDictionary<K, V>, IDictionary
     {
 #if DEBUG
         /// <summary>
@@ -488,7 +488,7 @@ namespace Microsoft.Build.Collections
         /// <typeparam name="K1">The key type.</typeparam>
         /// <typeparam name="V1">The value type.</typeparam>
         [Serializable]
-        private class CopyOnWriteBackingDictionary<K1, V1> : Dictionary<K1, V1> where V1 : class
+        private class CopyOnWriteBackingDictionary<K1, V1> : Dictionary<K1, V1>
         {
             /// <summary>
             /// An empty dictionary 

--- a/src/Shared/FileMatcher.cs
+++ b/src/Shared/FileMatcher.cs
@@ -1465,7 +1465,7 @@ namespace Microsoft.Build.Shared
                 : null;
         }
 
-        internal delegate Tuple<string, string, string> FixupParts(
+        internal delegate (string fixedDirectoryPart, string recursiveDirectoryPart, string fileNamePart) FixupParts(
             string fixedDirectoryPart,
             string recursiveDirectoryPart,
             string filenamePart);
@@ -1491,7 +1491,6 @@ namespace Microsoft.Build.Shared
             out bool isLegalFileSpec,
             FixupParts fixupParts = null)
         {
-            isLegalFileSpec = true;
             needsRecursion = false;
             fixedDirectoryPart = String.Empty;
             wildcardDirectoryPart = String.Empty;
@@ -1513,10 +1512,9 @@ namespace Microsoft.Build.Shared
             {
                 var newParts = fixupParts(fixedDirectoryPart, wildcardDirectoryPart, filenamePart);
 
-                // todo use named tuples when they'll be available
-                fixedDirectoryPart = newParts.Item1;
-                wildcardDirectoryPart = newParts.Item2;
-                filenamePart = newParts.Item3;
+                fixedDirectoryPart = newParts.fixedDirectoryPart;
+                wildcardDirectoryPart = newParts.recursiveDirectoryPart;
+                filenamePart = newParts.fileNamePart;
             }
 
             /*

--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -308,28 +308,28 @@ namespace Microsoft.Build.Shared
         /// The rules are maintained in a 2-dimensions array. Each row defines a rule. The first column
         /// defines the trigger condition. The second column defines the fallback .net and VS versions.
         /// </remarks>
-        private static readonly Tuple<Version, Version>[,] s_explicitFallbackRulesForPathToDotNetFrameworkSdkTools =
+        private static readonly (Version, Version)[,] s_explicitFallbackRulesForPathToDotNetFrameworkSdkTools =
         {
             // VS12
-            { Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion120), Tuple.Create(dotNetFrameworkVersion45, visualStudioVersion120) },
-            { Tuple.Create(dotNetFrameworkVersion452, visualStudioVersion120), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion120) },
+            { (dotNetFrameworkVersion451, visualStudioVersion120), (dotNetFrameworkVersion45, visualStudioVersion120) },
+            { (dotNetFrameworkVersion452, visualStudioVersion120), (dotNetFrameworkVersion451, visualStudioVersion120) },
 
             // VS14
-            { Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion140), Tuple.Create(dotNetFrameworkVersion45, visualStudioVersion140) },
-            { Tuple.Create(dotNetFrameworkVersion452, visualStudioVersion140), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion140) },
-            { Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion140), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion140) },
-            { Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion140), Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion140) },
+            { (dotNetFrameworkVersion451, visualStudioVersion140), (dotNetFrameworkVersion45, visualStudioVersion140) },
+            { (dotNetFrameworkVersion452, visualStudioVersion140), (dotNetFrameworkVersion451, visualStudioVersion140) },
+            { (dotNetFrameworkVersion46, visualStudioVersion140), (dotNetFrameworkVersion451, visualStudioVersion140) },
+            { (dotNetFrameworkVersion461, visualStudioVersion140), (dotNetFrameworkVersion46, visualStudioVersion140) },
 
             // VS15
-            { Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion45, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion452, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion451, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion46, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion462, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion461, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion462, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion471, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion47, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion472, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion471, visualStudioVersion150) },
-            { Tuple.Create(dotNetFrameworkVersion48, visualStudioVersion150), Tuple.Create(dotNetFrameworkVersion472, visualStudioVersion150) },
+            { (dotNetFrameworkVersion451, visualStudioVersion150), (dotNetFrameworkVersion45, visualStudioVersion150) },
+            { (dotNetFrameworkVersion452, visualStudioVersion150), (dotNetFrameworkVersion451, visualStudioVersion150) },
+            { (dotNetFrameworkVersion46, visualStudioVersion150), (dotNetFrameworkVersion451, visualStudioVersion150) },
+            { (dotNetFrameworkVersion461, visualStudioVersion150), (dotNetFrameworkVersion46, visualStudioVersion150) },
+            { (dotNetFrameworkVersion462, visualStudioVersion150), (dotNetFrameworkVersion461, visualStudioVersion150) },
+            { (dotNetFrameworkVersion47, visualStudioVersion150), (dotNetFrameworkVersion462, visualStudioVersion150) },
+            { (dotNetFrameworkVersion471, visualStudioVersion150), (dotNetFrameworkVersion47, visualStudioVersion150) },
+            { (dotNetFrameworkVersion472, visualStudioVersion150), (dotNetFrameworkVersion471, visualStudioVersion150) },
+            { (dotNetFrameworkVersion48, visualStudioVersion150), (dotNetFrameworkVersion472, visualStudioVersion150) },
        };
 #endif // FEATURE_WIN32_REGISTRY
 


### PR DESCRIPTION
We allocate a lot of Tuples.

Hopefully switching to ValueTuples will simplify the code and reduce allocations.

One concern is that CopyOnWriteDictionary had the generic constraint on V to be a reference type. I don't know why that is, if there's an underlying reason then we need to think what to do there.

Also it feels like (string, ElementLocation) deserves to be its own named type. But we can leave that for later.