### PR TITLE
Update bindingRedirect versions of Workflow build tasks dlls (dev16)

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -60,6 +60,7 @@
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="15.0.0.0" newVersion="16.0.0.0" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -59,8 +59,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
-          <bindingRedirect oldVersion="15.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -49,8 +49,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
-          <bindingRedirect oldVersion="15.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="4.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
           <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
         <dependentAssembly>

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -50,6 +50,7 @@
         <dependentAssembly>
           <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
           <bindingRedirect oldVersion="4.0.0.0" newVersion="16.0.0.0" />
+          <bindingRedirect oldVersion="15.0.0.0" newVersion="16.0.0.0" />
           <codeBase version="16.0.0.0" href=".\amd64\XamlBuildTask.dll" />
         </dependentAssembly>
         <dependentAssembly>


### PR DESCRIPTION
Fix the issue with the retail version of msbuild.exe.config, so it has a binding redirect for v15 xamlbuildtask.dll, as it does for v4.0.