### PR TITLE
Optimize metadata storage for items in immutable ProjectInstance

### DIFF
--- a/src/Build/Collections/CopyOnWritePropertyDictionary.cs
+++ b/src/Build/Collections/CopyOnWritePropertyDictionary.cs
@@ -68,6 +68,26 @@ namespace Microsoft.Build.Collections
         }
 
         /// <summary>
+        /// Creates a dictionary from another dictionary.
+        /// </summary>
+        /// <param name="dictionary">The other dictionary.</param>
+        public CopyOnWritePropertyDictionary(IDictionary<string, T> dictionary)
+        {
+            if (dictionary == null)
+            {
+                _properties = new CopyOnWriteDictionary<string, T>(MSBuildNameIgnoreCaseComparer.Default);
+            }
+            else if (dictionary is CopyOnWritePropertyDictionary<T> copyOnWriteDictionary)
+            {
+                _properties = copyOnWriteDictionary._properties.Clone(); // copy on write!
+            }
+            else
+            {
+                _properties = new CopyOnWriteDictionary<string, T>(dictionary); // have to clone
+            }
+        }
+
+        /// <summary>
         /// Cloning constructor, with deferred cloning semantics
         /// </summary>
         private CopyOnWritePropertyDictionary(CopyOnWritePropertyDictionary<T> that)

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Build.Execution
             this.CreateItemDefinitionsSnapshot(data);
 
             var keepEvaluationCache = (settings & ProjectInstanceSettings.ImmutableWithFastItemLookup) == ProjectInstanceSettings.ImmutableWithFastItemLookup;
-            var projectItemToInstanceMap = this.CreateItemsSnapshot(data, keepEvaluationCache);
+            var projectItemToInstanceMap = this.CreateItemsSnapshot(data, immutable, keepEvaluationCache);
 
             this.CreateEvaluatedIncludeSnapshotIfRequested(keepEvaluationCache, data, projectItemToInstanceMap);
             this.CreateGlobalPropertiesSnapshot(data);
@@ -2825,7 +2825,7 @@ namespace Microsoft.Build.Execution
         /// <summary>
         /// Create Items snapshot
         /// </summary>
-        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(Evaluation.Project.Data data, bool keepEvaluationCache)
+        private Dictionary<ProjectItem, ProjectItemInstance> CreateItemsSnapshot(Evaluation.Project.Data data, bool immutable, bool keepEvaluationCache)
         {
             _items = new ItemDictionary<ProjectItemInstance>(data.ItemTypes.Count);
 
@@ -2859,7 +2859,7 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                ProjectItemInstance instance = new ProjectItemInstance(this, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, item.Xml.ContainingProject.EscapedFullPath);
+                ProjectItemInstance instance = new ProjectItemInstance(this, immutable, item.ItemType, ((IItem)item).EvaluatedIncludeEscaped, item.EvaluatedIncludeBeforeWildcardExpansionEscaped, directMetadata, inheritedItemDefinitions, item.Xml.ContainingProject.EscapedFullPath);
 
                 _items.Add(instance);
 

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -1276,8 +1276,7 @@ namespace Microsoft.Build.Execution
                 ProjectMetadataInstance metadatum;
                 if (_directMetadata != null)
                 {
-                    metadatum = _directMetadata[metadataName];
-                    if (metadatum != null)
+                    if (_directMetadata.TryGetValue(metadataName, out metadatum))
                     {
                         return metadatum.EvaluatedValueEscaped;
                     }
@@ -1679,7 +1678,7 @@ namespace Microsoft.Build.Execution
                         {
                             string key = interner.GetString(translator.Reader.ReadInt32());
                             string value = interner.GetString(translator.Reader.ReadInt32());
-                            _directMetadata[key] = (new ProjectMetadataInstance(key, value, allowItemSpecModifiers: true));
+                            _directMetadata[key] = new ProjectMetadataInstance(key, value, allowItemSpecModifiers: true);
                         }
                     }
                 }
@@ -1693,10 +1692,7 @@ namespace Microsoft.Build.Execution
             {
                 ProjectMetadataInstance value = null;
 
-                if (_directMetadata != null)
-                {
-                    value = _directMetadata[name];
-                }
+                _directMetadata?.TryGetValue(name, out value);
 
                 if (value == null)
                 {

--- a/src/Build/Instance/ProjectItemInstance.cs
+++ b/src/Build/Instance/ProjectItemInstance.cs
@@ -89,7 +89,25 @@ namespace Microsoft.Build.Execution
         /// </remarks>
         internal ProjectItemInstance(ProjectInstance project, string itemType, string includeEscaped, string includeBeforeWildcardExpansionEscaped, IDictionary<string, ProjectMetadataInstance> directMetadata, List<ProjectItemDefinitionInstance> itemDefinitions, string definingFileEscaped)
         {
-            CommonConstructor(project, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, directMetadata, itemDefinitions, definingFileEscaped);
+            CommonConstructor(project, false, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, directMetadata, itemDefinitions, definingFileEscaped);
+        }
+
+        /// <summary>
+        /// Constructor for items with metadata.
+        /// Called before the build when virtual items are added, 
+        /// and during the build when tasks emit items.
+        /// Include may be empty.
+        /// Direct metadata may be null, indicating no metadata. It will be cloned.
+        /// Builtin metadata may be null, indicating it has not been populated. It will be cloned.
+        /// Inherited item definition metadata may be null. It is assumed to ALREADY HAVE BEEN CLONED.
+        /// Specifies mutability explicitly.
+        /// </summary>
+        /// <remarks>
+        /// Not public since the only creation scenario is setting on a project.
+        /// </remarks>
+        internal ProjectItemInstance(ProjectInstance project, bool immutable, string itemType, string includeEscaped, string includeBeforeWildcardExpansionEscaped, IDictionary<string, ProjectMetadataInstance> directMetadata, List<ProjectItemDefinitionInstance> itemDefinitions, string definingFileEscaped)
+        {
+            CommonConstructor(project, immutable, itemType, includeEscaped, includeBeforeWildcardExpansionEscaped, directMetadata, itemDefinitions, definingFileEscaped);
         }
 
         /// <summary>
@@ -116,7 +134,7 @@ namespace Microsoft.Build.Execution
                 }
             }
 
-            CommonConstructor(project, itemType, includeEscaped, includeEscaped, metadata, null /* need to add item definition metadata */, definingFileEscaped);
+            CommonConstructor(project, false, itemType, includeEscaped, includeEscaped, metadata, null /* need to add item definition metadata */, definingFileEscaped);
         }
 
         /// <summary>
@@ -687,7 +705,7 @@ namespace Microsoft.Build.Execution
         /// Inherited item definition metadata may be null. It is assumed to ALREADY HAVE BEEN CLONED.
         /// Mutability follows the project.
         /// </summary>
-        private void CommonConstructor(ProjectInstance projectToUse, string itemTypeToUse, string includeEscaped, string includeBeforeWildcardExpansionEscaped, IDictionary<string, ProjectMetadataInstance> directMetadata, List<ProjectItemDefinitionInstance> itemDefinitions, string definingFileEscaped)
+        private void CommonConstructor(ProjectInstance projectToUse, bool forceImmutable, string itemTypeToUse, string includeEscaped, string includeBeforeWildcardExpansionEscaped, IDictionary<string, ProjectMetadataInstance> directMetadata, List<ProjectItemDefinitionInstance> itemDefinitions, string definingFileEscaped)
         {
             ErrorUtilities.VerifyThrowArgumentNull(projectToUse, "project");
             ErrorUtilities.VerifyThrowArgumentLength(itemTypeToUse, "itemType");
@@ -712,7 +730,7 @@ namespace Microsoft.Build.Execution
                                      directMetadata,
                                      inheritedItemDefinitions,
                                      _project.Directory,
-                                     _project.IsImmutable,
+                                     _project.IsImmutable || forceImmutable,
                                      definingFileEscaped
                                      );
         }

--- a/src/Shared/BinaryTranslator.cs
+++ b/src/Shared/BinaryTranslator.cs
@@ -638,11 +638,11 @@ namespace Microsoft.Build.BackEnd
             /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
             /// <typeparam name="TAccum">The reference type for the dictionary accumulator.</typeparam>
             /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
+            /// <param name="objectTranslator">The factory used to instantiate values in the dictionary.</param>
             /// <param name="accumulatorFactory">The factory used to instantiate a dictionary accumulator.</param>
             /// <param name="accumulate">The function used to accumulate values.</param>
             /// <param name="complete">The function to complete accumulation.</param>
-            public void TranslateDictionary<D, T, TAccum>(ref D dictionary, NodePacketValueFactory<T> valueFactory, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
+            public void TranslateDictionary<D, T, TAccum>(ref D dictionary, ObjectTranslator<T> objectTranslator, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
                 where D : IDictionary<string, T>
                 where T : class, ITranslatable
             {
@@ -659,7 +659,7 @@ namespace Microsoft.Build.BackEnd
                     string key = null;
                     Translate(ref key);
                     T value = null;
-                    Translate(ref value, valueFactory);
+                    objectTranslator(this, ref value);
                     accumulate(builder, key, value);
                 }
 
@@ -1234,11 +1234,11 @@ namespace Microsoft.Build.BackEnd
             /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
             /// <typeparam name="TAccum">The reference type for the dictionary accumulator.</typeparam>
             /// <param name="dictionary">The dictionary to be translated.</param>
-            /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
+            /// <param name="objectTranslator">The factory used to instantiate values in the dictionary.</param>
             /// <param name="accumulatorFactory">The factory used to instantiate a dictionary accumulator.</param>
             /// <param name="accumulate">The function used to accumulate values.</param>
             /// <param name="complete">The function to complete accumulation.</param>
-            public void TranslateDictionary<D, T, TAccum>(ref D dictionary, NodePacketValueFactory<T> valueFactory, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
+            public void TranslateDictionary<D, T, TAccum>(ref D dictionary, ObjectTranslator<T> objectTranslator, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
                 where D : IDictionary<string, T>
                 where T : class, ITranslatable
             {
@@ -1255,7 +1255,7 @@ namespace Microsoft.Build.BackEnd
                     string key = pair.Key;
                     Translate(ref key);
                     T value = pair.Value;
-                    Translate(ref value, valueFactory);
+                    objectTranslator(this, ref value);
                 }
             }
 

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Build.BackEnd
             where T : class, ITranslatable;
 
         /// <summary>
-        /// Translates a dictionary of { string, T } for dictionaries with public parameterless constructors.
+        /// Translates a dictionary of { string, T }.
         /// </summary>
         /// <typeparam name="D">The reference type for the dictionary.</typeparam>
         /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
@@ -320,6 +320,21 @@ namespace Microsoft.Build.BackEnd
         /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
         /// <param name="collectionCreator">A factory used to create the dictionary.</param>
         void TranslateDictionary<D, T>(ref D dictionary, NodePacketValueFactory<T> valueFactory, NodePacketCollectionCreator<D> collectionCreator)
+            where D : IDictionary<string, T>
+            where T : class, ITranslatable;
+
+        /// <summary>
+        /// Translates a dictionary of { string, T }.
+        /// </summary>
+        /// <typeparam name="D">The reference type for the dictionary.</typeparam>
+        /// <typeparam name="T">The reference type for values in the dictionary.</typeparam>
+        /// <typeparam name="TAccum">The reference type for the dictionary accumulator.</typeparam>
+        /// <param name="dictionary">The dictionary to be translated.</param>
+        /// <param name="valueFactory">The factory used to instantiate values in the dictionary.</param>
+        /// <param name="accumulatorFactory">The factory used to instantiate a dictionary accumulator.</param>
+        /// <param name="accumulate">The function used to accumulate values.</param>
+        /// <param name="complete">The function to complete accumulation.</param>
+        void TranslateDictionary<D, T, TAccum>(ref D dictionary, NodePacketValueFactory<T> valueFactory, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
             where D : IDictionary<string, T>
             where T : class, ITranslatable;
 

--- a/src/Shared/ITranslator.cs
+++ b/src/Shared/ITranslator.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="accumulatorFactory">The factory used to instantiate a dictionary accumulator.</param>
         /// <param name="accumulate">The function used to accumulate values.</param>
         /// <param name="complete">The function to complete accumulation.</param>
-        void TranslateDictionary<D, T, TAccum>(ref D dictionary, NodePacketValueFactory<T> valueFactory, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
+        void TranslateDictionary<D, T, TAccum>(ref D dictionary, ObjectTranslator<T> objectTranslator, Func<TAccum> accumulatorFactory, Action<TAccum, string, T> accumulate, Func<TAccum, D> complete)
             where D : IDictionary<string, T>
             where T : class, ITranslatable;
 

--- a/src/Shared/TranslatorHelpers.cs
+++ b/src/Shared/TranslatorHelpers.cs
@@ -105,5 +105,18 @@ namespace Microsoft.Build.BackEnd
         {
             translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), collectionCreator);
         }
+
+        public static void TranslateDictionary<D, T, TAccum>(
+            this ITranslator translator,
+            ref D dictionary,
+            NodePacketValueFactory<T> valueFactory,
+            Func<TAccum> accumulatorFactory,
+            Action<TAccum, string, T> accumulate,
+            Func<TAccum, D> complete)
+            where D : IDictionary<string, T>
+            where T : class, ITranslatable
+        {
+            translator.TranslateDictionary(ref dictionary, AdaptFactory(valueFactory), accumulatorFactory, accumulate, complete);
+        }
     }
 }


### PR DESCRIPTION
Although ProjectInstance enforces the immutability flag, it doesn't actually do a lot of optimization of the underlying storage it uses. This is an issue for CPS which heavily uses immutable ProjectInstances to hold snapshots of projects. In large solutions, ProjectInstance snapshots can take significant portions of the heap. In one test solution of 755 projects, 10% of the managed heap was ProjectInstance snapshots.

This tackles one part of the problem. ProjectItemInstances hold the metadata on the item in a copy-on-write dictionary to optimize memory for the sparse write case. However, in an immutable ProjectInstance, there will never be any writing of metadata at all, so the overhead of the copy-on-write scheme is wasted. This PR generalizes the storage of the metadata to hold it in an ImmutableDictionary if the item is immutable. In the above example of 755 projects, this reduces the size of the ProjectInstances in memory by 20% and saves 2% of the overall heap.

This also fixes a bug where the project items weren't being marked as immutable. This is because when the ProjectInstance is being created, it doesn't set the immutable flag until after it has cloned everything. That _seemed_ wrong, but I don't know enough about ProjectInstance creation to change it, so instead I explicitly pass the flag through right now. Would be happy for any comments people who are more familiar with ProjectInstance.

Note that this is just one step along a bigger journey -- there are lots of other places in ProjectInstance where we can likely optimize storage for the immutable case, and we'll continue to work on those.