### PR TITLE
Support long paths on amd64

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,7 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
-      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false;Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
For some reason, these overrides appear to be necessary on x64/amd64
.NET Framework. They were removed in #3960 because we thought they
were redundant now, but that appears to only be the case on x86.

Fixes #5331.