### PR TITLE
Deduplicate and share Regex objects for globbing

### DIFF
--- a/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/MSBuildGlob_Tests.cs
@@ -149,6 +149,17 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
         }
 
         [Fact]
+        public void GlobParsingShouldDeduplicateRegexes()
+        {
+            var globRoot = NativeMethodsShared.IsWindows ? @"c:\a" : "/a";
+            var fileSpec = $"b/**/*.cs";
+            var glob1 = MSBuildGlob.Parse(globRoot, fileSpec);
+            var glob2 = MSBuildGlob.Parse(globRoot, fileSpec);
+
+            Assert.Same(glob1.TestOnlyRegex, glob2.TestOnlyRegex);
+        }
+
+        [Fact]
         public void GlobIsNotUnescaped()
         {
             var glob = MSBuildGlob.Parse("%42/%42");

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Globbing
     /// </summary>
     public class MSBuildGlob : IMSBuildGlob
     {
-        private struct GlobState
+        private readonly struct GlobState
         {
             public string GlobRoot { get; }
             public string FileSpec { get; }
@@ -222,7 +222,7 @@ namespace Microsoft.Build.Globbing
                                 s_regexCache[matchFileExpression] = newRegex;
                             }
                         }
-                        regex = regex ?? newRegex;
+                        regex ??= newRegex;
                     }
                 }
                 return new GlobState(globRoot, fileSpec, isLegalFileSpec, fixedDirectoryPart, wildcardDirectoryPart, filenamePart, matchFileExpression, needsRecursion, regex);

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Shared;
 
 namespace Microsoft.Build.Globbing
@@ -44,11 +45,15 @@ namespace Microsoft.Build.Globbing
             }
         }
 
+        // Cache of Regex objects that we have created and are still alive.
+        private static WeakValueDictionary<string, Regex> s_regexCache = new WeakValueDictionary<string, Regex>();
+
         private readonly Lazy<GlobState> _state;
 
         internal string TestOnlyGlobRoot => _state.Value.GlobRoot;
         internal string TestOnlyFileSpec => _state.Value.FileSpec;
         internal bool TestOnlyNeedsRecursion => _state.Value.NeedsRecursion;
+        internal Regex TestOnlyRegex => _state.Value.Regex;
 
         /// <summary>
         ///     The fixed directory part.
@@ -198,11 +203,28 @@ namespace Microsoft.Build.Globbing
                         return (normalizedFixedPart, wildcardDirPart, filePart);
                     });
 
-                // compile the regex since it's expected to be used multiple times
-                var regex = isLegalFileSpec
-                    ? new Regex(matchFileExpression, FileMatcher.DefaultRegexOptions | RegexOptions.Compiled)
-                    : null;
+                Regex regex = null;
+                if (isLegalFileSpec)
+                {
+                    lock (s_regexCache)
+                    {
+                        s_regexCache.TryGetValue(matchFileExpression, out regex);
+                    }
 
+                    if (regex == null)
+                    {
+                        // compile the regex since it's expected to be used multiple times
+                        Regex newRegex = new Regex(matchFileExpression, FileMatcher.DefaultRegexOptions | RegexOptions.Compiled);
+                        lock (s_regexCache)
+                        {
+                            if (!s_regexCache.TryGetValue(matchFileExpression, out regex))
+                            {
+                                s_regexCache[matchFileExpression] = newRegex;
+                            }
+                        }
+                        regex = regex ?? newRegex;
+                    }
+                }
                 return new GlobState(globRoot, fileSpec, isLegalFileSpec, fixedDirectoryPart, wildcardDirectoryPart, filenamePart, matchFileExpression, needsRecursion, regex);
             },
             true);


### PR DESCRIPTION
`Regex` is immutable and can be shared between `MSBuildGlob` instances. Analyzing the glob patterns used by real-world projects, it is clear that such sharing would have significant impact on memory. For example, loading the OrchardCore solution in Visual Studio creates ~12k instances of `MSBuildGlob` with only ~100 unique match file expressions.

The PR adds a simple process-wide cache of unique `Regex` objects that have been handed out. Reusing these expensive objects removes the memory pressure (at most one `Regex` per match file expression) and also saves non-trivial time compiling them.

Ballpark numbers:
- The memory cost of one compiled `Regex`: ~30 kB
- The time cost of compiling one `Regex`: ~5 ms

Fixes #3668 