### PR TITLE
Remove duplicate folders before adding files to cache.

### DIFF
--- a/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
+++ b/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Build.Shared
         /// The list of directory names found from the registry.
         /// </summary>
         private List<AssemblyFoldersExInfo> _directoryNames = new List<AssemblyFoldersExInfo>();
+
         /// <summary>
         /// Set of unique paths to directories found from the registry
         /// </summary>

--- a/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
+++ b/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
@@ -489,9 +489,9 @@ namespace Microsoft.Build.Shared
             return ((IEnumerable<AssemblyFoldersExInfo>)this).GetEnumerator();
         }
 
-        internal IEnumerable<string> UniqueDirectoryPaths()
+        internal IEnumerable<string> UniqueDirectoryPaths
         {
-            return _uniqueDirectoryPaths;
+            get => _uniqueDirectoryPaths;
         }
     }
 }

--- a/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
+++ b/src/Shared/AssemblyFolders/AssemblyFoldersEx.cs
@@ -45,6 +45,10 @@ namespace Microsoft.Build.Shared
         /// The list of directory names found from the registry.
         /// </summary>
         private List<AssemblyFoldersExInfo> _directoryNames = new List<AssemblyFoldersExInfo>();
+        /// <summary>
+        /// Set of unique paths to directories found from the registry
+        /// </summary>
+        private HashSet<string> _uniqueDirectoryPaths = new HashSet<string>();
 
         /// <summary>
         /// Construct.
@@ -258,6 +262,7 @@ namespace Microsoft.Build.Shared
 
                     if (null != directoryName)
                     {
+                        _uniqueDirectoryPaths.Add(directoryName);
                         _directoryNames.Add(new AssemblyFoldersExInfo(hive, view, directoryKey.RegistryKey, directoryName, directoryKey.TargetFrameworkVersion));
                     }
                 }
@@ -482,6 +487,11 @@ namespace Microsoft.Build.Shared
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((IEnumerable<AssemblyFoldersExInfo>)this).GetEnumerator();
+        }
+
+        internal IEnumerable<string> UniqueDirectoryPaths()
+        {
+            return _uniqueDirectoryPaths;
         }
     }
 }

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -307,8 +307,7 @@ namespace Microsoft.Build.Tasks
             {
                 var lockobject = new Object();
 
-                var foldersToSearch = assemblyFoldersEx.UniqueDirectoryPaths();
-                Parallel.ForEach(foldersToSearch, assemblyFolder =>
+                Parallel.ForEach(assemblyFoldersEx.UniqueDirectoryPaths, assemblyFolder =>
                 {
                     if (FileUtilities.DirectoryExistsNoThrow(assemblyFolder))
                     {

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -307,13 +307,7 @@ namespace Microsoft.Build.Tasks
             {
                 var lockobject = new Object();
 
-                // Remove duplicate folders
-                var foldersToSearch = new HashSet<string>();
-                foreach (var assemblyFolder in assemblyFoldersEx)
-                {
-                    foldersToSearch.Add(assemblyFolder.DirectoryPath);
-                }
-
+                var foldersToSearch = assemblyFoldersEx.UniqueDirectoryPaths();
                 Parallel.ForEach(foldersToSearch, assemblyFolder =>
                 {
                     if (FileUtilities.DirectoryExistsNoThrow(assemblyFolder))

--- a/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyFoldersExResolver.cs
@@ -307,11 +307,18 @@ namespace Microsoft.Build.Tasks
             {
                 var lockobject = new Object();
 
-                Parallel.ForEach(assemblyFoldersEx, assemblyFolder =>
+                // Remove duplicate folders
+                var foldersToSearch = new HashSet<string>();
+                foreach (var assemblyFolder in assemblyFoldersEx)
                 {
-                    if (FileUtilities.DirectoryExistsNoThrow(assemblyFolder.DirectoryPath))
+                    foldersToSearch.Add(assemblyFolder.DirectoryPath);
+                }
+
+                Parallel.ForEach(foldersToSearch, assemblyFolder =>
+                {
+                    if (FileUtilities.DirectoryExistsNoThrow(assemblyFolder))
                     {
-                        string[] files = Directory.GetFiles(assemblyFolder.DirectoryPath, "*.*", SearchOption.TopDirectoryOnly);
+                        string[] files = Directory.GetFiles(assemblyFolder, "*.*", SearchOption.TopDirectoryOnly);
 
                         lock (lockobject)
                         {

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1120,9 +1120,11 @@ namespace Microsoft.Build.Tasks
                         if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                         {
                             Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.AssemblyFoldersExSearchLocations", r.SearchPath);
+                            var usedFolders = new HashSet<string>();
                             foreach (AssemblyFoldersExInfo info in assemblyFoldersEx)
                             {
-                                Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", info.DirectoryPath);
+                                if (usedFolders.Add(info.DirectoryPath))
+                                    Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", info.DirectoryPath);
                             }
                         }
                     }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1120,8 +1120,7 @@ namespace Microsoft.Build.Tasks
                         if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                         {
                             Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.AssemblyFoldersExSearchLocations", r.SearchPath);
-                            var usedFolders = assemblyFoldersEx.UniqueDirectoryPaths();
-                            foreach (var path in usedFolders)
+                            foreach (var path in assemblyFoldersEx.UniqueDirectoryPaths)
                             {
                                 Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", path);
                             }

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -1120,11 +1120,10 @@ namespace Microsoft.Build.Tasks
                         if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                         {
                             Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.AssemblyFoldersExSearchLocations", r.SearchPath);
-                            var usedFolders = new HashSet<string>();
-                            foreach (AssemblyFoldersExInfo info in assemblyFoldersEx)
+                            var usedFolders = assemblyFoldersEx.UniqueDirectoryPaths();
+                            foreach (var path in usedFolders)
                             {
-                                if (usedFolders.Add(info.DirectoryPath))
-                                    Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", info.DirectoryPath);
+                                Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", path);
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #3783 

This PR doesn't modify the source list of AssemblyFoldersEx which contains additional data (the difference was in my case only in the View property). 

~~The source list is also used in the output which is shown in the issue, so the output will still contain duplicate entries, but the search is for actual files in the folders isn't done twice.~~

This PR also removes duplicate log output. 