### PR TITLE
Slnf from other directory Fixes #5431

### DIFF
--- a/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
+++ b/src/Build.UnitTests/Construction/SolutionProjectGenerator_Tests.cs
@@ -155,13 +155,14 @@ namespace Microsoft.Build.UnitTests.Construction
                     @"
                 {
                   ""solution"": {
-                    ""path"": """ + solutionFile.Path.Replace("\\", "\\\\") + @""",
+                    ""path"": """ + Path.Combine(".", "SimpleProject", "SimpleProject.sln").Replace("\\", "\\\\") + @""",
                     ""projects"": [
                       """ + Path.Combine("SimpleProject", "SimpleProject.csproj").Replace("\\", "\\\\") + @"""
                     ]
                     }
                 }
                 ");
+                Directory.GetCurrentDirectory().ShouldNotBe(Path.GetDirectoryName(filterFile.Path));
                 SolutionFile solution = SolutionFile.Parse(filterFile.Path);
                 ILoggingService mockLogger = CreateMockLoggingService();
                 ProjectInstance[] instances = SolutionProjectGenerator.Generate(solution, null, null, _buildEventContext, mockLogger);

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -2146,24 +2146,7 @@ namespace Microsoft.Build.Execution
                 string solutionFile = projectFile;
                 if (FileUtilities.IsSolutionFilterFilename(projectFile))
                 {
-                    try
-                    {
-                        using JsonDocument text = JsonDocument.Parse(File.ReadAllText(projectFile));
-                        JsonElement solution = text.RootElement.GetProperty("solution");
-                        solutionFile = Path.GetFullPath(solution.GetProperty("path").GetString());
-                    }
-                    catch (Exception e) when (e is JsonException || e is KeyNotFoundException || e is InvalidOperationException)
-                    {
-                        ProjectFileErrorUtilities.VerifyThrowInvalidProjectFile
-                        (
-                            false, /* Just throw the exception */
-                            "SubCategoryForSolutionParsingErrors",
-                            new BuildEventFileInfo(projectFile),
-                            e,
-                            "SolutionFilterJsonParsingError",
-                            projectFile
-                        );
-                    }
+                    solutionFile = SolutionFile.ParseSolutionFromSolutionFilter(projectFile, out _);
                 }
                 SolutionFile.GetSolutionFileAndVisualStudioMajorVersions(solutionFile, out int solutionVersion, out int visualStudioVersion);
 


### PR DESCRIPTION
Solution filter files erroneously combined the current directory with the path from the solution filter file to the solution file. This corrects it to combine the solution filter file's directory with the path from the solution filter file to the solution file and modifies a test to correct that problem.

Fixes #5431.