### PR TITLE
Respect current priority Fixes #5365

### DIFF
--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -627,7 +627,7 @@ namespace Microsoft.Build.CommandLine
 
                     // Honor the low priority flag, we place our selves below normal
                     // priority and let sub processes inherit that priority.
-                    ProcessPriorityClass priority = lowPriority ? ProcessPriorityClass.BelowNormal : ProcessPriorityClass.Normal;
+                    ProcessPriorityClass priority = lowPriority ? ProcessPriorityClass.BelowNormal : Process.GetCurrentProcess().PriorityClass;
                     Process.GetCurrentProcess().PriorityClass = priority;
 
                     DateTime t1 = DateTime.Now;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -625,8 +625,9 @@ namespace Microsoft.Build.CommandLine
                         Environment.SetEnvironmentVariable("MSBUILDLOADALLFILESASWRITEABLE", "1");
                     }
 
-                    // Honor the low priority flag, we place our selves below normal
-                    // priority and let sub processes inherit that priority.
+                    // Honor the low priority flag, we place our selves below normal priority and let sub processes inherit
+                    // that priority. Idle priority would prevent the build from proceeding as the user does normal actions.
+                    // We avoid increasing priority because that causes failures on mac/linux.
                     if (lowPriority && Process.GetCurrentProcess().PriorityClass != ProcessPriorityClass.Idle)
                     {
                         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -627,8 +627,10 @@ namespace Microsoft.Build.CommandLine
 
                     // Honor the low priority flag, we place our selves below normal
                     // priority and let sub processes inherit that priority.
-                    ProcessPriorityClass priority = lowPriority ? ProcessPriorityClass.BelowNormal : Process.GetCurrentProcess().PriorityClass;
-                    Process.GetCurrentProcess().PriorityClass = priority;
+                    if (lowPriority && Process.GetCurrentProcess().PriorityClass != ProcessPriorityClass.Idle)
+                    {
+                        Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+                    }
 
                     DateTime t1 = DateTime.Now;
 


### PR DESCRIPTION
This otherwise breaks in linux-like environments when starting MSBuild at below normal priority unless also run with administrator privileges.

Fixes #5365