### PR TITLE
Fix Comment at target ResolveComReferences

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2667,6 +2667,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         [IN]
         @(COMReference) - The list of COM references
         $(InteropOutputPath) - The output directory in which to generate wrapper assemblies
+                               When $(InteropOutputPath) is not set, then it defaults to $(IntermediateOutputPath).
 
         [OUT]
         @(ReferencePath) - Paths to referenced wrappers.

--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -2666,7 +2666,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 
         [IN]
         @(COMReference) - The list of COM references
-        $(BaseIntermediateOutputPath) - The output directory in which to generate wrapper assemblies
+        $(InteropOutputPath) - The output directory in which to generate wrapper assemblies
 
         [OUT]
         @(ReferencePath) - Paths to referenced wrappers.


### PR DESCRIPTION
It's actually `InteropOutputPath`