### PR TITLE
Fix visual studio applying nodereuse despite MSBUILDDISABLENODEREUSE being set

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -16,6 +16,7 @@ using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 using ForwardingLoggerRecord = Microsoft.Build.Logging.ForwardingLoggerRecord;
+using Microsoft.Build.Utilities;
 
 namespace Microsoft.Build.Execution
 {
@@ -394,7 +395,7 @@ namespace Microsoft.Build.Execution
         public bool EnableNodeReuse
         {
             get => _enableNodeReuse;
-            set => _enableNodeReuse = Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1" ? false : value;
+            set => _enableNodeReuse = Traits.Instance.DisableNodeReuse ? false : value;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Build.Execution
         public bool EnableNodeReuse
         {
             get => _enableNodeReuse;
-            set => _enableNodeReuse = value;
+            set => _enableNodeReuse = Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1" ? false : value;
         }
 
         /// <summary>

--- a/src/Build/BackEnd/BuildManager/BuildParameters.cs
+++ b/src/Build/BackEnd/BuildManager/BuildParameters.cs
@@ -906,7 +906,7 @@ namespace Microsoft.Build.Execution
             ResetCaches = true;
             _toolsetProvider = toolsetProvider;
 
-            if (Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1") // For example to disable node reuse within Visual Studio
+            if (Traits.Instance.DisableNodeReuse) // For example to disable node reuse within Visual Studio
             {
                 _enableNodeReuse = false;
             }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -2380,7 +2380,7 @@ namespace Microsoft.Build.CommandLine
             enableNodeReuse = false;
 #endif
 
-            if (Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1") // For example to disable node reuse in a gated checkin, without using the flag
+            if (Traits.Instance.DisableNodeReuse) // For example to disable node reuse in a gated checkin, without using the flag
             {
                 enableNodeReuse = false;
             }

--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -94,6 +94,11 @@ namespace Microsoft.Build.Utilities
         /// </summary>
         public readonly int LogPropertyTracking = ParseIntFromEnvironmentVariableOrDefault("MsBuildLogPropertyTracking", 0); // Default to logging nothing via the property tracker.
 
+        /// <summary>
+        /// Setting this environment variable to 1 disables the node reuse feature.
+        /// </summary>
+        public readonly bool DisableNodeReuse = Environment.GetEnvironmentVariable("MSBUILDDISABLENODEREUSE") == "1";
+
         private static int ParseIntFromEnvironmentVariableOrDefault(string environmentVariable, int defaultValue)
         {
             return int.TryParse(Environment.GetEnvironmentVariable(environmentVariable), out int result)


### PR DESCRIPTION
Fixes #5221 

See https://github.com/microsoft/msbuild/issues/5221#issuecomment-645026616 for details

> After some investigation it looks like MSBuild is launched differently for Design Time Builds compared to regular builds. These builds don't respect the environment variable MSBUILDDISABLENODEREUSE because they explicitly set nodeReuse to true.