### PR TITLE
Prevent invalidfilenamechars when globbing Fixes #5198

### DIFF
--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3744,11 +3744,6 @@ namespace Microsoft.Build.UnitTests.OM.Definition
             new[] {"ab", "de"},
             new[] {"bc", "b|c", "b", "c"}
             )]
-        [InlineData(
-            @"<A Include=`ab*;bc*;:de*`/>",
-            new[] { "ab", "bc" },
-            new[] { "de", ":de" }
-            )]
         public void GetAllGlobsShouldProduceGlobThatMatches(string itemContents, string[] stringsThatShouldMatch, string[] stringsThatShouldNotMatch)
         {
             var projectTemplate =

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3740,14 +3740,9 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         new[] {"b", "c"}
         )]
         [InlineData(
-            @"<A Include=`ab*;bc|*;de*`/>",
+            @"<A Include=`ab*;b|c*;de*`/>",
             new[] {"ab", "de"},
-            new[] {"bc", "bc|"}
-            )]
-        [InlineData(
-            @"<A Include=`\ab*;bc*;de*`/>",
-            new[] { "bc", "de" },
-            new[] { "ab", "\\ab" }
+            new[] {"bc", "b|c", "b", "c"}
             )]
         [InlineData(
             @"<A Include=`ab*;bc*;:de*`/>",

--- a/src/Build.OM.UnitTests/Definition/Project_Tests.cs
+++ b/src/Build.OM.UnitTests/Definition/Project_Tests.cs
@@ -3739,6 +3739,21 @@ namespace Microsoft.Build.UnitTests.OM.Definition
         new[] {"aa", "bb", "cc"},
         new[] {"b", "c"}
         )]
+        [InlineData(
+            @"<A Include=`ab*;bc|*;de*`/>",
+            new[] {"ab", "de"},
+            new[] {"bc", "bc|"}
+            )]
+        [InlineData(
+            @"<A Include=`\ab*;bc*;de*`/>",
+            new[] { "bc", "de" },
+            new[] { "ab", "\\ab" }
+            )]
+        [InlineData(
+            @"<A Include=`ab*;bc*;:de*`/>",
+            new[] { "ab", "bc" },
+            new[] { "de", ":de" }
+            )]
         public void GetAllGlobsShouldProduceGlobThatMatches(string itemContents, string[] stringsThatShouldMatch, string[] stringsThatShouldNotMatch)
         {
             var projectTemplate =

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// * and ? are invalid file name characters, but they occur in globs as wild cards.
         /// </summary>
-        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?' && c!= '/' && c != '\\').ToArray();
+        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?' && c!= '/' && c != '\\' && c != ':').ToArray();
 
         /// <summary>
         /// Context to log messages and events in

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// * and ? are invalid file name characters, but they occur in globs as wild cards.
         /// </summary>
-        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?').ToArray();
+        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?' && c!= '/' && c != '\\').ToArray();
 
         /// <summary>
         /// Context to log messages and events in
@@ -2506,7 +2506,7 @@ namespace Microsoft.Build.Evaluation
             {
                 var includeItemspec = new EvaluationItemSpec(itemElement.Include, _data.Expander, itemElement.IncludeLocation, itemElement.ContainingProject.DirectoryPath);
 
-                ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment && (NativeMethodsShared.IsWindows ? f.TextFragment.IndexOfAny(s_invalidGlobChars) == -1 : true)).ToImmutableArray();
+                ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment && f.TextFragment.IndexOfAny(s_invalidGlobChars) == -1).ToImmutableArray();
                 if (includeGlobFragments.Length == 0)
                 {
                     return null;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Build.Evaluation
         private static readonly bool s_debugEvaluation = (Environment.GetEnvironmentVariable("MSBUILDDEBUGEVALUATION") != null);
 
         /// <summary>
+        /// * and ? are invalid file name characters, but they occur in globs as wild cards.
+        /// </summary>
+        private static readonly char[] s_invalidGlobChars = FileUtilities.InvalidFileNameChars.Where(c => c != '*' && c != '?').ToArray();
+
+        /// <summary>
         /// Context to log messages and events in
         /// </summary>
         private static readonly BuildEventContext s_buildEventContext = new BuildEventContext(0 /* node ID */, BuildEventContext.InvalidTargetId, BuildEventContext.InvalidProjectContextId, BuildEventContext.InvalidTaskId);
@@ -2507,7 +2512,7 @@ namespace Microsoft.Build.Evaluation
                     return null;
                 }
 
-                if (NativeMethodsShared.IsWindows && itemElement.Include.IndexOfAny(FileUtilities.InvalidFileNameChars) != -1)
+                if (NativeMethodsShared.IsWindows && itemElement.Include.IndexOfAny(s_invalidGlobChars) != -1)
                 {
                     return null;
                 }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2506,13 +2506,8 @@ namespace Microsoft.Build.Evaluation
             {
                 var includeItemspec = new EvaluationItemSpec(itemElement.Include, _data.Expander, itemElement.IncludeLocation, itemElement.ContainingProject.DirectoryPath);
 
-                ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment).ToImmutableArray();
+                ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment && (NativeMethodsShared.IsWindows ? f.TextFragment.IndexOfAny(s_invalidGlobChars) == -1 : true)).ToImmutableArray();
                 if (includeGlobFragments.Length == 0)
-                {
-                    return null;
-                }
-
-                if (NativeMethodsShared.IsWindows && itemElement.Include.IndexOfAny(s_invalidGlobChars) != -1)
                 {
                     return null;
                 }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2479,6 +2479,10 @@ namespace Microsoft.Build.Evaluation
 
                     if (!string.IsNullOrEmpty(itemElement.Include))
                     {
+                        if (NativeMethodsShared.IsWindows && FileUtilities.InvalidFileNameChars.Any(c => itemElement.Include.Contains(c)))
+                        {
+                            continue;
+                        }
                         var globResult = BuildGlobResultFromIncludeItem(itemElement, removeElementCache);
 
                         if (globResult != null)
@@ -2488,6 +2492,10 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (!string.IsNullOrEmpty(itemElement.Remove))
                     {
+                        if (NativeMethodsShared.IsWindows && FileUtilities.InvalidFileNameChars.Any(c => itemElement.Include.Contains(c)))
+                        {
+                            continue;
+                        }
                         CacheInformationFromRemoveItem(itemElement, removeElementCache);
                     }
                 }

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -2479,10 +2479,6 @@ namespace Microsoft.Build.Evaluation
 
                     if (!string.IsNullOrEmpty(itemElement.Include))
                     {
-                        if (NativeMethodsShared.IsWindows && FileUtilities.InvalidFileNameChars.Any(c => itemElement.Include.Contains(c)))
-                        {
-                            continue;
-                        }
                         var globResult = BuildGlobResultFromIncludeItem(itemElement, removeElementCache);
 
                         if (globResult != null)
@@ -2492,10 +2488,6 @@ namespace Microsoft.Build.Evaluation
                     }
                     else if (!string.IsNullOrEmpty(itemElement.Remove))
                     {
-                        if (NativeMethodsShared.IsWindows && FileUtilities.InvalidFileNameChars.Any(c => itemElement.Include.Contains(c)))
-                        {
-                            continue;
-                        }
                         CacheInformationFromRemoveItem(itemElement, removeElementCache);
                     }
                 }
@@ -2511,6 +2503,11 @@ namespace Microsoft.Build.Evaluation
 
                 ImmutableArray<ItemSpecFragment> includeGlobFragments = includeItemspec.Fragments.Where(f => f is GlobFragment).ToImmutableArray();
                 if (includeGlobFragments.Length == 0)
+                {
+                    return null;
+                }
+
+                if (NativeMethodsShared.IsWindows && itemElement.Include.IndexOfAny(FileUtilities.InvalidFileNameChars) != -1)
                 {
                     return null;
                 }


### PR DESCRIPTION
This should fix #5198, but it would have perf implications, so we maybe shouldn't take it.