### PR TITLE
[vs16.8 snap] Updated branding for 16.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ For more information on MSBuild, see the [MSBuild documentation](https://docs.mi
 
 ### Build Status
 
-The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.7 and a corresponding version of the .NET Core SDK.
+The current development branch is `master`. Changes in `master` will go into a future update of MSBuild, which will release with Visual Studio 16.8 and a corresponding version of the .NET Core SDK.
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=master)
 
-We have forked for MSBuild 16.6 in the branch [`vs16.6`](https://github.com/Microsoft/msbuild/tree/vs16.6). Changes to that branch need special approval.
+We have forked for MSBuild 16.7 in the branch [`vs16.7`](https://github.com/Microsoft/msbuild/tree/vs16.7). Changes to that branch need special approval.
 
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.6)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.6)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/Microsoft/msbuild/msbuild-pr?branchName=vs16.7)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=86&branchName=vs16.7)
 
 MSBuild 16.4 builds from the branch [`vs16.4`](https://github.com/Microsoft/msbuild/tree/vs16.4). Only high-priority bugfixes will be considered for servicing 16.4.
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.7.0</VersionPrefix>
+    <VersionPrefix>16.8.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -42,8 +42,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.7.0.0" newVersion="16.7.0.0" />
-          <codeBase version="16.7.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.8.0.0" newVersion="16.8.0.0" />
+          <codeBase version="16.8.0.0" href="..\..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Redirects for components dropped by Visual Studio -->

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -54,8 +54,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-          <bindingRedirect oldVersion="16.0.0.0-16.7.0.0" newVersion="16.7.0.0" />
-          <codeBase version="16.7.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
+          <bindingRedirect oldVersion="16.0.0.0-16.8.0.0" newVersion="16.8.0.0" />
+          <codeBase version="16.8.0.0" href="..\..\Microsoft\VC\v160\Microsoft.Build.CPPTasks.Common.dll" />
         </dependentAssembly>
 
         <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->


### PR DESCRIPTION
Same changes as in the last update for 16.7.

Grepping the tree for "16.7", I'm wondering if we still need this override in eng\Versions.props:

```
    <!-- Override Arcade's default VSSDK version with one that supports client enablement.
         Can be removed after Arcade moves up. -->
    <MicrosoftVSSDKBuildToolsVersion>16.7.13</MicrosoftVSSDKBuildToolsVersion>
```