### PR TITLE
Revert "Reverted and rebuilt for localizable strings. (#5246)"

### DIFF
--- a/src/Build.UnitTests/BackEnd/BuildResult_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildResult_Tests.cs
@@ -10,8 +10,8 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Unittest;
+using Shouldly;
 using Xunit;
-
 using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
 
 namespace Microsoft.Build.UnitTests.BackEnd

--- a/src/Build.UnitTests/BackEnd/LoggingContext_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/LoggingContext_Tests.cs
@@ -4,8 +4,10 @@
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Shared;
+using Shouldly;
 using System;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.UnitTests.BackEnd
 {
@@ -14,29 +16,36 @@ namespace Microsoft.Build.UnitTests.BackEnd
     /// </summary>
     public class LoggingContext_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public LoggingContext_Tests(ITestOutputHelper outputHelper)
+        {
+            _output = outputHelper;
+        }
+
         /// <summary>
         /// A few simple tests for NodeLoggingContexts. 
         /// </summary>
         [Fact]
         public void CreateValidNodeLoggingContexts()
         {
-            NodeLoggingContext context = new NodeLoggingContext(new MockLoggingService(), 1, true);
-            Assert.True(context.IsInProcNode);
-            Assert.True(context.IsValid);
+            NodeLoggingContext context = new NodeLoggingContext(new MockLoggingService(_output.WriteLine), 1, true);
+            context.IsInProcNode.ShouldBeTrue();
+            context.IsValid.ShouldBeTrue();
 
             context.LogBuildFinished(true);
-            Assert.False(context.IsValid);
+            context.IsValid.ShouldBeFalse();
 
-            Assert.Equal(1, context.BuildEventContext.NodeId);
+            context.BuildEventContext.NodeId.ShouldBe(1);
 
-            NodeLoggingContext context2 = new NodeLoggingContext(new MockLoggingService(), 2, false);
-            Assert.False(context2.IsInProcNode);
-            Assert.True(context2.IsValid);
+            NodeLoggingContext context2 = new NodeLoggingContext(new MockLoggingService(_output.WriteLine), 2, false);
+            context2.IsInProcNode.ShouldBeFalse();
+            context2.IsValid.ShouldBeTrue();
 
             context2.LogBuildFinished(true);
-            Assert.False(context2.IsValid);
+            context2.IsValid.ShouldBeFalse();
 
-            Assert.Equal(2, context2.BuildEventContext.NodeId);
+            context2.BuildEventContext.NodeId.ShouldBe(2);
         }
 
         /// <summary>
@@ -49,9 +58,25 @@ namespace Microsoft.Build.UnitTests.BackEnd
         {
             Assert.Throws<InternalErrorException>(() =>
             {
-                NodeLoggingContext context = new NodeLoggingContext(new MockLoggingService(), -2, true);
+                _ = new NodeLoggingContext(new MockLoggingService(), -2, true);
             }
            );
+        }
+
+        [Fact]
+        public void HasLoggedErrors()
+        {
+            NodeLoggingContext context = new NodeLoggingContext(new MockLoggingService(_output.WriteLine), 1, true);
+            context.HasLoggedErrors.ShouldBeFalse();
+
+            context.LogCommentFromText(Framework.MessageImportance.High, "Test message");
+            context.HasLoggedErrors.ShouldBeFalse();
+
+            context.LogWarningFromText(null, null, null, null, "Test warning");
+            context.HasLoggedErrors.ShouldBeFalse();
+
+            context.LogErrorFromText(null, null, null, null, "Test error");
+            context.HasLoggedErrors.ShouldBeTrue();
         }
     }
 }

--- a/src/Build.UnitTests/BackEnd/ReturnFailureWithoutLoggingErrorTask.cs
+++ b/src/Build.UnitTests/BackEnd/ReturnFailureWithoutLoggingErrorTask.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+namespace Microsoft.Build.UnitTests
+{
+    /// <summary>
+    /// This task was created for https://github.com/microsoft/msbuild/issues/2036
+    /// </summary>
+    public class ReturnFailureWithoutLoggingErrorTask : Task
+    {
+        /// <summary>
+        /// Intentionally return false without logging an error to test proper error catching.
+        /// </summary>
+        /// <returns></returns>
+        public override bool Execute()
+        {
+            return false;
+        }
+    }
+}

--- a/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
+++ b/src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs
@@ -4,7 +4,9 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests;
+using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Build.Engine.UnitTests
 {
@@ -12,6 +14,13 @@ namespace Microsoft.Build.Engine.UnitTests
     {
         private const string ExpectedEventMessage = "03767942CDB147B98D0ECDBDE1436DA3";
         private const string ExpectedEventCode = "0BF68998";
+
+        ITestOutputHelper _output;
+
+        public WarningsAsMessagesAndErrorsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [Fact]
         public void TreatAllWarningsAsErrors()
@@ -29,7 +38,7 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void TreatWarningsAsErrorsWhenBuildingSameProjectMultipleTimes()
         {
-            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            using (TestEnvironment testEnvironment = TestEnvironment.Create(_output))
             {
                 TransientTestProjectWithFiles project2 = testEnvironment.CreateTestProjectWithFiles($@"
                 <Project xmlns=""msbuildnamespace"">
@@ -123,7 +132,7 @@ namespace Microsoft.Build.Engine.UnitTests
         [Fact]
         public void TreatWarningsAsMessagesWhenBuildingSameProjectMultipleTimes()
         {
-            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            using (TestEnvironment testEnvironment = TestEnvironment.Create(_output))
             {
                 TransientTestProjectWithFiles project2 = testEnvironment.CreateTestProjectWithFiles($@"
                 <Project xmlns=""msbuildnamespace"">
@@ -262,6 +271,112 @@ namespace Microsoft.Build.Engine.UnitTests
                     <Warning Text=""{ExpectedEventMessage}"" Code=""{ExpectedEventCode}"" />
                 </Target>
             </Project>";
+        }
+
+        [Fact]
+        public void TaskReturnsFailureButDoesNotLogError_ShouldCauseBuildFailure()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <Target Name='Build'>
+                        <ReturnFailureWithoutLoggingErrorTask/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.AssertLogContains("MSB4132");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsFailureButDoesNotLogError_ContinueOnError_WarnAndContinue()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <Target Name='Build'>
+                        <ReturnFailureWithoutLoggingErrorTask
+                            ContinueOnError=""WarnAndContinue""/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectSuccess();
+
+                logger.WarningCount.ShouldBe(1);
+
+                logger.AssertLogContains("MSB4132");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsFailureButDoesNotLogError_ContinueOnError_True()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <Target Name='Build'>
+                        <ReturnFailureWithoutLoggingErrorTask
+                            ContinueOnError=""true""/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectSuccess();
+
+                logger.AssertLogContains("MSB4132");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsFailureButDoesNotLogError_ContinueOnError_ErrorAndStop()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <Target Name='Build'>
+                        <ReturnFailureWithoutLoggingErrorTask
+                            ContinueOnError=""ErrorAndStop""/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.AssertLogContains("MSB4132");
+            }
+        }
+
+        [Fact]
+        public void TaskReturnsFailureButDoesNotLogError_ContinueOnError_False()
+        {
+
+            using (TestEnvironment env = TestEnvironment.Create(_output))
+            {
+                TransientTestProjectWithFiles proj = env.CreateTestProjectWithFiles($@"
+                <Project>
+                    <UsingTask TaskName = ""ReturnFailureWithoutLoggingErrorTask"" AssemblyName=""Microsoft.Build.Engine.UnitTests""/>
+                    <Target Name='Build'>
+                        <ReturnFailureWithoutLoggingErrorTask
+                            ContinueOnError=""false""/>
+                    </Target>
+                </Project>");
+
+                MockLogger logger = proj.BuildProjectExpectFailure();
+
+                logger.AssertLogContains("MSB4132");
+            }
         }
     }
 }

--- a/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/BuildLoggingContext.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogFatalTaskError(BuildEventContext, exception, file, taskName);
+            _hasLoggedErrors = true;
         }
     }
 }

--- a/src/Build/BackEnd/Components/Logging/LoggingContext.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingContext.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Build.BackEnd.Logging
         /// </summary>
         private bool _isValid;
 
+        protected bool _hasLoggedErrors;
+
         /// <summary>
         /// Constructs the logging context from a logging service and an event context.
         /// </summary>
@@ -41,6 +43,7 @@ namespace Microsoft.Build.BackEnd.Logging
             _loggingService = loggingService;
             _eventContext = eventContext;
             _isValid = false;
+            _hasLoggedErrors = false;
         }
 
         /// <summary>
@@ -106,6 +109,8 @@ namespace Microsoft.Build.BackEnd.Logging
             }
         }
 
+        internal bool HasLoggedErrors { get { return _hasLoggedErrors; } set { _hasLoggedErrors = value; } }
+
         /// <summary>
         ///  Helper method to create a message build event from a string resource and some parameters
         /// </summary>
@@ -139,6 +144,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogError(_eventContext, file, messageResourceName, messageArgs);
+            _hasLoggedErrors = true;
         }
 
         /// <summary>
@@ -152,6 +158,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogError(_eventContext, subcategoryResourceName, file, messageResourceName, messageArgs);
+            _hasLoggedErrors = true;
         }
 
         /// <summary>
@@ -166,6 +173,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogErrorFromText(_eventContext, subcategoryResourceName, errorCode, helpKeyword, file, message);
+            _hasLoggedErrors = true;
         }
 
         /// <summary>
@@ -176,6 +184,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogInvalidProjectFileError(_eventContext, invalidProjectFileException);
+            _hasLoggedErrors = true;
         }
 
         /// <summary>
@@ -189,6 +198,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(_isValid, "must be valid");
             _loggingService.LogFatalError(_eventContext, exception, file, messageResourceName, messageArgs);
+            _hasLoggedErrors = true;
         }
 
         /// <summary>
@@ -237,6 +247,7 @@ namespace Microsoft.Build.BackEnd.Logging
         {
             ErrorUtilities.VerifyThrow(IsValid, "must be valid");
             LoggingService.LogFatalBuildError(BuildEventContext, exception, file);
+            _hasLoggedErrors = true;
         }
     }
 }

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs
@@ -768,6 +768,7 @@ namespace Microsoft.Build.BackEnd
                     if (taskType == typeof(MSBuild))
                     {
                         MSBuild msbuildTask = host.TaskInstance as MSBuild;
+
                         ErrorUtilities.VerifyThrow(msbuildTask != null, "Unexpected MSBuild internal task.");
 
                         var undeclaredProjects = GetUndeclaredProjects(msbuildTask);
@@ -940,6 +941,29 @@ namespace Microsoft.Build.BackEnd
                     else
                     {
                         ErrorUtilities.ThrowInternalErrorUnreachable();
+                    }
+                }
+
+                // When a task fails it must log an error. If a task fails to do so,
+                // that is logged as an error. MSBuild tasks are an exception because
+                // errors are not logged directly from them, but the tasks spawned by them.
+                IBuildEngine be = host.TaskInstance.BuildEngine;
+                if (taskReturned && !taskResult && !taskLoggingContext.HasLoggedErrors && (be is TaskHost th ? th.BuildRequestsSucceeded : false))
+                {
+                    if (_continueOnError == ContinueOnError.WarnAndContinue)
+                    {
+                        taskLoggingContext.LogWarning(null,
+                            new BuildEventFileInfo(_targetChildInstance.Location),
+                            "TaskReturnedFalseButDidNotLogError",
+                            _taskNode.Name);
+
+                        taskLoggingContext.LogComment(MessageImportance.Normal, "ErrorConvertedIntoWarning");
+                    }
+                    else
+                    {
+                        taskLoggingContext.LogError(new BuildEventFileInfo(_targetChildInstance.Location),
+                            "TaskReturnedFalseButDidNotLogError",
+                            _taskNode.Name);
                     }
                 }
 

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -445,6 +445,7 @@ namespace Microsoft.Build.BackEnd
                 {
                     e.BuildEventContext = _taskLoggingContext.BuildEventContext;
                     _taskLoggingContext.LoggingService.LogBuildEvent(e);
+                    _taskLoggingContext.HasLoggedErrors = true;
                 }
             }
         }

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1066,6 +1066,10 @@
       LOCALIZATION: "{2}" is a localized message from a CLR/FX exception. Also, Microsoft.Build.Framework should not be localized
     </comment>
   </data>
+  <data name="TaskReturnedFalseButDidNotLogError">
+    <value>MSB4132: The "{0}" task returned false but did not log an error.</value>
+    <comment>{StrBegin="MSB4132: "}</comment>
+  </data>
   <data name="LoggerCreationError" UESanitized="true" Visibility="Public">
     <value>MSB1021: Cannot create an instance of the logger. {0}</value>
     <comment>{StrBegin="MSB1021: "}

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: Úloha {0} vrátila false, ale do protokolu se nezaznamenala chyba.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: Úloha MSBuild sestavuje projekty {0}, které nejsou zadané v položce ProjectReference. V izolovaných sestaveních to pravděpodobně znamená, že tyto odkazy nejsou v {1} explicitně zadané jako položka ProjectReference.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: Die Aufgabe "{0}" hat FALSE zurückgegeben, jedoch keinen Fehler protokolliert.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: Der MSBuild-Task erstellt die Projekte "{0}", die im ProjectReference-Element nicht angegeben sind. In isolierten Builds bedeutet dies wahrscheinlich, dass die Verweise nicht explizit als ProjectReference-Element in "{1}" angegeben werden.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="new">MSB4132: The "{0}" task returned false but did not log an error.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="new">MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: La tarea "{0}" devolvió false, pero no registró un error.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: La tarea MSBuild está compilando proyectos "{0}" que no se especifican en el elemento ProjectReference. En compilaciones aisladas, esto significa probablemente que las referencias no se especifican explícitamente como un elemento ProjectReference en "{1}".</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: la tâche "{0}" a retourné false mais n'a pas journalisé d'erreur.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: la tâche MSBuild génère un ou plusieurs projets "{0}" qui ne sont pas spécifiés dans l'élément ProjectReference. Dans les builds isolées, cela signifie probablement que les références ne sont pas explicitement spécifiées en tant qu'élément ProjectReference dans "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: l'attività "{0}" ha restituito false, ma non è stato registrato alcun errore.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: il task MSBuild compila progetti "{0}" che non sono specificati nell'elemento ProjectReference. Nelle compilazioni isolate questa condizione indica probabilmente che i riferimenti non sono specificati in modo esplicito come elemento ProjectReference in "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: "{0}" タスクから false が返されましたが、エラーがログに記録されませんでした。</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: ProjectReference 項目で指定されていないプロジェクト "{0}" が MSBuild task によってビルドされています。分離されたビルドでは、これは多くの場合、参照が "{1}" で ProjectReference 項目として明示的に指定されていないことを意味します</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: "{0}" 작업이 false를 반환했지만 오류를 기록하지 않았습니다.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: MSBuild 작업에서 ProjectReference 항목에 지정되지 않은 "{0}" 프로젝트를 빌드하고 있습니다. 격리된 빌드에서 참조가 "{1}"에서 ProjectReference 항목으로 명시적으로 지정되지 않은 상태일 수 있습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: Zadanie „{0}” zwróciło wartość false, ale nie zarejestrowało błędu.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: Zadanie programu MSBuild kompiluje projekty „{0}”, które nie są określone w elemencie ProjectReference. W przypadku kompilacji izolowanych prawdopodobnie oznacza to, że odwołania nie zostały jawnie określone jako element ProjectReference w pliku „{1}”</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: a tarefa "{0}" retornou false, mas não registrou um erro.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: a task MSBuild está criando projetos "{0}" que não estão especificados no item ProjectReference. Nos builds isolados isso provavelmente significa que as referências não estão explicitamente especificadas como um item ProjectReference em "{1}"</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: задача "{0}" возвратила значение false, но не зарегистрировала ошибку.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: задача MSBuild собирает проект(ы) {0}, которые не указаны в элементе ProjectReference. В изолированных сборках это может означать, что ссылки явно не указаны как элемент ProjectReference в "{1}".</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: "{0}" görevi false değerini döndürdü ancak günlüğe hata kaydetmedi.</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: MSBuild task, ProjectReference öğesinde belirtilmeyen "{0}" projelerini derliyor. Yalıtılmış derlemelerde bu, genellikle başvuruların "{1}" içinde açıkça ProjectReference öğesi olarak belirtilmediği anlamına gelir</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: “{0}”任务返回了 false，但未记录错误。</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: MSBuild 任务正在生成未在 ProjectReference 项中指定的项目“{0}”。在独立生成中，这可能表示未将引用显式地指定为“{1}”中的 ProjectReference 项</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -184,6 +184,11 @@
       LOCALIZATION: {0} is a file, {1} and {2} are semicolon delimited lists of messages
     </note>
       </trans-unit>
+      <trans-unit id="TaskReturnedFalseButDidNotLogError">
+        <source>MSB4132: The "{0}" task returned false but did not log an error.</source>
+        <target state="translated">MSB4132: "{0}" 工作傳回了 false，但並未記錄錯誤。</target>
+        <note>{StrBegin="MSB4132: "}</note>
+      </trans-unit>
       <trans-unit id="UndeclaredMSBuildTasksNotAllowedInIsolatedGraphBuilds">
         <source>MSB4254: The MSBuild task is building project(s) "{0}" which are not specified in the ProjectReference item. In isolated builds this probably means that the references are not explicitly specified as a ProjectReference item in "{1}"</source>
         <target state="translated">MSB4254: MSBuild 工作正在建置未在 ProjectReference 項目中指定的專案 "{0}"。在隔離式組建中，這可能代表未在 "{1}" 中將該參考明確指定為 ProjectReference 項目</target>


### PR DESCRIPTION
This reverts commit 5d306ccb597935dfdde1682d13d1099b23e3e637.

This reverts [#5246](https://github.com/microsoft/msbuild/pull/5246).

That PR removed an error message that appeared whenever a task returned false (failed) without logging an error. Although desirable for debugging behavior, multiple edge cases appeared after it was merged. Some of those were resolved with [#5173](https://github.com/microsoft/msbuild/pull/5173) and [#5191](https://github.com/microsoft/msbuild/pull/5191), but with [#5203](https://github.com/microsoft/msbuild/issues/5203), we decided to back this out until 16.7. The remaining problems should be fixed with [#5207](https://github.com/microsoft/msbuild/pull/5207).

This resolves #2036.