### PR TITLE
Introduce $(IncrementalCleanDependsOn)

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -4922,7 +4922,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     -->
   <Target
        Name="IncrementalClean"
-       DependsOnTargets="_CleanGetCurrentAndPriorFileWrites">
+       DependsOnTargets="$(IncrementalCleanDependsOn);_CleanGetCurrentAndPriorFileWrites">
 
     <!-- Subtract list of files produced in prior builds from list of files produced in this build. -->
     <ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4905
Fixes: https://github.com/microsoft/msbuild/issues/3916

Xamarin.Android runs MSBuild targets after `CoreCompile` and `Build`
that generates files in `$(IntermediateOutputPath)`. If you want to
add these files to `@(FileWrites)`, the build-in functionality from the
`IncrementalClean` target doesn't work unless you do something like:

    <Target Name="Foo" BeforeTargets="_CleanGetCurrentAndPriorFileWrites">

The problem here being `_CleanGetCurrentAndPriorFileWrites` is "private".

Or modify `$(CoreBuildDependsOn)`:

    <CoreBuildDependsOn>
      $([MSBuild]::Unescape($(CoreBuildDependsOn.Replace('IncrementalClean;', 'Foo;IncrementalClean;'))))
    </CoreBuildDependsOn>

This seems weird to me, and it could also break if a target was named
`FooIncrementalClean` or semi-colons moved around...

If we introduced `$(IncrementalCleanDependsOn)`, we could just do this
instead:

    <IncrementalCleanDependsOn>
      Foo;
      $(IncrementalCleanDependsOn);
    </IncrementalCleanDependsOn>