### PR TITLE
Mask first byte

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -312,9 +312,9 @@ namespace Microsoft.Build.Internal
             }
 #endif
 
-            // Mask out the first byte. That's because old
-            // builds used a single, non zero initial byte,
-            // and we don't want to risk communicating with them
+            // Mask out the first byte. Modern builds expect the first byte to be zero to indicate that they are modern
+            // and should be treated as such. Older builds used a non-zero initial byte. See here:
+            // https://github.com/microsoft/msbuild/blob/584ca5f11b28971f5651b4b8de5f173ad1cb2786/src/Shared/NodeEndpointOutOfProcBase.cs#L403.
             return baseHandshake & 0x00FFFFFFFFFFFFFF;
         }
 

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Build.Internal
             // Mask out the first byte. That's because old
             // builds used a single, non zero initial byte,
             // and we don't want to risk communicating with them
-            return baseHandshake;
+            return baseHandshake & 0x00FFFFFFFFFFFFFF;
         }
 
         /// <summary>


### PR DESCRIPTION
@rainersigwald 
This is the fix to mask the first byte. The nice part of having consolidated this logic is that I only have to do it once.

This is to fix https://github.com/dotnet/runtime/issues/37333.