### PR TITLE
Respect transforms in lazy eval

### DIFF
--- a/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ItemEvaluation_Tests.cs
@@ -121,6 +121,43 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Fact]
+        public void RemoveRespectsItemTransform()
+        {
+            var content = @"
+                            <i Include='a;b;c' />
+
+                            <i Remove='@(i->WithMetadataValue(`Identity`, `b`))' />
+                            <i Remove='@(i->`%(Extension)`)' /> <!-- should do nothing -->";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
+
+            ObjectModelHelpers.AssertItems(new[] { "a", "c" }, items);
+        }
+
+        [Fact]
+        public void UpdateRespectsItemTransform()
+        {
+            var content = @"
+                            <i Include='a;b;c' />
+
+                            <i Update='@(i->WithMetadataValue(`Identity`, `b`))'>
+                                <m1>m1_updated</m1>
+                            </i>
+                            <i Update=`@(i->'%(Extension)')`> <!-- should do nothing -->
+                                <m2>m2_updated</m2>
+                            </i>";
+
+            IList<ProjectItem> items = ObjectModelHelpers.GetItemsFromFragment(content, allItems: true);
+
+            ObjectModelHelpers.AssertItems(new[] { "a", "b", "c" }, items,
+                new[] {
+                    new Dictionary<string, string>(),
+                    new Dictionary<string, string> { ["m1"] = "m1_updated" },
+                    new Dictionary<string, string>(),
+                });
+        }
+
+        [Fact]
         public void UpdateShouldPreserveIntermediaryReferences()
         {
             var content = @"

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Build.Evaluation
             /// Is this spec a single reference to a specific item?
             /// </summary>
             /// <returns>True if the item is a simple reference to the referenced item type.</returns>
-            protected static bool ItemspecContainsASingleItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
+            protected static bool ItemspecContainsASingleBareItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
             {
                 if (itemSpec.Fragments.Count != 1)
                 {

--- a/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.LazyItemOperation.cs
@@ -324,6 +324,10 @@ namespace Microsoft.Build.Evaluation
                 return needToExpandMetadataForEachItem;
             }
 
+            /// <summary>
+            /// Is this spec a single reference to a specific item?
+            /// </summary>
+            /// <returns>True if the item is a simple reference to the referenced item type.</returns>
             protected static bool ItemspecContainsASingleItemReference(ItemSpec<P, I> itemSpec, string referencedItemType)
             {
                 if (itemSpec.Fragments.Count != 1)
@@ -338,6 +342,14 @@ namespace Microsoft.Build.Evaluation
                 }
 
                 if (!itemExpressionFragment.Capture.ItemType.Equals(referencedItemType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                // If the itemSpec is a single call to an item function, like @(X->Something(...)), it may get this
+                // far, but shouldn't be treated as a single reference: the item function may return entirely
+                // different results from a bare reference like @(X).
+                if (itemExpressionFragment.Capture.Captures is object)
                 {
                     return false;
                 }

--- a/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.RemoveOperation.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Evaluation
                     new BuildEventFileInfo(string.Empty),
                     "OM_MatchOnMetadataIsRestrictedToOnlyOneReferencedItem");
 
-                if (_matchOnMetadata.IsEmpty && ItemspecContainsASingleItemReference(_itemSpec, _itemElement.ItemType))
+                if (_matchOnMetadata.IsEmpty && ItemspecContainsASingleBareItemReference(_itemSpec, _itemElement.ItemType))
                 {
                     // Perf optimization: If the Remove operation references itself (e.g. <I Remove="@(I)"/>)
                     // then all items are removed and matching is not necessary

--- a/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.UpdateOperation.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Evaluation
                 ItemSpecMatchesItem matchItemspec;
                 bool? needToExpandMetadataForEachItem = null;
 
-                if (ItemspecContainsASingleItemReference(_itemSpec, _itemElement.ItemType))
+                if (ItemspecContainsASingleBareItemReference(_itemSpec, _itemElement.ItemType))
                 {
                     // Perf optimization: If the Update operation references itself (e.g. <I Update="@(I)"/>)
                     // then all items are updated and matching is not necessary

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -243,7 +243,10 @@ namespace Microsoft.Build.UnitTests
                 expectedItems.ShouldNotBeEmpty();
             }
 
-            for (var i = 0; i < expectedItems.Length; i++)
+            // iterate to the minimum length; if the lengths don't match but there's a prefix match the count assertion below will trigger
+            int minimumLength = Math.Min(expectedItems.Length, items.Count);
+
+            for (var i = 0; i < minimumLength; i++)
             {
                 if (!normalizeSlashes)
                 {
@@ -258,7 +261,8 @@ namespace Microsoft.Build.UnitTests
                 AssertItemHasMetadata(expectedDirectMetadataPerItem[i], items[i]);
             }
 
-            items.Count.ShouldBe(expectedItems.Length);
+            items.Count.ShouldBe(expectedItems.Length,
+                () => $"got items \"{string.Join(", ", items)}\", expected \"{string.Join(", ", expectedItems)}\"");
 
             expectedItems.Length.ShouldBe(expectedDirectMetadataPerItem.Length);
         }
@@ -422,7 +426,7 @@ namespace Microsoft.Build.UnitTests
         {
             expected ??= new Dictionary<string, string>();
 
-            item.DirectMetadataCount.ShouldBe(expected.Keys.Count);
+            item.DirectMetadataCount.ShouldBe(expected.Keys.Count, () => $"Expected {expected.Keys.Count} metadata, ({string.Join(", ", expected.Keys)}), got {item.DirectMetadataCount}");
 
             foreach (var key in expected.Keys)
             {


### PR DESCRIPTION
Fixes #5445 by checking to see if an item function is invoked (the captured
expression has subcaptures) before optimizing operations on same-item
captures.

Added regression tests and improved some asserts that didn't really help me when they fired.

fyi @cdmihai, @safern