### PR TITLE
Fix "Array dimensions exceeded supported range" exception

### DIFF
--- a/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
+++ b/src/Build.UnitTests/Graph/GraphTestingUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -218,13 +219,18 @@ namespace Microsoft.Build.Graph.UnitTests
 
         internal static IEnumerable<ProjectGraphNode> ComputeClosure(ProjectGraphNode node)
         {
-            foreach (var reference in node.ProjectReferences)
-            {
-                yield return reference;
+            return ComputeClosureRecursive(node).ToHashSet();
 
-                foreach (var closureReference in ComputeClosure(reference))
+            IEnumerable<ProjectGraphNode> ComputeClosureRecursive(ProjectGraphNode projectGraphNode)
+            {
+                foreach (var reference in projectGraphNode.ProjectReferences)
                 {
-                    yield return closureReference;
+                    yield return reference;
+
+                    foreach (var closureReference in ComputeClosureRecursive(reference))
+                    {
+                        yield return closureReference;
+                    }
                 }
             }
         }

--- a/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
+++ b/src/Build.UnitTests/Graph/ProjectGraph_Tests.cs
@@ -1409,6 +1409,19 @@ $@"
                 {
                     new Dictionary<int, int[]>
                     {
+                        {1, new []{2, 4, 3, 5} },
+                        {2, new []{5} },
+                        {3, new []{5} },
+                        {4, new []{6} },
+                        {5, new []{7} },
+                        {6, new []{5} }
+                    },
+                };
+
+                yield return new object[]
+                {
+                    new Dictionary<int, int[]>
+                    {
                         {1, new []{5, 4, 7}},
                         {2, new []{5}},
                         {3, new []{6, 5}},
@@ -1996,11 +2009,9 @@ $@"
 
             foreach (var node in graph.ProjectNodes)
             {
-                foreach (var closureReference in ComputeClosure(node))
-                {
-                    node.ProjectReferences.ShouldContain(closureReference);
-                    closureReference.ReferencingProjects.ShouldContain(node);
-                }
+                var expectedClosure = ComputeClosure(node);
+
+                node.ProjectReferences.ShouldBeSameIgnoringOrder(expectedClosure);
             }
         }
 


### PR DESCRIPTION
Hitting this on a quickbuild repo with ~550 projects and ~19K edges (due to transitive edges).

The problem was using an intermediary list to aggregate intermediary results, which exploded exponentially in size due to duplicates. Fix is to use a hash set.
The failure can't really be tested (without stress tests) because it appears in an intermediary list which finally gets dumped into a set, so there's no observable trace of the problem at the end of graph construction.

This fix avoids the exception and takes graph construction down from 5 minutes to 30 seconds on that specific repo.