### PR TITLE
Revert 5471 exp/drop amd64 codebase

### DIFF
--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -15,10 +15,12 @@
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Framework.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
@@ -27,18 +29,22 @@
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Tasks.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Utilities.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Engine.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
           <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+          <codeBase version="15.1.0.0" href="..\Microsoft.Build.Conversion.Core.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.CPPTasks.Common" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
Fixes https://github.com/microsoft/msbuild/issues/5494

Work item (Internal use): [AB#1150959](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1150959)

### Summary
A regression was introduced with https://github.com/microsoft/msbuild/pull/5471, which we did to enable long path support for x64 msbuild. This fix simply backs out what caused the regression.

### Customer Impact
The regression affects the following scenarios:

- Building any UWP application with the minimum platform version set to 15063 with the configuration set to Release / x64.
- Building any c++ application that contains any COM references.

### Regression?
Yes

### Testing
Manual patch passes test.

### Risk
Low