### PR TITLE
Compute hashes in parallel in GetFileHash

### DIFF
--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Build.Tasks
 
                 lock (writeLock)
                 {
-                    // We cannot guaranteee Files instances are uniques. Write to it inside a lock to
+                    // We cannot guarantee Files instances are unique. Write to it inside a lock to
                     // avoid concurrent edits.
                     file.SetMetadata("FileHashAlgorithm", Algorithm);
                     file.SetMetadata(MetadataName, encodedHash);

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
@@ -19,6 +20,13 @@ namespace Microsoft.Build.Tasks
         internal const string _defaultFileHashAlgorithm = "SHA256";
         internal const string _hashEncodingHex = "hex";
         internal const string _hashEncodingBase64 = "base64";
+        internal static readonly Dictionary<string, Func<HashAlgorithm>> SupportedAlgorithms
+            = new Dictionary<string, Func<HashAlgorithm>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["SHA256"] = SHA256.Create,
+                ["SHA384"] = SHA384.Create,
+                ["SHA512"] = SHA512.Create,
+            };
 
         /// <summary>
         /// The files to be hashed.
@@ -55,7 +63,7 @@ namespace Microsoft.Build.Tasks
 
         public override bool Execute()
         {
-            if (!SupportsAlgorithm(Algorithm))
+            if (!SupportedAlgorithms.TryGetValue(Algorithm, out var algorithmFactory))
             {
                 Log.LogErrorWithCodeFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
                 return false;
@@ -67,25 +75,27 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            foreach (var file in Files)
+            Parallel.For(0, Files.Length, index =>
             {
+                var file = Files[index];
                 if (!FileSystems.Default.FileExists(file.ItemSpec))
                 {
                     Log.LogErrorWithCodeFromResources("FileHash.FileNotFound", file.ItemSpec);
                 }
-            }
+            });
 
             if (Log.HasLoggedErrors)
             {
                 return false;
             }
 
-            foreach (var file in Files)
+            Parallel.For(0, Files.Length, index =>
             {
-                var hash = ComputeHash(Algorithm, file.ItemSpec);
+                var file = Files[index];
+                var hash = ComputeHash(algorithmFactory, file.ItemSpec);
                 file.SetMetadata("FileHashAlgorithm", Algorithm);
                 file.SetMetadata(MetadataName, EncodeHash(encoding, hash));
-            }
+            });
 
             Items = Files;
 
@@ -113,38 +123,12 @@ namespace Microsoft.Build.Tasks
         internal static bool TryParseHashEncoding(string value, out HashEncoding encoding)
             => Enum.TryParse<HashEncoding>(value, /*ignoreCase:*/ true, out encoding);
 
-        internal static bool SupportsAlgorithm(string algorithmName)
-            => _supportedAlgorithms.Contains(algorithmName);
-
-        internal static byte[] ComputeHash(string algorithmName, string filePath)
+        internal static byte[] ComputeHash(Func<HashAlgorithm> algorithmFactory, string filePath)
         {
             using (var stream = File.OpenRead(filePath))
-            using (var algorithm = CreateAlgorithm(algorithmName))
+            using (var algorithm = algorithmFactory())
             {
                 return algorithm.ComputeHash(stream);
-            }
-        }
-
-        private static readonly HashSet<string> _supportedAlgorithms
-            = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "SHA256",
-                "SHA384",
-                "SHA512",
-            };
-
-        private static HashAlgorithm CreateAlgorithm(string algorithmName)
-        {
-            switch (algorithmName.ToUpperInvariant())
-            {
-                case "SHA256":
-                    return SHA256.Create();
-                case "SHA384":
-                    return SHA384.Create();
-                case "SHA512":
-                    return SHA512.Create();
-                default:
-                    throw new ArgumentOutOfRangeException();
             }
         }
     }

--- a/src/Tasks/FileIO/GetFileHash.cs
+++ b/src/Tasks/FileIO/GetFileHash.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
+            var writeLock = new object();
             Parallel.For(0, Files.Length, index =>
             {
                 var file = Files[index];
@@ -88,7 +89,7 @@ namespace Microsoft.Build.Tasks
                 var hash = ComputeHash(algorithmFactory, file.ItemSpec);
                 var encodedHash = EncodeHash(encoding, hash);
 
-                lock (file)
+                lock (writeLock)
                 {
                     // We cannot guaranteee Files instances are uniques. Write to it inside a lock to
                     // avoid concurrent edits.

--- a/src/Tasks/FileIO/VerifyFileHash.cs
+++ b/src/Tasks/FileIO/VerifyFileHash.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            if (!GetFileHash.SupportsAlgorithm(Algorithm))
+            if (!GetFileHash.SupportedAlgorithms.TryGetValue(Algorithm, out var algorithmFactory))
             {
                 Log.LogErrorWithCodeFromResources("FileHash.UnrecognizedHashAlgorithm", Algorithm);
                 return false;
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Tasks
                 return false;
             }
 
-            byte[] hash = GetFileHash.ComputeHash(Algorithm, File);
+            byte[] hash = GetFileHash.ComputeHash(algorithmFactory, File);
             string actualHash = GetFileHash.EncodeHash(encoding, hash);
             var comparison = encoding == Tasks.HashEncoding.Hex
                 ? StringComparison.OrdinalIgnoreCase


### PR DESCRIPTION
Based on investigations here: https://github.com/dotnet/aspnetcore/pull/21021. 

Hashes produced by GetFileHash can be calculated in parallel. This scales better for larger number of files. Some before and after with this change:

## 10 files

### Before
![image](https://user-images.githubusercontent.com/174281/79812042-8d430200-832c-11ea-802e-08c8d48dd0c6.png)

### After
![image](https://user-images.githubusercontent.com/174281/79812090-b5cafc00-832c-11ea-97e0-86f338d593ea.png)

## 100 files 
### Before
![image](https://user-images.githubusercontent.com/174281/79812209-135f4880-832d-11ea-8129-9fd2035edfcb.png)

### After
![image](https://user-images.githubusercontent.com/174281/79812234-26721880-832d-11ea-9751-e91c528b0354.png)

In addition, this PR has a few more cleanups as suggested here by @bartonjs https://github.com/dotnet/aspnetcore/pull/21021#discussion_r411714968
