### PR TITLE
Add IsRunningInVisualStudio property to SdkResolverContext

### DIFF
--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Build.Framework
         protected SdkResultFactory() { }
         public abstract Microsoft.Build.Framework.SdkResult IndicateFailure(System.Collections.Generic.IEnumerable<string> errors, System.Collections.Generic.IEnumerable<string> warnings=null);
         public virtual Microsoft.Build.Framework.SdkResult IndicateSuccess(System.Collections.Generic.IEnumerable<string> paths, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd=null, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.SdkResultItem> itemsToAdd=null, System.Collections.Generic.IEnumerable<string> warnings=null) { throw null; }
-        public abstract Microsoft.Build.Framework.SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IEnumerable<string> warnings=null);
+        public abstract Microsoft.Build.Framework.SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd=null, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.SdkResultItem> itemsToAdd=null, System.Collections.Generic.IEnumerable<string> warnings=null);
     }
     public partial class SdkResultItem
     {

--- a/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/net/Microsoft.Build.Framework.cs
@@ -487,6 +487,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResolverContext() { }
         public virtual bool Interactive { get { throw null; } protected set { } }
+        public virtual bool IsRunningInVisualStudio { get { throw null; } protected set { } }
         public virtual Microsoft.Build.Framework.SdkLogger Logger { get { throw null; } protected set { } }
         public virtual System.Version MSBuildVersion { get { throw null; } protected set { } }
         public virtual string ProjectFilePath { get { throw null; } protected set { } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -486,6 +486,7 @@ namespace Microsoft.Build.Framework
     {
         protected SdkResolverContext() { }
         public virtual bool Interactive { get { throw null; } protected set { } }
+        public virtual bool IsRunningInVisualStudio { get { throw null; } protected set { } }
         public virtual Microsoft.Build.Framework.SdkLogger Logger { get { throw null; } protected set { } }
         public virtual System.Version MSBuildVersion { get { throw null; } protected set { } }
         public virtual string ProjectFilePath { get { throw null; } protected set { } }

--- a/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
+++ b/ref/Microsoft.Build.Framework/netstandard/Microsoft.Build.Framework.cs
@@ -508,7 +508,7 @@ namespace Microsoft.Build.Framework
         protected SdkResultFactory() { }
         public abstract Microsoft.Build.Framework.SdkResult IndicateFailure(System.Collections.Generic.IEnumerable<string> errors, System.Collections.Generic.IEnumerable<string> warnings=null);
         public virtual Microsoft.Build.Framework.SdkResult IndicateSuccess(System.Collections.Generic.IEnumerable<string> paths, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd=null, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.SdkResultItem> itemsToAdd=null, System.Collections.Generic.IEnumerable<string> warnings=null) { throw null; }
-        public abstract Microsoft.Build.Framework.SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IEnumerable<string> warnings=null);
+        public abstract Microsoft.Build.Framework.SdkResult IndicateSuccess(string path, string version, System.Collections.Generic.IDictionary<string, string> propertiesToAdd=null, System.Collections.Generic.IDictionary<string, Microsoft.Build.Framework.SdkResultItem> itemsToAdd=null, System.Collections.Generic.IEnumerable<string> warnings=null);
     }
     public partial class SdkResultItem
     {

--- a/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
+++ b/src/Build.UnitTests/BackEnd/MockSdkResolverService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         {
         }
 
-        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        public Build.BackEnd.SdkResolution.SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             return null;
         }

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("notfound", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Success.ShouldBeFalse();
             result.ShouldNotBeNull();
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                             ))
                 });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Path.ShouldBe("path");
 
@@ -94,7 +94,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("1sdkName", "version1", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Path.ShouldBe("resolverpath1");
             _logger.Warnings.Select(i => i.Message).ShouldBe(new [] { "The SDK resolver \"MockSdkResolverThrows\" failed to run. EXMESSAGE" });
@@ -107,7 +107,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkReference sdk = new SdkReference("1sdkName", "referencedVersion", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Path.ShouldBe("resolverpath1");
             _logger.BuildMessageEvents.Select(i => i.Message).ShouldContain("MockSdkResolver1 running");
@@ -122,7 +122,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             // be logged because MockSdkResolver2 will succeed.
             SdkReference sdk = new SdkReference("2sdkName", "version2", "minimumVersion");
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Path.ShouldBe("resolverpath2");
 
@@ -145,10 +145,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false).Path.ShouldBe(MockSdkResolverWithState.Expected);
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe(MockSdkResolverWithState.Expected);
         }
 
         [Fact]
@@ -161,10 +161,10 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             SdkReference sdk = new SdkReference("othersdk", "1.0", "minimumVersion");
 
             // First call should not know state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
 
             // Second call should have received state
-            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false).Path.ShouldBe("resolverpath");
+            SdkResolverService.Instance.ResolveSdk(submissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false).Path.ShouldBe("resolverpath");
         }
 
         [Theory]
@@ -207,13 +207,13 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     resolver
                 });
 
-            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
             _logger.WarningCount.ShouldBe(0);
 
-            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            result = service.ResolveSdk(BuildEventContext.InvalidSubmissionId, new SdkReference("foo", "2.0.0", null), _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
             resolver.ResolvedCalls.Count.ShouldBe(1);
             result.Path.ShouldBe("path");
             result.Version.ShouldBe("1.0.0");
@@ -289,7 +289,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBeNull();
@@ -326,7 +326,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Success.ShouldBeTrue();
             result.Path.ShouldBe(expectedPath);
@@ -373,7 +373,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Success.ShouldBeTrue();
 
@@ -421,7 +421,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
 
             SdkResolverService.Instance.InitializeForTests(null, new List<SdkResolver>() { resolver });
 
-            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false);
+            var result = SdkResolverService.Instance.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false);
 
             result.Success.ShouldBeTrue();
 
@@ -471,7 +471,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             Parallel.For(
                 0,
                 10,
-                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false));
+                _ => service.ResolveSdk(BuildEventContext.InvalidSubmissionId, sdk, _loggingContext, new MockElementLocation("file"), "sln", "projectPath", interactive: false, isRunningInVisualStudio: false));
 
             var result = resolver.ResolvedCalls.ShouldHaveSingleItem();
 
@@ -508,9 +508,40 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 "sln",
                 "projectPath",
                 // Pass along interactive and expect it to be received in the SdkResolverContext
-                interactive: true);
+                interactive: true,
+                false);
 
             interactive.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsRunningInVisualStudioIsSetForResolverContext()
+        {
+            bool isRunningInVisualStudio = false;
+
+            var service = new CachingSdkResolverService();
+            service.InitializeForTests(
+                resolvers: new List<SdkResolver>
+                {
+                    new SdkUtilities.ConfigurableMockSdkResolver((sdkRference, resolverContext, factory) =>
+                    {
+                        isRunningInVisualStudio = resolverContext.IsRunningInVisualStudio;
+                        return null;
+                    })
+                });
+
+            var result = service.ResolveSdk(
+                BuildEventContext.InvalidSubmissionId,
+                new SdkReference("foo", "1.0.0", null),
+                _loggingContext,
+                new MockElementLocation("file"),
+                "sln",
+                "projectPath",
+                false,
+                // Pass along isRunningInVisualStudio and expect it to be received in the SdkResolverContext
+                isRunningInVisualStudio: true);
+
+            isRunningInVisualStudio.ShouldBeTrue();
         }
 
         private class MockLoaderStrategy : SdkResolverLoader

--- a/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/SdkResolverService_Tests.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                             sdk,
                             "path",
                             "2.0.0",
+                            null,
+                            null,
                             Enumerable.Empty<string>()
                             ))
                 });
@@ -192,6 +194,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     sdk,
                     "path",
                     "1.0.0",
+                    null,
+                    null,
                     Enumerable.Empty<string>()
                     ));
 
@@ -450,6 +454,8 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                     sdk,
                     "path",
                     "1.0.0",
+                    null,
+                    null,
                     Enumerable.Empty<string>()
                 ));
 
@@ -572,7 +578,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 resolverContext.Logger.LogMessage("MockSdkResolver2 running", MessageImportance.Normal);
 
                 if (sdk.Name.StartsWith("2"))
-                    return factory.IndicateSuccess("resolverpath2", "version2", new[] {"WARNING2"});
+                    return factory.IndicateSuccess("resolverpath2", "version2", warnings: new[] {"WARNING2"});
 
                 return factory.IndicateFailure(new[] {"ERROR2"}, new[] {"WARNING2"});
             }

--- a/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
+++ b/src/Build.UnitTests/Definition/ProjectEvaluationContext_Tests.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Build.UnitTests.Definition
             _resolver = new SdkUtilities.ConfigurableMockSdkResolver(
                 new Dictionary<string, SdkResult>
                 {
-                    {"foo", new SdkResult(new SdkReference("foo", "1.0.0", null), "path", "1.0.0", null)},
-                    {"bar", new SdkResult(new SdkReference("bar", "1.0.0", null), "path", "1.0.0", null)}
+                    {"foo", new SdkResult(new SdkReference("foo", "1.0.0", null), "path", "1.0.0", null, null, null)},
+                    {"bar", new SdkResult(new SdkReference("bar", "1.0.0", null), "path", "1.0.0", null, null, null)}
                 });
         }
 

--- a/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/SdkResultEvaluation_Tests.cs
@@ -140,9 +140,10 @@ namespace Microsoft.Build.UnitTests.Evaluation
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void SdkResolverCanReturnSinglePath(bool includePropertiesAndItems)
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void SdkResolverCanReturnSinglePath(bool includePropertiesAndItems, bool useSinglePathResult)
         {
             Dictionary<string, string> propertiesToAdd = null;
             Dictionary<string, SdkResultItem> itemsToAdd = null;
@@ -152,16 +153,23 @@ namespace Microsoft.Build.UnitTests.Evaluation
                 CreateMockSdkResultPropertiesAndItems(out propertiesToAdd, out itemsToAdd);
             }
 
-            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(
+            var sdkResult = useSinglePathResult ?
                 new Build.BackEnd.SdkResolution.SdkResult(
-                        new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
-                        new[] { Path.Combine(_testFolder, "Sdk") },
-                        version: null,
-                        propertiesToAdd,
-                        itemsToAdd,
-                        warnings: null
-                    ))
-                );
+                    new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
+                    Path.Combine(_testFolder, "Sdk"),
+                    version: null,
+                    propertiesToAdd,
+                    itemsToAdd,
+                    warnings: null) :
+                new Build.BackEnd.SdkResolution.SdkResult(
+                    new SdkReference("TestPropsAndItemsFromResolverSdk", null, null),
+                    new[] { Path.Combine(_testFolder, "Sdk") },
+                    version: null,
+                    propertiesToAdd,
+                    itemsToAdd,
+                    warnings: null);
+
+            var projectOptions = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(sdkResult));
 
             string projectContent = @"
                     <Project>

--- a/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/CachingSdkResolverService.cs
@@ -34,13 +34,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _cache.Clear();
         }
 
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             SdkResult result;
 
             if (Traits.Instance.EscapeHatches.DisableSdkResolutionCache)
             {
-                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive);
+                result = base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
             }
             else
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                  */
                 Lazy<SdkResult> resultLazy = cached.GetOrAdd(
                     sdk.Name,
-                    key => new Lazy<SdkResult>(() => base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive)));
+                    key => new Lazy<SdkResult>(() => base.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio)));
 
                 // Get the lazy value which will block all waiting threads until the SDK is resolved at least once while subsequent calls get cached results.
                 result = resultLazy.Value;

--- a/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/HostedSdkResolverServiceBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public abstract void PacketReceived(int node, INodePacket packet);
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive);
+        public abstract SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio);
 
         /// <inheritdoc cref="IBuildComponent.ShutdownComponent"/>
         public virtual void ShutdownComponent()

--- a/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/ISdkResolverService.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         /// <param name="solutionPath">The full path to the solution file, if any, that is resolving the SDK.</param>
         /// <param name="projectPath">The full path to the project file that is resolving the SDK.</param>
         /// <param name="interactive">Indicates whether or not the resolver is allowed to be interactive.</param>
+        /// <param name="isRunningInVisualStudio">Indicates whether or not the resolver is running in Visual Studio.</param>
         /// <returns>An <see cref="SdkResult"/> containing information about the resolved SDK. If no resolver was able to resolve it, then <see cref="Framework.SdkResult.Success"/> == false. </returns>
-        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive);
+        SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio);
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/MainNodeSdkResolverService.cs
@@ -87,14 +87,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             ErrorUtilities.VerifyThrowInternalNull(sdk, nameof(sdk));
             ErrorUtilities.VerifyThrowInternalNull(loggingContext, nameof(loggingContext));
             ErrorUtilities.VerifyThrowInternalNull(sdkReferenceLocation, nameof(sdkReferenceLocation));
             ErrorUtilities.VerifyThrowInternalLength(projectPath, nameof(projectPath));
 
-            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive);
+            return _cachedSdkResolver.ResolveSdk(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
                         ILoggingService loggingService = Host.GetComponent(BuildComponentType.LoggingService) as ILoggingService;
 
                         // This call is usually cached so is very fast but can take longer for a new SDK that is downloaded.  Other queued threads for different SDKs will complete sooner and continue on which unblocks evaluations
-                        response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive);
+                        response = ResolveSdk(request.SubmissionId, sdkReference, new EvaluationLoggingContext(loggingService, request.BuildEventContext, request.ProjectPath), request.ElementLocation, request.SolutionPath, request.ProjectPath, request.Interactive, request.IsRunningInVisualStudio);
                     }
                     catch (Exception e)
                     {

--- a/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/OutOfProcNodeSdkResolverService.cs
@@ -61,14 +61,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        public override SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             // Get a cached response if possible, otherwise send the request
             var sdkResult = _responseCache.GetOrAdd(
                 sdk.Name,
                 key =>
                 {
-                    var result = RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive);
+                    var result = RequestSdkPathFromMainNode(submissionId, sdk, loggingContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
                     return result;
                 });
 
@@ -103,13 +103,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _responseReceivedEvent.Set();
         }
 
-        private SdkResult RequestSdkPathFromMainNode(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        private SdkResult RequestSdkPathFromMainNode(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             // Clear out the last response for good measure
             _lastResponse = null;
 
             // Create the SdkResolverRequest packet to send
-            INodePacket packet = SdkResolverRequest.Create(submissionId, sdk, loggingContext.BuildEventContext, sdkReferenceLocation, solutionPath, projectPath, interactive);
+            INodePacket packet = SdkResolverRequest.Create(submissionId, sdk, loggingContext.BuildEventContext, sdkReferenceLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
 
             SendPacket(packet);
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverContext.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverContext.cs
@@ -12,13 +12,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
     /// </summary>
     internal sealed class SdkResolverContext : SdkResolverContextBase
     {
-        public SdkResolverContext(Framework.SdkLogger logger, string projectFilePath, string solutionPath, Version msBuildVersion, bool interactive)
+        public SdkResolverContext(Framework.SdkLogger logger, string projectFilePath, string solutionPath, Version msBuildVersion, bool interactive, bool isRunningInVisualStudio)
         {
             Logger = logger;
             ProjectFilePath = projectFilePath;
             SolutionFilePath = solutionPath;
             MSBuildVersion = msBuildVersion;
             Interactive = interactive;
+            IsRunningInVisualStudio = isRunningInVisualStudio;
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverRequest.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverRequest.cs
@@ -21,13 +21,14 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         private int _submissionId;
         private string _version;
         private bool _interactive;
+        private bool _isRunningInVisualStudio;
 
         public SdkResolverRequest(ITranslator translator)
         {
             Translate(translator);
         }
 
-        private SdkResolverRequest(int submissionId, string name, string version, string minimumVersion, BuildEventContext buildEventContext, ElementLocation elementLocation, string solutionPath, string projectPath, bool interactive)
+        private SdkResolverRequest(int submissionId, string name, string version, string minimumVersion, BuildEventContext buildEventContext, ElementLocation elementLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             _buildEventContext = buildEventContext;
             _submissionId = submissionId;
@@ -38,6 +39,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             _solutionPath = solutionPath;
             _version = version;
             _interactive = interactive;
+            _isRunningInVisualStudio = isRunningInVisualStudio;
         }
 
         public BuildEventContext BuildEventContext => _buildEventContext;
@@ -45,6 +47,8 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         public ElementLocation ElementLocation => _elementLocation;
 
         public bool Interactive => _interactive;
+
+        public bool IsRunningInVisualStudio => _isRunningInVisualStudio;
 
         public string MinimumVersion => _minimumVersion;
 
@@ -62,9 +66,9 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
         public string Version => _version;
 
-        public static SdkResolverRequest Create(int submissionId, SdkReference sdkReference, BuildEventContext buildEventContext, ElementLocation elementLocation, string solutionPath, string projectPath, bool interactive)
+        public static SdkResolverRequest Create(int submissionId, SdkReference sdkReference, BuildEventContext buildEventContext, ElementLocation elementLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
-            return new SdkResolverRequest(submissionId, sdkReference.Name, sdkReference.Version, sdkReference.MinimumVersion, buildEventContext, elementLocation, solutionPath, projectPath, interactive);
+            return new SdkResolverRequest(submissionId, sdkReference.Name, sdkReference.Version, sdkReference.MinimumVersion, buildEventContext, elementLocation, solutionPath, projectPath, interactive, isRunningInVisualStudio);
         }
 
         public static INodePacket FactoryForDeserialization(ITranslator translator)
@@ -83,6 +87,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             translator.Translate(ref _submissionId);
             translator.Translate(ref _version);
             translator.Translate(ref _interactive);
+            translator.Translate(ref _isRunningInVisualStudio);
         }
     }
 }

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResolverService.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
         }
 
         /// <inheritdoc cref="ISdkResolverService.ResolveSdk"/>
-        public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive)
+        public virtual SdkResult ResolveSdk(int submissionId, SdkReference sdk, LoggingContext loggingContext, ElementLocation sdkReferenceLocation, string solutionPath, string projectPath, bool interactive, bool isRunningInVisualStudio)
         {
             // Lazy initialize the SDK resolvers
             if (_resolvers == null)
@@ -104,7 +104,7 @@ namespace Microsoft.Build.BackEnd.SdkResolution
 
             foreach (SdkResolver sdkResolver in _resolvers)
             {
-                SdkResolverContext context = new SdkResolverContext(buildEngineLogger, projectPath, solutionPath, ProjectCollection.Version, interactive)
+                SdkResolverContext context = new SdkResolverContext(buildEngineLogger, projectPath, solutionPath, ProjectCollection.Version, interactive, isRunningInVisualStudio)
                 {
                     State = GetResolverState(submissionId, sdkResolver)
                 };

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResult.cs
@@ -29,12 +29,16 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             Warnings = warnings;
         }
 
-        public SdkResult(SdkReference sdkReference, string path, string version, IEnumerable<string> warnings)
+        public SdkResult(SdkReference sdkReference, string path, string version, IDictionary<string, string> propertiesToAdd,
+                         IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings)
         {
             Success = true;
             SdkReference = sdkReference;
             Path = path;
             Version = version;
+
+            PropertiesToAdd = propertiesToAdd;
+            ItemsToAdd = itemsToAdd;
             Warnings = warnings;
         }
 

--- a/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
+++ b/src/Build/BackEnd/Components/SdkResolution/SdkResultFactory.cs
@@ -27,9 +27,13 @@ namespace Microsoft.Build.BackEnd.SdkResolution
             return new SdkResult(_sdkReference, errors, warnings);
         }
 
-        public override SdkResultBase IndicateSuccess(string path, string version, IEnumerable<string> warnings = null)
+        public override SdkResultBase IndicateSuccess(string path,
+                                                      string version,
+                                                      IDictionary<string, string> propertiesToAdd = null,
+                                                      IDictionary<string, SdkResultItem> itemsToAdd = null,
+                                                      IEnumerable<string> warnings = null)
         {
-            return new SdkResult(_sdkReference, path, version, warnings);
+            return new SdkResult(_sdkReference, path, version,propertiesToAdd, itemsToAdd, warnings);
         }
 
         public override SdkResultBase IndicateSuccess(IEnumerable<string> paths,

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -178,6 +178,8 @@ namespace Microsoft.Build.Evaluation
 
         private readonly bool _interactive;
 
+        private readonly bool _isRunningInVisualStudio;
+
         /// <summary>
         /// Private constructor called by the static Evaluate method.
         /// </summary>
@@ -240,6 +242,7 @@ namespace Microsoft.Build.Evaluation
             _sdkResolverService = sdkResolverService;
             _submissionId = submissionId;
             _evaluationProfiler = new EvaluationProfiler(profileEvaluation);
+            _isRunningInVisualStudio = BuildEnvironmentHelper.Instance.RunningInVisualStudio;
 
             // In 15.9 we added support for the global property "NuGetInteractive" to allow SDK resolvers to be interactive.
             // In 16.0 we added the /interactive command-line argument so the line below keeps back-compat
@@ -1788,7 +1791,7 @@ namespace Microsoft.Build.Evaluation
                 var projectPath = _data.GetProperty(ReservedPropertyNames.projectFullPath)?.EvaluatedValue;
 
                 // Combine SDK path with the "project" relative path
-                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, importElement.SdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive);
+                sdkResult = _sdkResolverService.ResolveSdk(_submissionId, importElement.SdkReference, _evaluationLoggingContext, importElement.Location, solutionPath, projectPath, _interactive, _isRunningInVisualStudio);
 
                 if (!sdkResult.Success)
                 {

--- a/src/Framework/Sdk/SdkResolverContext.cs
+++ b/src/Framework/Sdk/SdkResolverContext.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Build.Framework
         public virtual bool Interactive { get; protected set; }
 
         /// <summary>
+        /// Gets a value indicating if the resolver is running in Visual Studio.
+        /// </summary>
+        public virtual bool IsRunningInVisualStudio { get; protected set; }
+
+        /// <summary>
         ///     Logger to log real-time messages back to MSBuild.
         /// </summary>
         public virtual SdkLogger Logger { get; protected set; }

--- a/src/Framework/Sdk/SdkResultFactory.cs
+++ b/src/Framework/Sdk/SdkResultFactory.cs
@@ -17,9 +17,15 @@ namespace Microsoft.Build.Framework
         /// </summary>
         /// <param name="path">Path to the SDK.</param>
         /// <param name="version">Version of the SDK that was resolved.</param>
+        /// <param name="propertiesToAdd">Properties to set in the evaluation</param>
+        /// <param name="itemsToAdd">Items to add to the evaluation</param>
         /// <param name="warnings">Optional warnings to display during resolution.</param>
         /// <returns></returns>
-        public abstract SdkResult IndicateSuccess(string path, string version, IEnumerable<string> warnings = null);
+        public abstract SdkResult IndicateSuccess(string path,
+            string version,
+            IDictionary<string, string> propertiesToAdd = null,
+            IDictionary<string, SdkResultItem> itemsToAdd = null,
+            IEnumerable<string> warnings = null);
 
         /// <summary>
         ///     Create an <see cref="SdkResolver" /> object indicating success.


### PR DESCRIPTION
- 558fe2e adds the ability to pass items and properties along with a SDKResult in the single path case
- a470adc adds a `IsRunningInVisualStudio` property to SdkResolverContext