### PR TITLE
Rewrite OpportunisticIntern using weak GC handles

### DIFF
--- a/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
+++ b/src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj
@@ -87,6 +87,8 @@
     <Compile Include="..\Shared\StringBuilderCache.cs">
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>
+    <Compile Include="..\Shared\IInternable.cs" />
+    <Compile Include="..\Shared\WeakStringCache.cs" />
     <Compile Include="..\Shared\OpportunisticIntern.cs" />
     <Compile Include="..\Shared\ExceptionHandling.cs">
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>

--- a/src/Build.UnitTests/OpportunisticIntern_Tests.cs
+++ b/src/Build.UnitTests/OpportunisticIntern_Tests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.UnitTests
 {
     public class OpportunisticIntern_Tests
     {
-        private static bool IsInternable(OpportunisticIntern.IInternable internable)
+        private static bool IsInternable(IInternable internable)
         {
             string i1 = OpportunisticIntern.InternableToString(internable);
             string i2 = OpportunisticIntern.InternableToString(internable);
@@ -20,19 +20,19 @@ namespace Microsoft.Build.UnitTests
             return Object.ReferenceEquals(i1, i2);
         }
 
-        private static void AssertInternable(OpportunisticIntern.IInternable internable)
+        private static void AssertInternable(IInternable internable)
         {
             Assert.True(IsInternable(internable));
         }
 
         private static void AssertInternable(StringBuilder sb)
         {
-            AssertInternable(new OpportunisticIntern.StringBuilderInternTarget(sb));
+            AssertInternable(new StringBuilderInternTarget(sb));
         }
 
         private static string AssertInternable(char[] ch, int startIndex, int count)
         {
-            var target = new OpportunisticIntern.CharArrayInternTarget(ch, startIndex, count);
+            var target = new CharArrayInternTarget(ch, startIndex, count);
             AssertInternable(target);
             Assert.Equal(target.Length, count);
 
@@ -45,19 +45,19 @@ namespace Microsoft.Build.UnitTests
             AssertInternable(value.ToCharArray(), 0, value.ToCharArray().Length);
         }
 
-        private static void AssertNotInternable(OpportunisticIntern.IInternable internable)
+        private static void AssertNotInternable(IInternable internable)
         {
             Assert.False(IsInternable(internable));
         }
 
         private static void AssertNotInternable(StringBuilder sb)
         {
-            AssertNotInternable(new OpportunisticIntern.StringBuilderInternTarget(sb));
+            AssertNotInternable(new StringBuilderInternTarget(sb));
         }
 
         private static void AssertNotInternable(char[] ch)
         {
-            AssertNotInternable(new OpportunisticIntern.CharArrayInternTarget(ch, ch.Length));
+            AssertNotInternable(new CharArrayInternTarget(ch, ch.Length));
         }
 
         private static void AssertNotInternable(string value)
@@ -86,24 +86,6 @@ namespace Microsoft.Build.UnitTests
             var result = AssertInternable(new char[] { 'a', 't', 'r', 'u', 'e', 'x' }, 1, 4);
 
             Assert.Equal("true", result);
-        }
-
-        /// <summary>
-        /// Test a single know-to-intern tiny string to verify the mechanism.
-        /// </summary>
-        [Fact]
-        public void InternableTinyString()
-        {
-            AssertInternable("true");
-        }
-
-        /// <summary>
-        /// Test a single known-to-not-intern tiny string to verify the mechanism.
-        /// </summary>
-        [Fact]
-        public void NonInternableTinyString()
-        {
-            AssertNotInternable("1234");
         }
 
         /// <summary>

--- a/src/Build.UnitTests/WeakStringCache_Tests.cs
+++ b/src/Build.UnitTests/WeakStringCache_Tests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.IO;
+using Microsoft.Build;
+using Microsoft.Build.Shared;
+using Xunit;
+using Shouldly;
+using System.Runtime.CompilerServices;
+using System.Diagnostics;
+
+namespace Microsoft.Build.UnitTests
+{
+    public class WeakStringCache_Tests : IDisposable
+    {
+        /// <summary>
+        /// The weak string cache under test.
+        /// </summary>
+        private WeakStringCache _cache = new WeakStringCache();
+
+        public void Dispose()
+        {
+            _cache.Dispose();
+        }
+
+        /// <summary>
+        /// Adds a string to the cache under test.
+        /// </summary>
+        /// <param name="strPart1">Part one of the string (split to prevent runtime interning and unintended GC roots).</param>
+        /// <param name="strPart2">Part two of the string (split to prevent runtime interning and unintended GC roots).</param>
+        /// <param name="callbackToRunWithTheStringAlive">Callback to be invoked after the string has been added but before the strong GC ref is released.</param>
+        /// <returns>The hash code of the string as calculated by WeakStringCache.</returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private int AddString(string strPart1, string strPart2, Action<string> callbackToRunWithTheStringAlive)
+        {
+            // Compose the string with SB so it doesn't get interned by the runtime.
+            string testString = new StringBuilder(strPart1).Append(strPart2).ToString();
+            StringInternTarget testStringTarget = new StringInternTarget(testString);
+
+            int hashCode = WeakStringCache.GetInternableHashCode(testStringTarget);
+
+            string cachedString = _cache.GetOrCreateEntry(testStringTarget, out bool cacheHit);
+            cacheHit.ShouldBeFalse();
+            cachedString.ShouldBeSameAs(testString);
+
+            callbackToRunWithTheStringAlive(cachedString);
+
+            // Verify that the string is really in the cache and the cache returns the interned instance.
+            string testStringCopy = new StringBuilder(strPart1).Append(strPart2).ToString();
+            cachedString = _cache.GetOrCreateEntry(new StringInternTarget(testStringCopy), out cacheHit);
+            cacheHit.ShouldBeTrue();
+            cachedString.ShouldBeSameAs(testString);
+
+            // Trigger full GC and verify that nothing has changed since we're still keeping testString alive.
+            GC.Collect();
+
+            callbackToRunWithTheStringAlive(cachedString);
+
+            cachedString = _cache.GetOrCreateEntry(new StringInternTarget(testStringCopy), out cacheHit);
+            cacheHit.ShouldBeTrue();
+            cachedString.ShouldBeSameAs(testString);
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Adds two strings that are known to have a hash code collision to the cache under test.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void AddTwoStringsWithHashCollision()
+        {
+            string firstCachedString = null;
+
+            // Add strings to the cache using a non-inlinable method to make sure they're not reachable from a GC root.
+            int hashCode1 = AddString("Random string ", "1", (string cachedString) =>
+            {
+                _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+                {
+                    UsedBucketCount = 1,
+                    UnusedBucketCount = 0,
+                    LiveStringCount = 1,
+                    CollectedStringCount = 0,
+                    HashCollisionCount = 0
+                });
+                firstCachedString = cachedString;
+            });
+
+            int hashCode2 = AddString("Random string ", "14858396876", (string cachedString) =>
+            {
+                _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+                {
+                    UsedBucketCount = 1,
+                    UnusedBucketCount = 0,
+                    LiveStringCount = 2,
+                    CollectedStringCount = 0,
+                    HashCollisionCount = 1
+                });
+
+                string firstCachedStringFromCache = _cache.GetOrCreateEntry(new StringInternTarget(firstCachedString), out bool cacheHit);
+                cacheHit.ShouldBeTrue();
+                firstCachedStringFromCache.ShouldBeSameAs(firstCachedString);
+            });
+
+            // The two string have been carefully chosen to have the same hash code.
+            hashCode2.ShouldBe(hashCode1);
+        }
+
+        /// <summary>
+        /// Simple test case to verify that:
+        /// 1. A string added to the cache stays in the cache as long as it's alive.
+        /// 2. The string is no longer retrievable after all strong GC refs are gone.
+        /// 3. The cache completely removes the bucket with the string after calling Scavenge on it.
+        /// </summary>
+        [Fact]
+        public void RetainsStringUntilCollected()
+        {
+            // Add a string to the cache using a non-inlinable method to make sure it's not reachable from a GC root.
+            AddString("Random string ", "test", (string cachedString) =>
+            {
+                _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+                {
+                    UsedBucketCount = 1,
+                    UnusedBucketCount = 0,
+                    LiveStringCount = 1,
+                    CollectedStringCount = 0,
+                    HashCollisionCount = 0
+                });
+            });
+
+            // Trigger full GC.
+            GC.Collect();
+
+            // The bucket is still in the cache but it's unused now as the string has been collected.
+            _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+            {
+                UsedBucketCount = 0,
+                UnusedBucketCount = 1,
+                LiveStringCount = 0,
+                CollectedStringCount = 1,
+                HashCollisionCount = 0
+            });
+
+            // Ask the cache to get rid of unused buckets.
+            _cache.Scavenge();
+
+            // The cache should be empty now.
+            _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+            {
+                UsedBucketCount = 0,
+                UnusedBucketCount = 0,
+                LiveStringCount = 0,
+                CollectedStringCount = 0,
+                HashCollisionCount = 0
+            });
+        }
+
+        /// <summary>
+        /// Same as RetainsStringUntilCollected but with two strings with the same hash code. Verifies that the bucket overflow area
+        /// works correctly.
+        /// </summary>
+        [Fact]
+        public void RetainsStringsWithHashCollisions()
+        {
+            AddTwoStringsWithHashCollision();
+
+            // Trigger full GC.
+            GC.Collect();
+
+            // The bucket is still in the cache but it's unused now as the strings have been collected.
+            _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+            {
+                UsedBucketCount = 0,
+                UnusedBucketCount = 1,
+                LiveStringCount = 0,
+                CollectedStringCount = 2,
+                HashCollisionCount = 1
+            });
+
+            // Ask the cache to get rid of unused buckets.
+            _cache.Scavenge();
+
+            // The cache should be empty now.
+            _cache.GetDebugInfo().ShouldBe(new WeakStringCache.DebugInfo()
+            {
+                UsedBucketCount = 0,
+                UnusedBucketCount = 0,
+                LiveStringCount = 0,
+                CollectedStringCount = 0,
+                HashCollisionCount = 0
+            });
+        }
+    }
+}

--- a/src/Build/Evaluation/SemiColonTokenizer.cs
+++ b/src/Build/Evaluation/SemiColonTokenizer.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Build.Evaluation
                 }
                 if (startIndex < endIndex)
                 {
-                    var target = new OpportunisticIntern.SubstringInternTarget(_expression, startIndex, endIndex - startIndex);
+                    var target = new SubstringInternTarget(_expression, startIndex, endIndex - startIndex);
                     return OpportunisticIntern.InternableToString(target);
                 }
                 return null;

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -351,6 +351,8 @@
     <Compile Include="..\Shared\CollectionHelpers.cs" />
     <Compile Include="Collections\ConvertingEnumerable.cs" />
     <Compile Include="Collections\CopyOnReadEnumerable.cs" />
+    <Compile Include="..\Shared\IInternable.cs" />
+    <Compile Include="..\Shared\WeakStringCache.cs" />
     <Compile Include="..\Shared\OpportunisticIntern.cs" />
     <Compile Include="..\Shared\CopyOnWriteDictionary.cs">
       <Link>Collections\CopyOnWriteDictionary.cs</Link>

--- a/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
+++ b/src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
@@ -43,6 +43,8 @@
     <Compile Include="..\Shared\ExceptionHandling.cs" />
     <Compile Include="..\Shared\VisualStudioLocationHelper.cs" />
     <Compile Include="..\Shared\StringBuilderCache.cs" />
+    <Compile Include="..\Shared\IInternable.cs" />
+    <Compile Include="..\Shared\WeakStringCache.cs" />
     <Compile Include="..\Shared\OpportunisticIntern.cs" />
     <Compile Include="..\Shared\FileUtilitiesRegex.cs" />
     <Compile Include="..\Shared\UnitTests\AssemblyResources.cs" />

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -129,6 +129,8 @@
     <Compile Include="..\Shared\BinaryTranslator.cs" />
     <Compile Include="..\Shared\CommunicationsUtilities.cs" />
     <Compile Include="..\Shared\InterningBinaryReader.cs" />
+    <Compile Include="..\Shared\IInternable.cs" />
+    <Compile Include="..\Shared\WeakStringCache.cs" />
     <Compile Include="..\Shared\OpportunisticIntern.cs" />
     <Compile Include="..\Shared\TaskHostConfiguration.cs" />
     <Compile Include="..\Shared\TaskHostTaskComplete.cs" />

--- a/src/MSBuildTaskHost/MSBuildTaskHost.csproj
+++ b/src/MSBuildTaskHost/MSBuildTaskHost.csproj
@@ -125,6 +125,12 @@
     <Compile Include="..\Shared\NodeShutdown.cs">
       <Link>NodeShutdown.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IInternable.cs">
+      <Link>IInternable.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\WeakStringCache.cs">
+      <Link>WeakStringCache.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\OpportunisticIntern.cs">
       <Link>OpportunisticIntern.cs</Link>
     </Compile>

--- a/src/Shared/IInternable.cs
+++ b/src/Shared/IInternable.cs
@@ -1,0 +1,346 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using Microsoft.Build.Shared;
+
+namespace Microsoft.Build
+{
+    #region IInternable
+    /// <summary>
+    /// Define the methods needed to intern something.
+    /// </summary>
+    internal interface IInternable
+    {
+        /// <summary>
+        /// The length of the target.
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
+        /// Indexer into the target. Presumed to be fast.
+        /// </summary>
+        char this[int index] { get; }
+
+        /// <summary>
+        /// Convert target to string. Presumed to be slow (and will be called just once).
+        /// </summary>
+        string ExpensiveConvertToString();
+
+        /// <summary>
+        /// Compare target to string. Assumes string is of equal or smaller length than target.
+        /// </summary>
+        bool StartsWithStringByOrdinalComparison(string other);
+
+        /// <summary>
+        /// Reference compare target to string. If target is non-string this should return false.
+        /// </summary>
+        bool ReferenceEquals(string other);
+    }
+    #endregion
+
+
+    #region IInternable Implementations
+    /// <summary>
+    /// A wrapper over StringBuilder.
+    /// </summary>
+    internal struct StringBuilderInternTarget : IInternable
+    {
+        /// <summary>
+        /// The held StringBuilder
+        /// </summary>
+        private readonly StringBuilder _target;
+
+        /// <summary>
+        /// Pointless comment about constructor.
+        /// </summary>
+        internal StringBuilderInternTarget(StringBuilder target)
+        {
+            _target = target;
+        }
+
+        /// <summary>
+        /// The length of the target.
+        /// </summary>
+        public int Length => _target.Length;
+
+        /// <summary>
+        /// Indexer into the target. Presumed to be fast.
+        /// </summary>
+        public char this[int index] => _target[index];
+
+        /// <summary>
+        /// Never reference equals to string.
+        /// </summary>
+        public bool ReferenceEquals(string other) => false;
+
+        /// <summary>
+        /// Convert target to string. Presumed to be slow (and will be called just once).
+        /// </summary>
+        public string ExpensiveConvertToString()
+        {
+            // PERF NOTE: This will be an allocation hot-spot because the StringBuilder is finally determined to
+            // not be internable. There is still only one conversion of StringBuilder into string it has just
+            // moved into this single spot.
+            return _target.ToString();
+        }
+
+        /// <summary>
+        /// Compare target to string. Assumes string is of equal or smaller length than target.
+        /// </summary>
+        public bool StartsWithStringByOrdinalComparison(string other)
+        {
+#if DEBUG
+            ErrorUtilities.VerifyThrow(other.Length <= _target.Length, "should be at most as long as target");
+#endif
+            int length = other.Length;
+
+            // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
+            // For example, C:\project1, C:\project2
+            for (int i = length - 1; i >= 0; --i)
+            {
+                if (_target[i] != other[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Don't use this function. Use ExpensiveConvertToString
+        /// </summary>
+        public override string ToString() => throw new InvalidOperationException();
+    }
+
+    /// <summary>
+    /// A wrapper over char[].
+    /// </summary>
+    internal struct CharArrayInternTarget : IInternable
+    {
+        /// <summary>
+        /// Start index for the string
+        /// </summary>
+        private readonly int _startIndex;
+
+        /// <summary>
+        /// The held array
+        /// </summary>
+        private readonly char[] _target;
+
+        /// <summary>
+        /// Pointless comment about constructor.
+        /// </summary>
+        internal CharArrayInternTarget(char[] target, int count)
+            : this(target, 0, count)
+        {
+        }
+
+        /// <summary>
+        /// Pointless comment about constructor.
+        /// </summary>
+        internal CharArrayInternTarget(char[] target, int startIndex, int count)
+        {
+#if DEBUG
+            if (startIndex + count > target.Length)
+            {
+                ErrorUtilities.ThrowInternalError("wrong length");
+            }
+#endif
+            _target = target;
+            _startIndex = startIndex;
+            Length = count;
+        }
+
+        /// <summary>
+        /// The length of the target.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Indexer into the target. Presumed to be fast.
+        /// </summary>
+        public char this[int index]
+        {
+            get
+            {
+                if (index > _startIndex + Length - 1 || index < 0)
+                {
+                    ErrorUtilities.ThrowInternalError("past end");
+                }
+
+                return _target[index + _startIndex];
+            }
+        }
+
+        /// <summary>
+        /// Convert target to string. Presumed to be slow (and will be called just once).
+        /// </summary>
+        public bool ReferenceEquals(string other)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Convert target to string. Presumed to be slow (and will be called just once).
+        /// </summary>
+        public string ExpensiveConvertToString()
+        {
+            // PERF NOTE: This will be an allocation hot-spot because the char[] is finally determined to
+            // not be internable. There is still only one conversion of char[] into string it has just
+            // moved into this single spot.
+            return new string(_target, _startIndex, Length);
+        }
+
+        /// <summary>
+        /// Compare target to string. Assumes string is of equal or smaller length than target.
+        /// </summary>
+        public bool StartsWithStringByOrdinalComparison(string other)
+        {
+#if DEBUG
+            ErrorUtilities.VerifyThrow(other.Length <= Length, "should be at most as long as target");
+#endif
+            // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
+            // For example, C:\project1, C:\project2
+            for (int i = other.Length - 1; i >= 0; --i)
+            {
+                if (_target[i + _startIndex] != other[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Don't use this function. Use ExpensiveConvertToString
+        /// </summary>
+        public override string ToString()
+        {
+            throw new InvalidOperationException();
+        }
+    }
+
+    /// <summary>
+    /// Wrapper over a string.
+    /// </summary>
+    internal struct StringInternTarget : IInternable
+    {
+        /// <summary>
+        /// Stores the wrapped string.
+        /// </summary>
+        private readonly string _target;
+
+        /// <summary>
+        /// Constructor of the class
+        /// </summary>
+        /// <param name="target">The string to wrap</param>
+        internal StringInternTarget(string target)
+        {
+            ErrorUtilities.VerifyThrowArgumentLength(target, nameof(target));
+            _target = target;
+        }
+
+        /// <summary>
+        /// Gets the length of the target string.
+        /// </summary>
+        public int Length => _target.Length;
+
+        /// <summary>
+        /// Gets the n character in the target string.
+        /// </summary>
+        /// <param name="index">Index of the character to gather.</param>
+        /// <returns>The character in the position marked by index.</returns>
+        public char this[int index] => _target[index];
+
+        /// <summary>
+        /// Returns the target which is already a string.
+        /// </summary>
+        /// <returns>The target string.</returns>
+        public string ExpensiveConvertToString() => _target;
+
+        /// <summary>
+        /// Compare target to string. Assumes string is of equal or smaller length than target.
+        /// </summary>
+        /// <param name="other">The string to compare with the target.</param>
+        /// <returns>True if target starts with <paramref name="other"/>, false otherwise.</returns>
+        public bool StartsWithStringByOrdinalComparison(string other) => _target.StartsWith(other, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Verifies if the reference of the target string is the same of the given string.
+        /// </summary>
+        /// <param name="other">The string reference to compare to.</param>
+        /// <returns>True if both references are equal, false otherwise.</returns>
+        public bool ReferenceEquals(string other) => ReferenceEquals(_target, other);
+    }
+
+    /// <summary>
+    /// Wrapper over a substring of a string.
+    /// </summary>
+    internal struct SubstringInternTarget : IInternable
+    {
+        /// <summary>
+        /// Stores the wrapped string.
+        /// </summary>
+        private readonly string _target;
+
+        /// <summary>
+        /// Start index of the substring within the wrapped string.
+        /// </summary>
+        private readonly int _startIndex;
+
+        /// <summary>
+        /// Constructor of the class
+        /// </summary>
+        /// <param name="target">The string to wrap.</param>
+        /// <param name="startIndex">Start index of the substring within <paramref name="target"/>.</param>
+        /// <param name="length">Length of the substring.</param>
+        internal SubstringInternTarget(string target, int startIndex, int length)
+        {
+#if DEBUG
+            if (startIndex + length > target.Length)
+            {
+                ErrorUtilities.ThrowInternalError("wrong length");
+            }
+#endif
+            _target = target;
+            _startIndex = startIndex;
+            Length = length;
+        }
+
+        /// <summary>
+        /// Gets the length of the target substring.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Gets the n character in the target substring.
+        /// </summary>
+        /// <param name="index">Index of the character to gather.</param>
+        /// <returns>The character in the position marked by index.</returns>
+        public char this[int index] => _target[index + _startIndex];
+
+        /// <summary>
+        /// Returns the target substring as a string.
+        /// </summary>
+        /// <returns>The substring.</returns>
+        public string ExpensiveConvertToString() => _target.Substring(_startIndex, Length);
+
+        /// <summary>
+        /// Compare target substring to a string. Assumes string is of equal or smaller length than the target substring.
+        /// </summary>
+        /// <param name="other">The string to compare with the target substring.</param>
+        /// <returns>True if target substring starts with <paramref name="other"/>, false otherwise.</returns>
+        public bool StartsWithStringByOrdinalComparison(string other) => (String.CompareOrdinal(_target, _startIndex, other, 0, other.Length) == 0);
+
+        /// <summary>
+        /// Never reference equals to string.
+        /// </summary>
+        public bool ReferenceEquals(string other) => false;
+    }
+
+    #endregion
+}

--- a/src/Shared/OpportunisticIntern.cs
+++ b/src/Shared/OpportunisticIntern.cs
@@ -2,16 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-#if !CLR2COMPATIBILITY
-using System.Collections.Concurrent;
-#endif
 using System.Text;
-using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using Microsoft.Build.Shared;
-using Microsoft.Build.Utilities;
+using System.Linq;
+using System.Globalization;
 
 namespace Microsoft.Build
 {
@@ -21,140 +17,75 @@ namespace Microsoft.Build
     ///
     ///     string interned = OpportunisticIntern.Intern(String.Join(",",someStrings));
     ///
-    /// This class uses heuristics to decide whether it will be efficient to intern a string or not. There is no
-    /// guarantee that a string will intern.
-    ///
-    /// The thresholds and sizes were determined by experimentation to give the best number of bytes saved
-    /// at reasonable elapsed time cost.
     /// </summary>
     internal static class OpportunisticIntern
     {
-        private static readonly bool s_useSimpleConcurrency = Traits.Instance.UseSimpleInternConcurrency;
-
         /// <summary>
-        /// The size of the small mru list.
+        /// Enumerates the possible interning results.
         /// </summary>
-        private static readonly int s_smallMruSize = AssignViaEnvironment("MSBUILDSMALLINTERNSIZE", 50);
-
-        /// <summary>
-        /// The size of the large mru list.
-        /// </summary>
-        private static readonly int s_largeMruSize = AssignViaEnvironment("MSBUILDLARGEINTERNSIZE", 100);
-
-        /// <summary>
-        /// The size of the huge mru list.
-        /// </summary>
-        private static readonly int s_hugeMruSize = AssignViaEnvironment("MSBUILDHUGEINTERNSIZE", 100);
-
-        /// <summary>
-        /// The smallest size a string can be to be considered small.
-        /// </summary>
-        private static readonly int s_smallMruThreshold = AssignViaEnvironment("MSBUILDSMALLINTERNTHRESHOLD", 50);
-
-        /// <summary>
-        /// The smallest size a string can be to be considered large.
-        /// </summary>
-        private static readonly int s_largeMruThreshold = AssignViaEnvironment("MSBUILDLARGEINTERNTHRESHOLD", 70);
-
-        /// <summary>
-        /// The smallest size a string can be to be considered huge.
-        /// </summary>
-        private static readonly int s_hugeMruThreshold = AssignViaEnvironment("MSBUILDHUGEINTERNTHRESHOLD", 200);
-
-        /// <summary>
-        /// The smallest size a string can be to be ginormous.
-        /// 8K for large object heap.
-        /// </summary>
-        private static readonly int s_ginormousThreshold = AssignViaEnvironment("MSBUILDGINORMOUSINTERNTHRESHOLD", 8000);
+        private enum InternResult
+        {
+            MatchedHardcodedString,
+            FoundInWeakStringCache,
+            AddedToWeakStringCache,
+            RejectedFromInterning
+        }
 
         /// <summary>
         /// Manages the separate MRU lists.
         /// </summary>
-        private static BucketedPrioritizedStringList s_si = new BucketedPrioritizedStringList(/*gatherStatistics*/ false, s_smallMruSize, s_largeMruSize, s_hugeMruSize, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
+        private static readonly WeakStringCache s_weakStringCache = new WeakStringCache();
 
         #region Statistics
         /// <summary>
-        /// What if Mru lists were infinitely long?
+        /// Whether or not to gather statistics
         /// </summary>
-        private static BucketedPrioritizedStringList s_whatIfInfinite;
+        private static bool s_gatherStatistics;
 
         /// <summary>
-        /// What if we doubled the size of the Mru lists?
+        /// Number of times interning worked.
         /// </summary>
-        private static BucketedPrioritizedStringList s_whatIfDoubled;
+        private static int s_hardcodedInternHits;
 
         /// <summary>
-        /// What if we halved the size of the Mru lists?
+        /// Number of times interning didn't work.
         /// </summary>
-        private static BucketedPrioritizedStringList s_whatIfHalved;
+        private static int s_regularInternHits;
 
         /// <summary>
-        /// What if the size of Mru lists was zero? (We still intern tiny strings in this case)
+        /// Number of times interning wasn't attempted.
         /// </summary>
-        private static BucketedPrioritizedStringList s_whatIfZero;
+        private static int s_regularInternMisses;
+
+        /// <summary>
+        /// Number of times interning wasn't attempted.
+        /// </summary>
+        private static int s_rejectedStrings;
+
+        /// <summary>
+        /// Total number of strings eliminated by interning.
+        /// </summary>
+        private static int s_internEliminatedStrings;
+
+        /// <summary>
+        /// Total number of chars eliminated across all strings.
+        /// </summary>
+        private static int s_internEliminatedChars;
+
+        /// <summary>
+        /// Strings which did not intern
+        /// </summary>
+        private static Dictionary<string, int> s_missedHardcodedStrings;
+
         #endregion
-
-        #region IInternable
-        /// <summary>
-        /// Define the methods needed to intern something.
-        /// </summary>
-        internal interface IInternable
-        {
-            /// <summary>
-            /// The length of the target.
-            /// </summary>
-            int Length { get; }
-
-            /// <summary>
-            /// Indexer into the target. Presumed to be fast.
-            /// </summary>
-            char this[int index] { get; }
-
-            /// <summary>
-            /// Convert target to string. Presumed to be slow (and will be called just once).
-            /// </summary>
-            string ExpensiveConvertToString();
-
-            /// <summary>
-            /// Compare target to string. Assumes string is of equal or smaller length than target.
-            /// </summary>
-            bool StartsWithStringByOrdinalComparison(string other);
-
-            /// <summary>
-            /// Reference compare target to string. If target is non-string this should return false.
-            /// </summary>
-            bool ReferenceEquals(string other);
-        }
-        #endregion
-
-        /// <summary>
-        /// Assign an int from an environment variable. If its not present, use the default.
-        /// </summary>
-        internal static int AssignViaEnvironment(string env, int @default)
-        {
-            string threshold = Environment.GetEnvironmentVariable(env);
-            if (!string.IsNullOrEmpty(threshold))
-            {
-                if (int.TryParse(threshold, out int result))
-                {
-                    return result;
-                }
-            }
-
-            return @default;
-        }
 
         /// <summary>
         /// Turn on statistics gathering.
         /// </summary>
         internal static void EnableStatisticsGathering()
         {
-            // Statistics include several 'what if' scenarios such as doubling the size of the MRU lists.
-            s_si = new BucketedPrioritizedStringList(/*gatherStatistics*/ true, s_smallMruSize, s_largeMruSize, s_hugeMruSize, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
-            s_whatIfInfinite = new BucketedPrioritizedStringList(/*gatherStatistics*/ true, int.MaxValue, int.MaxValue, int.MaxValue, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
-            s_whatIfDoubled = new BucketedPrioritizedStringList(/*gatherStatistics*/ true, s_smallMruSize * 2, s_largeMruSize * 2, s_hugeMruSize * 2, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
-            s_whatIfHalved = new BucketedPrioritizedStringList(/*gatherStatistics*/ true, s_smallMruSize / 2, s_largeMruSize / 2, s_hugeMruSize / 2, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
-            s_whatIfZero = new BucketedPrioritizedStringList(/*gatherStatistics*/ true, 0, 0, 0, s_smallMruThreshold, s_largeMruThreshold, s_hugeMruThreshold, s_ginormousThreshold, s_useSimpleConcurrency);
+            s_missedHardcodedStrings = new Dictionary<string, int>();
+            s_gatherStatistics = true;
         }
 
         /// <summary>
@@ -162,15 +93,7 @@ namespace Microsoft.Build
         /// </summary>
         internal static string InternableToString<T>(T candidate) where T : IInternable
         {
-            if (s_whatIfInfinite != null)
-            {
-                s_whatIfInfinite.InterningToString(candidate);
-                s_whatIfDoubled.InterningToString(candidate);
-                s_whatIfHalved.InterningToString(candidate);
-                s_whatIfZero.InterningToString(candidate);
-            }
-
-            string result = s_si.InterningToString(candidate);
+            string result = InterningToString(candidate);
 #if DEBUG
             string expected = candidate.ExpensiveConvertToString();
             if (!String.Equals(result, expected))
@@ -216,934 +139,205 @@ namespace Microsoft.Build
         }
 
         /// <summary>
-        /// Report statistics about interning. Don't call unless GatherStatistics has been called beforehand.
+        /// Intern the given internable.
+        /// </summary>
+        internal static string InterningToString<T>(T candidate) where T : IInternable
+        {
+            if (candidate.Length == 0)
+            {
+                // As in the case that a property or itemlist has evaluated to empty.
+                return string.Empty;
+            }
+
+            if (s_gatherStatistics)
+            {
+                return InternWithStatistics(candidate);
+            }
+            else
+            {
+                TryIntern(candidate, out string result);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Report statistics to the console.
         /// </summary>
         internal static void ReportStatistics()
         {
-            s_si.ReportStatistics("Main");
-            s_whatIfInfinite.ReportStatistics("if Infinite");
-            s_whatIfDoubled.ReportStatistics("if Doubled");
-            s_whatIfHalved.ReportStatistics("if Halved");
-            s_whatIfZero.ReportStatistics("if Zero");
-            Console.WriteLine(" * Even for MRU size of zero there will still be some intern hits because of the tiny ");
-            Console.WriteLine("   string matching (eg. 'true')");
+            string title = "Opportunistic Intern";
+            Console.WriteLine("\n{0}{1}{0}", new string('=', 41 - (title.Length / 2)), title);
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Hardcoded Hits", s_hardcodedInternHits, "hits");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Hardcoded Rejects", s_rejectedStrings, "rejects");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "WeakStringCache Hits", s_regularInternHits, "hits");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "WeakStringCache Misses", s_regularInternMisses, "misses");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Eliminated Strings*", s_internEliminatedStrings, "strings");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Eliminated Chars", s_internEliminatedChars, "chars");
+            Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Estimated Eliminated Bytes", s_internEliminatedChars * 2, "bytes");
+            Console.WriteLine("Elimination assumes that strings provided were unique objects.");
+            Console.WriteLine("|---------------------------------------------------------------------------------|");
+
+            IEnumerable<string> topMissingHardcodedString =
+                s_missedHardcodedStrings
+                .OrderByDescending(kv => kv.Value * kv.Key.Length)
+                .Take(15)
+                .Where(kv => kv.Value > 1)
+                .Select(kv => string.Format(CultureInfo.InvariantCulture, "({1} instances x each {2} chars)\n{0}", kv.Key, kv.Value, kv.Key.Length));
+
+            Console.WriteLine("##########Top Missing Hardcoded Strings:  \n{0} ", string.Join("\n==============\n", topMissingHardcodedString.ToArray()));
+            Console.WriteLine();
+
+            WeakStringCache.DebugInfo debugInfo = s_weakStringCache.GetDebugInfo();
+            Console.WriteLine("WeakStringCache statistics:");
+            Console.WriteLine("Bucket count used/unused/total    = {0}/{1}/{2}", debugInfo.UsedBucketCount, debugInfo.UnusedBucketCount, debugInfo.UsedBucketCount + debugInfo.UnusedBucketCount);
+            Console.WriteLine("String count live/collected/total = {0}/{1}/{2}", debugInfo.LiveStringCount, debugInfo.CollectedStringCount, debugInfo.LiveStringCount + debugInfo.CollectedStringCount);
+            Console.WriteLine("Hash collisions                   = {0}", debugInfo.HashCollisionCount);
         }
 
-        #region IInternable Implementations
-        /// <summary>
-        /// A wrapper over StringBuilder.
-        /// </summary>
-        internal struct StringBuilderInternTarget : IInternable
+        private static bool TryInternHardcodedString<T>(T candidate, string str, ref string interned) where T : IInternable
         {
-            /// <summary>
-            /// The held StringBuilder
-            /// </summary>
-            private readonly StringBuilder _target;
+            Debug.Assert(candidate.Length == str.Length);
 
-            /// <summary>
-            /// Pointless comment about constructor.
-            /// </summary>
-            internal StringBuilderInternTarget(StringBuilder target)
+            if (candidate.StartsWithStringByOrdinalComparison(str))
             {
-                _target = target;
-            }
-
-            /// <summary>
-            /// The length of the target.
-            /// </summary>
-            public int Length => _target.Length;
-
-            /// <summary>
-            /// Indexer into the target. Presumed to be fast.
-            /// </summary>
-            public char this[int index] => _target[index];
-
-            /// <summary>
-            /// Never reference equals to string.
-            /// </summary>
-            public bool ReferenceEquals(string other) => false;
-
-            /// <summary>
-            /// Convert target to string. Presumed to be slow (and will be called just once).
-            /// </summary>
-            public string ExpensiveConvertToString()
-            {
-                // PERF NOTE: This will be an allocation hot-spot because the StringBuilder is finally determined to
-                // not be internable. There is still only one conversion of StringBuilder into string it has just
-                // moved into this single spot.
-                return _target.ToString();
-            }
-
-            /// <summary>
-            /// Compare target to string. Assumes string is of equal or smaller length than target.
-            /// </summary>
-            public bool StartsWithStringByOrdinalComparison(string other)
-            {
-#if DEBUG
-                ErrorUtilities.VerifyThrow(other.Length <= _target.Length, "should be at most as long as target");
-#endif
-                int length = other.Length;
-
-                // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
-                // For example, C:\project1, C:\project2
-                for (int i = length - 1; i >= 0; --i)
-                {
-                    if (_target[i] != other[i])
-                    {
-                        return false;
-                    }
-                }
-
+                interned = str;
                 return true;
             }
-
-            /// <summary>
-            /// Don't use this function. Use ExpensiveConvertToString
-            /// </summary>
-            public override string ToString() => throw new InvalidOperationException();
+            return false;
         }
 
         /// <summary>
-        /// A wrapper over char[].
+        /// Try to intern the string.
+        /// The return value indicates the how the string was interned (if at all).
         /// </summary>
-        internal struct CharArrayInternTarget : IInternable
+        private static InternResult TryIntern<T>(T candidate, out string interned) where T : IInternable
         {
-            /// <summary>
-            /// Start index for the string
-            /// </summary>
-            private readonly int _startIndex;
+            int length = candidate.Length;
+            interned = null;
 
-            /// <summary>
-            /// The held array
-            /// </summary>
-            private readonly char[] _target;
-
-            /// <summary>
-            /// Pointless comment about constructor.
-            /// </summary>
-            internal CharArrayInternTarget(char[] target, int count)
-                : this(target, 0, count)
+            // First, try the hard coded intern strings.
+            // Each of the hard-coded small strings below showed up in a profile run with considerable duplication in memory.
+            if (length == 2)
             {
-            }
-
-            /// <summary>
-            /// Pointless comment about constructor.
-            /// </summary>
-            internal CharArrayInternTarget(char[] target, int startIndex, int count)
-            {
-#if DEBUG
-                if (startIndex + count > target.Length)
+                if (candidate[1] == '#')
                 {
-                    ErrorUtilities.ThrowInternalError("wrong length");
-                }
-#endif
-                _target = target;
-                _startIndex = startIndex;
-                Length = count;
-            }
-
-            /// <summary>
-            /// The length of the target.
-            /// </summary>
-            public int Length { get; }
-
-            /// <summary>
-            /// Indexer into the target. Presumed to be fast.
-            /// </summary>
-            public char this[int index]
-            {
-                get
-                {
-                    if (index > _startIndex + Length - 1 || index < 0)
+                    if (candidate[0] == 'C')
                     {
-                        ErrorUtilities.ThrowInternalError("past end");
+                        interned = "C#";
+                        return InternResult.MatchedHardcodedString;
                     }
 
-                    return _target[index + _startIndex];
-                }
-            }
-
-            /// <summary>
-            /// Convert target to string. Presumed to be slow (and will be called just once).
-            /// </summary>
-            public bool ReferenceEquals(string other)
-            {
-                return false;
-            }
-
-            /// <summary>
-            /// Convert target to string. Presumed to be slow (and will be called just once).
-            /// </summary>
-            public string ExpensiveConvertToString()
-            {
-                // PERF NOTE: This will be an allocation hot-spot because the char[] is finally determined to
-                // not be internable. There is still only one conversion of char[] into string it has just
-                // moved into this single spot.
-                return new string(_target, _startIndex, Length);
-            }
-
-            /// <summary>
-            /// Compare target to string. Assumes string is of equal or smaller length than target.
-            /// </summary>
-            public bool StartsWithStringByOrdinalComparison(string other)
-            {
-#if DEBUG
-                ErrorUtilities.VerifyThrow(other.Length <= Length, "should be at most as long as target");
-#endif
-                // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
-                // For example, C:\project1, C:\project2
-                for (int i = other.Length - 1; i >= 0; --i)
-                {
-                    if (_target[i + _startIndex] != other[i])
+                    if (candidate[0] == 'F')
                     {
-                        return false;
+                        interned = "F#";
+                        return InternResult.MatchedHardcodedString;
                     }
                 }
 
-                return true;
-            }
-
-            /// <summary>
-            /// Don't use this function. Use ExpensiveConvertToString
-            /// </summary>
-            public override string ToString()
-            {
-                throw new InvalidOperationException();
-            }
-        }
-
-        /// <summary>
-        /// Wrapper over a string.
-        /// </summary>
-        internal struct StringInternTarget : IInternable
-        {
-            /// <summary>
-            /// Stores the wrapped string.
-            /// </summary>
-            private readonly string _target;
-
-            /// <summary>
-            /// Constructor of the class
-            /// </summary>
-            /// <param name="target">The string to wrap</param>
-            internal StringInternTarget(string target)
-            {
-                ErrorUtilities.VerifyThrowArgumentLength(target, nameof(target));
-                _target = target;
-            }
-
-            /// <summary>
-            /// Gets the length of the target string.
-            /// </summary>
-            public int Length => _target.Length;
-
-            /// <summary>
-            /// Gets the n character in the target string.
-            /// </summary>
-            /// <param name="index">Index of the character to gather.</param>
-            /// <returns>The character in the position marked by index.</returns>
-            public char this[int index] => _target[index];
-
-            /// <summary>
-            /// Returns the target which is already a string.
-            /// </summary>
-            /// <returns>The target string.</returns>
-            public string ExpensiveConvertToString() => _target;
-
-            /// <summary>
-            /// Compare target to string. Assumes string is of equal or smaller length than target.
-            /// </summary>
-            /// <param name="other">The string to compare with the target.</param>
-            /// <returns>True if target starts with <paramref name="other"/>, false otherwise.</returns>
-            public bool StartsWithStringByOrdinalComparison(string other) => _target.StartsWith(other, StringComparison.Ordinal);
-
-            /// <summary>
-            /// Verifies if the reference of the target string is the same of the given string.
-            /// </summary>
-            /// <param name="other">The string reference to compare to.</param>
-            /// <returns>True if both references are equal, false otherwise.</returns>
-            public bool ReferenceEquals(string other) => ReferenceEquals(_target, other);
-        }
-
-        /// <summary>
-        /// Wrapper over a substring of a string.
-        /// </summary>
-        internal struct SubstringInternTarget : IInternable
-        {
-            /// <summary>
-            /// Stores the wrapped string.
-            /// </summary>
-            private readonly string _target;
-
-            /// <summary>
-            /// Start index of the substring within the wrapped string.
-            /// </summary>
-            private readonly int _startIndex;
-
-            /// <summary>
-            /// Constructor of the class
-            /// </summary>
-            /// <param name="target">The string to wrap.</param>
-            /// <param name="startIndex">Start index of the substring within <paramref name="target"/>.</param>
-            /// <param name="length">Length of the substring.</param>
-            internal SubstringInternTarget(string target, int startIndex, int length)
-            {
-#if DEBUG
-                if (startIndex + length > target.Length)
+                if (candidate[0] == 'V' && candidate[1] == 'B')
                 {
-                    ErrorUtilities.ThrowInternalError("wrong length");
-                }
-#endif
-                _target = target;
-                _startIndex = startIndex;
-                Length = length;
-            }
-
-            /// <summary>
-            /// Gets the length of the target substring.
-            /// </summary>
-            public int Length { get; }
-
-            /// <summary>
-            /// Gets the n character in the target substring.
-            /// </summary>
-            /// <param name="index">Index of the character to gather.</param>
-            /// <returns>The character in the position marked by index.</returns>
-            public char this[int index] => _target[index + _startIndex];
-
-            /// <summary>
-            /// Returns the target substring as a string.
-            /// </summary>
-            /// <returns>The substring.</returns>
-            public string ExpensiveConvertToString() => _target.Substring(_startIndex, Length);
-
-            /// <summary>
-            /// Compare target substring to a string. Assumes string is of equal or smaller length than the target substring.
-            /// </summary>
-            /// <param name="other">The string to compare with the target substring.</param>
-            /// <returns>True if target substring starts with <paramref name="other"/>, false otherwise.</returns>
-            public bool StartsWithStringByOrdinalComparison(string other) => (String.CompareOrdinal(_target, _startIndex, other, 0, other.Length) == 0);
-
-            /// <summary>
-            /// Never reference equals to string.
-            /// </summary>
-            public bool ReferenceEquals(string other) => false;
-        }
-
-        #endregion
-
-        /// <summary>
-        /// Manages a set of mru lists that hold strings in varying size ranges.
-        /// </summary>
-        private class BucketedPrioritizedStringList
-        {
-            /// <summary>
-            /// The small string Mru list.
-            /// </summary>
-            private readonly PrioritizedStringList _smallMru;
-
-            /// <summary>
-            /// The large string Mru list.
-            /// </summary>
-            private readonly PrioritizedStringList _largeMru;
-
-            /// <summary>
-            /// The huge string Mru list.
-            /// </summary>
-            private readonly PrioritizedStringList _hugeMru;
-
-            /// <summary>
-            /// Three most recently used strings over 8K.
-            /// </summary>
-            private readonly LinkedList<WeakReference> _ginormous = new LinkedList<WeakReference>();
-
-            /// <summary>
-            /// The smallest size a string can be to be considered small.
-            /// </summary>
-            private readonly int _smallMruThreshold;
-
-            /// <summary>
-            /// The smallest size a string can be to be considered large.
-            /// </summary>
-            private readonly int _largeMruThreshold;
-
-            /// <summary>
-            /// The smallest size a string can be to be considered huge.
-            /// </summary>
-            private readonly int _hugeMruThreshold;
-
-            /// <summary>
-            /// The smallest size a string can be to be ginormous.
-            /// </summary>
-            private readonly int _ginormousThreshold;
-
-            private readonly bool _useSimpleConcurrency;
-
-#if !CLR2COMPATIBILITY
-            // ConcurrentDictionary starts with capacity 31 but we're usually adding far more than that. Make a better first capacity guess to reduce
-            // ConcurrentDictionary having to take all internal locks to upgrade its bucket list. Note that the number should be prime per the
-            // comments on the code at https://referencesource.microsoft.com/#mscorlib/system/Collections/Concurrent/ConcurrentDictionary.cs,122 
-            // Also note default lock count is Environment.ProcessorCount from the same code.
-            private const int InitialCapacity = 2053;
-            private readonly ConcurrentDictionary<string, string> _internedStrings = new ConcurrentDictionary<string, string>(Environment.ProcessorCount, InitialCapacity, StringComparer.Ordinal);
-#endif
-
-            #region Statistics
-            /// <summary>
-            /// Whether or not to gather statistics
-            /// </summary>
-            private readonly bool _gatherStatistics;
-
-            /// <summary>
-            /// Number of times interning worked.
-            /// </summary>
-            private int _internHits;
-
-            /// <summary>
-            /// Number of times interning didn't work.
-            /// </summary>
-            private int _internMisses;
-
-            /// <summary>
-            /// Number of times interning wasn't attempted.
-            /// </summary>
-            private int _internRejects;
-
-            /// <summary>
-            /// Total number of strings eliminated by interning.
-            /// </summary>
-            private int _internEliminatedStrings;
-
-            /// <summary>
-            /// Total number of chars eliminated across all strings.
-            /// </summary>
-            private int _internEliminatedChars;
-
-            /// <summary>
-            /// Number of times the ginourmous string hit.
-            /// </summary>
-            private int _ginormousHits;
-
-            /// <summary>
-            /// Number of times the ginourmous string missed.
-            /// </summary>
-            private int _ginormousMisses;
-
-            /// <summary>
-            /// Chars interned for ginormous range.
-            /// </summary>
-            private int _ginormousCharsSaved;
-
-            /// <summary>
-            /// Whether or not to track ginormous strings.
-            /// </summary>
-            private readonly bool _dontTrack;
-
-            /// <summary>
-            /// The time spent interning.
-            /// </summary>
-            private readonly Stopwatch _stopwatch;
-
-            /// <summary>
-            /// Strings which did not intern
-            /// </summary>
-            private readonly Dictionary<string, int> _missedStrings;
-
-            /// <summary>
-            /// Strings which we didn't attempt to intern
-            /// </summary>
-            private readonly Dictionary<string, int> _rejectedStrings;
-
-            /// <summary>
-            /// Number of ginormous strings to keep
-            /// By observation of Auto7, there are about three variations of the huge solution config blob
-            /// There aren't really any other strings of this size, but make it 10 to be sure. (There will barely be any misses)
-            /// </summary>
-            private const int GinormousSize = 10;
-
-            #endregion
-
-            /// <summary>
-            /// Construct.
-            /// </summary>
-            internal BucketedPrioritizedStringList(bool gatherStatistics, int smallMruSize, int largeMruSize, int hugeMruSize, int smallMruThreshold, int largeMruThreshold, int hugeMruThreshold, int ginormousThreshold, bool useSimpleConcurrency)
-            {
-                if (smallMruSize == 0 && largeMruSize == 0 && hugeMruSize == 0)
-                {
-                    _dontTrack = true;
-                }
-
-                _smallMru = new PrioritizedStringList(smallMruSize);
-                _largeMru = new PrioritizedStringList(largeMruSize);
-                _hugeMru = new PrioritizedStringList(hugeMruSize);
-                _smallMruThreshold = smallMruThreshold;
-                _largeMruThreshold = largeMruThreshold;
-                _hugeMruThreshold = hugeMruThreshold;
-                _ginormousThreshold = ginormousThreshold;
-                _useSimpleConcurrency = useSimpleConcurrency;
-
-                for (int i = 0; i < GinormousSize; i++)
-                {
-                    _ginormous.AddFirst(new WeakReference(string.Empty));
-                }
-
-                _gatherStatistics = gatherStatistics;
-                if (gatherStatistics)
-                {
-                    _stopwatch = new Stopwatch();
-                    _missedStrings = new Dictionary<string, int>(StringComparer.Ordinal);
-                    _rejectedStrings = new Dictionary<string, int>(StringComparer.Ordinal);
+                    interned = "VB";
+                    return InternResult.MatchedHardcodedString;
                 }
             }
-
-            /// <summary>
-            /// Intern the given internable.
-            /// </summary>
-            internal string InterningToString<T>(T candidate) where T : IInternable
+            else if (length == 4)
             {
-                if (candidate.Length == 0)
+                if (TryInternHardcodedString(candidate, "TRUE", ref interned) ||
+                    TryInternHardcodedString(candidate, "True", ref interned) ||
+                    TryInternHardcodedString(candidate, "Copy", ref interned) ||
+                    TryInternHardcodedString(candidate, "true", ref interned) ||
+                    TryInternHardcodedString(candidate, "v4.0", ref interned))
                 {
-                    // As in the case that a property or itemlist has evaluated to empty.
-                    return string.Empty;
-                }
-
-                if (_gatherStatistics)
-                {
-                    return InternWithStatistics(candidate);
-                }
-                else
-                {
-                    TryIntern(candidate, out string result);
-                    return result;
+                    return InternResult.MatchedHardcodedString;
                 }
             }
-
-            /// <summary>
-            /// Report statistics to the console.
-            /// </summary>
-            internal void ReportStatistics(string heading)
+            else if (length == 5)
             {
-                string title = "Opportunistic Intern (" + heading + ")";
-                Console.WriteLine("\n{0}{1}{0}", new string('=', 41 - (title.Length / 2)), title);
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Intern Hits", _internHits, "hits");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Intern Misses", _internMisses, "misses");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Intern Rejects (as shorter than " + s_smallMruThreshold + " bytes)", _internRejects, "rejects");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Eliminated Strings*", _internEliminatedStrings, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Eliminated Chars", _internEliminatedChars, "chars");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Estimated Eliminated Bytes", _internEliminatedChars * 2, "bytes");
-                Console.WriteLine("Elimination assumes that strings provided were unique objects.");
-                Console.WriteLine("|---------------------------------------------------------------------------------|");
-                KeyValuePair<int, int> held = _smallMru.Statistics();
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Small Strings MRU Size", s_smallMruSize, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Small Strings (>=" + _smallMruThreshold + " chars) Held", held.Key, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Small Estimated Bytes Held", held.Value * 2, "bytes");
-                Console.WriteLine("|---------------------------------------------------------------------------------|");
-                held = _largeMru.Statistics();
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Large Strings MRU Size", s_largeMruSize, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Large Strings  (>=" + _largeMruThreshold + " chars) Held", held.Key, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Large Estimated Bytes Held", held.Value * 2, "bytes");
-                Console.WriteLine("|---------------------------------------------------------------------------------|");
-                held = _hugeMru.Statistics();
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Huge Strings MRU Size", s_hugeMruSize, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Huge Strings  (>=" + _hugeMruThreshold + " chars) Held", held.Key, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Huge Estimated Bytes Held", held.Value * 2, "bytes");
-                Console.WriteLine("|---------------------------------------------------------------------------------|");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Ginormous Strings MRU Size", GinormousSize, "strings");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Ginormous (>=" + _ginormousThreshold + " chars)  Hits", _ginormousHits, "hits");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Ginormous Misses", _ginormousMisses, "misses");
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Ginormous Chars Saved", _ginormousCharsSaved, "chars");
-                Console.WriteLine("|---------------------------------------------------------------------------------|");
-
-                // There's no point in reporting the ginormous string because it will have evaporated by now.
-                Console.WriteLine("||{0,50}|{1,20:N0}|{2,8}|", "Time Spent Interning", _stopwatch.ElapsedMilliseconds, "ms");
-                Console.WriteLine("{0}{0}", new string('=', 41));
-
-                IEnumerable<string> topMissingString =
-                    _missedStrings
-                    .OrderByDescending(kv => kv.Value * kv.Key.Length)
-                    .Take(15)
-                    .Where(kv => kv.Value > 1)
-                    .Select(kv => string.Format(CultureInfo.InvariantCulture, "({1} instances x each {2} chars = {3}KB wasted)\n{0}", kv.Key, kv.Value, kv.Key.Length, (kv.Value - 1) * kv.Key.Length * 2 / 1024));
-
-                Console.WriteLine("##########Top Missed Strings:  \n{0} ", string.Join("\n==============\n", topMissingString.ToArray()));
-                Console.WriteLine();
-
-                IEnumerable<string> topRejectedString =
-                    _rejectedStrings
-                    .OrderByDescending(kv => kv.Value * kv.Key.Length)
-                    .Take(15)
-                    .Where(kv => kv.Value > 1)
-                    .Select(kv => string.Format(CultureInfo.InvariantCulture, "({1} instances x each {2} chars = {3}KB wasted)\n{0}", kv.Key, kv.Value, kv.Key.Length, (kv.Value - 1) * kv.Key.Length * 2 / 1024));
-
-                Console.WriteLine("##########Top Rejected Strings: \n{0} ", string.Join("\n==============\n", topRejectedString.ToArray()));
-            }
-
-            private bool TryInternHardcodedString<T>(T candidate, string str, ref string interned) where T : IInternable
-            {
-                Debug.Assert(candidate.Length == str.Length);
-
-                if (candidate.StartsWithStringByOrdinalComparison(str))
+                if (TryInternHardcodedString(candidate, "FALSE", ref interned) ||
+                    TryInternHardcodedString(candidate, "false", ref interned) ||
+                    TryInternHardcodedString(candidate, "Debug", ref interned) ||
+                    TryInternHardcodedString(candidate, "Build", ref interned) ||
+                    TryInternHardcodedString(candidate, "Win32", ref interned))
                 {
-                    interned = str;
-                    return true;
+                    return InternResult.MatchedHardcodedString;
                 }
-                return false;
             }
-
-            /// <summary>
-            /// Try to intern the string.
-            /// Return true if an interned value could be returned.
-            /// Return false if it was added to the intern list, but wasn't there already.
-            /// Return null if it didn't meet the length criteria for any of the buckets. Interning was rejected
-            /// </summary>
-            private bool? TryIntern<T>(T candidate, out string interned) where T : IInternable
+            else if (length == 6)
             {
-                int length = candidate.Length;
-                interned = null;
-
-                // First, try the hard coded intern strings.
-                // Each of the hard-coded small strings below showed up in a profile run with considerable duplication in memory.
-                if (!_dontTrack)
+                if (TryInternHardcodedString(candidate, "''!=''", ref interned) ||
+                    TryInternHardcodedString(candidate, "AnyCPU", ref interned))
                 {
-                    if (length == 2)
-                    {
-                        if (candidate[1] == '#')
-                        {
-                            if (candidate[0] == 'C')
-                            {
-                                interned = "C#";
-                                return true;
-                            }
-
-                            if (candidate[0] == 'F')
-                            {
-                                interned = "F#";
-                                return true;
-                            }
-                        }
-
-                        if (candidate[0] == 'V' && candidate[1] == 'B')
-                        {
-                            interned = "VB";
-                            return true;
-                        }
-                    }
-                    else if (length == 4)
-                    {
-                        if (TryInternHardcodedString(candidate, "TRUE", ref interned) ||
-                            TryInternHardcodedString(candidate, "True", ref interned) ||
-                            TryInternHardcodedString(candidate, "Copy", ref interned) ||
-                            TryInternHardcodedString(candidate, "true", ref interned) ||
-                            TryInternHardcodedString(candidate, "v4.0", ref interned))
-                        {
-                            return true;
-                        }
-                    }
-                    else if (length == 5)
-                    {
-                        if (TryInternHardcodedString(candidate, "FALSE", ref interned) ||
-                            TryInternHardcodedString(candidate, "false", ref interned) ||
-                            TryInternHardcodedString(candidate, "Debug", ref interned) ||
-                            TryInternHardcodedString(candidate, "Build", ref interned) ||
-                            TryInternHardcodedString(candidate, "Win32", ref interned))
-                        {
-                            return true;
-                        }
-                    }
-                    else if (length == 6)
-                    {
-                        if (TryInternHardcodedString(candidate, "''!=''", ref interned) ||
-                            TryInternHardcodedString(candidate, "AnyCPU", ref interned))
-                        {
-                            return true;
-                        }
-                    }
-                    else if (length == 7)
-                    {
-                        if (TryInternHardcodedString(candidate, "Library", ref interned) ||
-                            TryInternHardcodedString(candidate, "MSBuild", ref interned) ||
-                            TryInternHardcodedString(candidate, "Release", ref interned))
-                        {
-                            return true;
-                        }
-                    }
-                    // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
-                    else if (length > MSBuildConstants.MSBuildDummyGlobalPropertyHeader.Length &&
-                            candidate.StartsWithStringByOrdinalComparison(MSBuildConstants.MSBuildDummyGlobalPropertyHeader))
-                    {
-                        // don't want to leak unique strings into the cache
-                        interned = candidate.ExpensiveConvertToString();
-                        return null;
-                    }
-                    else if (length == 24)
-                    {
-                        if (TryInternHardcodedString(candidate, "ResolveAssemblyReference", ref interned))
-                        {
-                            return true;
-                        }
-                    }
-                    else if (length > _ginormousThreshold)
-                    {
-                        lock (_ginormous)
-                        {
-                            LinkedListNode<WeakReference> current = _ginormous.First;
-
-                            while (current != null)
-                            {
-                                if (current.Value.Target is string last && last.Length == candidate.Length && candidate.StartsWithStringByOrdinalComparison(last))
-                                {
-                                    interned = last;
-                                    _ginormousHits++;
-                                    _ginormousCharsSaved += last.Length;
-
-                                    _ginormous.Remove(current);
-                                    _ginormous.AddFirst(current);
-
-                                    return true;
-                                }
-
-                                current = current.Next;
-                            }
-
-                            _ginormousMisses++;
-                            interned = candidate.ExpensiveConvertToString();
-
-                            LinkedListNode<WeakReference> lastNode = _ginormous.Last;
-                            _ginormous.RemoveLast();
-                            _ginormous.AddFirst(lastNode);
-                            lastNode.Value.Target = interned;
-
-                            return false;
-                        }
-                    }
-#if !CLR2COMPATIBILITY
-                    else if (_useSimpleConcurrency)
-                    {
-                        var stringified = candidate.ExpensiveConvertToString();
-                        interned = _internedStrings.GetOrAdd(stringified, stringified);
-                        return true;
-                    }
-#endif
-                    else if (length >= _hugeMruThreshold)
-                    {
-                        lock (_hugeMru)
-                        {
-                            return _hugeMru.TryGet(candidate, out interned);
-                        }
-                    }
-                    else if (length >= _largeMruThreshold)
-                    {
-                        lock (_largeMru)
-                        {
-                            return _largeMru.TryGet(candidate, out interned);
-                        }
-                    }
-                    else if (length >= _smallMruThreshold)
-                    {
-                        lock (_smallMru)
-                        {
-                            return _smallMru.TryGet(candidate, out interned);
-                        }
-                    }
+                    return InternResult.MatchedHardcodedString;
                 }
-
+            }
+            else if (length == 7)
+            {
+                if (TryInternHardcodedString(candidate, "Library", ref interned) ||
+                    TryInternHardcodedString(candidate, "MSBuild", ref interned) ||
+                    TryInternHardcodedString(candidate, "Release", ref interned))
+                {
+                    return InternResult.MatchedHardcodedString;
+                }
+            }
+            // see Microsoft.Build.BackEnd.BuildRequestConfiguration.CreateUniqueGlobalProperty
+            else if (length > MSBuildConstants.MSBuildDummyGlobalPropertyHeader.Length &&
+                    candidate.StartsWithStringByOrdinalComparison(MSBuildConstants.MSBuildDummyGlobalPropertyHeader))
+            {
+                // don't want to leak unique strings into the cache
                 interned = candidate.ExpensiveConvertToString();
-                return null;
+                return InternResult.RejectedFromInterning;
             }
-
-            /// <summary>
-            /// Version of Intern that gathers statistics
-            /// </summary>
-            private string InternWithStatistics<T>(T candidate) where T : IInternable
+            else if (length == 24)
             {
-                lock (_missedStrings)
+                if (TryInternHardcodedString(candidate, "ResolveAssemblyReference", ref interned))
                 {
-                    _stopwatch.Start();
-                    bool? interned = TryIntern(candidate, out string result);
-                    _stopwatch.Stop();
-
-                    if (interned.HasValue && !interned.Value)
-                    {
-                        // Could not intern.
-                        _internMisses++;
-
-                        _missedStrings.TryGetValue(result, out int priorCount);
-                        _missedStrings[result] = priorCount + 1;
-
-                        return result;
-                    }
-                    else if (interned == null)
-                    {
-                        // Decided not to attempt interning
-                        _internRejects++;
-
-                        _rejectedStrings.TryGetValue(result, out int priorCount);
-                        _rejectedStrings[result] = priorCount + 1;
-
-                        return result;
-                    }
-
-                    _internHits++;
-                    if (!candidate.ReferenceEquals(result))
-                    {
-                        // Reference changed so 'candidate' is now released and should save memory.
-                        _internEliminatedStrings++;
-                        _internEliminatedChars += candidate.Length;
-                    }
-
-                    return result;
+                    return InternResult.MatchedHardcodedString;
                 }
             }
 
-            /// <summary>
-            /// A singly linked list of strings where the most recently accessed string is at the top.
-            /// Size expands up to a fixed number of strings.
-            /// </summary>
-            private class PrioritizedStringList
+            interned = s_weakStringCache.GetOrCreateEntry(candidate, out bool cacheHit);
+            return cacheHit ? InternResult.FoundInWeakStringCache : InternResult.AddedToWeakStringCache;
+        }
+
+        /// <summary>
+        /// Version of Intern that gathers statistics
+        /// </summary>
+        private static string InternWithStatistics<T>(T candidate) where T : IInternable
+        {
+            lock (s_missedHardcodedStrings)
             {
-                /// <summary>
-                /// Maximum size of the mru list.
-                /// </summary>
-                private readonly int _size;
+                InternResult internResult = TryIntern(candidate, out string result);
 
-                /// <summary>
-                /// Head of the mru list.
-                /// </summary>
-                private Node _mru;
-
-                /// <summary>
-                /// Construct an Mru list with a fixed maximum size.
-                /// </summary>
-                internal PrioritizedStringList(int size)
+                switch (internResult)
                 {
-                    _size = size;
+                    case InternResult.MatchedHardcodedString:
+                        s_hardcodedInternHits++;
+                        break;
+                    case InternResult.FoundInWeakStringCache:
+                        s_regularInternHits++;
+                        break;
+                    case InternResult.AddedToWeakStringCache:
+                        s_regularInternMisses++;
+                        break;
+                    case InternResult.RejectedFromInterning:
+                        s_rejectedStrings++;
+                        break;
                 }
 
-                /// <summary>
-                /// Try to get one element from the list. Upon leaving the function 'candidate' will be at the head of the Mru list.
-                /// This function is not thread-safe.
-                /// </summary>
-                internal bool TryGet<T>(T candidate, out string interned) where T : IInternable
+                if (internResult != InternResult.MatchedHardcodedString && internResult != InternResult.RejectedFromInterning)
                 {
-                    if (_size == 0)
-                    {
-                        interned = candidate.ExpensiveConvertToString();
-                        return false;
-                    }
-
-                    int length = candidate.Length;
-                    Node secondPrior = null;
-                    Node prior = null;
-                    Node head = _mru;
-                    bool found = false;
-                    int itemCount = 0;
-
-                    while (head != null && !found)
-                    {
-                        if (head.Value.Length == length)
-                        {
-                            if (candidate.StartsWithStringByOrdinalComparison(head.Value))
-                            {
-                                found = true;
-                            }
-                        }
-
-                        if (!found)
-                        {
-                            secondPrior = prior;
-                            prior = head;
-                            head = head.Next;
-                        }
-
-                        itemCount++;
-                    }
-
-                    if (found)
-                    {
-                        // Move it to the top and return the interned version.
-                        if (prior != null)
-                        {
-                            if (!candidate.ReferenceEquals(head.Value))
-                            {
-                                // Wasn't at the top already, so move it there.
-                                prior.Next = head.Next;
-                                head.Next = _mru;
-                                _mru = head;
-                                interned = _mru.Value;
-                                return true;
-                            }
-                            else
-                            {
-                                // But don't move it up if there is reference equality so that multiple calls to Intern don't redundantly emphasize a string.
-                                interned = head.Value;
-                                return true;
-                            }
-                        }
-                        else
-                        {
-                            // Found the item in the top spot. No need to move anything.
-                            interned = _mru.Value;
-                            return true;
-                        }
-                    }
-                    else
-                    {
-                        // Not found. Create a new entry and place it at the top.
-                        Node old = _mru;
-                        _mru = new Node(candidate.ExpensiveConvertToString()) { Next = old };
-
-                        // Cache miss. Use this opportunity to discard any element over the max size.
-                        if (itemCount >= _size && secondPrior != null)
-                        {
-                            secondPrior.Next = null;
-                        }
-
-                        interned = _mru.Value;
-                        return false;
-                    }
+                    s_missedHardcodedStrings.TryGetValue(result, out int priorCount);
+                    s_missedHardcodedStrings[result] = priorCount + 1;
                 }
 
-                /// <summary>
-                /// Returns the number of strings held and the total number of chars held.
-                /// </summary>
-                internal KeyValuePair<int, int> Statistics()
+                if (!candidate.ReferenceEquals(result))
                 {
-                    Node head = _mru;
-                    int chars = 0;
-                    int strings = 0;
-                    while (head != null)
-                    {
-                        chars += head.Value.Length;
-                        strings++;
-                        head = head.Next;
-                    }
-
-                    return new KeyValuePair<int, int>(strings, chars);
+                    // Reference changed so 'candidate' is now released and should save memory.
+                    s_internEliminatedStrings++;
+                    s_internEliminatedChars += candidate.Length;
                 }
 
-                /// <summary>
-                /// Singly linked list node.
-                /// </summary>
-                private class Node
-                {
-                    /// <summary>
-                    /// Construct a Node
-                    /// </summary>
-                    internal Node(string value)
-                    {
-                        Value = value;
-                    }
-
-                    /// <summary>
-                    /// The next node in the list.
-                    /// </summary>
-                    internal Node Next { get; set; }
-
-                    /// <summary>
-                    /// The held string.
-                    /// </summary>
-                    internal string Value { get; }
-                }
+                return result;
             }
         }
     }

--- a/src/Shared/ReuseableStringBuilder.cs
+++ b/src/Shared/ReuseableStringBuilder.cs
@@ -6,10 +6,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Reflection;
 using System.Text;
 using System.Threading;
-using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Shared
 {
@@ -19,7 +17,7 @@ namespace Microsoft.Build.Shared
     /// <remarks>
     /// You can add any properties or methods on the real StringBuilder that are needed.
     /// </remarks>
-    internal sealed class ReuseableStringBuilder : IDisposable, OpportunisticIntern.IInternable
+    internal sealed class ReuseableStringBuilder : IDisposable, IInternable
     {
         /// <summary>
         /// Captured string builder.
@@ -63,7 +61,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Indexer into the target. Presumed to be fast.
         /// </summary>
-        char OpportunisticIntern.IInternable.this[int index]
+        char IInternable.this[int index]
         {
             get
             {
@@ -75,7 +73,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Convert target to string. Presumed to be slow (and will be called just once).
         /// </summary>
-        string OpportunisticIntern.IInternable.ExpensiveConvertToString()
+        string IInternable.ExpensiveConvertToString()
         {
             if( _cachedString == null)
             {
@@ -96,14 +94,14 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Compare target to string. 
         /// </summary>
-        bool OpportunisticIntern.IInternable.StartsWithStringByOrdinalComparison(string other)
+        bool IInternable.StartsWithStringByOrdinalComparison(string other)
         {
 #if DEBUG
             ErrorUtilities.VerifyThrow(other.Length <= _borrowedBuilder.Length, "should be at most as long as target");
 #endif
             if (other.Length > MaxByCharCompareLength)
             {
-                return ((OpportunisticIntern.IInternable) this).ExpensiveConvertToString().StartsWith(other, StringComparison.Ordinal);
+                return ((IInternable) this).ExpensiveConvertToString().StartsWith(other, StringComparison.Ordinal);
             }
             // Backwards because the end of the string is (by observation of Australian Government build) more likely to be different earlier in the loop.
             // For example, C:\project1, C:\project2
@@ -121,7 +119,7 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Never reference equals to string.
         /// </summary>
-        bool OpportunisticIntern.IInternable.ReferenceEquals(string other)
+        bool IInternable.ReferenceEquals(string other)
         {
             return false;
         }
@@ -129,7 +127,8 @@ namespace Microsoft.Build.Shared
         /// <summary>
         /// Convert to a string.
         /// </summary>
-        public override string ToString()
+        public override string ToString
+            ()
         {
             if (_borrowedBuilder == null)
             {

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly bool CacheFileExistence = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileExistence"));
 
-        /// <summary>
-        /// Eliminate locking in OpportunisticIntern at the expense of memory
-        /// </summary>
-        public readonly bool UseSimpleInternConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleInternConcurrency"));
-
         public readonly bool UseSimpleProjectRootElementCacheConcurrency = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildUseSimpleProjectRootElementCacheConcurrency"));
 
         /// <summary>

--- a/src/Shared/WeakStringCache.cs
+++ b/src/Shared/WeakStringCache.cs
@@ -1,0 +1,355 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build
+{
+    /// <summary>
+    /// A cache of weak GC handles (equivalent to weak references) pointing to strings. As long as a string has an ordinary strong GC root
+    /// elsewhere in the process, the cache has a reference to it and can match it to an internable. When the string is collected, it is
+    /// also automatically "removed" from the cache by becoming unrecoverable from the GC handle. Buckets of GC handles that do not
+    /// reference any live strings anymore are freed lazily.
+    /// </summary>
+    internal sealed class WeakStringCache : IDisposable
+    {
+        /// <summary>
+        /// Debug stats returned by GetDebugInfo().
+        /// </summary>
+        public struct DebugInfo
+        {
+            public int UsedBucketCount;
+            public int UnusedBucketCount;
+            public int LiveStringCount;
+            public int CollectedStringCount;
+            public int HashCollisionCount;
+        }
+
+        /// <summary>
+        /// Holds weak GC handles to one or more strings that share the same hash code.
+        /// </summary>
+        private struct StringBucket
+        {
+            /// <summary>
+            /// Weak GC handle to the first string of the given hashcode we've seen.
+            /// </summary>
+            public GCHandle WeakHandle;
+
+            /// <summary>
+            /// Overflow area used for additional strings sharing the same hash code. Since hash collisions should
+            /// to be very rare, this field is expected to be null in most buckets.
+            /// </summary>
+            public List<GCHandle> WeakHandleOverflow;
+
+            /// <summary>
+            /// Returns true if and only if this bucket contains a handle to at least one live string.
+            /// </summary>
+            public bool IsUsed
+            {
+                get
+                {
+                    if (WeakHandle.Target != null)
+                    {
+                        return true;
+                    }
+                    if (WeakHandleOverflow != null)
+                    {
+                        for (int i = 0; i < WeakHandleOverflow.Count; i++)
+                        {
+                            if (WeakHandleOverflow[i].Target != null)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Gets the number of GC handles allocated by this bucket.
+            /// </summary>
+            public int HandleCount
+            {
+                get
+                {
+                    return 1 + (WeakHandleOverflow != null ? WeakHandleOverflow.Count : 0);
+                }
+            }
+
+            /// <summary>
+            /// Gets the number of GC handles allocated by this bucket and referencing live strings.
+            /// </summary>
+            public int LiveHandleCount
+            {
+                get
+                {
+                    int liveCount = 0;
+                    if (WeakHandle.Target != null)
+                    {
+                        liveCount++;
+                    }
+                    if (WeakHandleOverflow != null)
+                    {
+                        for (int i = 0; i < WeakHandleOverflow.Count; i++)
+                        {
+                            if (WeakHandleOverflow[i].Target != null)
+                            {
+                                liveCount++;
+                            }
+                        }
+                    }
+                    return liveCount;
+                }
+            }
+
+            /// <summary>
+            /// Returns the string referenced by this bucket that is equal to the given internable.
+            /// </summary>
+            /// <param name="internable">The internable describing the string we're looking for.</param>
+            /// <returns>The string matching the internable or null if no such string exists.</returns>
+            public string GetString<T>(T internable) where T : IInternable
+            {
+                if (WeakHandle.IsAllocated && WeakHandle.Target is string baseString)
+                {
+                    if (internable.Length == baseString.Length &&
+                        internable.StartsWithStringByOrdinalComparison(baseString))
+                    {
+                        return baseString;
+                    }
+                }
+                if (WeakHandleOverflow != null)
+                {
+                    for (int i = 0; i < WeakHandleOverflow.Count; i++)
+                    {
+                        if (WeakHandleOverflow[i].Target is string extendedString)
+                        {
+                            if (internable.Length == extendedString.Length &&
+                                internable.StartsWithStringByOrdinalComparison(extendedString))
+                            {
+                                return extendedString;
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+
+            /// <summary>
+            /// Adds a string to this bucket, reusing one of the existing weak GC handles if they reference an already collected string.
+            /// </summary>
+            /// <param name="str">The string to add.</param>
+            public void AddString(string str)
+            {
+                if (!WeakHandle.IsAllocated)
+                {
+                    // The main handle is not allocated - allocate it.
+                    WeakHandle = GCHandle.Alloc(str, GCHandleType.Weak);
+                }
+                else if (WeakHandle.Target == null)
+                {
+                    // The main handle is allocated but the target has been collected - reuse it.
+                    WeakHandle.Target = str;
+                }
+                else if (WeakHandleOverflow == null)
+                {
+                    // The overflow area is not initialized - initialize it and add a new handle.
+                    // Note that collisions are rare so we start with a very conservative capacity of 2.
+                    WeakHandleOverflow = new List<GCHandle>(2);
+                    WeakHandleOverflow.Add(GCHandle.Alloc(str, GCHandleType.Weak));
+                }
+                else
+                {
+                    // Find the first usable slot in the overflow area or add a new slot if there is none.
+                    bool foundExistingSlot = false;
+                    for (int i = 0; i < WeakHandleOverflow.Count; i++)
+                    {
+                        if (WeakHandleOverflow[i].Target == null)
+                        {
+                            GCHandle handle = WeakHandleOverflow[i];
+                            handle.Target = str;
+                            WeakHandleOverflow[i] = handle;
+                            foundExistingSlot = true;
+                            break;
+                        }
+                    }
+                    if (!foundExistingSlot)
+                    {
+                        WeakHandleOverflow.Add(GCHandle.Alloc(str, GCHandleType.Weak));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Frees all GC handles allocated in this bucket.
+            /// </summary>
+            public void Free()
+            {
+                WeakHandle.Free();
+                if (WeakHandleOverflow != null)
+                {
+                    for (int i = 0; i < WeakHandleOverflow.Count; i++)
+                    {
+                        WeakHandleOverflow[i].Free();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Improvised capacity for the scavenging heuristics.
+        /// </summary>
+        private int _capacity = 100;
+
+        /// <summary>
+        /// A dictionary mapping string hash codes to string buckets holding the actual weak GC handles.
+        /// </summary>
+        private Dictionary<int, StringBucket> _stringsByHashCode;
+
+        public WeakStringCache()
+        {
+            _stringsByHashCode = new Dictionary<int, StringBucket>(_capacity);
+        }
+
+        /// <summary>
+        /// Main entrypoint of this cache. Tries to look up a string that matches the given internable. If it succeeds, returns
+        /// the string and sets cacheHit to true. If the string is not found, calls ExpensiveConvertToString on the internable,
+        /// adds the resulting string to the cache, and returns it setting cacheHit to false.
+        /// </summary>
+        /// <param name="internable">The internable describing the string we're looking for.</param>
+        /// <returns>A string matching the given internable.</returns>
+        public string GetOrCreateEntry<T>(T internable, out bool cacheHit) where T : IInternable
+        {
+            int hashCode = GetInternableHashCode(internable);
+
+            StringBucket bucket;
+            string result;
+            lock (_stringsByHashCode)
+            {
+                if (!_stringsByHashCode.TryGetValue(hashCode, out bucket))
+                {
+                    bucket = new StringBucket();
+                }
+                result = bucket.GetString(internable);
+                if (result != null)
+                {
+                    cacheHit = true;
+                    return result;
+                }
+            }
+
+            // We don't have the string in the dictionary - create it.
+            result = internable.ExpensiveConvertToString();
+
+            lock (_stringsByHashCode)
+            {
+                bucket.AddString(result);
+
+                // Prevent the dictionary from growing forever with buckets whose underlying GC handles
+                // don't reference any live strings anymore.
+                if (_stringsByHashCode.Count >= _capacity)
+                {
+                    // Get rid of unused buckets.
+                    Scavenge();
+                    // And do this again if the number of buckets reaches double the current after-scavenge number.
+                    _capacity = _stringsByHashCode.Count * 2;
+                }
+                _stringsByHashCode[hashCode] = bucket;
+            }
+            cacheHit = false;
+            return result;
+        }
+
+        /// <summary>
+        /// Implements the simple yet very decently performing djb2 hash function.
+        /// </summary>
+        /// <param name="internable">The internable to compute the hash code for.</param>
+        /// <returns>The 32-bit hash code.</returns>
+        internal static int GetInternableHashCode<T>(T internable) where T : IInternable
+        {
+            int hashCode = 5381;
+            for (int i = 0; i < internable.Length; i++)
+            {
+                unchecked
+                {
+                    hashCode = hashCode * 33 + internable[i];
+                }
+            }
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Iterates over the cache and removes unused buckets, i.e. buckets that don't reference live strings.
+        /// This is expensive so try to call such that the cost is amortized to O(1) per GetOrCreateEntry() invocation.
+        /// Assumes exclusive access to the dictionary, i.e. the lock is taken.
+        /// </summary>
+        public void Scavenge()
+        {
+            List<int> keysToRemove = null;
+            foreach (KeyValuePair<int, StringBucket> entry in _stringsByHashCode)
+            {
+                if (!entry.Value.IsUsed)
+                {
+                    entry.Value.Free();
+                    keysToRemove ??= new List<int>();
+                    keysToRemove.Add(entry.Key);
+                }
+            }
+            if (keysToRemove != null)
+            {
+                for (int i = 0; i < keysToRemove.Count; i++)
+                {
+                    _stringsByHashCode.Remove(keysToRemove[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Frees all GC handles and clears the cache.
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (KeyValuePair<int, StringBucket> entry in _stringsByHashCode)
+            {
+                entry.Value.Free();
+            }
+            _stringsByHashCode.Clear();
+        }
+
+        /// <summary>
+        /// Returns internal debug counters calculated based on the current state of the cache.
+        /// </summary>
+        public DebugInfo GetDebugInfo()
+        {
+            DebugInfo debugInfo = new DebugInfo();
+
+            lock (_stringsByHashCode)
+            {
+                foreach (KeyValuePair<int, StringBucket> entry in _stringsByHashCode)
+                {
+                    if (entry.Value.IsUsed)
+                    {
+                        debugInfo.UsedBucketCount++;
+                    }
+                    else
+                    {
+                        debugInfo.UnusedBucketCount++;
+                    }
+
+                    int handleCount = entry.Value.HandleCount;
+                    int liveHandleCount = entry.Value.LiveHandleCount;
+                    debugInfo.LiveStringCount += liveHandleCount;
+                    debugInfo.CollectedStringCount += (handleCount - liveHandleCount);
+                    if (handleCount > 1)
+                    {
+                        debugInfo.HashCollisionCount += handleCount - 1;
+                    }
+                }
+            }
+
+            return debugInfo;
+        }
+    }
+}

--- a/src/Tasks/Microsoft.Build.Tasks.csproj
+++ b/src/Tasks/Microsoft.Build.Tasks.csproj
@@ -81,6 +81,12 @@
     <Compile Include="..\Shared\NGen.cs">
       <Link>NGen.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IInternable.cs">
+      <Link>IInternable.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\WeakStringCache.cs">
+      <Link>WeakStringCache.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\OpportunisticIntern.cs">
       <Link>OpportunisticIntern.cs</Link>
     </Compile>

--- a/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
+++ b/src/UnitTests.Shared/Microsoft.Build.UnitTests.Shared.csproj
@@ -63,6 +63,12 @@
     <Compile Include="..\Shared\NativeMethodsShared.cs">
       <Link>NativeMethodsShared.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IInternable.cs">
+      <Link>IInternable.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\WeakStringCache.cs">
+      <Link>WeakStringCache.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\OpportunisticIntern.cs">
       <Link>OpportunisticIntern.cs</Link>
     </Compile>

--- a/src/Utilities/Microsoft.Build.Utilities.csproj
+++ b/src/Utilities/Microsoft.Build.Utilities.csproj
@@ -127,6 +127,12 @@
     <Compile Include="..\Shared\InprocTrackingNativeMethods.cs">
       <Link>Shared\InprocTrackingNativeMethods.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\IInternable.cs">
+      <Link>Shared\IInternable.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\WeakStringCache.cs">
+      <Link>Shared\WeakStringCache.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\OpportunisticIntern.cs">
       <Link>Shared\OpportunisticIntern.cs</Link>
     </Compile>


### PR DESCRIPTION
This PR contains a rewrite of the OpportunisticIntern logic, addressing scalability concerns with the original implementation.

The changes are structured as follows:
- The `IInternable` interface and its implementations are factored out of OpportunisticIntern.cs into a separate file src/Shared/IInternable.cs with no changes other than making them top-level types.
- A new data structure for maintaining weak GC handles to strings is introduced in a new file src/Shared/WeakStringCache.cs.
- `PrioritizedStringList` and friends is removed from OpportunisticIntern.cs as it's no longer used. The file now contains only common hard-coded strings, the logic to report statistics, and simple wrappers.

Motivation:
- The original implementation centered around MRU lists exposes many parameters to trade speed for memory as well as memory for memory. Make the lists too small and important strings will be falling out of the cache and won't be getting de-duplicated (#4172). Make the list too large and the linear search will take too long to find the string.
- The original implementation keeps strong references to the cached strings. This means that strings may be taking up memory even though they are not actually used anymore. By the cache that is supposed to save memory, ironically.

The new implementation:
- Does not expose any parameters. All strings are cached, regardless of length and prior state of the cache.
- Keeps only weak references to strings so it's not preventing them from being collected after they're not used anymore.

Performance:
- The memory win depends on the characteristics of the projects, it tends to be more significant the larger the project/solution is. For example, compared to the original implementation, `Microsoft.Build.Execution.ProjectInstance` instances use ~11% less memory in the Visual Studio process with a 300 project solution loaded.
- Time-wise, the new implementation is
  - Faster by 30% when interning hard-coded strings (result of the code becoming slightly simpler as the hard-coded string logic hasn't changed)
  - Faster when there is a cache hit, unless the hit is in the first few strings in the old MRU list (previously: linear search, depends on when the string is found; now: hash table lookup, fast regardless of size but requiring two passes over the string, one to hash it and one to compare it). The worst case where the hit is in the most recent item on the MRU list makes the new implementation about 2.5x slower (depends on the length of the string).
  - Typically faster when there is a cache miss (old implementation has to compare the string to all items of the same length). Depends on the size of the old MRU list and lengths of its strings.
- % of time spent in GC hasn't shown any measurable change. A common concern with GC handles is that they make the GC work harder.
- The memory overhead of `WeakStringCache` is the internal overhead of `Dictionary` + 16 bytes per string on 32-bit platforms / 28 bytes per string on 64-bit platforms.
  - 32-bit integer (hash code).
  - Pointer sized `GCHandle`.
  - Pointer sized overflow area for additional handles.
  - The runtime handle itself (pointer sized).