### PR TITLE
Use the file version instead of timestamp in handshake

### DIFF
--- a/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeEndpointOutOfProc.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         protected override long GetClientHandshake()
         {
-            return NodeProviderOutOfProc.GetClientHandshake();
+            return NodeProviderOutOfProc.GetClientHandshake(_enableReuse, _lowPriority);
         }
 
         #region Structs

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Build.BackEnd
             // Mask out the first byte. That's because old
             // builds used a single, non zero initial byte,
             // and we don't want to risk communicating with them
-            return (Constants.AssemblyTimestamp ^ Int64.MaxValue) & 0x00FFFFFFFFFFFFFF;
+            return (CommunicationsUtilities.FileVersionHash ^ Int64.MaxValue) & 0x00FFFFFFFFFFFFFF;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProc.cs
@@ -80,12 +80,9 @@ namespace Microsoft.Build.BackEnd
         /// Magic number sent by the client to the host during the handshake.
         /// Munged version of the host handshake.
         /// </summary>
-        internal static long GetClientHandshake()
+        internal static long GetClientHandshake(bool enableNodeReuse, bool enableLowPriority)
         {
-            // Mask out the first byte. That's because old
-            // builds used a single, non zero initial byte,
-            // and we don't want to risk communicating with them
-            return (CommunicationsUtilities.FileVersionHash ^ Int64.MaxValue) & 0x00FFFFFFFFFFFFFF;
+            return CommunicationsUtilities.GetClientHandshake(CommunicationsUtilities.GetHandshakeOptions(false, nodeReuse: enableNodeReuse, lowPriority: enableLowPriority, is64Bit: EnvironmentUtilities.Is64BitProcess));
         }
 
         /// <summary>
@@ -111,7 +108,7 @@ namespace Microsoft.Build.BackEnd
             CommunicationsUtilities.Trace("Starting to acquire a new or existing node to establish node ID {0}...", nodeId);
 
             long hostHandShake = NodeProviderOutOfProc.GetHostHandshake(ComponentHost.BuildParameters.EnableNodeReuse, ComponentHost.BuildParameters.LowPriority);
-            NodeContext context = GetNode(null, commandLineArgs, nodeId, factory, hostHandShake, NodeProviderOutOfProc.GetClientHandshake(), NodeContextTerminated);
+            NodeContext context = GetNode(null, commandLineArgs, nodeId, factory, hostHandShake, NodeProviderOutOfProc.GetClientHandshake(ComponentHost.BuildParameters.EnableNodeReuse, ComponentHost.BuildParameters.LowPriority), NodeContextTerminated);
 
             if (null != context)
             {
@@ -173,11 +170,7 @@ namespace Microsoft.Build.BackEnd
             // down all the nodes on exit, we will attempt to shutdown
             // all matching nodes with and without the priority bit set.
             // This means we need both versions of the handshake.
-            ShutdownAllNodes(
-                NodeProviderOutOfProc.GetHostHandshake(nodeReuse, enableLowPriority: false),
-                NodeProviderOutOfProc.GetHostHandshake(nodeReuse, enableLowPriority: true),
-                NodeProviderOutOfProc.GetClientHandshake(),
-                NodeContextTerminated);
+            ShutdownAllNodes(nodeReuse, NodeContextTerminated);
         }
 
         #endregion

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="hostHandshakeWithLowPriority">host handshake key with low priority added</param>
         /// <param name="clientHandshake">client handshake key</param>
         /// <param name="terminateNode">Delegate used to tell the node provider that a context has terminated</param>
-        protected void ShutdownAllNodes(long hostHandshake, long hostHandshakeWithLowPriority, long clientHandshake, NodeContextTerminateDelegate terminateNode)
+        protected void ShutdownAllNodes(bool nodeReuse, NodeContextTerminateDelegate terminateNode)
         {
             // INodePacketFactory
             INodePacketFactory factory = new NodePacketFactory();
@@ -126,12 +126,12 @@ namespace Microsoft.Build.BackEnd
                 int timeout = 30;
 
                 // Attempt to connect to the process with the handshake without low priority.
-                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, hostHandshake, clientHandshake);
+                Stream nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHostHandshake(nodeReuse, false), NodeProviderOutOfProc.GetClientHandshake(nodeReuse, false));
 
                 if (null == nodeStream)
                 {
                     // If we couldn't connect attempt to connect to the process with the handshake including low priority.
-                    nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, hostHandshakeWithLowPriority, clientHandshake);
+                    nodeStream = TryConnectToProcess(nodeProcess.Id, timeout, NodeProviderOutOfProc.GetHostHandshake(nodeReuse, true), NodeProviderOutOfProc.GetClientHandshake(nodeReuse, true));
                 }
 
                 if (null != nodeStream)

--- a/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
+++ b/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcTaskHost.cs
@@ -226,11 +226,7 @@ namespace Microsoft.Build.BackEnd
             long hostHandshake = NodeProviderOutOfProc.GetHostHandshake(nodeReuse, enableLowPriority: false);
             long hostHandshakeWithLow = NodeProviderOutOfProc.GetHostHandshake(nodeReuse, enableLowPriority: true);
 
-            ShutdownAllNodes(
-                hostHandshake,
-                hostHandshakeWithLow,
-                NodeProviderOutOfProc.GetClientHandshake(),
-                NodeContextTerminated);
+            ShutdownAllNodes(nodeReuse, NodeContextTerminated);
         }
         #endregion
 

--- a/src/Build/Resources/Constants.cs
+++ b/src/Build/Resources/Constants.cs
@@ -136,11 +136,6 @@ namespace Microsoft.Build.Internal
         internal const string Dev10SubToolsetValue = "10.0";
 
         /// <summary>
-        /// Number representing the current assembly's timestamp
-        /// </summary>
-        internal static long assemblyTimestamp;
-
-        /// <summary>
         /// Current version of this MSBuild Engine assembly in the 
         /// form, e.g, "4.0"
         /// </summary>
@@ -149,29 +144,6 @@ namespace Microsoft.Build.Internal
             get
             {
                 return MSBuildConstants.CurrentProductVersion;
-            }
-        }
-
-
-        /// <summary>
-        /// Number representing the current assembly's timestamp
-        /// </summary>
-        internal static long AssemblyTimestamp
-        {
-            get
-            {
-                if (assemblyTimestamp == 0)
-                {
-                    // Get the file version from the currently executing assembly.
-                    // Use .CodeBase instead of .Location, because .Location doesn't
-                    // work when Microsoft.Build.dll has been shadow-copied, for example
-                    // in scenarios where NUnit is loading Microsoft.Build.
-                    string path = FileUtilities.ExecutingAssemblyPath;
-
-                    assemblyTimestamp = new FileInfo(path).LastWriteTime.Ticks;
-                }
-
-                return assemblyTimestamp;
             }
         }
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Internal
         /// Looks up the file version and caches the hashcode
         /// This file version hashcode is used in calculating the handshake
         /// </summary>
-        internal static int FileVersionHash
+        private static int FileVersionHash
         {
             get
             {

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Build.Internal
         /// Looks up the file version and caches the hashcode
         /// This file version hashcode is used in calculating the handshake
         /// </summary>
-        private static int FileVersionHash
+        internal static int FileVersionHash
         {
             get
             {


### PR DESCRIPTION
Fixes https://github.com/microsoft/msbuild/issues/5375. A timestamp can be different between Microsoft.Build.dll in the toolset and the copy in the amd64 subfolder.

Getting the hash of AssemblyInformationalVersion gets the SHA of the actual file.