### PR TITLE
Fix ProjectRootElement.SdkReference

### DIFF
--- a/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Construction
+{
+    public class ProjectImportElement_Tests
+    {
+        /// <summary>
+        /// Verifies that the <see cref="ProjectImportElement.ParsedSdkReference" /> object is correctly set when creating <see cref="ProjectImportElement" /> objects.
+        /// </summary>
+        [Fact]
+        public void SdkReferenceIsCorrect()
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                ProjectRootElement rootElement = ProjectRootElement.Create(NewProjectFileOptions.None);
+
+                ProjectImportElement importElement = rootElement.AddImport("Sdk.props");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Sdk = "My.Sdk", "Set Import Sdk My.Sdk");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Sdk = "My.Sdk");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBeNull();
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBeNull();
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = "1.2.0", "Set Import Version 1.2.0");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Version = "1.2.0");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBeNull();
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "1.0.0", "Set Import Minimum Version 1.0.0");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.MinimumVersion = "1.0.0");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+
+                rootElement.Save(env.GetTempFile(".csproj").Path);
+
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Sdk = "My.Sdk");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Sdk = "Some.Other.Sdk", "Set Import Sdk Some.Other.Sdk");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+
+                rootElement.Save();
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = "4.0.0", "Set Import Version 4.0.0");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBe("4.0.0");
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+
+                rootElement.Save();
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "2.0.0", "Set Import Minimum Version 2.0.0");
+
+                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.ParsedSdkReference.Version.ShouldBe("4.0.0");
+                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("2.0.0");
+            }
+        }
+
+        private void SetPropertyAndExpectProjectXmlChangedEventToFire(ProjectRootElement rootElement, Action action, string expectedReason)
+        {
+            ProjectXmlChangedEventArgs projectXmlChangedEventArgs = null;
+
+            void OnProjectXmlChanged(object sender, ProjectXmlChangedEventArgs args)
+            {
+                projectXmlChangedEventArgs = args;
+            }
+
+            rootElement.OnProjectXmlChanged += OnProjectXmlChanged;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                rootElement.OnProjectXmlChanged -= OnProjectXmlChanged;
+            }
+
+            projectXmlChangedEventArgs.ShouldNotBeNull();
+            projectXmlChangedEventArgs.Reason.ShouldBe(expectedReason);
+        }
+
+        private void SetPropertyAndExpectProjectXmlChangedEventToNotFire(ProjectRootElement rootElement, Action action)
+        {
+            ProjectXmlChangedEventArgs projectXmlChangedEventArgs = null;
+
+            void OnProjectXmlChanged(object sender, ProjectXmlChangedEventArgs args)
+            {
+                projectXmlChangedEventArgs = args;
+            }
+
+            rootElement.OnProjectXmlChanged += OnProjectXmlChanged;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                rootElement.OnProjectXmlChanged -= OnProjectXmlChanged;
+            }
+
+            projectXmlChangedEventArgs.ShouldBeNull();
+        }
+    }
+}

--- a/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.UnitTests.Construction
     public class ProjectImportElement_Tests
     {
         /// <summary>
-        /// Verifies that the <see cref="ProjectImportElement.ParsedSdkReference" /> object is correctly set when creating <see cref="ProjectImportElement" /> objects.
+        /// Verifies that the <see cref="ProjectImportElement.SdkReference" /> object is correctly set when creating <see cref="ProjectImportElement" /> objects.
         /// </summary>
         [Fact]
         public void SdkReferenceIsCorrect()
@@ -26,23 +26,23 @@ namespace Microsoft.Build.UnitTests.Construction
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Sdk = "My.Sdk", "Set Import Sdk My.Sdk");
                 SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Sdk = "My.Sdk");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBeNull();
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBeNull();
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBeNull();
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
 
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = "1.2.0", "Set Import Version 1.2.0");
                 SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Version = "1.2.0");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBeNull();
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
 
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "1.0.0", "Set Import Minimum Version 1.0.0");
                 SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.MinimumVersion = "1.0.0");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("My.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
 
                 rootElement.Save(env.GetTempFile(".csproj").Path);
 
@@ -50,25 +50,25 @@ namespace Microsoft.Build.UnitTests.Construction
 
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Sdk = "Some.Other.Sdk", "Set Import Sdk Some.Other.Sdk");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBe("1.2.0");
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
 
                 rootElement.Save();
 
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = "4.0.0", "Set Import Version 4.0.0");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBe("4.0.0");
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("1.0.0");
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBe("4.0.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
 
                 rootElement.Save();
 
                 SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "2.0.0", "Set Import Minimum Version 2.0.0");
 
-                importElement.ParsedSdkReference.Name.ShouldBe("Some.Other.Sdk");
-                importElement.ParsedSdkReference.Version.ShouldBe("4.0.0");
-                importElement.ParsedSdkReference.MinimumVersion.ShouldBe("2.0.0");
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBe("4.0.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("2.0.0");
             }
         }
 

--- a/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
+++ b/src/Build.UnitTests/Construction/ProjectImportElement_Tests.cs
@@ -5,17 +5,92 @@ using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Shouldly;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Build.UnitTests.Construction
 {
     public class ProjectImportElement_Tests
     {
+        [Fact]
+        public void SdkReferenceIsCorrect_CreatedFromOnDiskProject_SdkAndVersionAttributeSet()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFile projectFile = testEnvironment.CreateFile(
+                    "test.proj",
+                    @"
+<Project>
+  <Import Project=""Sdk.props"" Sdk=""My.Sdk"" Version=""1.2.0"" />
+</Project>");
+                ProjectRootElement rootElement = ProjectRootElement.Open(projectFile.Path);
+
+                ProjectImportElement importElement = rootElement.Imports.First();
+
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
+
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Sdk = "My.Sdk");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Version = "1.2.0");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "1.0.0", "Set Import Minimum Version 1.0.0");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.MinimumVersion = "1.0.0");
+
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Sdk = "Some.Other.Sdk", "Set Import Sdk Some.Other.Sdk");
+
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
+            }
+        }
+
+        [Fact]
+        public void SdkReferenceIsCorrect_CreatedFromOnDiskProject_SdkAttributeSet()
+        {
+            using (TestEnvironment testEnvironment = TestEnvironment.Create())
+            {
+                TransientTestFile projectFile = testEnvironment.CreateFile(
+                    "test.proj",
+                    @"
+<Project>
+  <Import Project=""Sdk.props"" Sdk=""My.Sdk"" />
+</Project>");
+                ProjectRootElement rootElement = ProjectRootElement.Open(projectFile.Path);
+
+                ProjectImportElement importElement = rootElement.Imports.First();
+
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBeNull();
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
+
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Sdk = "My.Sdk");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = "1.2.0", "Set Import Version 1.2.0");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.Version = "1.2.0");
+
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = "1.0.0", "Set Import Minimum Version 1.0.0");
+                SetPropertyAndExpectProjectXmlChangedEventToNotFire(rootElement, () => importElement.MinimumVersion = "1.0.0");
+
+                importElement.SdkReference.Name.ShouldBe("My.Sdk");
+                importElement.SdkReference.Version.ShouldBe("1.2.0");
+                importElement.SdkReference.MinimumVersion.ShouldBe("1.0.0");
+            }
+        }
+
         /// <summary>
         /// Verifies that the <see cref="ProjectImportElement.SdkReference" /> object is correctly set when creating <see cref="ProjectImportElement" /> objects.
         /// </summary>
         [Fact]
-        public void SdkReferenceIsCorrect()
+        public void SdkReferenceIsCorrect_CreatedInMemory()
         {
             using (var env = TestEnvironment.Create())
             {
@@ -69,6 +144,18 @@ namespace Microsoft.Build.UnitTests.Construction
                 importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
                 importElement.SdkReference.Version.ShouldBe("4.0.0");
                 importElement.SdkReference.MinimumVersion.ShouldBe("2.0.0");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.Version = null, "Set Import Version ");
+
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBeNull();
+                importElement.SdkReference.MinimumVersion.ShouldBe("2.0.0");
+
+                SetPropertyAndExpectProjectXmlChangedEventToFire(rootElement, () => importElement.MinimumVersion = null, "Set Import Minimum Version ");
+
+                importElement.SdkReference.Name.ShouldBe("Some.Other.Sdk");
+                importElement.SdkReference.Version.ShouldBeNull();
+                importElement.SdkReference.MinimumVersion.ShouldBeNull();
             }
         }
 

--- a/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ProjectSdkImplicitImport_Tests.cs
@@ -511,9 +511,9 @@ namespace Microsoft.Build.UnitTests.OM.Construction
                 var import = imports[i];
                 var importingElement = import.ImportingElement;
                 importingElement.Sdk.ShouldBe(SdkName + $"/{version}");
-                importingElement.ParsedSdkReference.Name.ShouldBe(SdkName);
-                importingElement.ParsedSdkReference.Version.ShouldBe(expectedVersion);
-                importingElement.ParsedSdkReference.MinimumVersion.ShouldBe(expectedMinimumVersion);
+                importingElement.SdkReference.Name.ShouldBe(SdkName);
+                importingElement.SdkReference.Version.ShouldBe(expectedVersion);
+                importingElement.SdkReference.MinimumVersion.ShouldBe(expectedMinimumVersion);
                 importingElement.SdkLocation.ShouldBe(ElementLocation.EmptyLocation);
                 importingElement.OriginalElement.ShouldBeOfType(expectedOriginalElementType);
 
@@ -523,7 +523,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
                 importingElement.ImplicitImportLocation.ShouldBe(implicitLocation);
 
-                import.SdkResult.SdkReference.ShouldBeSameAs(importingElement.ParsedSdkReference);
+                import.SdkResult.SdkReference.ShouldBeSameAs(importingElement.SdkReference);
 
                 var expectedSdkPath = i == 0
                     ? _sdkPropsPath
@@ -554,7 +554,7 @@ namespace Microsoft.Build.UnitTests.OM.Construction
 
         private SdkReference GetParsedSdk(ProjectImportElement element)
         {
-            PropertyInfo parsedSdkInfo = typeof(ProjectImportElement).GetProperty("ParsedSdkReference", BindingFlags.Instance | BindingFlags.NonPublic);
+            PropertyInfo parsedSdkInfo = typeof(ProjectImportElement).GetProperty("SdkReference", BindingFlags.Instance | BindingFlags.NonPublic);
             return (SdkReference)parsedSdkInfo.GetValue(element);
         }
     }

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Construction
             : base(xmlElement, parent, containingProject)
         {
             ErrorUtilities.VerifyThrowArgumentNull(parent, nameof(parent));
-            ParsedSdkReference = sdkReference;
+            SdkReference = sdkReference;
         }
 
         /// <summary>
@@ -130,9 +130,9 @@ namespace Microsoft.Build.Construction
 
 
         /// <summary>
-        /// <see cref="SdkReference"/> if applicable to this import element.
+        /// <see cref="Framework.SdkReference"/> if applicable to this import element.
         /// </summary>
-        internal SdkReference ParsedSdkReference { get; set; }
+        internal SdkReference SdkReference { get; set; }
 
         /// <summary>
         /// Creates an unparented ProjectImportElement, wrapping an unparented XmlElement.
@@ -162,7 +162,7 @@ namespace Microsoft.Build.Construction
                 Project = project,
                 Sdk = sdkReference.ToString(),
                 ImplicitImportLocation = implicitImportLocation,
-                ParsedSdkReference = sdkReference,
+                SdkReference = sdkReference,
                 OriginalElement = originalElement
             };
         }
@@ -183,22 +183,22 @@ namespace Microsoft.Build.Construction
         }
 
         /// <summary>
-        /// Helper method to update the <see cref="ParsedSdkReference" /> property if necessary (update only when changed).
+        /// Helper method to update the <see cref="SdkReference" /> property if necessary (update only when changed).
         /// </summary>
-        /// <returns>True if the <see cref="ParsedSdkReference" /> property was updated, otherwise false (no update necessary).</returns>
+        /// <returns>True if the <see cref="SdkReference" /> property was updated, otherwise false (no update necessary).</returns>
         private bool UpdateSdkReference(string name = null, string version = null, string minimumVersion = null)
         {
             var sdk = new SdkReference(
-                name ?? ParsedSdkReference?.Name ?? GetAttributeValue(XMakeAttributes.sdk, true),
-                version ?? ParsedSdkReference?.Version ?? GetAttributeValue(XMakeAttributes.sdkVersion, true),
-                minimumVersion ?? ParsedSdkReference?.MinimumVersion ?? GetAttributeValue(XMakeAttributes.sdkMinimumVersion, true));
+                name ?? SdkReference?.Name ?? GetAttributeValue(XMakeAttributes.sdk, true),
+                version ?? SdkReference?.Version ?? GetAttributeValue(XMakeAttributes.sdkVersion, true),
+                minimumVersion ?? SdkReference?.MinimumVersion ?? GetAttributeValue(XMakeAttributes.sdkMinimumVersion, true));
 
-            if (sdk.Equals(ParsedSdkReference))
+            if (sdk.Equals(SdkReference))
             {
                 return false;
             }
 
-            ParsedSdkReference = sdk;
+            SdkReference = sdk;
 
             return true;
         }

--- a/src/Build/Construction/ProjectImportElement.cs
+++ b/src/Build/Construction/ProjectImportElement.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Build.Construction
             set
             {
                 ErrorUtilities.VerifyThrowArgumentLength(value, XMakeAttributes.sdk);
-                if (UpdateSdkReference(name: value))
+                if (UpdateSdkReference(name: value, SdkReference?.Version, SdkReference?.MinimumVersion))
                 {
                     SetOrRemoveAttribute(XMakeAttributes.sdk, value, "Set Import Sdk {0}", value);
                 }
@@ -88,7 +88,7 @@ namespace Microsoft.Build.Construction
             get => GetAttributeValue(XMakeAttributes.sdkVersion);
             set
             {
-                if (UpdateSdkReference(version: value))
+                if (UpdateSdkReference(SdkReference?.Name, version: value, SdkReference?.MinimumVersion))
                 {
                     SetOrRemoveAttribute(XMakeAttributes.sdkVersion, value, "Set Import Version {0}", value);
                 }
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Construction
             get => GetAttributeValue(XMakeAttributes.sdkMinimumVersion);
             set
             {
-                if (UpdateSdkReference(minimumVersion: value))
+                if (UpdateSdkReference(SdkReference?.Name, SdkReference?.Version, minimumVersion: value))
                 {
                     SetOrRemoveAttribute(XMakeAttributes.sdkMinimumVersion, value, "Set Import Minimum Version {0}", value);
                 }
@@ -186,12 +186,9 @@ namespace Microsoft.Build.Construction
         /// Helper method to update the <see cref="SdkReference" /> property if necessary (update only when changed).
         /// </summary>
         /// <returns>True if the <see cref="SdkReference" /> property was updated, otherwise false (no update necessary).</returns>
-        private bool UpdateSdkReference(string name = null, string version = null, string minimumVersion = null)
+        private bool UpdateSdkReference(string name, string version, string minimumVersion)
         {
-            var sdk = new SdkReference(
-                name ?? SdkReference?.Name ?? GetAttributeValue(XMakeAttributes.sdk, true),
-                version ?? SdkReference?.Version ?? GetAttributeValue(XMakeAttributes.sdkVersion, true),
-                minimumVersion ?? SdkReference?.MinimumVersion ?? GetAttributeValue(XMakeAttributes.sdkMinimumVersion, true));
+            SdkReference sdk = new SdkReference(name, version, minimumVersion);
 
             if (sdk.Equals(SdkReference))
             {

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -1776,7 +1776,7 @@ namespace Microsoft.Build.Evaluation
 
             string project = importElement.Project;
 
-            if (importElement.ParsedSdkReference != null)
+            if (importElement.SdkReference != null)
             {
                 // Try to get the path to the solution and project being built. The solution path is not directly known
                 // in MSBuild. It is passed in as a property either by the VS project system or by MSBuild's solution
@@ -1788,7 +1788,7 @@ namespace Microsoft.Build.Evaluation
                 var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
 
                 // Combine SDK path with the "project" relative path
-                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, importElement.ParsedSdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive);
+                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, importElement.SdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive);
 
                 if (!sdkResult.Success)
                 {
@@ -1798,7 +1798,7 @@ namespace Microsoft.Build.Evaluation
                             importElement.Location.Line,
                             importElement.Location.Column,
                             ResourceUtilities.GetResourceString("CouldNotResolveSdk"),
-                            importElement.ParsedSdkReference.ToString())
+                            importElement.SdkReference.ToString())
                         {
                             BuildEventContext = _evaluationLoggingContext.BuildEventContext,
                             UnexpandedProject = importElement.Project,
@@ -1814,7 +1814,7 @@ namespace Microsoft.Build.Evaluation
                         return;
                     }
 
-                    ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "CouldNotResolveSdk", importElement.ParsedSdkReference.ToString());
+                    ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "CouldNotResolveSdk", importElement.SdkReference.ToString());
                 }
 
                 project = Path.Combine(sdkResult.Path, project);

--- a/src/Framework/Sdk/SdkReference.cs
+++ b/src/Framework/Sdk/SdkReference.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Shared;
 
@@ -10,6 +11,7 @@ namespace Microsoft.Build.Framework
     /// <summary>
     ///     Represents a software development kit (SDK) that is referenced in a &lt;Project /&gt; or &lt;Import /&gt; element.
     /// </summary>
+    [DebuggerDisplay("Name={Name} Version={Version} MinimumVersion={MinimumVersion}")]
     public sealed class SdkReference : IEquatable<SdkReference>
     {
         /// <summary>


### PR DESCRIPTION
The logic around whether or not to mark the project dirty when changing one of the three properties for an SDK on an import was not taking into account that a new value might be coming from a setter.  The code now accepts these values and calculates whether or not the set operation affects the import element.

I also renamed the property to make it more clear what it represents.

I added a unit test before fixing the code to verify that this is correctly verified.

Fixes #5320