### PR TITLE
Sync XSD "IntelliSense" with VS repo automatically on insertion

### DIFF
--- a/.vsts-dotnet.yml
+++ b/.vsts-dotnet.yml
@@ -181,6 +181,15 @@ stages:
         ArtifactName: PackageArtifacts
       condition: succeeded()
 
+    # Publish "IntelliSense" XSD files to their own artifact
+    # so it can be consumed by the insertion-to-VS job
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Artifact: xsd'
+      inputs:
+        path: 'artifacts\xsd'
+        artifactName: xsd
+      condition: succeeded()
+
     # Publish Asset Manifests for Build Asset Registry job
     - task: PublishBuildArtifacts@1
       displayName: Publish Asset Manifests

--- a/src/MSBuild/MSBuild.csproj
+++ b/src/MSBuild/MSBuild.csproj
@@ -216,16 +216,9 @@
     <Content Include="MSBuild.rsp" Pack="false">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="MSBuild\Microsoft.Build.CommonTypes.xsd">
-      <SubType>Designer</SubType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="MSBuild\Microsoft.Build.Core.xsd">
-      <SubType>Designer</SubType>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Microsoft.Build.xsd">
-      <SubType>Designer</SubType>
+    <XsdsForVS Include="**\*.xsd" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <XsdsForVS Include="Update-MSBuildXsds.ps1" />
+    <None Include="@(XsdsForVS)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -246,6 +239,14 @@
     <ProjectReference Include="..\Framework\Microsoft.Build.Framework.csproj" PrivateAssets="All" />
     <ProjectReference Include="..\Tasks\Microsoft.Build.Tasks.csproj" />
   </ItemGroup>
+
+  <Target Name="CopyXsds"
+          BeforeTargets="AfterBuild">
+    <Copy SourceFiles="@(XsdsForVS)"
+          DestinationFiles="@(XsdsForVS->'$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'xsd'))%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+          />
+  </Target>
 
   <!-- Include MSBuild.deps.json and MSBuild.runtimeconfig.json in ContentWithTargetPath so they will be copied to the output folder of projects
        that reference this one. -->

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5624,7 +5624,7 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
-
+<!-- a change made on GitHub that should flow -->
     <xs:element name="ValidateStoreManifest" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>

--- a/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
+++ b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd
@@ -5624,7 +5624,7 @@ elementFormDefault="qualified">
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
-<!-- a change made on GitHub that should flow -->
+
     <xs:element name="ValidateStoreManifest" substitutionGroup="msb:Task">
         <xs:complexType>
             <xs:complexContent>

--- a/src/MSBuild/Update-MSBuildXsds.ps1
+++ b/src/MSBuild/Update-MSBuildXsds.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+
+$vsXsdPath = (Join-Path $env:RepoRoot "src\xmake\XMakeCommandLine")
+
+Copy-Item -Path (Join-Path $PSScriptRoot "Microsoft.Build.xsd") -Destination $vsXsdPath -Force
+Copy-Item -Path (Join-Path $PSScriptRoot "MSBuild\Microsoft.Build.CommonTypes.xsd") -Destination $vsXsdPath -Force
+Copy-Item -Path (Join-Path $PSScriptRoot "MSBuild\Microsoft.Build.Core.xsd") -Destination $vsXsdPath -Force

--- a/src/MSBuild/Update-MSBuildXsds.ps1
+++ b/src/MSBuild/Update-MSBuildXsds.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 
-cmd /c set
-
 $vsXsdPath = "src\xmake\XMakeCommandLine"
+
+Write-Host "Updating XSDs in $(Resolve-Path $vsXsdPath)"
 
 Copy-Item -Path (Join-Path $PSScriptRoot "Microsoft.Build.xsd") -Destination $vsXsdPath -Force
 Copy-Item -Path (Join-Path $PSScriptRoot "MSBuild\Microsoft.Build.CommonTypes.xsd") -Destination $vsXsdPath -Force

--- a/src/MSBuild/Update-MSBuildXsds.ps1
+++ b/src/MSBuild/Update-MSBuildXsds.ps1
@@ -1,6 +1,8 @@
 $ErrorActionPreference = 'Stop'
 
-$vsXsdPath = (Join-Path $env:RepoRoot "src\xmake\XMakeCommandLine")
+cmd /c set
+
+$vsXsdPath = "src\xmake\XMakeCommandLine"
 
 Copy-Item -Path (Join-Path $PSScriptRoot "Microsoft.Build.xsd") -Destination $vsXsdPath -Force
 Copy-Item -Path (Join-Path $PSScriptRoot "MSBuild\Microsoft.Build.CommonTypes.xsd") -Destination $vsXsdPath -Force


### PR DESCRIPTION
We've been manually managing this and naturally forgotten it a few times. That's not cool. Let's let a robot do it.

This requires change to the releases: https://dev.azure.com/devdiv/DevDiv/_releaseProgress?releaseId=749728&_a=release-history but it will be harmless to do this first and then change them.

Example internal PR: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/262150?_a=files