### PR TITLE
Revert "Switch to Pipeline Artifacts (#5062)"

### DIFF
--- a/.vsts-dotnet-ci.yml
+++ b/.vsts-dotnet-ci.yml
@@ -33,19 +33,18 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      targetPath: 'artifacts/log/Debug'
-      artifact: 'FullOnWindows build logs'
-      publishLocation: 'pipeline'
+      PathtoPublish: 'artifacts/log/Debug'
+      ArtifactName: 'FullOnWindows build logs'
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'FullOnWindows test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'FullOnWindows test logs'
     continueOnError: true
     condition: always()
 
@@ -79,18 +78,18 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      path: 'artifacts/log/Debug'
-      artifactName: 'CoreOnWindows build logs'
+      PathtoPublish: 'artifacts/log/Debug'
+      ArtifactName: 'CoreOnWindows build logs'
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'CoreOnWindows test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'CoreOnWindows test logs'
     continueOnError: true
     condition: always()
 
@@ -124,18 +123,18 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      path: 'artifacts/Log/Release'
-      artifactName: 'FullOnWindows Release build logs'
+      PathtoPublish: 'artifacts/Log/Release'
+      ArtifactName: 'FullOnWindows Release build logs'
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'FullOnWindows Release test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'FullOnWindows Release test logs'
     continueOnError: true
     condition: always()
 
@@ -156,18 +155,18 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      path: 'artifacts/log/Debug'
-      artifactName: 'CoreOnLinux build logs'
+      PathtoPublish: 'artifacts/log/Debug'
+      ArtifactName: 'CoreOnLinux build logs'
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'CoreOnLinux test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'CoreOnLinux test logs'
     continueOnError: true
     condition: always()
 
@@ -188,18 +187,18 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      path: 'artifacts/log/Debug'
-      artifactName: 'CoreOnMac build logs'
+      PathtoPublish: 'artifacts/log/Debug'
+      ArtifactName: 'CoreOnMac build logs'
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'CoreOnMac test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'CoreOnMac test logs'
     continueOnError: true
     condition: always()
 
@@ -228,16 +227,16 @@ jobs:
       mergeTestResults: true
     continueOnError: true
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: logs'
     inputs:
-      path: 'artifacts/log'
-      artifactName: 'MonoOnMac build logs'
+      PathtoPublish: 'artifacts/log'
+      ArtifactName: 'MonoOnMac build logs'
     condition: always()
-  - task: PublishPipelineArtifact@1
+  - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     inputs:
-      path: 'artifacts/TestResults'
-      artifactName: 'MonoOnMac test logs'
+      PathtoPublish: 'artifacts/TestResults'
+      ArtifactName: 'MonoOnMac test logs'
     continueOnError: true
     condition: always()

--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -132,25 +132,26 @@ stages:
       condition: succeeded()
 
     # Publish bootstrapper info
-    - task: PublishPipelineArtifact@1
+    - task: PublishBuildArtifacts@1
       inputs:
-        path: $(Build.StagingDirectory)\MicroBuild\Output
-        artifactName: MicroBuildOutputs
+        PathtoPublish: $(Build.StagingDirectory)\MicroBuild\Output
+        ArtifactName: MicroBuildOutputs
+        ArtifactType: Container
       displayName: 'OptProf - Publish Artifact: MicroBuildOutputs'
       condition: succeeded()
 
-    - task: PublishPipelineArtifact@1
+    - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: logs'
       inputs:
-        path: 'artifacts\log\$(BuildConfiguration)'
-        artifactName: logs
+        PathtoPublish: 'artifacts\log\$(BuildConfiguration)'
+        ArtifactName: logs
       condition: succeededOrFailed()
 
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Artifact: bin'
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: symbols'
       inputs:
-        path: 'artifacts\bin'
-        artifactName: bin
+        PathtoPublish: 'artifacts\bin'
+        ArtifactName: symbols
       condition: succeededOrFailed()
 
     # Publishes setup VSIXes to a drop.
@@ -163,11 +164,29 @@ stages:
       condition: succeeded()
 
     # Publish an artifact that the RoslynInsertionTool is able to find by its name.
-    - task: PublishPipelineArtifact@1
+    - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: VSSetup'
       inputs:
-        path: 'artifacts\VSSetup\$(BuildConfiguration)'
-        artifactName: VSSetup
+        PathtoPublish: 'artifacts\VSSetup\$(BuildConfiguration)'
+        ArtifactName: VSSetup
+      condition: succeeded()
+
+    # Archive NuGet packages to DevOps.
+    # Publish our NuPkgs as an artifact. The name of this artifact must be PackageArtifacts as the 
+    # arcade templates depend on the name.
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: packages'
+      inputs:
+        PathtoPublish: 'artifacts\packages\$(BuildConfiguration)'
+        ArtifactName: PackageArtifacts
+      condition: succeeded()
+
+    # Publish Asset Manifests for Build Asset Registry job
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Asset Manifests
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(BuildConfiguration)/AssetManifest'
+        ArtifactName: AssetManifests
       condition: succeeded()
 
     # Tag the build at the very end when we know it's been successful.


### PR DESCRIPTION
Causes spurious failures on PR build rerun like

```
##[error]Artifact FullOnWindows build logs already exists for build 683197.
```

https://dev.azure.com/dnceng/public/_build/results?buildId=683197&view=logs&j=9f11c3b6-ab7b-5d31-db2e-f92a12840391&t=161d3658-037b-58d7-7ae4-bd96b8f471dc&l=30

Many DevComm issues on this, for instance https://developercommunity.visualstudio.com/content/problem/774908/publish-artifact-fails-when-retry-failed-job.html

Just reverting the whole thing to get back to known-good.