### PR TITLE
Enable handshake timeout on Mono

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Build.BackEnd
                 nodeStream.WriteLongForHandshake(hostHandshake);
 
                 CommunicationsUtilities.Trace("Reading handshake from pipe {0}", pipeName);
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
                 long handshake = nodeStream.ReadLongForHandshake(timeout);
 #else
                 long handshake = nodeStream.ReadLongForHandshake();

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -369,13 +369,13 @@ namespace Microsoft.Build.Internal
         /// Extension method to read a series of bytes from a stream
         /// </summary>
         internal static long ReadLongForHandshake(this PipeStream stream
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
             , int handshakeReadTimeout
 #endif
             )
         {
             return stream.ReadLongForHandshake((byte[])null, 0
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
                 , handshakeReadTimeout
 #endif
                 );
@@ -387,14 +387,14 @@ namespace Microsoft.Build.Internal
         /// </summary>
         internal static long ReadLongForHandshake(this PipeStream stream, byte[] leadingBytesToReject,
             byte rejectionByteToReturn
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
             , int timeout
 #endif
             )
         {
             byte[] bytes = new byte[8];
 
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
             if (!NativeMethodsShared.IsWindows)
             {
                 // Enforce a minimum timeout because the Windows code can pass

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Build.BackEnd
     {
         #region Private Data
 
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
         /// <summary>
         /// The amount of time to wait for the client to connect to the host.
         /// </summary>
         private const int ClientConnectTimeout = 60000;
-#endif // NETCOREAPP2_1
+#endif // NETCOREAPP2_1 || MONO
 
         /// <summary>
         /// The size of the buffers to use for named pipes
@@ -401,7 +401,7 @@ namespace Microsoft.Build.BackEnd
                     try
                     {
                         long handshake = localReadPipe.ReadLongForHandshake(/* reject these leads */ new byte[] { 0x5F, 0x60 }, 0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1 || MONO
                             , ClientConnectTimeout /* wait a long time for the handshake from this side */
 #endif
                             );

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -186,9 +186,12 @@ namespace Microsoft.Build.UnitTests
             env.SetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD", "0");
 
             BuildRequestData data = new BuildRequestData(projectFileFullPath, new Dictionary<string, string>(), null, new string[] { "Repro" }, null);
-            BuildParameters parameters = new BuildParameters();
-            parameters.DisableInProcNode = true;
-            parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
+            BuildParameters parameters = new BuildParameters
+            {
+                DisableInProcNode = true,
+                EnableNodeReuse = false,
+                Loggers = new ILogger[] { new MockLogger(_testOutput) },
+            };
             BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
             result.OverallResult.ShouldBe(BuildResultCode.Success);
             result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.DirectorySeparatorChar);

--- a/src/Tasks.UnitTests/CreateItem_Tests.cs
+++ b/src/Tasks.UnitTests/CreateItem_Tests.cs
@@ -186,12 +186,9 @@ namespace Microsoft.Build.UnitTests
             env.SetEnvironmentVariable("MSBUILDTARGETRESULTCOMPRESSIONTHRESHOLD", "0");
 
             BuildRequestData data = new BuildRequestData(projectFileFullPath, new Dictionary<string, string>(), null, new string[] { "Repro" }, null);
-            BuildParameters parameters = new BuildParameters
-            {
-                DisableInProcNode = true,
-                EnableNodeReuse = false,
-                Loggers = new ILogger[] { new MockLogger(_testOutput) },
-            };
+            BuildParameters parameters = new BuildParameters();
+            parameters.DisableInProcNode = true;
+            parameters.Loggers = new ILogger[] { new MockLogger(_testOutput) };
             BuildResult result = BuildManager.DefaultBuildManager.Build(parameters, data);
             result.OverallResult.ShouldBe(BuildResultCode.Success);
             result.ResultsByTarget["Repro"].Items[0].GetMetadata("RecursiveDir").ShouldBe("Subdir" + Path.DirectorySeparatorChar);


### PR DESCRIPTION
I am seeing consistent test hangs on macOS Mono. A node is getting into a bad state and is failing to respond to handshakes. While I do not yet understand the root cause, it is clear that having a timeout on the handshake operation mitigates the issue. The test is now failing but does not hang, saving developer time as well as test pipeline resources.