### PR TITLE
Test if timeouts are from starvation

### DIFF
--- a/src/MSBuild.UnitTests/XMake_Tests.cs
+++ b/src/MSBuild.UnitTests/XMake_Tests.cs
@@ -1218,6 +1218,7 @@ namespace Microsoft.Build.UnitTests
         [Fact]
         public void LowPriorityBuild()
         {
+            _output.WriteLine("Low priority build starting");
             RunPriorityBuildTest(expectedPrority: ProcessPriorityClass.BelowNormal, arguments: "/low");
         }
 

--- a/src/UnitTests.Shared/RunnerUtilities.cs
+++ b/src/UnitTests.Shared/RunnerUtilities.cs
@@ -112,7 +112,13 @@ namespace Microsoft.Build.UnitTests.Shared
                 p.BeginOutputReadLine();
                 p.BeginErrorReadLine();
                 p.StandardInput.Dispose();
-                p.WaitForExit();
+                p.WaitForExit(10000);
+                while (!p.HasExited)
+                {
+                    Console.WriteLine(p.TotalProcessorTime.TotalMilliseconds);
+                    Console.WriteLine(p.PriorityClass);
+                    p.WaitForExit(10000);
+                }
 
                 successfulExit = p.ExitCode == 0;
             }


### PR DESCRIPTION
Every 10 seconds, print out both the total CPU time a process has used as well as its priority class. If it repeatedly prints a low value, that suggests a process is being starved.

This is designed to identify if the problem identified [here](https://github.com/microsoft/msbuild/pull/5265#issuecomment-612870526) was due to running at below normal priority.

@rainersigwald