### PR TITLE
Port fix for Kudu to not call PriorityClass unless low priority build is specified

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,6 +34,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.1.100</DotNetCliVersion>
+    <DropAppVersion>18.165.29912-buildid11693003</DropAppVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,10 +15,9 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.6.0</VersionPrefix>
+    <VersionPrefix>16.6.1</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>qfe</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
     <SemanticVersioningV1>true</SemanticVersioningV1>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -625,10 +625,13 @@ namespace Microsoft.Build.CommandLine
                         Environment.SetEnvironmentVariable("MSBUILDLOADALLFILESASWRITEABLE", "1");
                     }
 
-                    // Honor the low priority flag, we place our selves below normal
-                    // priority and let sub processes inherit that priority.
-                    ProcessPriorityClass priority = lowPriority ? ProcessPriorityClass.BelowNormal : ProcessPriorityClass.Normal;
-                    Process.GetCurrentProcess().PriorityClass = priority;
+                    // Honor the low priority flag, we place our selves below normal priority and let sub processes inherit
+                    // that priority. Idle priority would prevent the build from proceeding as the user does normal actions.
+                    // We avoid increasing priority because that causes failures on mac/linux.
+                    if (lowPriority && Process.GetCurrentProcess().PriorityClass != ProcessPriorityClass.Idle)
+                    {
+                        Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal;
+                    }
 
                     DateTime t1 = DateTime.Now;
 


### PR DESCRIPTION
Customer scenario

Kudu and Linux scenarios where the api to set the priority is disabled are blocked from using msbuild.  When lowpriority build is not set, we were still previously setting priority to Normal which was not allowed on some system.

Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.BelowNormal

Bugs this fixes

https://github.com/microsoft/msbuild/issues/5365

Workarounds, if any

None

Risk

Low, we moved the set within a check for is lowpriority build enabled.  The fix is NOT required for VS.

Performance impact

Low

Root cause analysis

We didn't realize this win32 api was blocked on some systems

How was the bug found?

https://github.com/dotnet/core/issues/4719