### PR TITLE
Updating bootstrapper package locator to include a fixed location under MSBuild extensions folder

### DIFF
--- a/src/Tasks/BootstrapperUtil/Util.cs
+++ b/src/Tasks/BootstrapperUtil/Util.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using Microsoft.Build.Shared;
 using Microsoft.Win32;
 
 namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
@@ -19,6 +20,7 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
         private const string REGISTRY_DEFAULTPATH = "Path";
 
         private const string BOOTSTRAPPER_REGISTRY_ADDITIONAL_PACKAGE_PATHS_KEYNAME = "AdditionalPackagePaths";
+        private const string BOOTSTRAPPER_MSBUILD_ADDITIONAL_PACKAGES_PATH = "Microsoft\\VisualStudio\\BootstrapperPackages";
 
         private static string s_defaultPath;
         private static List<string> s_additionalPackagePaths;
@@ -179,6 +181,15 @@ namespace Microsoft.Build.Tasks.Deployment.Bootstrapper
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(BuildEnvironmentHelper.Instance.MSBuildExtensionsPath))
+                    {
+                        string msbuildExtensionPackagesPath = Path.Combine(BuildEnvironmentHelper.Instance.MSBuildExtensionsPath, BOOTSTRAPPER_MSBUILD_ADDITIONAL_PACKAGES_PATH);
+                        if (Directory.Exists(msbuildExtensionPackagesPath))
+                        {
+                            additionalPackagePaths.Add(msbuildExtensionPackagesPath);
                         }
                     }
 


### PR DESCRIPTION
Right now bootstrapper packages (used by ClickOnce and VS Installer Projects) are discovered in one of two ways:
 - In a default path under "Program Files (x86)\Microsoft SDKs\ClickOnce Bootstrapper\Packages"
 - In customizable paths set under the "Software\Microsoft\GenericBootstrapper\AdditionalPackagePaths" reg key

Both of these involve paths/keys outside the VS install root.  For the new .NET Core packages we want to install them per instance under the MSBuild extensions path.  So this change is adding an entry to the list of folders used during package discovery to include "MSBuild\Microsoft\VisualStudio\BootstrapperPackages".
