### PR TITLE
Make Remove-all-items O(1)

### DIFF
--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -323,6 +323,27 @@ namespace Microsoft.Build.Evaluation
 
                 return needToExpandMetadataForEachItem;
             }
+
+            protected static bool ItemspecContainsASingleItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
+            {
+                if (itemSpec.Fragments.Count != 1)
+                {
+                    return false;
+                }
+
+                var itemExpressionFragment = itemSpec.Fragments[0] as ItemSpec<P, I>.ItemExpressionFragment;
+                if (itemExpressionFragment == null)
+                {
+                    return false;
+                }
+
+                if (!itemExpressionFragment.Capture.ItemType.Equals(referencedItemType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -134,27 +134,6 @@ namespace Microsoft.Build.Evaluation
             {
                 return itemSpec.Fragments.Any(f => f is ItemSpec<P,I>.ItemExpressionFragment);
             }
-
-            private static bool ItemspecContainsASingleItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
-            {
-                if (itemSpec.Fragments.Count != 1)
-                {
-                    return false;
-                }
-
-                var itemExpressionFragment = itemSpec.Fragments[0] as ItemSpec<P,I>.ItemExpressionFragment;
-                if (itemExpressionFragment == null)
-                {
-                    return false;
-                }
-
-                if (!itemExpressionFragment.Capture.ItemType.Equals(referencedItemType, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-
-                return true;
-            }
         }
     }
 }


### PR DESCRIPTION
In the special case where a remove operation removes all items like

```xml
<Compile Remove="@(Compile)" />
```

We currently have poor behavior because we match ("everything matches")
and then remove items one at a time. Instead, we can just empty out the
list.

Fixes #2314. Encouraged to finally do this by @maartenba's blog post https://blog.jetbrains.com/dotnet/2020/05/11/story-csproj-large-solutions-memory-usage/.