### PR TITLE
Revert build-pool-selection workaround

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -31,7 +31,6 @@ stages:
       name: VSEng-MicroBuildVS2019
       demands:
       - agent.os -equals Windows_NT
-      - VSTS_OS -equals Windows_Server_2019_Data_Center_with_Containers
 
     timeoutInMinutes: 180
 


### PR DESCRIPTION
This reverts commit f516095bba73ef0cf4c76034c854aea5fdfcbd0a.

This workaround is no longer needed after dotnet/arcade#5239.
