### PR TITLE
Do not check first byte before handshake

### DIFF
--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Build.Internal
 #endif
             )
         {
-            return stream.ReadLongForHandshake((byte[])null, 0
+            return stream.ReadLongForHandshake(0
 #if NETCOREAPP2_1 || MONO
                 , handshakeReadTimeout
 #endif
@@ -388,7 +388,7 @@ namespace Microsoft.Build.Internal
         /// Extension method to read a series of bytes from a stream.
         /// If specified, leading byte matches one in the supplied array if any, returns rejection byte and throws IOException.
         /// </summary>
-        internal static long ReadLongForHandshake(this PipeStream stream, byte[] leadingBytesToReject,
+        internal static long ReadLongForHandshake(this PipeStream stream,
             byte rejectionByteToReturn
 #if NETCOREAPP2_1 || MONO
             , int timeout
@@ -433,19 +433,6 @@ namespace Microsoft.Build.Internal
                         // We've unexpectly reached end of stream.
                         // We are now in a bad state, disconnect on our end
                         throw new IOException(String.Format(CultureInfo.InvariantCulture, "Unexpected end of stream while reading for handshake"));
-                    }
-
-                    if (i == 0 && leadingBytesToReject != null)
-                    {
-                        foreach (byte reject in leadingBytesToReject)
-                        {
-                            if (read == reject)
-                            {
-                                stream.WriteByte(rejectionByteToReturn); // disconnect the host
-
-                                throw new IOException(String.Format(CultureInfo.InvariantCulture, "Client: rejected old host. Received byte {0} but this matched a byte to reject.", bytes[i]));  // disconnect and quit
-                            }
-                        }
                     }
 
                     bytes[i] = Convert.ToByte(read);

--- a/src/Shared/CommunicationsUtilities.cs
+++ b/src/Shared/CommunicationsUtilities.cs
@@ -311,11 +311,7 @@ namespace Microsoft.Build.Internal
                 }
             }
 #endif
-
-            // Mask out the first byte. Modern builds expect the first byte to be zero to indicate that they are modern
-            // and should be treated as such. Older builds used a non-zero initial byte. See here:
-            // https://github.com/microsoft/msbuild/blob/584ca5f11b28971f5651b4b8de5f173ad1cb2786/src/Shared/NodeEndpointOutOfProcBase.cs#L403.
-            return baseHandshake & 0x00FFFFFFFFFFFFFF;
+            return baseHandshake;
         }
 
         /// <summary>

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -384,20 +384,6 @@ namespace Microsoft.Build.BackEnd
                     // respond with another long.  Once the handshake is complete, both sides can be assured the
                     // other is ready to accept data.
                     // To avoid mixing client and server builds, the long is the MSBuild binary timestamp.
-
-                    // Compatibility issue here.
-                    // Previous builds of MSBuild 4.0 would exchange just a byte.
-                    // Host would send either 0x5F or 0x60 depending on whether it was the toolset or not respectively.
-                    // Client would return either 0xF5 or 0x06 respectively.
-                    // Therefore an old host on a machine with new clients running will hang, 
-                    // sending a byte and waiting for a byte until it eventually times out;
-                    // because the new client will want 7 more bytes before it returns anything.
-                    // The other way around is not a problem, because the old client would immediately return the (wrong)
-                    // byte on receiving the first byte of the long sent by the new host, and the new host would disconnect.
-                    // To avoid the hang, special case here:
-                    // Make sure our handshakes always start with 00.
-                    // If we received ONLY one byte AND it's 0x5F or 0x60, return 0xFF (it doesn't matter what as long as
-                    // it will cause the host to reject us; new hosts expect 00 and old hosts expect F5 or 06).
                     try
                     {
                         long handshake = localReadPipe.ReadLongForHandshake(0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Build.BackEnd
                     // it will cause the host to reject us; new hosts expect 00 and old hosts expect F5 or 06).
                     try
                     {
-                        long handshake = localReadPipe.ReadLongForHandshake(/* reject these leads */ new byte[] { 0x5F, 0x60 }, 0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */
+                        long handshake = localReadPipe.ReadLongForHandshake(0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */
 #if NETCOREAPP2_1 || MONO
                             , ClientConnectTimeout /* wait a long time for the handshake from this side */
 #endif

--- a/src/Shared/NodeEndpointOutOfProcBase.cs
+++ b/src/Shared/NodeEndpointOutOfProcBase.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Build.BackEnd
                     // To avoid mixing client and server builds, the long is the MSBuild binary timestamp.
                     try
                     {
-                        long handshake = localReadPipe.ReadLongForHandshake(0xFF /* this will disconnect the host; it expects leading 00 or F5 or 06 */
+                        long handshake = localReadPipe.ReadLongForHandshake(0xFF /* this will disconnect a < 4.5 host; it expects leading 00 or F5 or 06 */
 #if NETCOREAPP2_1 || MONO
                             , ClientConnectTimeout /* wait a long time for the handshake from this side */
 #endif


### PR DESCRIPTION
Related to dotnet/runtime#37333. This is an alternate (and, perhaps, better) way to resolve the problem.