### PR TITLE
Intern substrings created by SemiColonTokenizer

### DIFF
--- a/src/Build.UnitTests/Evaluation/SemiColonTokenizer_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SemiColonTokenizer_Tests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Evaluation;
+
+using Xunit;
+using Shouldly;
+
+namespace Microsoft.Build.UnitTests.Evaluation
+{
+    public class SemiColonTokenizer_Tests
+    {
+        [Theory]
+        [InlineData("", new string[0])]
+        [InlineData(";", new string[0])]
+        [InlineData(";;", new string[0])]
+        [InlineData(" ; ; ", new string[0])]
+        [InlineData("First", new string[] { "First" })]
+        [InlineData("First;", new string[] { "First" })]
+        [InlineData("First;Second", new string[] { "First", "Second" })]
+        [InlineData("First;Second;Third", new string[] { "First", "Second", "Third" })]
+        [InlineData(" First ;\tSecond\t;\nThird\n", new string[] { "First", "Second", "Third" })]
+        [InlineData("@(foo->'xxx;xxx');@(foo, 'xxx;xxx');@(foo->'xxx;xxx', 'xxx;xxx')", new string[] { "@(foo->'xxx;xxx')", "@(foo, 'xxx;xxx')", "@(foo->'xxx;xxx', 'xxx;xxx')" })]
+        public void TokenizeExpression(string expression, string[] expectedTokens)
+        {
+            SemiColonTokenizer tokenizer = new SemiColonTokenizer(expression);
+
+            int index = 0;
+            foreach (string actualToken in tokenizer)
+            {
+                actualToken.ShouldBe(expectedTokens[index]);
+                index++;
+            }
+            index.ShouldBe(expectedTokens.Length);
+        }
+    }
+}

--- a/src/Build.UnitTests/Evaluation/SemiColonTokenizer_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SemiColonTokenizer_Tests.cs
@@ -23,15 +23,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
         [InlineData("@(foo->'xxx;xxx');@(foo, 'xxx;xxx');@(foo->'xxx;xxx', 'xxx;xxx')", new string[] { "@(foo->'xxx;xxx')", "@(foo, 'xxx;xxx')", "@(foo->'xxx;xxx', 'xxx;xxx')" })]
         public void TokenizeExpression(string expression, string[] expectedTokens)
         {
-            SemiColonTokenizer tokenizer = new SemiColonTokenizer(expression);
-
-            int index = 0;
-            foreach (string actualToken in tokenizer)
-            {
-                actualToken.ShouldBe(expectedTokens[index]);
-                index++;
-            }
-            index.ShouldBe(expectedTokens.Length);
+            new SemiColonTokenizer(expression).ShouldBe(expectedTokens);
         }
     }
 }

--- a/src/Build/Evaluation/SemiColonTokenizer.cs
+++ b/src/Build/Evaluation/SemiColonTokenizer.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Build.Evaluation
                             if (!insideItemList)
                             {
                                 // End of segment, so add it to the list
-                                segment = _expression.Substring(segmentStart, _index - segmentStart).Trim();
-                                if (segment.Length > 0)
+                                segment = GetExpressionSubstring(segmentStart, _index - segmentStart);
+                                if (segment != null)
                                 {
                                     _current = segment;
                                     return true;
@@ -116,21 +116,39 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 // Reached the end of the string: what's left is another segment
-                segment = _expression.Substring(segmentStart, _expression.Length - segmentStart).Trim();
-                if (segment.Length > 0)
-                {
-                    _current = segment;
-                    return true;
-                }
-
-                _current = null;
-                return false;
+                _current = GetExpressionSubstring(segmentStart, _expression.Length - segmentStart);
+                return _current != null;
             }
 
             public void Reset()
             {
                 _current = default(string);
                 _index = 0;
+            }
+
+            /// <summary>
+            /// Returns a whitespace-trimmed and possibly interned substring of the expression.
+            /// </summary>
+            /// <param name="startIndex">Start index of the substring.</param>
+            /// <param name="length">Length of the substring.</param>
+            /// <returns>Equivalent to _expression.Substring(startIndex, length).Trim() or null if the trimmed substring is empty.</returns>
+            private string GetExpressionSubstring(int startIndex, int length)
+            {
+                int endIndex = startIndex + length;
+                while (startIndex < endIndex && char.IsWhiteSpace(_expression[startIndex]))
+                {
+                    startIndex++;
+                }
+                while (endIndex > startIndex && char.IsWhiteSpace(_expression[endIndex - 1]))
+                {
+                    endIndex--;
+                }
+                if (endIndex > startIndex)
+                {
+                    var target = new OpportunisticIntern.SubstringInternTarget(_expression, startIndex, endIndex - startIndex);
+                    return OpportunisticIntern.InternableToString(target);
+                }
+                return null;
             }
         }
     }

--- a/src/Build/Evaluation/SemiColonTokenizer.cs
+++ b/src/Build/Evaluation/SemiColonTokenizer.cs
@@ -139,11 +139,11 @@ namespace Microsoft.Build.Evaluation
                 {
                     startIndex++;
                 }
-                while (endIndex > startIndex && char.IsWhiteSpace(_expression[endIndex - 1]))
+                while (startIndex < endIndex && char.IsWhiteSpace(_expression[endIndex - 1]))
                 {
                     endIndex--;
                 }
-                if (endIndex > startIndex)
+                if (startIndex < endIndex)
                 {
                     var target = new OpportunisticIntern.SubstringInternTarget(_expression, startIndex, endIndex - startIndex);
                     return OpportunisticIntern.InternableToString(target);

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -465,6 +465,71 @@ namespace Microsoft.Build
             public bool ReferenceEquals(string other) => ReferenceEquals(_target, other);
         }
 
+        /// <summary>
+        /// Wrapper over a substring of a string.
+        /// </summary>
+        internal struct SubstringInternTarget : IInternable
+        {
+            /// <summary>
+            /// Stores the wrapped string.
+            /// </summary>
+            private readonly string _target;
+
+            /// <summary>
+            /// Start index of the substring within the wrapped string.
+            /// </summary>
+            private readonly int _startIndex;
+
+            /// <summary>
+            /// Constructor of the class
+            /// </summary>
+            /// <param name="target">The string to wrap.</param>
+            /// <param name="startIndex">Start index of the substring within <paramref name="target"/>.</param>
+            /// <param name="length">Length of the substring.</param>
+            internal SubstringInternTarget(string target, int startIndex, int length)
+            {
+#if DEBUG
+                if (startIndex + length > target.Length)
+                {
+                    ErrorUtilities.ThrowInternalError("wrong length");
+                }
+#endif
+                _target = target;
+                _startIndex = startIndex;
+                Length = length;
+            }
+
+            /// <summary>
+            /// Gets the length of the target substring.
+            /// </summary>
+            public int Length { get; }
+
+            /// <summary>
+            /// Gets the n character in the target substring.
+            /// </summary>
+            /// <param name="index">Index of the character to gather.</param>
+            /// <returns>The character in the position marked by index.</returns>
+            public char this[int index] => _target[index + _startIndex];
+
+            /// <summary>
+            /// Returns the target substring as a string.
+            /// </summary>
+            /// <returns>The substring.</returns>
+            public string ExpensiveConvertToString() => _target.Substring(_startIndex, Length);
+
+            /// <summary>
+            /// Compare if the target substring is equal to the given string.
+            /// </summary>
+            /// <param name="other">The string to compare with the target substring.</param>
+            /// <returns>True if the strings are equal, false otherwise.</returns>
+            public bool IsOrdinalEqualToStringOfSameLength(string other) => (String.CompareOrdinal(_target, _startIndex, other, 0, other.Length) == 0);
+
+            /// <summary>
+            /// Never reference equals to string.
+            /// </summary>
+            public bool ReferenceEquals(string other) => false;
+        }
+
         #endregion
 
         /// <summary>

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -451,10 +451,10 @@ namespace Microsoft.Build
             public string ExpensiveConvertToString() => _target;
 
             /// <summary>
-            /// Compare if the target string is equal to the given string.
+            /// Compare target to string. Assumes string is of equal or smaller length than target.
             /// </summary>
             /// <param name="other">The string to compare with the target.</param>
-            /// <returns>True if the strings are equal, false otherwise.</returns>
+            /// <returns>True if target starts with <paramref name="other"/>, false otherwise.</returns>
             public bool StartsWithStringByOrdinalComparison(string other) => _target.StartsWith(other, StringComparison.Ordinal);
 
             /// <summary>
@@ -518,11 +518,11 @@ namespace Microsoft.Build
             public string ExpensiveConvertToString() => _target.Substring(_startIndex, Length);
 
             /// <summary>
-            /// Compare if the target substring is equal to the given string.
+            /// Compare target substring to a string. Assumes string is of equal or smaller length than the target substring.
             /// </summary>
             /// <param name="other">The string to compare with the target substring.</param>
-            /// <returns>True if the strings are equal, false otherwise.</returns>
-            public bool IsOrdinalEqualToStringOfSameLength(string other) => (String.CompareOrdinal(_target, _startIndex, other, 0, other.Length) == 0);
+            /// <returns>True if target substring starts with <paramref name="other"/>, false otherwise.</returns>
+            public bool StartsWithStringByOrdinalComparison(string other) => (String.CompareOrdinal(_target, _startIndex, other, 0, other.Length) == 0);
 
             /// <summary>
             /// Never reference equals to string.


### PR DESCRIPTION
This change eliminates unnecessary string allocations in `SemiColonTokenizer` and makes it use `OpportunisticIntern` instead.

- Introduced `SubstringInternTarget ` for cases when one wishes to create substrings of an existing string. This struct wraps the string and the location of the substring.
- Implemented manual white-space trimming in `SemiColonTokenizer` to avoid potential string allocations in `String.Trim()`.
- Made `SemiColonTokenizer` use `OpportunisticIntern` so the token being returned is checked against the set of already interned strings and may itself become interned (subject to the inner workings of `OpportunisticIntern`).

Partially fixes #4172