### PR TITLE
Add additional parameters to referenceassemblyresolver

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2056,6 +2056,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ResolveAssemblyReferencesSilent Condition="'$(ResolveAssemblyReferencesSilent)' == '' and '$(TraceDesignTime)' != 'true' and '$(BuildingProject)' == 'false'">true</ResolveAssemblyReferencesSilent>
       <ResolveAssemblyReferencesSilent Condition="'$(ResolveAssemblyReferencesSilent)' == ''">false</ResolveAssemblyReferencesSilent>
       <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch Condition="'$(ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch)' == ''">Warning</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+      <ResolveAssemblyReferencesFindRelatedSatellites Condition="'$(ResolveAssemblyReferencesFindRelatedSatellites)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedSatellites>
+      <ResolveAssemblyReferencesFindSerializationAssemblies Condition="'$(ResolveAssemblyReferencesFindSerializationAssemblies)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindSerializationAssemblies>
+      <ResolveAssemblyReferencesFindRelatedFiles Condition="'$(ResolveAssemblyReferencesFindRelatedFiles)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedFiles>
     </PropertyGroup>
 
     <ItemGroup>
@@ -2095,9 +2098,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         SupportsBindingRedirectGeneration="$(GenerateBindingRedirectsOutputType)"
         IgnoreVersionForFrameworkReferences="$(IgnoreVersionForFrameworkReferences)"
         FindDependencies="$(_FindDependencies)"
-        FindSatellites="$(BuildingProject)"
-        FindSerializationAssemblies="$(BuildingProject)"
-        FindRelatedFiles="$(BuildingProject)"
+        FindSatellites="$(ResolveAssemblyReferencesFindRelatedSatellites)"
+        FindSerializationAssemblies="$(ResolveAssemblyReferencesFindSerializationAssemblies)"
+        FindRelatedFiles="$(ResolveAssemblyReferencesFindRelatedFiles)"
         Silent="$(ResolveAssemblyReferencesSilent)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         TargetFrameworkMoniker="$(TargetFrameworkMoniker)"

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2056,9 +2056,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <ResolveAssemblyReferencesSilent Condition="'$(ResolveAssemblyReferencesSilent)' == '' and '$(TraceDesignTime)' != 'true' and '$(BuildingProject)' == 'false'">true</ResolveAssemblyReferencesSilent>
       <ResolveAssemblyReferencesSilent Condition="'$(ResolveAssemblyReferencesSilent)' == ''">false</ResolveAssemblyReferencesSilent>
       <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch Condition="'$(ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch)' == ''">Warning</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
-      <ResolveAssemblyReferencesFindRelatedSatellites Condition="'$(ResolveAssemblyReferencesFindRelatedSatellites)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedSatellites>
-      <ResolveAssemblyReferencesFindSerializationAssemblies Condition="'$(ResolveAssemblyReferencesFindSerializationAssemblies)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindSerializationAssemblies>
-      <ResolveAssemblyReferencesFindRelatedFiles Condition="'$(ResolveAssemblyReferencesFindRelatedFiles)' != ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedFiles>
+      <ResolveAssemblyReferencesFindRelatedSatellites Condition="'$(ResolveAssemblyReferencesFindRelatedSatellites)' == ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedSatellites>
+      <ResolveAssemblyReferencesFindSerializationAssemblies Condition="'$(ResolveAssemblyReferencesFindSerializationAssemblies)' == ''">$(BuildingProject)</ResolveAssemblyReferencesFindSerializationAssemblies>
+      <ResolveAssemblyReferencesFindRelatedFiles Condition="'$(ResolveAssemblyReferencesFindRelatedFiles)' == ''">$(BuildingProject)</ResolveAssemblyReferencesFindRelatedFiles>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Referenceassemblyresolver target does not contain properties to control finding of extra files.  This results in extra file accesses being done when they are not wanted simply because the file does not exist.  We would like the ability to turn this functionality off without setting BuildingProject to false as that has other implications for build logic.