### PR TITLE
Log CurrentUICulture in binlog.

### DIFF
--- a/src/Build/Logging/BinaryLogger/BinaryLogger.cs
+++ b/src/Build/Logging/BinaryLogger/BinaryLogger.cs
@@ -154,6 +154,7 @@ namespace Microsoft.Build.Logging
         private void LogInitialInfo()
         {
             LogMessage("BinLogFilePath=" + FilePath);
+            LogMessage("CurrentUICulture=" + System.Globalization.CultureInfo.CurrentUICulture.Name);
         }
 
         private void LogMessage(string text)


### PR DESCRIPTION
This will be useful to be able to open localized binlogs. If we know the culture of the log we can fetch the right resources from the MSBuild .dlls.